### PR TITLE
[vidio] Add VidioPremierIE and VidioLiveIE

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -67,10 +67,7 @@ from .appletrailers import (
     AppleTrailersSectionIE,
 )
 from .applepodcasts import ApplePodcastsIE
-from .archiveorg import (
-    ArchiveOrgIE,
-    YoutubeWebArchiveIE,
-)
+from .archiveorg import ArchiveOrgIE
 from .arcpublishing import ArcPublishingIE
 from .arkena import ArkenaIE
 from .ard import (
@@ -505,7 +502,6 @@ from .hotnewhiphop import HotNewHipHopIE
 from .hotstar import (
     HotStarIE,
     HotStarPlaylistIE,
-    HotStarSeriesIE,
 )
 from .howcast import HowcastIE
 from .howstuffworks import HowStuffWorksIE
@@ -1510,7 +1506,11 @@ from .videomore import (
     VideomoreSeasonIE,
 )
 from .videopress import VideoPressIE
-from .vidio import VidioIE
+from .vidio import (
+    VidioIE,
+    VidioPremierIE,
+    VidioLiveIE,
+)
 from .vidlii import VidLiiIE
 from .vidme import (
     VidmeIE,

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -67,7 +67,10 @@ from .appletrailers import (
     AppleTrailersSectionIE,
 )
 from .applepodcasts import ApplePodcastsIE
-from .archiveorg import ArchiveOrgIE
+from .archiveorg import (
+    ArchiveOrgIE,
+    YoutubeWebArchiveIE,
+)
 from .arcpublishing import ArcPublishingIE
 from .arkena import ArkenaIE
 from .ard import (
@@ -502,6 +505,7 @@ from .hotnewhiphop import HotNewHipHopIE
 from .hotstar import (
     HotStarIE,
     HotStarPlaylistIE,
+    HotStarSeriesIE,
 )
 from .howcast import HowcastIE
 from .howstuffworks import HowStuffWorksIE
@@ -1509,7 +1513,7 @@ from .videopress import VideoPressIE
 from .vidio import (
     VidioIE,
     VidioPremierIE,
-    VidioLiveIE,
+    VidioLiveIE
 )
 from .vidlii import VidLiiIE
 from .vidme import (

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -241,10 +241,9 @@ class VidioLiveIE(VidioBaseIE):
                 self.raise_no_formats(
                     'This video is DRM protected.', expected=True)
 
-            drm_hls_url = stream_meta.get('drm_stream_hls_url')
-            if drm_hls_url:
+            if stream_meta.get('drm_stream_hls_url'):
                 formats.extend(self._extract_m3u8_formats(
-                    drm_hls_url, display_id, 'mp4', 'm3u8_native'))
+                    stream_meta['drm_stream_hls_url'], display_id, 'mp4', 'm3u8-native'))
         elif stream_meta.get('is_premium'):
             sources = self._download_json(
                 'https://www.vidio.com/interactions_stream.json?video_id=%s&type=livestreamings' % video_id,
@@ -258,16 +257,18 @@ class VidioLiveIE(VidioBaseIE):
                     display_id, note='Downloading HLS token JSON', data=b'')
                 formats.extend(self._extract_m3u8_formats(
                     sources['source'] + '?' + token_json.get('token', ''), display_id, 'mp4', 'm3u8_native'))
+            if sources.get('source_dash'):
+                pass
         elif stream_meta.get('stream_token_url') or stream_meta.get('stream_dash_url'):
             # prioritize token urls
-            token_hls_url = stream_meta.get('stream_token_url')
-
-            if token_hls_url:
+            if stream_meta.get('stream_token_url'):
                 token_json = self._download_json(
                     'https://www.vidio.com/live/%s/tokens' % video_id,
                     display_id, note='Downloading HLS token JSON', data=b'')
                 formats.extend(self._extract_m3u8_formats(
-                    token_hls_url + '?' + token_json.get('token', ''), display_id, 'mp4', 'm3u8_native'))
+                    stream_meta['stream_token_url'] + '?' + token_json.get('token', ''), display_id, 'mp4', 'm3u8_native'))
+            if stream_meta.get('stream_dash_url'):
+                pass
         else:
             hls_url = stream_meta['stream_url']
             formats.extend(self._extract_m3u8_formats(

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -256,15 +256,15 @@ class VidioLiveIE(VidioBaseIE):
             if str_or_none(sources.get('source_dash')):
                 pass
         else:
-            if stream_meta.get('stream_token_url') or stream_meta.get('stream_dash_url'):
-                if stream_meta.get('stream_token_url'):
-                    token_json = self._download_json(
-                        'https://www.vidio.com/live/%s/tokens' % video_id,
-                        display_id, note='Downloading HLS token JSON', data=b'')
-                    formats.extend(self._extract_m3u8_formats(
-                        stream_meta['stream_token_url'] + '?' + token_json.get('token', ''), display_id, 'mp4', 'm3u8_native'))
-                if stream_meta.get('stream_dash_url'):
-                    pass
+            if stream_meta.get('stream_token_url'):
+                token_json = self._download_json(
+                    'https://www.vidio.com/live/%s/tokens' % video_id,
+                    display_id, note='Downloading HLS token JSON', data=b'')
+                formats.extend(self._extract_m3u8_formats(
+                    stream_meta['stream_token_url'] + '?' + token_json.get('token', ''),
+                    display_id, 'mp4', 'm3u8_native'))
+            if stream_meta.get('stream_dash_url'):
+                pass
             if stream_meta.get('stream_url'):
                 formats.extend(self._extract_m3u8_formats(
                     stream_meta['stream_url'], display_id, 'mp4', 'm3u8_native'))

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -244,7 +244,7 @@ class VidioLiveIE(VidioBaseIE):
             drm_hls_url = stream_meta.get('drm_stream_hls_url')
             if drm_hls_url:
                 formats.extend(self._extract_m3u8_formats(
-                    drm_hls_url, display_id, 'mp4', 'm3u8-native'))
+                    drm_hls_url, display_id, 'mp4', 'm3u8_native'))
         elif stream_meta.get('is_premium'):
             sources = self._download_json(
                 'https://www.vidio.com/interactions_stream.json?video_id=%s&type=livestreamings' % video_id,

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -66,7 +66,7 @@ class VidioBaseIE(InfoExtractor):
 
 
 class VidioIE(VidioBaseIE):
-_VALID_URL = r'https?://(?:www\.)?vidio\.com/watch/(?P<id>\d+)-(?P<display_id>[^/?#&]+)'
+    _VALID_URL = r'https?://(?:www\.)?vidio\.com/watch/(?P<id>\d+)-(?P<display_id>[^/?#&]+)'
     _TESTS = [{
         'url': 'http://www.vidio.com/watch/165683-dj_ambred-booyah-live-2015',
         'md5': 'cd2801394afc164e9775db6a140b91fe',

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -243,7 +243,7 @@ class VidioLiveIE(VidioBaseIE):
 
             if stream_meta.get('drm_stream_hls_url'):
                 formats.extend(self._extract_m3u8_formats(
-                    stream_meta['drm_stream_hls_url'], display_id, 'mp4', 'm3u8-native'))
+                    stream_meta['drm_stream_hls_url'], display_id, 'mp4', 'm3u8_native'))
         elif stream_meta.get('is_premium'):
             sources = self._download_json(
                 'https://www.vidio.com/interactions_stream.json?video_id=%s&type=livestreamings' % video_id,

--- a/yt_dlp/extractor/vidio.py
+++ b/yt_dlp/extractor/vidio.py
@@ -66,12 +66,7 @@ class VidioBaseIE(InfoExtractor):
 
 
 class VidioIE(VidioBaseIE):
-    _VALID_URL = r'''(?x)
-                    (?:
-                        vidio:|
-                        https?://(?:www\.)?vidio\.com/watch/
-                    )(?P<id>\d+)(-(?P<display_id>[^/?#&]+))?
-                '''
+_VALID_URL = r'https?://(?:www\.)?vidio\.com/watch/(?P<id>\d+)-(?P<display_id>[^/?#&]+)'
     _TESTS = [{
         'url': 'http://www.vidio.com/watch/165683-dj_ambred-booyah-live-2015',
         'md5': 'cd2801394afc164e9775db6a140b91fe',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (VideoPremierIE got revamped for nested playlists, courtesy of @pukkandan)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Add support for /premier/ playlists and /live/ streams