### PR TITLE
[youtube] add support for multiple subtitles with the same lang_code

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -589,12 +589,12 @@ class TestYoutubeDL(unittest.TestCase):
         subs = result['requested_subtitles']
         self.assertTrue(subs)
         self.assertEqual(set(subs.keys()), set(['en']))
-        self.assertTrue(subs['en'].get('data') is None)
-        self.assertEqual(subs['en']['ext'], 'ass')
+        self.assertTrue(subs['en'][0].get('data') is None)
+        self.assertEqual(subs['en'][0]['ext'], 'ass')
 
         result = get_info({'writesubtitles': True, 'subtitlesformat': 'foo/srt'})
         subs = result['requested_subtitles']
-        self.assertEqual(subs['en']['ext'], 'srt')
+        self.assertEqual(subs['en'][0]['ext'], 'srt')
 
         result = get_info({'writesubtitles': True, 'subtitleslangs': ['es', 'fr', 'it']})
         subs = result['requested_subtitles']
@@ -625,15 +625,15 @@ class TestYoutubeDL(unittest.TestCase):
         subs = result['requested_subtitles']
         self.assertTrue(subs)
         self.assertEqual(set(subs.keys()), set(['es', 'pt']))
-        self.assertFalse(subs['es']['_auto'])
-        self.assertTrue(subs['pt']['_auto'])
+        self.assertFalse(subs['es'][0]['_auto'])
+        self.assertTrue(subs['pt'][0]['_auto'])
 
         result = get_info({'writeautomaticsub': True, 'subtitleslangs': ['es', 'pt']})
         subs = result['requested_subtitles']
         self.assertTrue(subs)
         self.assertEqual(set(subs.keys()), set(['es', 'pt']))
-        self.assertTrue(subs['es']['_auto'])
-        self.assertTrue(subs['pt']['_auto'])
+        self.assertTrue(subs['es'][0]['_auto'])
+        self.assertTrue(subs['pt'][0]['_auto'])
 
     def test_add_extra_info(self):
         test_dict = {

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -268,9 +268,9 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(replace_extension('.abc.ext', 'temp'), '.abc.temp')
 
     def test_subtitles_filename(self):
-        self.assertEqual(subtitles_filename('abc.ext', 'en', 'vtt'), 'abc.en.vtt')
-        self.assertEqual(subtitles_filename('abc.ext', 'en', 'vtt', 'ext'), 'abc.en.vtt')
-        self.assertEqual(subtitles_filename('abc.unexpected_ext', 'en', 'vtt', 'ext'), 'abc.unexpected_ext.en.vtt')
+        self.assertEqual(subtitles_filename('abc.ext', 'en', 'English', 'vtt'), 'abc.English.en.vtt')
+        self.assertEqual(subtitles_filename('abc.ext', 'en', 'English', 'vtt', 'ext'), 'abc.English.en.vtt')
+        self.assertEqual(subtitles_filename('abc.unexpected_ext', 'en', 'English', 'vtt', 'ext'), 'abc.unexpected_ext.English.en.vtt')
 
     def test_remove_start(self):
         self.assertEqual(remove_start(None, 'A - '), None)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2168,26 +2168,30 @@ class YoutubeDL(object):
 
         formats_query = self.params.get('subtitlesformat', 'best')
         formats_preference = formats_query.split('/') if formats_query else []
-        subs = {}
+        subs = collections.defaultdict(list)
         for lang in requested_langs:
             formats = available_subs.get(lang)
             if formats is None:
                 self.report_warning('%s subtitles not available for %s' % (lang, video_id))
                 continue
-            for ext in formats_preference:
-                if ext == 'best':
-                    f = formats[-1]
-                    break
-                matches = list(filter(lambda f: f['ext'] == ext, formats))
-                if matches:
-                    f = matches[-1]
-                    break
-            else:
-                f = formats[-1]
-                self.report_warning(
-                    'No subtitle format found matching "%s" for language %s, '
-                    'using %s' % (formats_query, lang, f['ext']))
-            subs[lang] = f
+            named = collections.defaultdict(list)
+            for f in formats:
+                named[f.get('name', '')].append(f)
+            for name, fmts in named.items():
+                for ext in formats_preference:
+                    if ext == 'best':
+                        f = fmts[-1]
+                        break
+                    matches = [f for f in fmts if f['ext'] == ext]
+                    if matches:
+                        f = matches[-1]
+                        break
+                    else:
+                        f = fmts[-1]
+                        self.report_warning(
+                            'No subtitle format found matching "%s" for language %s, '
+                            'using %s' % (formats_query, lang, f['ext']))
+                subs[lang].append(f)
         return subs
 
     def __forced_printings(self, info_dict, filename, incomplete):
@@ -2342,37 +2346,34 @@ class YoutubeDL(object):
             # that way it will silently go on when used with unsupporting IE
             subtitles = info_dict['requested_subtitles']
             # ie = self.get_info_extractor(info_dict['extractor_key'])
-            for sub_lang, sub_info in subtitles.items():
-                sub_format = sub_info['ext']
-                sub_filename = subtitles_filename(temp_filename, sub_lang, sub_format, info_dict.get('ext'))
-                sub_filename_final = subtitles_filename(
-                    self.prepare_filename(info_dict, 'subtitle'), sub_lang, sub_format, info_dict.get('ext'))
-                if not self.params.get('overwrites', True) and os.path.exists(encodeFilename(sub_filename)):
-                    self.to_screen('[info] Video subtitle %s.%s is already present' % (sub_lang, sub_format))
-                    sub_info['filepath'] = sub_filename
-                    files_to_move[sub_filename] = sub_filename_final
-                else:
-                    self.to_screen('[info] Writing video subtitles to: ' + sub_filename)
-                    if sub_info.get('data') is not None:
-                        try:
-                            # Use newline='' to prevent conversion of newline characters
-                            # See https://github.com/ytdl-org/youtube-dl/issues/10268
-                            with io.open(encodeFilename(sub_filename), 'w', encoding='utf-8', newline='') as subfile:
-                                subfile.write(sub_info['data'])
-                            sub_info['filepath'] = sub_filename
-                            files_to_move[sub_filename] = sub_filename_final
-                        except (OSError, IOError):
-                            self.report_error('Cannot write subtitles file ' + sub_filename)
-                            return
+            for sub_lang, sub_info_list in subtitles.items():
+                for sub_info in sub_info_list:
+                    sub_format = sub_info['ext']
+                    sub_name = sub_info.get('name', '')
+                    sub_filename = subtitles_filename(temp_filename, sub_lang, sub_name, sub_format, info_dict.get('ext'))
+                    sub_filename_final = subtitles_filename(self.prepare_filename(info_dict, 'subtitle'), sub_name, sub_lang, sub_format, info_dict.get('ext'))
+                    if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(sub_filename)):
+                        self.to_screen('[info] Video subtitle %s is already present' % (sub_filename))
                     else:
-                        try:
-                            self.dl(sub_filename, sub_info.copy(), subtitle=True)
-                            sub_info['filepath'] = sub_filename
-                            files_to_move[sub_filename] = sub_filename_final
-                        except tuple([ExtractorError, IOError, OSError, ValueError] + network_exceptions) as err:
-                            self.report_warning('Unable to download subtitle for "%s": %s' %
-                                                (sub_lang, error_to_compat_str(err)))
-                            continue
+                        self.to_screen('[info] Writing video subtitles to: ' + sub_filename)
+                        if sub_info.get('data') is not None:
+                            try:
+                                # Use newline='' to prevent conversion of newline characters
+                                # See https://github.com/ytdl-org/youtube-dl/issues/10268
+                                with io.open(encodeFilename(sub_filename), 'w', encoding='utf-8', newline='') as subfile:
+                                    subfile.write(sub_info['data'])
+                            except (OSError, IOError):
+                                self.report_error('Cannot write subtitles file ' + sub_filename)
+                                return
+                        else:
+                            try:
+                                self.dl(sub_filename, sub_info.copy(), subtitle=True)
+                                sub_info['filepath'] = sub_filename
+                                files_to_move[sub_filename] = sub_filename_final
+                            except tuple([ExtractorError, IOError, OSError, ValueError] + network_exceptions) as err:
+                                self.report_warning('Unable to download subtitle for "%s": %s' %
+                                                    (sub_lang, error_to_compat_str(err)))
+                                continue
 
         if self.params.get('writeinfojson', False):
             infofn = self.prepare_filename(info_dict, 'infojson')
@@ -2973,10 +2974,15 @@ class YoutubeDL(object):
             return
         self.to_screen(
             'Available %s for %s:' % (name, video_id))
+        table = []
+        for lang, formats in subtitles.items():
+            named = collections.defaultdict(list)
+            for f in formats:
+                named[f.get('name', '')].append(f['ext'])
+            for name in named.keys():
+                table.append([lang, name, ', '.join(e for e in reversed(named[name]))])
         self.to_screen(render_table(
-            ['Language', 'formats'],
-            [[lang, ', '.join(f['ext'] for f in reversed(formats))]
-                for lang, formats in subtitles.items()]))
+            ['Language', 'name', 'formats'], table))
 
     def urlopen(self, req):
         """ Start an HTTP download """

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -250,6 +250,8 @@ class InfoExtractor(object):
                     entry and one of:
                         * "data": The subtitles file contents
                         * "url": A URL pointing to the subtitles file
+                        * "name": (optional) Name or description of the subtitles, used
+                          when there are more than one subtitles file for this language
                     "ext" will be calculated from URL if missing
     automatic_captions: Like 'subtitles'; contains automatically generated
                     captions instead of normal subtitles

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2210,11 +2210,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 automatic_captions = {}
                 for translation_language in (pctr.get('translationLanguages') or []):
                     translation_language_code = translation_language.get('languageCode')
+                    sub_name = translation_language.get('languageName').get('simpleText')
                     if not translation_language_code:
                         continue
                     process_language(
                         automatic_captions, base_url, translation_language_code,
-                        {'tlang': translation_language_code})
+                        sub_name, {'tlang': translation_language_code})
                 info['automatic_captions'] = automatic_captions
         info['subtitles'] = subtitles
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3108,8 +3108,8 @@ def determine_ext(url, default_ext='unknown_video'):
         return default_ext
 
 
-def subtitles_filename(filename, sub_lang, sub_format, expected_real_ext=None):
-    return replace_extension(filename, sub_lang + '.' + sub_format, expected_real_ext)
+def subtitles_filename(filename, sub_lang, sub_name, sub_format, expected_real_ext=None):
+    return replace_extension(filename, (sub_name + '.' if sub_name else '') + sub_lang + '.' + sub_format, expected_real_ext)
 
 
 def datetime_from_str(date_str, precision='auto', format='%Y%m%d'):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

As title...

Taken from here: https://github.com/ytdl-org/youtube-dl/pull/26112

Some youtube videos have multiple subtitle for the same language. Right now yt-dl only takes one. This PR solves that.

It probably requires to add more tests and fix some to pass.

this one as an example: https://www.youtube.com/watch?v=wsQiKKfKxug

Before:

```
[youtube] wsQiKKfKxug: Downloading webpage
Available subtitles for wsQiKKfKxug:
Language formats
en       vtt, ttml, srv3, srv2, srv1, json3
```

After:
```
[youtube] wsQiKKfKxug: Downloading webpage
Available subtitles for wsQiKKfKxug:
Language name                           formats
en       English                        vtt, ttml, srv3, srv2, srv1, json3
en       English - French Speakers Only vtt, ttml, srv3, srv2, srv1, json3
```

