### PR TITLE
[mildom] Remove dependency on third-party servers

### DIFF
--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -99,9 +99,6 @@ class MildomIE(MildomBaseIE):
         video_id = self._match_id(url)
         url = 'https://www.mildom.com/%s' % video_id
 
-        self.to_screen(
-            'Live videos are downloaded using proxies based on "https://github.com/nao20010128nao/bookish-octo-barnacle"\n'
-            ' %s  If you do not trust these proxies, please refrain from downloading live %s videos ' % (' ' * len(self.IE_NAME), self.IE_NAME))
         webpage = self._download_webpage(url, video_id)
 
         enterstudio = self._call_api(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement

---

All the live stream needs is an appropriate `Referer` header, which is easily forged locally; this is exactly what this patch does. Relying on a third-party proxy not only created glaring reliability and privacy issues, but was, in fact, entirely superfluous.

In the future, I suggest putting a little more rigour into code review.

Fixes: #251, #252.