### PR TITLE
[vidio] Add support for premier-exclusive videos

### DIFF
--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -62,22 +62,15 @@ class VidioIE(InfoExtractor):
         title = video['title'].strip()
         hls_url = data['clips'][0]['hls_url']
 
-        # Note: _extract_m3u8_formats(_and_subtitles) non-fatal warnings can't be disabled for now, so workaround
-        res = self._download_webpage_handle(
-            hls_url, display_id, errnote=False, fatal=False)
-        if res:
-            hls_doc, urlh = res
-            hls_url = urlh.geturl()
-            formats, subs = self._parse_m3u8_formats_and_subtitles(
-                hls_doc, hls_url, 'mp4', 'm3u8_native')
-        else:
+        formats, subs = self._extract_m3u8_formats_and_subtitles(
+            hls_url, display_id, 'mp4', 'm3u8_native', errnote=False, fatal=False)
+        if not formats:
             self.to_screen('Falling back to premier mode.')
             sources = self._download_json(
                 'https://www.vidio.com/interactions_stream.json?video_id=' + video_id + '&type=videos', display_id)
             if not (sources.get('source') or sources.get('source_dash')):
                 self.raise_login_required()
 
-            formats, subs = [], {}
             if sources.get('source'):
                 hls_formats, hls_subs = self._extract_m3u8_formats_and_subtitles(
                     sources['source'], display_id, 'mp4', 'm3u8_native')

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -62,9 +62,9 @@ class VidioIE(InfoExtractor):
         title = video['title'].strip()
         is_premium = video.get('is_premium')
         if is_premium:
-            self.to_screen('Premier-exclusive video detected, switching to premier mode')
-            sources = self._download_json(
-                'https://www.vidio.com/interactions_stream.json?video_id=' + video_id + '&type=videos', display_id)
+            sources = sources = self._download_json(
+                'https://www.vidio.com/interactions_stream.json?video_id=%s&type=videos' % video_id,
+                display_id, note='Downloading premier API JSON')
             if not (sources.get('source') or sources.get('source_dash')):
                 self.raise_login_required(method='cookies')
 

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -74,16 +74,16 @@ class VidioIE(InfoExtractor):
             self.to_screen('Falling back to premier mode.')
             sources = self._download_json(
                 'https://www.vidio.com/interactions_stream.json?video_id=' + video_id + '&type=videos', display_id)
-            if not (sources['source'] or sources['source_dash']):
+            if not (sources.get('source') or sources.get('source_dash')):
                 self.raise_login_required()
 
             formats, subs = [], {}
-            if sources['source']:
+            if sources.get('source'):
                 hls_formats, hls_subs = self._extract_m3u8_formats_and_subtitles(
                     sources['source'], display_id, 'mp4', 'm3u8_native')
                 formats.extend(hls_formats)
                 subs.update(hls_subs)
-            if sources['source_dash']:  # TODO: Find video example with source_dash, can both exist at the same time?
+            if sources.get('source_dash'):  # TODO: Find video example with source_dash, can both exist at the same time?
                 dash_formats, dash_subs = self._extract_mpd_formats_and_subtitles(
                     sources['source_dash'], display_id, 'dash')
                 formats.extend(dash_formats)

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -62,7 +62,7 @@ class VidioIE(InfoExtractor):
         title = video['title'].strip()
         is_premium = video.get('is_premium')
         if is_premium:
-            sources = sources = self._download_json(
+            sources = self._download_json(
                 'https://www.vidio.com/interactions_stream.json?video_id=%s&type=videos' % video_id,
                 display_id, note='Downloading premier API JSON')
             if not (sources.get('source') or sources.get('source_dash')):

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -60,7 +60,7 @@ class VidioIE(InfoExtractor):
             })
         video = data['videos'][0]
         title = video['title'].strip()
-        is_premium = video['is_premium']
+        is_premium = video.get('is_premium')
         if is_premium:
             self.to_screen('Premier-exclusive video detected, switching to premier mode')
             sources = self._download_json(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Add another API endpoint for downloading premier-only videos (requires account regardless of video, so old URL may still be used)

(also adds subtitle support)