### PR TITLE
[youtube] Improve channel syncid extraction to support ytcfg

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -341,10 +341,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         params:
         - data: can be either response or ytcfg
         """
-        sync_ids = (
-                try_get(data, (lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'],
-                               lambda x: x['DATASYNC_ID']), compat_str)
-                or '').split("||")
+        sync_ids = (try_get(
+            data, (lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'],
+                   lambda x: x['DATASYNC_ID']), compat_str) or '').split("||")
         if len(sync_ids) >= 2 and sync_ids[1]:
             # datasyncid is of the form "channel_syncid||user_syncid" for secondary channel
             # and just "user_syncid||" for primary channel. We only want the channel_syncid

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -336,14 +336,21 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     @staticmethod
     def _extract_account_syncid(data):
-        """Extract syncId required to download private playlists of secondary channels"""
+        """
+        Extract syncId required to download private playlists of secondary channels
+        params:
+        - data: can be either response or ytcfg
+        """
         sync_ids = (
-            try_get(data, lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'], compat_str)
-            or '').split("||")
+                try_get(data, (lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'],
+                               lambda x: x['DATASYNC_ID']), compat_str)
+                or '').split("||")
         if len(sync_ids) >= 2 and sync_ids[1]:
             # datasyncid is of the form "channel_syncid||user_syncid" for secondary channel
             # and just "user_syncid||" for primary channel. We only want the channel_syncid
             return sync_ids[0]
+        # ytcfg includes channel_syncid if on secondary channel
+        return data.get('DELEGATED_SESSION_ID')
 
     def _extract_ytcfg(self, video_id, webpage):
         return self._parse_json(

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -338,8 +338,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def _extract_account_syncid(data):
         """
         Extract syncId required to download private playlists of secondary channels
-        params:
-        - data: can be either response or ytcfg
+        @param data Either response or ytcfg
         """
         sync_ids = (try_get(
             data, (lambda x: x['responseContext']['mainAppWebResponseContext']['datasyncId'],


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

The channel syncid (or "delegated session id") is also available in the ytcfg. This PR adds support to the syncid extraction function to be able to extract it from ytcfg.

In ytcfg:
`DATASYNC_ID` is the exact same format as `datasyncId`
`DELEGATED_SESSION_ID` appears to be the channel syncid itself that we extract only if we are on a secondary account.

Also to note - the comment extractor was already calling this function using ytcfg. Which means it was never extracting the syncid. (Though the comment api ajax endpoint may not require this syncid at this time)
