### PR TITLE
Add support for PNG thumbnail conversion and default to it if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ Then simply run `make`. You can also run `make yt-dlp` instead to compile only t
                                      (currently supported: srt|ass|vtt|lrc)
                                      (Alias: --convert-subtitles)
     --convert-thumbnails FORMAT      Convert the thumbnails to another format
-                                     (currently supported: jpg)
+                                     (currently supported: jpg, png)
     --split-chapters                 Split video into multiple files based on
                                      internal chapters. The "chapter:" prefix
                                      can be used with "--paths" and "--output"

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -227,7 +227,7 @@ def _real_main(argv=None):
         if opts.convertsubtitles not in ('srt', 'vtt', 'ass', 'lrc'):
             parser.error('invalid subtitle format specified')
     if opts.convertthumbnails is not None:
-        if opts.convertthumbnails not in ('jpg', ):
+        if opts.convertthumbnails not in ('jpg', 'png'):
             parser.error('invalid thumbnail format specified')
 
     if opts.date is not None:

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1253,7 +1253,7 @@ def parseOpts(overrideArguments=None):
     postproc.add_option(
         '--convert-thumbnails',
         metavar='FORMAT', dest='convertthumbnails', default=None,
-        help='Convert the thumbnails to another format (currently supported: jpg)')
+        help='Convert the thumbnails to another format (currently supported: jpg, png)')
     postproc.add_option(
         '--split-chapters', '--split-tracks',
         dest='split_chapters', action='store_true', default=False,

--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -77,11 +77,14 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         original_thumbnail = thumbnail_filename = info['thumbnails'][-1]['filepath']
 
-        # Convert unsupported thumbnail formats to JPEG (see #25687, #25717)
+        # Convert unsupported thumbnail formats to PNG (see #25687, #25717)
+        # Original behavior was to convert to JPG, but since JPG is a lossy
+        # format, there will be some additional data loss.
+        # PNG, on the other hand, is lossless.
         thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:]
         if thumbnail_ext not in ('jpg', 'png'):
-            thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'jpg')
-            thumbnail_ext = 'jpg'
+            thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'png')
+            thumbnail_ext = 'png'
 
         mtime = os.stat(encodeFilename(filename)).st_mtime
 

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -872,7 +872,7 @@ class FFmpegThumbnailsConvertorPP(FFmpegPostProcessor):
 
     def run(self, info):
         if self.format not in ('jpg', 'png'):
-            raise FFmpegPostProcessorError('Only conversion to jpg or png is currently supported')
+            raise FFmpegPostProcessorError('Only conversion to either jpg or png is currently supported')
         files_to_delete = []
         has_thumbnail = False
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [X] New feature

---

### Description of your *pull request* and other information

Hi! This is my first pull request, so forgive me if there are any formatting errors or such in the code.

As mentioned in [youtube-dl PR #25717](https://github.com/ytdl-org/youtube-dl/pull/25717), both `ffmpeg` and `AtomicParsley` support embedding both JPEG and PNG files. Accordingly, if `yt-dlp` is given either a JPEG or PNG file, `yt-dlp` will pass the files along without issue to be embedded.

However, `yt-dlp` currently only supports converting thumbnails to JPG if they are in another, unsupported format. I believe this is behavior inherited from `youtube-dl`. This confused me a bit since although *both* JPG and PNG are allowed to be embedded, you can *only* convert to JPG. Since `ffmpeg` supports converting files to PNG (I've tested this on `ffmpeg-win-2.2.2`), I've opened this pull request to allow thumbnails to be converted to PNG using `--convert-thumbnails png`.

Since PNG is a lossless format in contrast to JPEG, which is lossy, I've also changed the default behavior to convert thumbnails in unsupported formats to PNG. PNG is supported in both `.mp4` files (via ID3) and `.mkv` files.

Thank you for your time!