### PR TITLE
[YouTube] Fix trending feed extraction

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2520,17 +2520,20 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             channel_url, 'channel id')
 
     @staticmethod
-    def _extract_grid_item_renderer(item):
-        for item_kind in ('Playlist', 'Video', 'Channel'):
-            renderer = item.get('grid%sRenderer' % item_kind)
-            if renderer:
-                return renderer
+    def _extract_basic_item_renderer(item):
+        for item_kind in ('playlist', 'video', 'channel'):
+            for renderer_prefix in ('', 'grid'):
+                if renderer_prefix:
+                    item_kind = item_kind.title()
+                renderer = item.get('%s%sRenderer' % (renderer_prefix, item_kind))
+                if renderer:
+                    return renderer
 
     def _grid_entries(self, grid_renderer):
         for item in grid_renderer['items']:
             if not isinstance(item, dict):
                 continue
-            renderer = self._extract_grid_item_renderer(item)
+            renderer = self._extract_basic_item_renderer(item)
             if not isinstance(renderer, dict):
                 continue
             title = try_get(
@@ -2559,7 +2562,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         content = shelf_renderer.get('content')
         if not isinstance(content, dict):
             return
-        renderer = content.get('gridRenderer')
+        renderer = content.get('gridRenderer') or content.get('expandedShelfContentsRenderer')
         if renderer:
             # TODO: add support for nested playlists so each shelf is processed
             # as separate playlist


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

One potential fix for trending tab extraction.

When extracting the trending feed, it is currently hitting the `_shelf_entries_from_content()` function, which has nothing to handle the  `expandedShelfContentsRenderer`. Hence no videos are being extracted.

This PR adds functionality to use `_grid_entries()` to process `expandedShelfContentsRenderer`. 
Note that the contents of `expandedShelfContentsRenderer` is `{'items':[videoRenderer dicts]}`


