### PR TITLE
[Youtube] Fix private feeds/playlists on multi-channel Youtube accounts.

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3019,7 +3019,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         datasyncid = try_get(data, lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'], str)
         if datasyncid:
             sync_ids = datasyncid.split("||")
-            if len(sync_ids) > 1:
+            if len(sync_ids) >= 2 and sync_ids[1]:
                 # First page_id is the current accounts
                 return sync_ids[0]
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -301,7 +301,6 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         auth = self._generate_sapisidhash_header()
         if auth is not None:
             headers.update({'Authorization': auth, 'X-Origin': 'https://www.youtube.com'})
-
         return self._download_json(
             'https://www.youtube.com/youtubei/v1/%s' % ep,
             video_id=video_id, fatal=fatal, note=note, errnote=errnote,
@@ -2704,7 +2703,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             ctp = continuation_ep.get('clickTrackingParams')
             return YoutubeTabIE._build_continuation_query(continuation, ctp)
 
-    def _entries(self, tab, identity_token, item_id):
+    def _entries(self, tab, identity_token, item_id, account_syncid):
 
         def extract_entries(parent_renderer):  # this needs to called again for continuation to work with feeds
             contents = try_get(parent_renderer, lambda x: x['contents'], list) or []
@@ -2763,6 +2762,10 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         }
         if identity_token:
             headers['x-youtube-identity-token'] = identity_token
+
+        if account_syncid:
+            headers['X-Goog-PageId'] = account_syncid
+            headers['X-Goog-AuthUser'] = 0
 
         for page_num in itertools.count(1):
             if not continuation:
@@ -2879,7 +2882,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
                         try_get(owner, lambda x: x['navigationEndpoint']['browseEndpoint']['canonicalBaseUrl'], compat_str))
         return {k: v for k, v in uploader.items() if v is not None}
 
-    def _extract_from_tabs(self, item_id, webpage, data, tabs, identity_token):
+    def _extract_from_tabs(self, item_id, webpage, data, tabs, identity_token, account_syncid):
         playlist_id = title = description = channel_url = channel_name = channel_id = None
         thumbnails_list = tags = []
 
@@ -2943,7 +2946,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             'channel_id': metadata['uploader_id'],
             'channel_url': metadata['uploader_url']})
         return self.playlist_result(
-            self._entries(selected_tab, identity_token, playlist_id),
+            self._entries(selected_tab, identity_token, playlist_id, account_syncid),
             **metadata)
 
     def _extract_mix_playlist(self, playlist, playlist_id):
@@ -3009,6 +3012,16 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         return self._search_regex(
             r'\bID_TOKEN["\']\s*:\s*["\'](.+?)["\']', webpage,
             'identity token', default=None)
+
+    @staticmethod
+    def _extract_account_syncid(data):
+        # Required for secondary accounts
+        datasyncid = try_get(data, lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'], str)
+        if datasyncid:
+            sync_ids = datasyncid.split("||")
+            if len(sync_ids) > 1:
+                # First page_id is the current accounts
+                return sync_ids[0]
 
     def _extract_webpage(self, url, item_id):
         retries = self._downloader.params.get('extractor_retries', 3)
@@ -3079,7 +3092,8 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             data, lambda x: x['contents']['twoColumnBrowseResultsRenderer']['tabs'], list)
         if tabs:
             identity_token = self._extract_identity_token(webpage, item_id)
-            return self._extract_from_tabs(item_id, webpage, data, tabs, identity_token)
+            account_syncid = self._extract_account_syncid(data)
+            return self._extract_from_tabs(item_id, webpage, data, tabs, identity_token, account_syncid)
 
         playlist = try_get(
             data, lambda x: x['contents']['twoColumnWatchNextResults']['playlist']['playlist'], dict)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

**Current behavior:**
On multi-channel YouTube accounts, when accessing private feeds/playlists from the secondary channel account, the continuation of such pages will be accessed as if they were being called by the main channel account. 

This causes weird behavior - such as the continuation pages on a liked videos playlist being the main channel account's when downloading from the first. Note that the initial page is correct for the channel account.

**Solution**
The fix for this requires the two headers *when on a channel account other than the main*:
- add `X-Goog-AuthUser: 0` when on secondary channel account
- add `X-Goog-PageId: <unique number to that channel account>`

It gets a bit complex from here, this is what I have been able to understand regarding `X-Goog-PageId`:
`X-Goog-PageId` can be found in the `datasyncId` in the initial YouTube data payload.

`datasyncId` doesn't appear to exist when logged out.

This string appears to be in the format:
When on main account:
`<main channel acc sync id>|| `
When on secondary account:
`<secondary channel acc sync id>||<main channel acc sync id> `

(not sure what to call this "sync id" variable)

I'm assuming the pattern is the id before the first `||` is the sync id for the current channel account.
Furthermore, YouTube doesn't appear to add this header when using the main channel account.

When on secondary channel account, YouTube appears to add this header to calls to the `browse` endpoint in the API.

Not tested:
- 3+ channel accounts
- ??

Edit: Not sure what the "main channel acc syncid" I refer to is, the main channel accounts sync id. If it is used when on the main account the continuation page download fails. 