### PR TITLE
Make comment extraction lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Then simply run `make`. You can also run `make yt-dlp` instead to compile only t
                                      "OUTPUT TEMPLATE" for a list of available
                                      keys) to match if the key is present, !key
                                      to check if the key is not present,
-                                     key>NUMBER (like "comment_count > 12", also
+                                     key>NUMBER (like "view_count > 12", also
                                      works with >=, <, <=, !=, =) to compare
                                      against a number, key = 'LITERAL' (like
                                      "uploader = 'Mike Smith'", also works with
@@ -403,7 +403,9 @@ Then simply run `make`. You can also run `make yt-dlp` instead to compile only t
     --no-write-playlist-metafiles    Do not write playlist metadata when using
                                      --write-info-json, --write-description etc.
     --get-comments                   Retrieve video comments to be placed in the
-                                     .info.json file
+                                     .info.json file. The comments are fetched
+                                     even without this option if the extraction
+                                     is known to be quick
     --load-info-json FILE            JSON file containing the video information
                                      (created with the "--write-info-json"
                                      option)
@@ -814,7 +816,7 @@ The available fields are:
  - `dislike_count` (numeric): Number of negative ratings of the video
  - `repost_count` (numeric): Number of reposts of the video
  - `average_rating` (numeric): Average rating give by users, the scale used depends on the webpage
- - `comment_count` (numeric): Number of comments on the video
+ - `comment_count` (numeric): Number of comments on the video (For some extractors, comments are only downloaded at the end, and so this field cannot be used)
  - `age_limit` (numeric): Age restriction for the video (years)
  - `is_live` (boolean): Whether this video is a live stream or a fixed-length video
  - `was_live` (boolean): Whether this video was originally a live stream

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2499,7 +2499,7 @@ class YoutubeDL(object):
                 raise
             else:
                 if self.params.get('dump_single_json', False):
-                    self.post_extract(info_dict)
+                    self.post_extract(res)
                     self.to_stdout(json.dumps(res))
 
         return self._download_retcode

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2041,6 +2041,7 @@ class YoutubeDL(object):
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
         if self.params.get('forcejson', False):
+            self.post_extract(info_dict)
             self.to_stdout(json.dumps(info_dict))
 
     def process_info(self, info_dict):
@@ -2064,6 +2065,7 @@ class YoutubeDL(object):
         if self._match_entry(info_dict, incomplete=False) is not None:
             return
 
+        self.post_extract(info_dict)
         self._num_downloads += 1
 
         info_dict = self.pre_process(info_dict)
@@ -2497,6 +2499,7 @@ class YoutubeDL(object):
                 raise
             else:
                 if self.params.get('dump_single_json', False):
+                    self.post_extract(info_dict)
                     self.to_stdout(json.dumps(res))
 
         return self._download_retcode
@@ -2544,6 +2547,15 @@ class YoutubeDL(object):
                 if old_filename in files_to_move:
                     del files_to_move[old_filename]
         return files_to_move, infodict
+
+    @staticmethod
+    def post_extract(info_dict):
+        if '__post_extractor' not in info_dict:
+            return
+        post_extractor = info_dict['__post_extractor']
+        if post_extractor:
+            info_dict.update(post_extractor(info_dict).items())
+        del info_dict['__post_extractor']
 
     def pre_process(self, ie_info):
         info = dict(ie_info)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2550,12 +2550,21 @@ class YoutubeDL(object):
 
     @staticmethod
     def post_extract(info_dict):
-        if '__post_extractor' not in info_dict:
+        def actual_post_extract(info_dict):
+            if info_dict.get('_type') in ('playlist', 'multi_video'):
+                for video_dict in info_dict.get('entries', {}):
+                    actual_post_extract(video_dict)
+                return
+
+            if '__post_extractor' not in info_dict:
+                return
+            post_extractor = info_dict['__post_extractor']
+            if post_extractor:
+                info_dict.update(post_extractor().items())
+            del info_dict['__post_extractor']
             return
-        post_extractor = info_dict['__post_extractor']
-        if post_extractor:
-            info_dict.update(post_extractor(info_dict).items())
-        del info_dict['__post_extractor']
+
+        actual_post_extract(info_dict)
 
     def pre_process(self, ie_info):
         info = dict(ie_info)

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -266,7 +266,7 @@ class BiliBiliIE(InfoExtractor):
             'raw_tags': raw_tags,
         }
         if self._downloader.params.get('getcomments', False):
-            def get_comments(video_id):
+            def get_comments():
                 comments = self._get_all_comment_pages(video_id)
                 return {
                     'comments': comments,

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -255,10 +255,6 @@ class BiliBiliIE(InfoExtractor):
             info['uploader'] = self._html_search_meta(
                 'author', webpage, 'uploader', default=None)
 
-        comments = None
-        if self._downloader.params.get('getcomments', False):
-            comments = self._get_all_comment_pages(video_id)
-
         raw_danmaku = self._get_raw_danmaku(video_id, cid)
 
         raw_tags = self._get_tags(video_id)
@@ -266,11 +262,19 @@ class BiliBiliIE(InfoExtractor):
 
         top_level_info = {
             'raw_danmaku': raw_danmaku,
-            'comments': comments,
-            'comment_count': len(comments) if comments is not None else None,
             'tags': tags,
             'raw_tags': raw_tags,
         }
+        if self._downloader.params.get('getcomments', False):
+            def get_comments(video_id):
+                comments = self._get_all_comment_pages(video_id)
+                return {
+                    'comments': comments,
+                    'comment_count': len(comments)
+                }
+
+            top_level_info['__post_extractor'] = get_comments
+
 
         '''
         # Requires https://github.com/m13253/danmaku2ass which is licenced under GPL3

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -275,7 +275,6 @@ class BiliBiliIE(InfoExtractor):
 
             top_level_info['__post_extractor'] = get_comments
 
-
         '''
         # Requires https://github.com/m13253/danmaku2ass which is licenced under GPL3
         # See https://github.com/animelover1984/youtube-dl

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -299,7 +299,7 @@ class InfoExtractor(object):
                     must return a dict which will be added to the info_dict.
                     This is usefull for additional information that is
                     time-consuming to extract. Note that the fields thus
-                    extracted will not be available to output template and 
+                    extracted will not be available to output template and
                     match_filter. So, only "comments" and "comment_count" are
                     currently allowed to be extracted via this method.
 

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -294,6 +294,14 @@ class InfoExtractor(object):
                     players on other sites. Can be True (=always allowed),
                     False (=never allowed), None (=unknown), or a string
                     specifying the criteria for embedability (Eg: 'whitelist').
+    __post_extractor: A function to be called just before the metadata is
+                    written to either disk, logger or console. The function
+                    must return a dict which will be added to the info_dict.
+                    This is usefull for additional information that is
+                    time-consuming to extract. Note that the fields thus
+                    extracted will not be available to output template and 
+                    match_filter. So, only "comments" and "comment_count" are
+                    currently allowed to be extracted via this method.
 
     The following fields should only be used when the video belongs to some logical
     chapter or section:

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -347,7 +347,7 @@ def parseOpts(overrideArguments=None):
             'Specify any key (see "OUTPUT TEMPLATE" for a list of available keys) to '
             'match if the key is present, '
             '!key to check if the key is not present, '
-            'key>NUMBER (like "comment_count > 12", also works with '
+            'key>NUMBER (like "view_count > 12", also works with '
             '>=, <, <=, !=, =) to compare against a number, '
             'key = \'LITERAL\' (like "uploader = \'Mike Smith\'", also works with !=) '
             'to match against a string literal '
@@ -985,7 +985,9 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '--get-comments',
         action='store_true', dest='getcomments', default=False,
-        help='Retrieve video comments to be placed in the .info.json file')
+        help=(
+            'Retrieve video comments to be placed in the .info.json file. '
+            'The comments are fetched even without this option if the extraction is known to be quick'))
     filesystem.add_option(
         '--load-info-json', '--load-info',
         dest='load_info_filename', metavar='FILE',


### PR DESCRIPTION
Make comment extraction lazy so that it only runs when the comment data is actually needed

Closes #94 

~~This is currently only a proof of concept. The code needs to be generalized so that other fields can also make use of lazy extraction in the future.~~
