### PR TITLE
Show Python version in EXE metadata

### DIFF
--- a/pyinst.py
+++ b/pyinst.py
@@ -60,7 +60,7 @@ VERSION_FILE = VSVersionInfo(
                     StringStruct('ProductName', 'yt-dlp%s' % _x86),
                     StringStruct(
                         'ProductVersion',
-                        '%s%s on Python %s' % (VERSION, _x86, (platform.python_version()))),
+                        '%s%s on Python %s' % (VERSION, _x86, platform.python_version())),
                 ])]),
         VarFileInfo([VarStruct('Translation', [0, 1200])])
     ]

--- a/pyinst.py
+++ b/pyinst.py
@@ -25,6 +25,7 @@ FILE_DESCRIPTION = 'yt-dlp%s' % (' (32 Bit)' if _x86 else '')
 
 exec(compile(open('yt_dlp/version.py').read(), 'yt_dlp/version.py', 'exec'))
 VERSION = locals()['__version__']
+PY_VER = '.'.join(map(str, sys.version_info[:3]))
 
 VERSION_LIST = VERSION.split('.')
 VERSION_LIST = list(map(int, VERSION_LIST)) + [0] * (4 - len(VERSION_LIST))
@@ -58,7 +59,7 @@ VERSION_FILE = VSVersionInfo(
                     ),
                     StringStruct('OriginalFilename', 'yt-dlp%s.exe' % _x86),
                     StringStruct('ProductName', 'yt-dlp%s' % _x86),
-                    StringStruct('ProductVersion', '%s%s' % (VERSION, _x86)),
+                    StringStruct('ProductVersion', '%s%s on Python %s' % (VERSION, _x86, PY_VER)),
                 ])]),
         VarFileInfo([VarStruct('Translation', [0, 1200])])
     ]

--- a/pyinst.py
+++ b/pyinst.py
@@ -25,7 +25,6 @@ FILE_DESCRIPTION = 'yt-dlp%s' % (' (32 Bit)' if _x86 else '')
 
 exec(compile(open('yt_dlp/version.py').read(), 'yt_dlp/version.py', 'exec'))
 VERSION = locals()['__version__']
-PY_VER = '.'.join(map(str, sys.version_info[:3]))
 
 VERSION_LIST = VERSION.split('.')
 VERSION_LIST = list(map(int, VERSION_LIST)) + [0] * (4 - len(VERSION_LIST))
@@ -59,7 +58,9 @@ VERSION_FILE = VSVersionInfo(
                     ),
                     StringStruct('OriginalFilename', 'yt-dlp%s.exe' % _x86),
                     StringStruct('ProductName', 'yt-dlp%s' % _x86),
-                    StringStruct('ProductVersion', '%s%s on Python %s' % (VERSION, _x86, PY_VER)),
+                    StringStruct(
+                        'ProductVersion',
+                        '%s%s on Python %s' % (VERSION, _x86, (platform.python_version()))),
                 ])]),
         VarFileInfo([VarStruct('Translation', [0, 1200])])
     ]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Currently there is no way of knowing what Python version provided `exe`s are bundled with. In particular, it's hard to find out whether the latest security fixes are included. To solve it, this pull request adds Python version to product version string.