### PR TITLE
Add NFHS Network extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -817,6 +817,7 @@ from .nexx import (
     NexxIE,
     NexxEmbedIE,
 )
+from .nfhsnetwork import NFHSNetworkIE
 from .nfl import (
     NFLIE,
     NFLArticleIE,

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -22,6 +22,8 @@ class NFHSNetworkIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'Rockford vs Spring Lake - Girls Varsity Lacrosse 03/27/2021',
             'uploader': 'MHSAA - Michigan: Rockford High School, Rockford, MI',
+            'uploader_id': 'cd2622cf76',
+            'uploader_url': 'https://www.nfhsnetwork.com/schools/rockford-high-school-rockford-mi',
             'location': 'Rockford, Michigan',
             'timestamp': 1616859000,
             'upload_date': '20210327'
@@ -39,6 +41,8 @@ class NFHSNetworkIE(InfoExtractor):
             'title': 'Drama Performance Limon High School vs. Limon High School - 12/13/2020',
             'description': 'Join the broadcast of the Limon High School Musical Performance at 2 PM.',
             'uploader': 'CHSAA: Limon High School, Limon, CO',
+            'uploader_id': '7d2d121332',
+            'uploader_url': 'https://www.nfhsnetwork.com/schools/limon-high-school-limon-co',
             'location': 'Limon, Colorado',
             'timestamp': 1607893200,
             'upload_date': '20201213'
@@ -55,6 +59,8 @@ class NFHSNetworkIE(InfoExtractor):
             'ext': 'mp4',
             'title': '2015 UA Holiday Classic Tournament: National Division  - 12/26/2015',
             'uploader': 'SoCal Sports Productions',
+            'uploader_id': '063dba0150',
+            'uploader_url': 'https://www.nfhsnetwork.com/affiliates/socal-sports-productions',
             'location': 'San Diego, California',
             'timestamp': 1451187000,
             'upload_date': '20151226'
@@ -72,6 +78,8 @@ class NFHSNetworkIE(InfoExtractor):
             'title': 'Competitive Equity  - 01/21/2015',
             'description': 'Committee members discuss points of their research regarding a competitive equity plan',
             'uploader': 'WIAA - Wisconsin: Wisconsin Interscholastic Athletic Association',
+            'uploader_id': 'a49f7d1002',
+            'uploader_url': 'https://www.nfhsnetwork.com/associations/wiaa-wi',
             'location': 'Stevens Point, Wisconsin',
             'timestamp': 1421856000,
             'upload_date': '20150121'
@@ -92,6 +100,10 @@ class NFHSNetworkIE(InfoExtractor):
         publisher = data.get('publishers')[0]  # always exists
         broadcast = (publisher.get('broadcasts') or publisher.get('vods'))[0]  # some (older) videos don't have a broadcasts object
         uploader = publisher.get('formatted_name') or publisher.get('name')
+        uploaderID = publisher.get('publisher_key')
+        pubType = publisher.get('type')
+        uploaderPrefix = ("schools" if pubType == "school" else "associations" if "association" in pubType else "affiliates" if (pubType == "publisher" or pubType == "affiliate") else "schools")
+        uploaderPage = 'https://www.nfhsnetwork.com/%s/%s' % (uploaderPrefix, publisher.get('slug'))
         location = '%s, %s' % (data.get('city'), data.get('state_name'))
         description = broadcast.get('description')
         isLive = broadcast.get('on_air') or broadcast.get('status') == 'on_air' or False
@@ -120,6 +132,8 @@ class NFHSNetworkIE(InfoExtractor):
             'description': description,
             'timestamp': timestamp,
             'uploader': uploader,
+            'uploader_id': uploaderID,
+            'uploader_url': uploaderPage,
             'location': location,
             'upload_date': upload_date,
             'is_live': isLive

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -91,7 +91,7 @@ class NFHSNetworkIE(InfoExtractor):
             video_id)
         publisher = data.get('publishers')[0]  # always exists
         broadcast = (publisher.get('broadcasts') or publisher.get('vods'))[0]  # some (older) videos don't have a broadcasts object
-        uploader = publisher.get('formatted_name') or publisher.get('name') or None
+        uploader = publisher.get('formatted_name') or publisher.get('name')
         location = '%s, %s' % (data.get('city'), data.get('state_name'))
         description = broadcast.get('description') or None
         isLive = broadcast.get('on_air') or broadcast.get('status') == 'on_air' or False

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -103,7 +103,7 @@ class NFHSNetworkIE(InfoExtractor):
         uploader = publisher.get('formatted_name') or publisher.get('name') or ''
         location = data.get('city') + ', ' + data.get('state_name')
         description = broadcast.get('description') or ''
-        isLive = broadcast.get('on_air') or False
+        isLive = broadcast.get('on_air') or broadcast.get('status') == 'on_air' or False
 
         timestamp = unified_timestamp(data.get('local_start_time'))
         upload_date = unified_strdate(data.get('local_start_time'))
@@ -111,7 +111,7 @@ class NFHSNetworkIE(InfoExtractor):
         title = self._og_search_title(webpage) or self._html_search_regex(r'<h1 class="sr-hidden">(.*?)</h1>', webpage, 'title')
         title = title[:title.find('|') - 1]
 
-        if broadcast['status'] == 'complete':
+        if broadcast.get('status') == 'complete':
             m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/vods/' + publisher['vods'][0]['key'] + '/url', video_id)
         else:
             m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/broadcasts/' + broadcast['key'] + '/url', video_id)
@@ -122,7 +122,6 @@ class NFHSNetworkIE(InfoExtractor):
         formats.extend(self._extract_m3u8_formats(
             m3u8_url, video_id, 'mp4',
             m3u8_id='hls', fatal=False))
-        self._sort_formats(formats)
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -1,0 +1,137 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+from ..utils import (
+    unified_strdate,
+    unified_timestamp
+)
+
+
+class NFHSNetworkIE(InfoExtractor):
+    IE_NAME = 'NFHSNetwork'
+    _VALID_URL = r'https?://(?:www\.)?nfhsnetwork\.com/events/[\w-]+/(?P<id>(?:gam|evt|dd|)?[\w\d]{0,10})'
+    _TESTS = [{
+        # Auto-generated two-team sport (pixellot)
+        'url': 'https://www.nfhsnetwork.com/events/rockford-high-school-rockford-mi/gamcf7e54cfbc',
+        # 'md5': 'ed2cb6931860ad1b6749591df4ce75e8',
+        'info_dict': {
+            'id': 'gamcf7e54cfbc',
+            'ext': 'mp4',
+            'title': 'Rockford vs Spring Lake - Girls Varsity Lacrosse 03/27/2021',
+            # 'url': 'https://dj61qgvno4s9v.cloudfront.net/playOnPoly/6058966300a36f1495880ced/venue_hls/hd_hls/hd_hls.m3u8',
+            'description': '',
+            'uploader': 'MHSAA - Michigan: Rockford High School, Rockford, MI',
+            'location': 'Rockford, Michigan',
+            'timestamp': 1616859000,
+            'upload_date': '20210327'
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        }
+    }, {
+        # Non-sport activity with description
+        'url': 'https://www.nfhsnetwork.com/events/limon-high-school-limon-co/evt4a30e3726c',
+        # 'md5': '6220983b27843c93f76c0e55df66f539',
+        'info_dict': {
+            'id': 'evt4a30e3726c',
+            'ext': 'mp4',
+            'title': 'Drama Performance Limon High School vs. Limon High School - 12/13/2020',
+            # 'url': 'https://hls.bcast.nfhsnetwork.com/broadcast/bdc8582dbf08d/vod.m3u8',
+            'description': 'Join the broadcast of the Limon High School Musical Performance at 2 PM.',
+            'uploader': 'CHSAA: Limon High School, Limon, CO',
+            'location': 'Limon, Colorado',
+            'timestamp': 1607893200,
+            'upload_date': '20201213'
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        }
+    }, {
+        # Postseason game
+        'url': 'https://www.nfhsnetwork.com/events/nfhs-network-special-events/dd8de71d45',
+        # 'md5': '07708e7b6408384aa93df279db253fad',
+        'info_dict': {
+            'id': 'dd8de71d45',
+            'ext': 'mp4',
+            'title': '2015 UA Holiday Classic Tournament: National Division  - 12/26/2015',
+            # 'url': 'https://cfhls.nfhsnetwork.com/155125/155125.m3u8',
+            'description': '',
+            'uploader': 'SoCal Sports Productions',
+            'location': 'San Diego, California',
+            'timestamp': 1451187000,
+            'upload_date': '20151226'
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        }
+    }, {
+        # Video with no broadcasts object
+        'url': 'https://www.nfhsnetwork.com/events/wiaa-wi/9aa2f92f82',
+        # 'md5': 'e9d5d94aa36f15ab7daf5a8488720c7f',
+        'info_dict': {
+            'id': '9aa2f92f82',
+            'ext': 'mp4',
+            'title': 'Competitive Equity  - 01/21/2015',
+            # 'url': 'https://cfhls.nfhsnetwork.com/121689/121689.m3u8',
+            'description': 'Committee members discuss points of their research regarding a competitive equity plan',
+            'uploader': 'WIAA - Wisconsin: Wisconsin Interscholastic Athletic Association',
+            'location': 'Stevens Point, Wisconsin',
+            'timestamp': 1421856000,
+            'upload_date': '20150121'
+        },
+        'params': {
+            # m3u8 download
+            'skip_download': True,
+        }
+    }
+    ]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        data = self._download_json(
+            'https://cfunity.nfhsnetwork.com/v2/game_or_event/' + video_id,
+            video_id)
+        publisher = data.get('publishers')[0]  # always exists
+        broadcast = (publisher.get('broadcasts') or publisher.get('vods'))[0]  # some (older) videos don't have a broadcasts object
+        uploader = publisher.get('formatted_name') or publisher.get('name') or ''
+        location = data.get('city') + ', ' + data.get('state_name')
+        description = broadcast.get('description') or ''
+        isLive = broadcast.get('on_air') or False
+
+        timestamp = unified_timestamp(data.get('local_start_time'))
+        upload_date = unified_strdate(data.get('local_start_time'))
+
+        title = self._og_search_title(webpage) or self._html_search_regex(r'<h1 class="sr-hidden">(.*?)</h1>', webpage, 'title')
+        title = title[:title.find('|') - 1]
+
+        if broadcast['status'] == 'complete':
+            m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/vods/' + publisher['vods'][0]['key'] + '/url', video_id)
+        else:
+            m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/broadcasts/' + broadcast['key'] + '/url', video_id)
+
+        m3u8_url = m3u8_url.get('video_url')
+
+        formats = []
+        formats.extend(self._extract_m3u8_formats(
+            m3u8_url, video_id, 'mp4',
+            m3u8_id='hls', fatal=False))
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': title,
+            'formats': formats,
+            'description': description,
+            'timestamp': timestamp,
+            'uploader': uploader,
+            'location': location,
+            'upload_date': upload_date,
+            'is_live': isLive
+        }

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -112,9 +112,9 @@ class NFHSNetworkIE(InfoExtractor):
         title = title[:title.find('|') - 1]
 
         if broadcast.get('status') == 'complete':
-            m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/vods/' + publisher['vods'][0]['key'] + '/url', video_id)
+            m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/vods/' + broadcast.get('key') + '/url', video_id)
         else:
-            m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/broadcasts/' + broadcast['key'] + '/url', video_id)
+            m3u8_url = self._download_json('https://cfunity.nfhsnetwork.com/v2/broadcasts/' + broadcast.get('key') + '/url', video_id)
 
         m3u8_url = m3u8_url.get('video_url')
 

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -17,12 +17,10 @@ class NFHSNetworkIE(InfoExtractor):
     _TESTS = [{
         # Auto-generated two-team sport (pixellot)
         'url': 'https://www.nfhsnetwork.com/events/rockford-high-school-rockford-mi/gamcf7e54cfbc',
-        # 'md5': 'ed2cb6931860ad1b6749591df4ce75e8',
         'info_dict': {
             'id': 'gamcf7e54cfbc',
             'ext': 'mp4',
             'title': 'Rockford vs Spring Lake - Girls Varsity Lacrosse 03/27/2021',
-            # 'url': 'https://dj61qgvno4s9v.cloudfront.net/playOnPoly/6058966300a36f1495880ced/venue_hls/hd_hls/hd_hls.m3u8',
             'uploader': 'MHSAA - Michigan: Rockford High School, Rockford, MI',
             'location': 'Rockford, Michigan',
             'timestamp': 1616859000,
@@ -35,12 +33,10 @@ class NFHSNetworkIE(InfoExtractor):
     }, {
         # Non-sport activity with description
         'url': 'https://www.nfhsnetwork.com/events/limon-high-school-limon-co/evt4a30e3726c',
-        # 'md5': '6220983b27843c93f76c0e55df66f539',
         'info_dict': {
             'id': 'evt4a30e3726c',
             'ext': 'mp4',
             'title': 'Drama Performance Limon High School vs. Limon High School - 12/13/2020',
-            # 'url': 'https://hls.bcast.nfhsnetwork.com/broadcast/bdc8582dbf08d/vod.m3u8',
             'description': 'Join the broadcast of the Limon High School Musical Performance at 2 PM.',
             'uploader': 'CHSAA: Limon High School, Limon, CO',
             'location': 'Limon, Colorado',
@@ -54,12 +50,10 @@ class NFHSNetworkIE(InfoExtractor):
     }, {
         # Postseason game
         'url': 'https://www.nfhsnetwork.com/events/nfhs-network-special-events/dd8de71d45',
-        # 'md5': '07708e7b6408384aa93df279db253fad',
         'info_dict': {
             'id': 'dd8de71d45',
             'ext': 'mp4',
             'title': '2015 UA Holiday Classic Tournament: National Division  - 12/26/2015',
-            # 'url': 'https://cfhls.nfhsnetwork.com/155125/155125.m3u8',
             'uploader': 'SoCal Sports Productions',
             'location': 'San Diego, California',
             'timestamp': 1451187000,
@@ -72,12 +66,10 @@ class NFHSNetworkIE(InfoExtractor):
     }, {
         # Video with no broadcasts object
         'url': 'https://www.nfhsnetwork.com/events/wiaa-wi/9aa2f92f82',
-        # 'md5': 'e9d5d94aa36f15ab7daf5a8488720c7f',
         'info_dict': {
             'id': '9aa2f92f82',
             'ext': 'mp4',
             'title': 'Competitive Equity  - 01/21/2015',
-            # 'url': 'https://cfhls.nfhsnetwork.com/121689/121689.m3u8',
             'description': 'Committee members discuss points of their research regarding a competitive equity plan',
             'uploader': 'WIAA - Wisconsin: Wisconsin Interscholastic Athletic Association',
             'location': 'Stevens Point, Wisconsin',

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -93,7 +93,7 @@ class NFHSNetworkIE(InfoExtractor):
         broadcast = (publisher.get('broadcasts') or publisher.get('vods'))[0]  # some (older) videos don't have a broadcasts object
         uploader = publisher.get('formatted_name') or publisher.get('name')
         location = '%s, %s' % (data.get('city'), data.get('state_name'))
-        description = broadcast.get('description') or None
+        description = broadcast.get('description')
         isLive = broadcast.get('on_air') or broadcast.get('status') == 'on_air' or False
 
         timestamp = unified_timestamp(data.get('local_start_time'))

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -110,10 +110,8 @@ class NFHSNetworkIE(InfoExtractor):
             'https://cfunity.nfhsnetwork.com/v2/%s/%s/url' % (video_type, key),
             video_id).get('video_url')
 
-        formats = []
-        formats.extend(self._extract_m3u8_formats(
-            m3u8_url, video_id, 'mp4',
-            m3u8_id='hls', fatal=False))
+        formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', live=isLive)
+        self._sort_formats(formats, ['res', 'tbr'])
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -92,7 +92,7 @@ class NFHSNetworkIE(InfoExtractor):
         publisher = data.get('publishers')[0]  # always exists
         broadcast = (publisher.get('broadcasts') or publisher.get('vods'))[0]  # some (older) videos don't have a broadcasts object
         uploader = publisher.get('formatted_name') or publisher.get('name') or None
-        location = data.get('city') + ', ' + data.get('state_name')
+        location = '%s, %s' % (data.get('city'), data.get('state_name'))
         description = broadcast.get('description') or None
         isLive = broadcast.get('on_air') or broadcast.get('status') == 'on_air' or False
 

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -99,8 +99,10 @@ class NFHSNetworkIE(InfoExtractor):
         timestamp = unified_timestamp(data.get('local_start_time'))
         upload_date = unified_strdate(data.get('local_start_time'))
 
-        title = self._og_search_title(webpage) or self._html_search_regex(r'<h1 class="sr-hidden">(.*?)</h1>', webpage, 'title')
-        title = title[:title.find('|') - 1]
+        title = (
+            self._og_search_title(webpage)
+            or self._html_search_regex(r'<h1 class="sr-hidden">(.*?)</h1>', webpage, 'title'))
+        title = title.split('|')[0].strip()
 
         video_type = 'broadcasts' if isLive else 'vods'
         key = broadcast.get('key') if isLive else try_get(publisher, lambda x: x['vods'][0]['key'])

--- a/yt_dlp/extractor/nfhsnetwork.py
+++ b/yt_dlp/extractor/nfhsnetwork.py
@@ -102,7 +102,11 @@ class NFHSNetworkIE(InfoExtractor):
         uploader = publisher.get('formatted_name') or publisher.get('name')
         uploaderID = publisher.get('publisher_key')
         pubType = publisher.get('type')
-        uploaderPrefix = ("schools" if pubType == "school" else "associations" if "association" in pubType else "affiliates" if (pubType == "publisher" or pubType == "affiliate") else "schools")
+        uploaderPrefix = (
+            "schools" if pubType == "school"
+            else "associations" if "association" in pubType
+            else "affiliates" if (pubType == "publisher" or pubType == "affiliate")
+            else "schools")
         uploaderPage = 'https://www.nfhsnetwork.com/%s/%s' % (uploaderPrefix, publisher.get('slug'))
         location = '%s, %s' % (data.get('city'), data.get('state_name'))
         description = broadcast.get('description')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adds extractor for NFHS Network, a subscription site for high school sporting events. This site has terrible security and all data can be accessed through unauthenticated API endpoints. I purposely left some things commented because I have a couple questions. 

1. Should `url` be hardcoded in each of the test's `info_dict`? Unlike most streaming sites today, NFHS Network uses static m3u8 urls with no parameters or variation of any kind. 

2. I'm not sure how to sort the formats, because `_sort_formats` incorrectly chooses `best` when given one stream with a lower bitrate and declared codecs and another stream with higher bitrate and no declared codecs. This is why I (temporarily) removed it.

![image](https://user-images.githubusercontent.com/16567977/113611831-0cecde00-961d-11eb-8540-f8aaa4792c4d.png)
![image](https://user-images.githubusercontent.com/16567977/113611695-dd3dd600-961c-11eb-8879-8f33b2c37af1.png)

Not all HLS playlists served by NFHS Network are sorted, so some sorting must be implemented. 
Example: the playlist served for this event `https://www.nfhsnetwork.com/events/wiaa-wi/gam5cb37c4cfc`: `https://hls.bcast.nfhsnetwork.com/broadcast/bdcb2c62fccc9/vod.m3u8` is not sorted. 

This is my first time contributing to yt-dlp, so I hope the code isn't too terrible. 


