### PR TITLE
[niconico] minor fix of original title and thumbnail extraction

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -509,8 +509,8 @@ class NiconicoIE(InfoExtractor):
         thumbnail = (
             self._html_search_regex(r'<meta property="og:image" content="([^"]+)">', webpage, 'thumbnail data', default=None)
             or try_get(  # choose highest from 720p to 240p
-                    get_video_info_web('thumbnail'),
-                    ['ogp', 'player', 'largeUrl', 'middleUrl', 'url'])
+                get_video_info_web('thumbnail'),
+                ['ogp', 'player', 'largeUrl', 'middleUrl', 'url'])
             or self._html_search_meta('image', webpage, 'thumbnail', default=None)
             or video_detail.get('thumbnail'))
 

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -493,7 +493,7 @@ class NiconicoIE(InfoExtractor):
 
         # Start extracting information
         title = (
-            get_video_info_xml('title') # prefer to get the untranslated original title (e.g. 砂の惑星 instead of Sand Planet)
+            get_video_info_xml('title')  # prefer to get the untranslated original title
             or get_video_info_web(['originalTitle', 'title'])
             or self._og_search_title(webpage, default=None)
             or self._html_search_regex(

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -493,7 +493,8 @@ class NiconicoIE(InfoExtractor):
 
         # Start extracting information
         title = (
-            get_video_info_web(['originalTitle', 'title'])
+            get_video_info_xml('title') # prefer to get the untranslated original title (e.g. 砂の惑星 instead of Sand Planet)
+            or get_video_info_web(['originalTitle', 'title'])
             or self._og_search_title(webpage, default=None)
             or self._html_search_regex(
                 r'<span[^>]+class="videoHeaderTitle"[^>]*>([^<]+)</span>',
@@ -507,7 +508,7 @@ class NiconicoIE(InfoExtractor):
 
         thumbnail = (
             self._html_search_regex(r'<meta property="og:image" content="([^"]+)">', webpage, 'thumbnail data', default=None)
-            or get_video_info_web(['thumbnail_url', 'largeThumbnailURL', 'thumbnailURL'])
+            or try_get(get_video_info_web("thumbnail"), ["ogp", "player", "largeUrl", "middleUrl", "url"]) # choose highest from 720p to 240p
             or self._html_search_meta('image', webpage, 'thumbnail', default=None)
             or video_detail.get('thumbnail'))
 

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -508,7 +508,9 @@ class NiconicoIE(InfoExtractor):
 
         thumbnail = (
             self._html_search_regex(r'<meta property="og:image" content="([^"]+)">', webpage, 'thumbnail data', default=None)
-            or try_get(get_video_info_web("thumbnail"), ["ogp", "player", "largeUrl", "middleUrl", "url"]) # choose highest from 720p to 240p
+            or try_get(  # choose highest from 720p to 240p
+                    get_video_info_web('thumbnail'),
+                    ['ogp', 'player', 'largeUrl', 'middleUrl', 'url'])
             or self._html_search_meta('image', webpage, 'thumbnail', default=None)
             or video_detail.get('thumbnail'))
 


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

### Description of your *pull request* and other information

This is part of my changes that I made when trying to fix #171, where I restored the behavior of using untranslated title, plus fixed the thumbnail extraction
