### PR TITLE
[youtube:comments, utils] Implement parser for time_text

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -23,6 +23,7 @@ from yt_dlp.utils import (
     clean_html,
     clean_podcast_url,
     date_from_str,
+    datetime_from_str,
     DateRange,
     detect_exe_version,
     determine_ext,
@@ -313,6 +314,16 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(date_from_str('now+14day'), date_from_str('now+2week'))
         self.assertEqual(date_from_str('now+365day'), date_from_str('now+1year'))
         self.assertEqual(date_from_str('now+30day'), date_from_str('now+1month'))
+
+    def test_datetime_from_str(self):
+        self.assertEqual(datetime_from_str('yesterday', precision='day'), datetime_from_str('now-1day', precision='auto'))
+        self.assertEqual(datetime_from_str('now+7day', precision='day'), datetime_from_str('now+1week', precision='auto'))
+        self.assertEqual(datetime_from_str('now+14day', precision='day'), datetime_from_str('now+2week', precision='auto'))
+        self.assertEqual(datetime_from_str('now+365day', precision='day'), datetime_from_str('now+1year', precision='auto'))
+        self.assertLessEqual(datetime_from_str('now+28day', precision='day'), datetime_from_str('now+1month', precision='auto'))
+        self.assertLessEqual(datetime_from_str('now+58day', precision='day'), datetime_from_str('now+2month', precision='auto'))
+        self.assertEqual(datetime_from_str('now+1day', precision='hour'), datetime_from_str('now+24hours', precision='auto'))
+        self.assertEqual(datetime_from_str('now+23hours', precision='hour'), datetime_from_str('now+23hours', precision='auto'))
 
     def test_daterange(self):
         _20century = DateRange("19000101", "20000101")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -312,16 +312,16 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(date_from_str('yesterday'), date_from_str('now-1day'))
         self.assertEqual(date_from_str('now+7day'), date_from_str('now+1week'))
         self.assertEqual(date_from_str('now+14day'), date_from_str('now+2week'))
-        self.assertLessEqual(date_from_str('now+365day'), date_from_str('now+1year'))
-        self.assertLessEqual(date_from_str('now+28day'), date_from_str('now+1month'))
+        self.assertEqual(date_from_str('20200229+365day'), date_from_str('20200229+1year'))
+        self.assertEqual(date_from_str('20210131+28day'), date_from_str('20210131+1month'))
 
     def test_datetime_from_str(self):
         self.assertEqual(datetime_from_str('yesterday', precision='day'), datetime_from_str('now-1day', precision='auto'))
         self.assertEqual(datetime_from_str('now+7day', precision='day'), datetime_from_str('now+1week', precision='auto'))
         self.assertEqual(datetime_from_str('now+14day', precision='day'), datetime_from_str('now+2week', precision='auto'))
-        self.assertEqual(datetime_from_str('now+365day', precision='day'), datetime_from_str('now+1year', precision='auto'))
-        self.assertLessEqual(datetime_from_str('now+28day', precision='day'), datetime_from_str('now+1month', precision='auto'))
-        self.assertLessEqual(datetime_from_str('now+58day', precision='day'), datetime_from_str('now+2month', precision='auto'))
+        self.assertEqual(datetime_from_str('20200229+365day', precision='day'), datetime_from_str('20200229+1year', precision='auto'))
+        self.assertEqual(datetime_from_str('20210131+28day', precision='day'), datetime_from_str('20210131+1month', precision='auto'))
+        self.assertEqual(datetime_from_str('20210131+59day', precision='day'), datetime_from_str('20210131+2month', precision='auto'))
         self.assertEqual(datetime_from_str('now+1day', precision='hour'), datetime_from_str('now+24hours', precision='auto'))
         self.assertEqual(datetime_from_str('now+23hours', precision='hour'), datetime_from_str('now+23hours', precision='auto'))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -312,8 +312,8 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(date_from_str('yesterday'), date_from_str('now-1day'))
         self.assertEqual(date_from_str('now+7day'), date_from_str('now+1week'))
         self.assertEqual(date_from_str('now+14day'), date_from_str('now+2week'))
-        self.assertEqual(date_from_str('now+365day'), date_from_str('now+1year'))
-        self.assertEqual(date_from_str('now+30day'), date_from_str('now+1month'))
+        self.assertLessEqual(date_from_str('now+365day'), date_from_str('now+1year'))
+        self.assertLessEqual(date_from_str('now+28day'), date_from_str('now+1month'))
 
     def test_datetime_from_str(self):
         self.assertEqual(datetime_from_str('yesterday', precision='day'), datetime_from_str('now-1day', precision='auto'))

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1507,9 +1507,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         Parse the comment time text
         time_text is in the format 'X units ago (edited)'
         """
-        time_text_split = time_text.split(" ")
+        time_text_split = time_text.split(' ')
         if len(time_text_split) >= 3:
-            return datetime_from_str("now-%s%s" % (time_text_split[0], time_text_split[1]), precision='auto')
+            return datetime_from_str('now-%s%s' % (time_text_split[0], time_text_split[1]), precision='auto')
 
     @staticmethod
     def _join_text_entries(runs):
@@ -1635,12 +1635,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     comment_prog_str = '(%d/%d)' % (comment_counts[0], comment_counts[1])
                     if page_num == 0:
                         if first_continuation:
-                            note_prefix = "Downloading initial comment continuation page"
+                            note_prefix = 'Downloading initial comment continuation page'
                         else:
-                            note_prefix = "    Downloading comment reply thread %d %s" % (comment_counts[2], comment_prog_str)
+                            note_prefix = '    Downloading comment reply thread %d %s' % (comment_counts[2], comment_prog_str)
                     else:
-                        note_prefix = "%sDownloading comment%s page %d %s" % (
-                            "       " if parent else "",
+                        note_prefix = '%sDownloading comment%s page %d %s' % (
+                            '       ' if parent else '',
                             ' replies' if parent else '',
                             page_num,
                             comment_prog_str)
@@ -1655,13 +1655,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 except ExtractorError as e:
                     if isinstance(e.cause, compat_HTTPError) and e.cause.code in (500, 503, 404, 413):
                         if e.cause.code == 413:
-                            self.report_warning("Assumed end of comments (received HTTP Error 413)")
+                            self.report_warning('Assumed end of comments (received HTTP Error 413)')
                             return
                         # Downloading page may result in intermittent 5xx HTTP error
                         # Sometimes a 404 is also recieved. See: https://github.com/ytdl-org/youtube-dl/issues/28289
                         last_error = 'HTTP Error %s' % e.cause.code
                         if e.cause.code == 404:
-                            last_error = last_error + " (this API is probably deprecated)"
+                            last_error = last_error + ' (this API is probably deprecated)'
                         if count < retries:
                             continue
                     raise
@@ -1679,7 +1679,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
                     # YouTube sometimes gives reload: now json if something went wrong (e.g. bad auth)
                     if browse.get('reload'):
-                        raise ExtractorError("Invalid or missing params in continuation request", expected=False)
+                        raise ExtractorError('Invalid or missing params in continuation request', expected=False)
 
                     # TODO: not tested, merged from old extractor
                     err_msg = browse.get('externalErrorMessage')
@@ -1719,7 +1719,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
                     if expected_comment_count:
                         comment_counts[1] = str_to_int(expected_comment_count)
-                        self.to_screen("Downloading ~%d comments" % str_to_int(expected_comment_count))
+                        self.to_screen('Downloading ~%d comments' % str_to_int(expected_comment_count))
                         yield comment_counts[1]
 
                     # TODO: cli arg.
@@ -1735,7 +1735,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         continuation = YoutubeTabIE._build_continuation_query(
                             continuation=sort_continuation_renderer.get('continuation'),
                             ctp=sort_continuation_renderer.get('clickTrackingParams'))
-                        self.to_screen("Sorting comments by %s" % ('popular' if comment_sort_index == 0 else 'newest'))
+                        self.to_screen('Sorting comments by %s' % ('popular' if comment_sort_index == 0 else 'newest'))
                         break
 
                 for entry in known_continuation_renderers[key](continuation_renderer):
@@ -1768,7 +1768,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         continue
                     comments.append(comment)
                 break
-        self.to_screen("Downloaded %d/%d comments" % (len(comments), estimated_total))
+        self.to_screen('Downloaded %d/%d comments' % (len(comments), estimated_total))
         return {
             'comments': comments,
             'comment_count': len(comments),
@@ -2990,7 +2990,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
                     self.report_warning('%s. Retrying ...' % last_error)
                 try:
                     response = self._call_api(
-                        ep="browse", fatal=True, headers=headers,
+                        ep='browse', fatal=True, headers=headers,
                         video_id='%s page %s' % (item_id, page_num),
                         query={
                             'continuation': continuation['continuation'],

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1505,7 +1505,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def parse_time_text(time_text):
         time_text_split = time_text.split(" ")
         if len(time_text_split) >= 2:
-            return datetime_from_str("now-%s%s" % (time_text_split[0], time_text_split[1]), precision='second', relative_precision=True)
+            return datetime_from_str("now-%s%s" % (time_text_split[0], time_text_split[1]), precision='auto')
 
     @staticmethod
     def _join_text_entries(runs):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-import datetime
+import calendar
 import hashlib
 import itertools
 import json
@@ -1533,7 +1533,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         text = self._join_text_entries(comment_text_runs) or ''
         comment_time_text = try_get(comment_renderer, lambda x: x['publishedTimeText']['runs']) or []
         time_text = self._join_text_entries(comment_time_text)
-        timestamp = (self.parse_time_text(time_text) - datetime.datetime(1970, 1, 1)).total_seconds()
+        timestamp = calendar.timegm(self.parse_time_text(time_text).timetuple())
         author = try_get(comment_renderer, lambda x: x['authorText']['simpleText'], compat_str)
         author_id = try_get(comment_renderer,
                             lambda x: x['authorEndpoint']['browseEndpoint']['browseId'], compat_str)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import datetime
 import hashlib
 import itertools
 import json
@@ -10,7 +11,6 @@ import random
 import re
 import time
 import traceback
-from datetime import datetime
 
 from .common import InfoExtractor, SearchInfoExtractor
 from ..compat import (
@@ -28,6 +28,7 @@ from ..utils import (
     bool_or_none,
     clean_html,
     dict_get,
+    datetime_from_str,
     ExtractorError,
     format_field,
     float_or_none,
@@ -47,8 +48,7 @@ from ..utils import (
     update_url_query,
     url_or_none,
     urlencode_postdata,
-    urljoin,
-    datetime_from_str
+    urljoin
 )
 
 
@@ -1503,8 +1503,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
     @staticmethod
     def parse_time_text(time_text):
+        """
+        Parse the comment time text
+        time_text is in the format 'X units ago (edited)'
+        """
         time_text_split = time_text.split(" ")
-        if len(time_text_split) >= 2:
+        if len(time_text_split) >= 3:
             return datetime_from_str("now-%s%s" % (time_text_split[0], time_text_split[1]), precision='auto')
 
     @staticmethod
@@ -1529,7 +1533,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         text = self._join_text_entries(comment_text_runs) or ''
         comment_time_text = try_get(comment_renderer, lambda x: x['publishedTimeText']['runs']) or []
         time_text = self._join_text_entries(comment_time_text)
-        timestamp = (self.parse_time_text(time_text) - datetime(1970,1,1)).total_seconds()
+        timestamp = (self.parse_time_text(time_text) - datetime.datetime(1970, 1, 1)).total_seconds()
         author = try_get(comment_renderer, lambda x: x['authorText']['simpleText'], compat_str)
         author_id = try_get(comment_renderer,
                             lambda x: x['authorEndpoint']['browseEndpoint']['browseId'], compat_str)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -48,7 +48,7 @@ from ..utils import (
     url_or_none,
     urlencode_postdata,
     urljoin,
-    date_from_str
+    datetime_from_str
 )
 
 
@@ -1505,7 +1505,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def parse_time_text(time_text):
         time_text_split = time_text.split(" ")
         if len(time_text_split) >= 2:
-            return date_from_str("now-%s%s" % (time_text_split[0], time_text_split[1]), precision='second')
+            return datetime_from_str("now-%s%s" % (time_text_split[0], time_text_split[1]), precision='second', relative_precision=True)
 
     @staticmethod
     def _join_text_entries(runs):
@@ -1529,7 +1529,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         text = self._join_text_entries(comment_text_runs) or ''
         comment_time_text = try_get(comment_renderer, lambda x: x['publishedTimeText']['runs']) or []
         time_text = self._join_text_entries(comment_time_text)
-        timestamp = str(self.parse_time_text(time_text))
+        timestamp = (self.parse_time_text(time_text) - datetime(1970,1,1)).total_seconds()
         author = try_get(comment_renderer, lambda x: x['authorText']['simpleText'], compat_str)
         author_id = try_get(comment_renderer,
                             lambda x: x['authorEndpoint']['browseEndpoint']['browseId'], compat_str)
@@ -1543,7 +1543,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         return {
             'id': comment_id,
             'text': text,
-            # TODO: This should be parsed to timestamp
             'timestamp': timestamp,
             'time_text': time_text,
             'like_count': votes,

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3109,7 +3109,7 @@ def datetime_precision(dt, precision='day'):
         microsecond=0
     )
     units = list(defaults.keys())
-    return dt.replace(**{unit:defaults[unit] for unit in units[units.index(precision):]})
+    return dt.replace(**{unit:defaults[unit] for unit in units[units.index(precision)+1:]})
 
 
 def hyphenate_date(date_str):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3117,8 +3117,8 @@ def round_datetime(dt, precision='day'):
 
     if precision == 'microsecond':
         return dt
-
-    unit_defaults = collections.OrderedDict(
+    ordered_units = ('year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond')
+    unit_defaults = dict(
         year=1970,
         month=1,
         day=1,
@@ -3127,8 +3127,7 @@ def round_datetime(dt, precision='day'):
         second=0,
         microsecond=0
     )
-    units = list(unit_defaults.keys())
-    return dt.replace(**{unit: unit_defaults[unit] for unit in units[units.index(precision) + 1:]})
+    return dt.replace(**{unit: unit_defaults[unit] for unit in ordered_units[ordered_units.index(precision) + 1:]})
 
 
 def hyphenate_date(date_str):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3101,7 +3101,7 @@ def date_from_str(date_str, format='%Y%m%d'):
 
     format: string date format used to return datetime object from
     """
-    return datetime_from_str(date_str, precision='day', format=format).date()
+    return datetime_from_str(date_str, precision='microsecond', format=format).date()
 
 
 def datetime_add_months(dt, months):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3052,48 +3052,52 @@ def subtitles_filename(filename, sub_lang, sub_format, expected_real_ext=None):
     return replace_extension(filename, sub_lang + '.' + sub_format, expected_real_ext)
 
 
-def datetime_from_str(date_str, precision='microsecond', format='%Y%m%d'):
+def datetime_from_str(date_str, precision='auto', format='%Y%m%d'):
     """
     Return a datetime object from a string in the format YYYYMMDD or
-    (now|today)[+-][0-9](microsecond|second|minute|hour|day|week|month|year)(s)?
+    (now|today|date)[+-][0-9](microsecond|second|minute|hour|day|week|month|year)(s)?
 
     format: string date format used to return datetime object from
-    precision: (floor) round the time portion of a datetime object.
+    precision: round the time portion of a datetime object.
                 auto|microsecond|second|minute|hour|day.
                 auto: round to the unit provided in date_str (if applicable).
     """
-    today = datetime_round(datetime.datetime.now(), 'microsecond' if precision == 'auto' else precision)
+    auto_precision = False
+    if precision == 'auto':
+        auto_precision = True
+        precision = 'microsecond'
+    today = datetime_round(datetime.datetime.now(), precision)
     if date_str in ('now', 'today'):
         return today
     if date_str == 'yesterday':
         return today - datetime.timedelta(days=1)
-    match = re.match(r'(now|today)(?P<sign>[+-])(?P<time>\d+)(?P<unit>microsecond|second|minute|hour|day|week|month|year)(s)?', date_str)
+    match = re.match(
+        r'(?P<start>.+)(?P<sign>[+-])(?P<time>\d+)(?P<unit>microsecond|second|minute|hour|day|week|month|year)(s)?',
+        date_str)
     if match is not None:
-        sign = match.group('sign')
-        time = int(match.group('time'))
-        if sign == '-':
-            time = -time
+        start_time = datetime_from_str(match.group('start'), precision, format)
+        time = int(match.group('time')) * (-1 if match.group('sign') == '-' else 1)
         unit = match.group('unit')
         if unit == 'month' or unit == 'year':
-            new_date = datetime_add_months(today, time * 12 if unit == 'year' else time)
+            new_date = datetime_add_months(start_time, time * 12 if unit == 'year' else time)
             unit = 'day'
         else:
             if unit == 'week':
                 unit = 'day'
                 time *= 7
             delta = datetime.timedelta(**{unit + 's': time})
-            new_date = today + delta
-        if precision == 'auto':
-            return datetime_round(new_date, precision=unit)
+            new_date = start_time + delta
+        if auto_precision:
+            return datetime_round(new_date, unit)
         return new_date
 
-    return datetime.datetime.strptime(date_str, format)
+    return datetime_round(datetime.datetime.strptime(date_str, format), precision)
 
 
 def date_from_str(date_str, format='%Y%m%d'):
     """
     Return a datetime object from a string in the format YYYYMMDD or
-    (now|today)[+-][0-9](microsecond|second|minute|hour|day|week|month|year)(s)?
+    (now|today|date)[+-][0-9](microsecond|second|minute|hour|day|week|month|year)(s)?
 
     format: string date format used to return datetime object from
     """

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3062,7 +3062,7 @@ def datetime_from_str(date_str, precision='microsecond', format='%Y%m%d'):
                 auto|microsecond|second|minute|hour|day.
                 auto: round to the unit provided in date_str (if applicable).
     """
-    today = round_time(datetime.datetime.now(), 'microsecond' if precision == 'auto' else precision)
+    today = datetime_round(datetime.datetime.now(), 'microsecond' if precision == 'auto' else precision)
     if date_str in ('now', 'today'):
         return today
     if date_str == 'yesterday':
@@ -3084,7 +3084,7 @@ def datetime_from_str(date_str, precision='microsecond', format='%Y%m%d'):
             delta = datetime.timedelta(**{unit + 's': time})
             new_date = today + delta
         if precision == 'auto':
-            return round_time(new_date, precision=unit)
+            return datetime_round(new_date, precision=unit)
         return new_date
 
     return datetime.datetime.strptime(date_str, format)
@@ -3109,23 +3109,22 @@ def datetime_add_months(dt, months):
     return dt.replace(year, month, day)
 
 
-def round_time(dt, precision='day'):
+def datetime_round(dt, precision='day'):
     """
     Round a datetime object's time to a specific precision
     """
     if precision == 'microsecond':
         return dt
 
-    unit_seconds = dict(
-        day=86400,
-        hour=3600,
-        minute=60,
-        second=1,
-    )
-
-    delta = datetime.timedelta(hours=dt.hour, minutes=dt.minute, seconds=dt.second, microseconds=dt.microsecond)
-    rounded_delta = datetime.timedelta(**{precision + 's': round(delta.total_seconds() / unit_seconds[precision])})
-    return datetime.datetime.combine(dt, datetime.time(0)) + rounded_delta
+    unit_seconds = {
+        'day': 86400,
+        'hour': 3600,
+        'minute': 60,
+        'second': 1,
+    }
+    roundto = lambda x, n: ((x + n / 2) // n) * n
+    timestamp = calendar.timegm(dt.timetuple())
+    return datetime.datetime.utcfromtimestamp(roundto(timestamp, unit_seconds[precision]))
 
 
 def hyphenate_date(date_str):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3055,7 +3055,13 @@ def subtitles_filename(filename, sub_lang, sub_format, expected_real_ext=None):
 def datetime_from_str(date_str, precision='microsecond', format='%Y%m%d'):
     """
     Return a datetime object from a string in the format YYYYMMDD or
-    (now|today)[+-][0-9](second|minute|hour|day|week|month|year/)(s)?"""
+    (now|today)[+-][0-9](microsecond|second|minute|hour|day|week|month|year)(s)?
+
+    format: string date format used to return datetime object from
+    precision: (floor) round the datetime object.
+                auto|microsecond|second|minute|hour|day|week|month|year.
+                auto: round to the unit provided in date_str (if applicable).
+    """
     today = round_datetime(datetime.datetime.now(), 'microsecond' if precision == 'auto' else precision)
     if date_str in ('now', 'today'):
         return today
@@ -3069,13 +3075,13 @@ def datetime_from_str(date_str, precision='microsecond', format='%Y%m%d'):
             time = -time
         unit = match.group('unit')
         if unit == 'month' or unit == 'year':
-            new_date = datetime_add_months(today, time*12 if unit == 'year' else time)
+            new_date = datetime_add_months(today, time * 12 if unit == 'year' else time)
             unit = 'day'
         else:
             if unit == 'week':
                 unit = 'day'
                 time *= 7
-            delta = datetime.timedelta(**{unit+'s': time})
+            delta = datetime.timedelta(**{unit + 's': time})
             new_date = today + delta
         if precision == 'auto':
             return round_datetime(new_date, precision=unit)
@@ -3087,11 +3093,15 @@ def datetime_from_str(date_str, precision='microsecond', format='%Y%m%d'):
 def date_from_str(date_str, format='%Y%m%d'):
     """
     Return a datetime object from a string in the format YYYYMMDD or
-    (now|today)[+-][0-9](second|minute|hour|day|week|month|year/)(s)?"""
-    return datetime_from_str(date_str, precision='day',format=format).date()
+    (now|today)[+-][0-9](microsecond|second|minute|hour|day|week|month|year)(s)?
+
+    format: string date format used to return datetime object from
+    """
+    return datetime_from_str(date_str, precision='day', format=format).date()
 
 
 def datetime_add_months(dt, months):
+    """Increment/Decrement a datetime object by months."""
     month = dt.month + months - 1
     year = dt.year + month // 12
     month = month % 12 + 1
@@ -3100,12 +3110,15 @@ def datetime_add_months(dt, months):
 
 
 def round_datetime(dt, precision='day'):
-    """Round a datetime object to a specific precision"""
-    # TODO: actual rounding
+    """
+    Round a datetime object to a specific precision unit
+    Note: floor rounding
+    """
+
     if precision == 'microsecond':
         return dt
 
-    defaults = collections.OrderedDict(
+    unit_defaults = collections.OrderedDict(
         year=1970,
         month=1,
         day=1,
@@ -3114,8 +3127,8 @@ def round_datetime(dt, precision='day'):
         second=0,
         microsecond=0
     )
-    units = list(defaults.keys())
-    return dt.replace(**{unit:defaults[unit] for unit in units[units.index(precision)+1:]})
+    units = list(unit_defaults.keys())
+    return dt.replace(**{unit: unit_defaults[unit] for unit in units[units.index(precision) + 1:]})
 
 
 def hyphenate_date(date_str):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3124,7 +3124,7 @@ def round_time(dt, precision='day'):
     )
 
     delta = datetime.timedelta(hours=dt.hour, minutes=dt.minute, seconds=dt.second, microseconds=dt.microsecond)
-    rounded_delta = datetime.timedelta(**{precision+'s': round(delta.total_seconds() / unit_seconds[precision])})
+    rounded_delta = datetime.timedelta(**{precision + 's': round(delta.total_seconds() / unit_seconds[precision])})
     return datetime.datetime.combine(dt, datetime.time(0)) + rounded_delta
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [X] New feature

---

### Description of your *pull request* and other information

Adds a parser to parse the comment time text by YouTube into a UNIX timestamp. 
This is generally in the format `X units ago (edited)`, where `(edited)` is optional.

Due to the nature of the time_text, the resultant timestamp is an **estimate** (and probably becomes less accurate the greater the unit i.e. years vs minutes).

This extends the existing `date_from_str` util function into `datetime_from_str` to extend functionality (while keeping backwards compatibility). 

Notably, this adds to this function: 
- support time
- precision rounding (floor round to a specified unit, or automatically round relative to the unit in date_str)
- accurate conversion of years and months into days
- customise the date format

---

TODO:
- [x] Thoroughly test this doesn't break anything (other extractors etc. relying on `date_from_str`)
- [ ] Handling if time_text is an invalid format
- [x] Extra test cases for `datetime_from_str`
- [X] Better rounding algorithm for `round_datetime` (instead of flooring everything)

