### PR TITLE
Remove the reliance on the yt_dlp.extractors.extractors module

### DIFF
--- a/test/test_InfoExtractor.py
+++ b/test/test_InfoExtractor.py
@@ -12,7 +12,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from test.helper import FakeYDL, expect_dict, expect_value, http_server_port
 from yt_dlp.compat import compat_etree_fromstring, compat_http_server
 from yt_dlp.extractor.common import InfoExtractor
-from yt_dlp.extractor import YoutubeIE, get_info_extractor
+from yt_dlp.extractor import get_info_extractor
+from yt_dlp.extractor.youtube import YoutubeIE
 from yt_dlp.utils import encode_data_uri, strip_jsonp, ExtractorError, RegexNotFoundError
 import threading
 

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -14,7 +14,7 @@ import copy
 from test.helper import FakeYDL, assertRegexpMatches
 from yt_dlp import YoutubeDL
 from yt_dlp.compat import compat_str, compat_urllib_error
-from yt_dlp.extractor import YoutubeIE
+from yt_dlp.extractor.youtube import YoutubeIE
 from yt_dlp.extractor.common import InfoExtractor
 from yt_dlp.postprocessor.common import PostProcessor
 from yt_dlp.utils import ExtractorError, float_or_none, match_filter_func

--- a/test/test_all_urls.py
+++ b/test/test_all_urls.py
@@ -12,11 +12,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from test.helper import gettestcases
 
-from yt_dlp.extractor import (
-    FacebookIE,
-    gen_extractors,
-    YoutubeIE,
-)
+from yt_dlp.extractor import gen_extractors
+from yt_dlp.extractor.facebook import FacebookIE
+from yt_dlp.extractor.youtube import YoutubeIE
 
 
 class TestAllURLsMatching(unittest.TestCase):

--- a/test/test_youtube_misc.py
+++ b/test/test_youtube_misc.py
@@ -8,7 +8,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-from yt_dlp.extractor import YoutubeIE
+from yt_dlp.extractor.youtube import YoutubeIE
 
 
 class TestYoutubeMisc(unittest.TestCase):

--- a/test/test_youtube_signature.py
+++ b/test/test_youtube_signature.py
@@ -13,7 +13,7 @@ import re
 import string
 
 from test.helper import FakeYDL
-from yt_dlp.extractor import YoutubeIE
+from yt_dlp.extractor.youtube import YoutubeIE
 from yt_dlp.compat import compat_str, compat_urlretrieve
 
 _TESTS = [

--- a/yt_dlp/extractor/cbs.py
+++ b/yt_dlp/extractor/cbs.py
@@ -11,7 +11,7 @@ from ..utils import (
 )
 
 
-class CBSBaseIE(ThePlatformFeedIE):
+class CBSBaseIE(ThePlatformFeedIE, register=False):
     def _parse_smil_subtitles(self, smil, namespace=None, subtitles_lang='en'):
         subtitles = {}
         for k, ext in [('sMPTE-TTCCURL', 'tt'), ('ClosedCaptionURL', 'ttml'), ('webVTTCaptionURL', 'vtt')]:

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -139,6 +139,7 @@ from .wimtv import WimTVIE
 
 
 class GenericIE(InfoExtractor):
+    _REGISTRY_TIER = float('inf')
     IE_DESC = 'Generic downloader that works on some sites'
     _VALID_URL = r'.*'
     IE_NAME = 'generic'

--- a/yt_dlp/extractor/laola1tv.py
+++ b/yt_dlp/extractor/laola1tv.py
@@ -121,7 +121,7 @@ class Laola1TvEmbedIE(InfoExtractor):
         }
 
 
-class Laola1TvBaseIE(Laola1TvEmbedIE):
+class Laola1TvBaseIE(Laola1TvEmbedIE, register=False):
     def _extract_video(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)

--- a/yt_dlp/extractor/npo.py
+++ b/yt_dlp/extractor/npo.py
@@ -656,7 +656,7 @@ class HetKlokhuisIE(NPODataMidEmbedIE):
     }
 
 
-class NPOPlaylistBaseIE(NPOIE):
+class NPOPlaylistBaseIE(NPOIE, register=False):
     def _real_extract(self, url):
         playlist_id = self._match_id(url)
 

--- a/yt_dlp/extractor/once.py
+++ b/yt_dlp/extractor/once.py
@@ -6,7 +6,7 @@ import re
 from .common import InfoExtractor
 
 
-class OnceIE(InfoExtractor):
+class OnceIE(InfoExtractor, register=False):
     _VALID_URL = r'https?://.+?\.unicornmedia\.com/now/(?:ads/vmap/)?[^/]+/[^/]+/(?P<domain_id>[^/]+)/(?P<application_id>[^/]+)/(?:[^/]+/)?(?P<media_item_id>[^/]+)/content\.(?:once|m3u8|mp4)'
     ADAPTIVE_URL_TEMPLATE = 'http://once.unicornmedia.com/now/master/playlist/%s/%s/%s/content.m3u8'
     PROGRESSIVE_URL_TEMPLATE = 'http://once.unicornmedia.com/now/media/progressive/%s/%s/%s/%s/content.mp4'

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -574,7 +574,7 @@ class SoundcloudIE(InfoExtractor):
         return self._extract_info_dict(info, full_title, token)
 
 
-class SoundcloudPlaylistBaseIE(SoundcloudIE):
+class SoundcloudPlaylistBaseIE(SoundcloudIE, register=False):
     def _extract_set(self, playlist, token=None):
         playlist_id = compat_str(playlist['id'])
         tracks = playlist.get('tracks') or []
@@ -647,7 +647,7 @@ class SoundcloudSetIE(SoundcloudPlaylistBaseIE):
         return self._extract_set(info, token)
 
 
-class SoundcloudPagedPlaylistBaseIE(SoundcloudIE):
+class SoundcloudPagedPlaylistBaseIE(SoundcloudIE, register=False):
     def _extract_playlist(self, base_url, playlist_id, playlist_title):
         # Per the SoundCloud documentation, the maximum limit for a linked partitioning query is 200.
         # https://developers.soundcloud.com/blog/offset-pagination-deprecated

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4026,7 +4026,7 @@ class YoutubeSearchURLIE(YoutubeSearchIE):
         return self._get_n_results(query, self._MAX_RESULTS)
 
 
-class YoutubeFeedsInfoExtractor(YoutubeTabIE):
+class YoutubeFeedsInfoExtractor(YoutubeTabIE, register=False):
     """
     Base class for feed extractors
     Subclasses must define the _FEED_NAME property.


### PR DESCRIPTION
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Improvement

---

This PR makes extractors automatically register themselves when the `InfoExtractor` class is subclassed, and dynamically walks the list of submodules of the `yt_dlp.extractors` module to walk through the list of all extractors. This removes the need to keep a giant list of extractors in the `yt_dlp.extractors.extractors` module; the file was therefore dropped as redundant. Dropping reliance on that module should prevent merge conflicts in the future when independently merging in extractors whose names appear near each other in the alphabet.

Plugin loading implementation is something of a hack right now and may need to be revisited later. But I don’t think it’s an outright blocker.

This change creates a hard dependency on Python ~~3.0~~ 3.4, due to relying on some `importlib` features. My initial sketch even raised the dependency to 3.6, because it relied on [PEP 487], but later on I decided to re-write it with a metaclass instead, since it may prove useful later anyway (I have some ideas already for what to put in `__prepare__`). Since we don’t officially support Python < 3.6 any more, either would be fine.

This patch seems to work fine on my machine, but it badly needs testing in other environments. In particular, I have no idea if the pre-built Windows binaries are going to work.

[PEP 487]: https://www.python.org/dev/peps/pep-0487/