### PR TITLE
[rai] add support for http formats

### DIFF
--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -5,12 +5,12 @@ import re
 
 from .common import InfoExtractor
 from ..compat import (
-    compat_urlparse,
     compat_str,
+    compat_urlparse,
 )
 from ..utils import (
-    ExtractorError,
     determine_ext,
+    ExtractorError,
     find_xpath_attr,
     fix_xml_ampersands,
     GeoRestrictedError,
@@ -182,10 +182,11 @@ class RaiBaseIE(InfoExtractor):
 
         formats = []
         for q in available_qualities:
-            fmt = {}
-            fmt['url'] = _MP4_TMPL % (relinker_url, q)
-            fmt['protocol'] = 'https'
-            fmt['ext'] = 'mp4'
+            fmt = {
+                'url': _MP4_TMPL % (relinker_url, q),
+                'protocol': 'https',
+                'ext': 'mp4',
+            }
             fmt.update(get_format_info(q))
             formats.append(fmt)
         return formats
@@ -242,7 +243,7 @@ class RaiPlayIE(RaiBaseIE):
     }, {
         # 1080p direct mp4 url
         'url': 'https://www.raiplay.it/video/2021/03/Leonardo-S1E1-b5703b02-82ee-475a-85b6-c9e4a8adf642.html',
-        'md5': '1955a87ffe625e913bff2dafc23e1143',
+        'md5': '2e501e8651d72f05ffe8f5d286ad560b',
         'info_dict': {
             'id': 'b5703b02-82ee-475a-85b6-c9e4a8adf642',
             'ext': 'mp4',
@@ -251,7 +252,7 @@ class RaiPlayIE(RaiBaseIE):
             'description': 'md5:f5360cd267d2de146e4e3879a5a47d31',
             'thumbnail': r're:^https?://.*\.jpg$',
             'uploader': 'Rai 1',
-            'duration': 3230,
+            'duration': 3229,
             'series': 'Leonardo',
             'season': 'Season 1',
         },

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -452,7 +452,7 @@ class RaiIE(RaiBaseIE):
     }, {
         # with ContentItem in og:url
         'url': 'http://www.rai.it/dl/RaiTV/programmi/media/ContentItem-efb17665-691c-45d5-a60c-5301333cbb0c.html',
-        'md5': '6865dd00cf0bbf5772fdd89d59bd768a',
+        'md5': '7fc9308e97f57ba80a734f6998b1c92e',
         'info_dict': {
             'id': 'efb17665-691c-45d5-a60c-5301333cbb0c',
             'ext': 'mp4',
@@ -480,22 +480,6 @@ class RaiIE(RaiBaseIE):
             'id': '3156f2f2-dc70-4953-8e2f-70d7489d4ce9',
             'ext': 'mp4',
             'title': 'La diretta di Rainews24',
-        },
-        'params': {
-            'skip_download': True,
-        },
-    }, {
-        # ContentItem in iframe (see #12652) and subtitle at 'subtitlesUrl' key
-        'url': 'http://www.presadiretta.rai.it/dl/portali/site/puntata/ContentItem-3ed19d13-26c2-46ff-a551-b10828262f1b.html',
-        'info_dict': {
-            'id': '1ad6dc64-444a-42a4-9bea-e5419ad2f5fd',
-            'ext': 'mp4',
-            'title': 'Partiti acchiappavoti - Presa diretta del 13/09/2015',
-            'description': 'md5:d291b03407ec505f95f27970c0b025f4',
-            'upload_date': '20150913',
-            'subtitles': {
-                'it': 'count:2',
-            },
         },
         'params': {
             'skip_download': True,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Improvement
- [x] New feature

---

### Description of your *pull request* and other information
As title.

Add support for direct http mp4 formats, with support for higher resolution as well (sometimes)

addresses #207 