### PR TITLE
[youtube:tab] Generalise retry method for API calls

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3278,15 +3278,13 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             raise ExtractorError('YouTube said: %s' % errors[-1][1], expected=expected)
 
     def _extract_response(self, item_id, query, note='Downloading API JSON', headers=None,
-                          ytcfg=None, check_get_keys=None, check_get_functions=None, ep='browse'):
+                          ytcfg=None, check_get_keys=None, ep='browse'):
         response = None
         last_error = None
         count = -1
         retries = self._downloader.params.get('extractor_retries', 3)
         if check_get_keys is None:
             check_get_keys = []
-        if check_get_functions is None:
-            check_get_functions = []
         while count < retries:
             count += 1
             if last_error:
@@ -3310,12 +3308,8 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             else:
                 # Youtube may send alerts if there was an issue with the continuation page
                 self._extract_alerts(response, expected=False)
-
-                if not check_get_keys and not check_get_functions:
+                if not check_get_keys or dict_get(response, check_get_keys):
                     break
-                if dict_get(response, check_get_keys) or try_get(response, check_get_functions):
-                    break
-
                 # Youtube sometimes sends incomplete data
                 # See: https://github.com/ytdl-org/youtube-dl/issues/28194
                 last_error = 'Incomplete data received'

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3231,7 +3231,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             query = {
                 'playlistId': playlist_id,
                 'videoId': watch_endpoint.get('videoId') or last_id,
-                'index': watch_endpoint.get('index') or start,
+                'index': watch_endpoint.get('index') or len(videos),
                 'params': watch_endpoint.get('params') or 'OAE%3D'
             }
             response = self._extract_response(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Potential generalisation of the "retry" code that is starting to be repeated for calls to the API.

This will also be useful for https://github.com/yt-dlp/yt-dlp/pull/242
As well as for if the comments API changes to this new one.

This also adds upgrades the mix extractor to use the API.