### PR TITLE
[niconico] fix a small mistake of thumbnail extraction

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -511,7 +511,7 @@ class NiconicoIE(InfoExtractor):
 
         thumbnail = (
             self._html_search_regex(r'<meta property="og:image" content="([^"]+)">', webpage, 'thumbnail data', default=None)
-            or try_get(  # choose highest from 720p to 240p
+            or dict_get(  # choose highest from 720p to 240p
                 get_video_info_web('thumbnail'),
                 ['ogp', 'player', 'largeUrl', 'middleUrl', 'url'])
             or self._html_search_meta('image', webpage, 'thumbnail', default=None)


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl, each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

### Description of your *pull request* and other information

Thumbnails are still not downloading, but it's my fault. I realized `try_get()` only accept a list of lambda, so using `dict_get()` now. This time I have tested my PR to make sure things work. 
