### PR TITLE
fixed multiple bugs in amcnetworks.py extractor

### DIFF
--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -85,7 +85,7 @@ class AMCNetworksIE(ThePlatformIE):
                     media_url = 'https://link.theplatform.com/s/' + tp_path
                     has_releasePid = True
                     video_player_count += 1
-        except:
+        except KeyError:
             pass
         if video_player_count > 1:
             self.report_warning ('The JSON data has more than one video player.')
@@ -119,7 +119,7 @@ class AMCNetworksIE(ThePlatformIE):
         for thumbnail_url in thumbnail_temp:
             if not thumbnail_url:
                 continue
-            i = { 'url': thumbnail_url }
+            i = {'url': thumbnail_url}
             mobj = re.search(r'(\d+)x(\d+)', thumbnail_url)
             if mobj:
                 i.update({
@@ -130,7 +130,7 @@ class AMCNetworksIE(ThePlatformIE):
         # Sometimes these thumbnails are the same image despite having
         # different URLs.  Sometimes they're entirely different images,
         # not just different resolutions of one image.
- 
+
         info.update({
             'id': video_id,
             'subtitles': subtitles,

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -74,27 +74,23 @@ class AMCNetworksIE(ThePlatformIE):
             'manifest': 'm3u',
         }
 
-        has_releasePid = False
         video_player_count = 0
         try:
             for v in page_data['children']:
                 if v.get('type') == 'video-player':
-                    releasePid = \
-                        v['properties']['currentVideo']['meta']['releasePid']
+                    releasePid = v['properties']['currentVideo']['meta']['releasePid']
                     tp_path = 'M_UwQC/' + releasePid
                     media_url = 'https://link.theplatform.com/s/' + tp_path
-                    has_releasePid = True
                     video_player_count += 1
         except KeyError:
             pass
         if video_player_count > 1:
             self.report_warning(
-                'The JSON data has ' + str(video_player_count)
-                + ' video players.'
-            )
+                'The JSON data has %d video players. Only one will be extracted' % video_player_count)
+
         # Fall back to videoPid if releasePid not found.
-        # To do: Fall back to videoPid if releasePid manifest uses DRM.
-        if not has_releasePid:
+        # TODO: Fall back to videoPid if releasePid manifest uses DRM.
+        if not video_player_count:
             tp_path = 'M_UwQC/media/' + properties['videoPid']
             media_url = 'https://link.theplatform.com/s/' + tp_path
 

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -144,9 +144,7 @@ class AMCNetworksIE(ThePlatformIE):
         ns_keys = theplatform_metadata.get('$xmlns', {}).keys()
         if ns_keys:
             ns = list(ns_keys)[0]
-            series = theplatform_metadata.get(ns + '$show')
-            if not series:
-                series = None  # Convert empty string to None
+            series = theplatform_metadata.get(ns + '$show') or None
             season_number = int_or_none(
                 theplatform_metadata.get(ns + '$season'))
             episode = theplatform_metadata.get(ns + '$episodeTitle')

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -147,9 +147,7 @@ class AMCNetworksIE(ThePlatformIE):
             series = theplatform_metadata.get(ns + '$show') or None
             season_number = int_or_none(
                 theplatform_metadata.get(ns + '$season'))
-            episode = theplatform_metadata.get(ns + '$episodeTitle')
-            if not episode:
-                episode = None
+            episode = theplatform_metadata.get(ns + '$episodeTitle') or None
             episode_number = int_or_none(
                 theplatform_metadata.get(ns + '$episode'))
             info.update({

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -68,7 +68,7 @@ class AMCNetworksIE(ThePlatformIE):
         page_data = self._download_json(
             'https://content-delivery-gw.svc.ds.amcn.com/api/v2/content/amcn/%s/url/%s'
             % (requestor_id.lower(), display_id), display_id)['data']
-        properties = page_data.get('properties')
+        properties = page_data.get('properties') or {}
         query = {
             'mbr': 'true',
             'manifest': 'm3u',

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -130,7 +130,7 @@ class AMCNetworksIE(ThePlatformIE):
             })
 
         info.update({
-            'age_limit': parse_age_limit(parse_age_limit(rating)),
+            'age_limit': parse_age_limit(rating),
             'formats': formats,
             'id': video_id,
             'subtitles': subtitles,

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -88,7 +88,10 @@ class AMCNetworksIE(ThePlatformIE):
         except KeyError:
             pass
         if video_player_count > 1:
-            self.report_warning('The JSON data has more than one video player.')
+            self.report_warning(
+                'The JSON data has ' + str(video_player_count)
+                + ' video players.'
+                )
         # This extractor originally used videoPid instead of releasePid
         # but some of those resulting manifests have DRM.
         if not has_releasePid:

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -91,7 +91,7 @@ class AMCNetworksIE(ThePlatformIE):
             self.report_warning(
                 'The JSON data has ' + str(video_player_count)
                 + ' video players.'
-                )
+            )
         # This extractor originally used videoPid instead of releasePid
         # but some of those resulting manifests have DRM.
         if not has_releasePid:

--- a/yt_dlp/extractor/amcnetworks.py
+++ b/yt_dlp/extractor/amcnetworks.py
@@ -88,7 +88,7 @@ class AMCNetworksIE(ThePlatformIE):
         except KeyError:
             pass
         if video_player_count > 1:
-            self.report_warning ('The JSON data has more than one video player.')
+            self.report_warning('The JSON data has more than one video player.')
         # This extractor originally used videoPid instead of releasePid
         # but some of those resulting manifests have DRM.
         if not has_releasePid:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4106,6 +4106,7 @@ def parse_age_limit(s):
     m = re.match(r'^(?P<age>\d{1,2})\+?$', s)
     if m:
         return int(m.group('age'))
+    s = s.upper()
     if s in US_RATINGS:
         return US_RATINGS[s]
     m = re.match(r'^TV[_-]?(%s)$' % '|'.join(k[3:] for k in TV_PARENTAL_GUIDELINES), s)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some videos couldn't be downloaded because of Fairplay encryption. Alternate video manifests are available that don't use Fairplay.

Additional thumbnail images were added, often larger than the single 1920x1080 image identified by the previous version of the extractor.

"season_number" and "series" were being added to "title" for some reason. That behavior was removed.

 "series" now gets displayed as "NA" rather than "_" when its value is empty.

To do: Add fallbacks.

