### PR TITLE
[youtube] Improve extraction of livestream metadata

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2181,6 +2181,8 @@ class YoutubeDL(object):
 
         formats_to_download = list(format_selector(ctx))
         if not formats_to_download:
+            # Process what we can, even without any available formats.
+            self.process_info(dict(info_dict))
             if not self.params.get('ignore_no_formats_error'):
                 raise ExtractorError('Requested format is not available', expected=True)
             else:
@@ -2301,7 +2303,6 @@ class YoutubeDL(object):
         if self.params.get('forceduration', False) and info_dict.get('duration') is not None:
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
-
         if self.params.get('forcejson', False):
             self.post_extract(info_dict)
             self.to_stdout(json.dumps(info_dict, default=repr))
@@ -2349,7 +2350,7 @@ class YoutubeDL(object):
         # TODO: backward compatibility, to be removed
         info_dict['fulltitle'] = info_dict['title']
 
-        if 'format' not in info_dict:
+        if 'format' not in info_dict and 'ext' in info_dict:
             info_dict['format'] = info_dict['ext']
 
         if self._match_entry(info_dict) is not None:
@@ -2364,7 +2365,7 @@ class YoutubeDL(object):
         files_to_move = {}
 
         # Forced printings
-        self.__forced_printings(info_dict, full_filename, incomplete=False)
+        self.__forced_printings(info_dict, full_filename, incomplete=('format' not in info_dict))
 
         if self.params.get('simulate', False):
             if self.params.get('force_write_download_archive', False):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2186,8 +2186,6 @@ class YoutubeDL(object):
 
         formats_to_download = list(format_selector(ctx))
         if not formats_to_download:
-            # Process what we can, even without any available formats.
-            self.process_info(dict(info_dict))
             if not self.params.get('ignore_no_formats_error'):
                 raise ExtractorError('Requested format is not available', expected=True)
             else:
@@ -2310,6 +2308,7 @@ class YoutubeDL(object):
         if self.params.get('forceduration', False) and info_dict.get('duration') is not None:
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
+
         if self.params.get('forcejson', False):
             self.post_extract(info_dict)
             self.to_stdout(json.dumps(info_dict, default=repr))

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2231,7 +2231,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             video_details.get('lengthSeconds')
             or microformat.get('lengthSeconds')) \
             or parse_duration(search_meta('duration'))
-        is_live = video_details.get('isLive')
+        live_broadcast_details = microformat.get('liveBroadcastDetails')
+        is_live = video_details.get('isLive') \
+            or try_get(live_broadcast_details, lambda x: x['isLiveNow'], dict)
+        is_upcoming = video_details.get('isUpcoming'),
         owner_profile_url = microformat.get('ownerProfileUrl')
 
         info = {
@@ -2262,8 +2265,11 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'categories': [category] if category else None,
             'tags': keywords,
             'is_live': is_live,
+            'is_upcoming': is_upcoming,
             'playable_in_embed': playability_status.get('playableInEmbed'),
             'was_live': video_details.get('isLiveContent'),
+            'live_starttime': try_get(live_broadcast_details, lambda x: x['startTimestamp'], dict),
+            'live_endtime': try_get(live_broadcast_details, lambda x: x['endTimestamp'], dict),
         }
 
         pctr = try_get(

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2233,8 +2233,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             or parse_duration(search_meta('duration'))
         live_broadcast_details = microformat.get('liveBroadcastDetails')
         is_live = video_details.get('isLive') \
-            or try_get(live_broadcast_details, lambda x: x['isLiveNow'], dict)
-        is_upcoming = video_details.get('isUpcoming'),
+            or try_get(live_broadcast_details, lambda x: x['isLiveNow'], bool)
+        is_upcoming = video_details.get('isUpcoming')
         owner_profile_url = microformat.get('ownerProfileUrl')
 
         info = {
@@ -2268,8 +2268,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'is_upcoming': is_upcoming,
             'playable_in_embed': playability_status.get('playableInEmbed'),
             'was_live': video_details.get('isLiveContent'),
-            'live_starttime': try_get(live_broadcast_details, lambda x: x['startTimestamp'], dict),
-            'live_endtime': try_get(live_broadcast_details, lambda x: x['endTimestamp'], dict),
+            'live_starttime': try_get(live_broadcast_details, lambda x: x['startTimestamp'], compat_str),
+            'live_endtime': try_get(live_broadcast_details, lambda x: x['endTimestamp'], compat_str),
         }
 
         pctr = try_get(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The "--ignore-no-formats-error" parameter does not work as expected when extracting video info using the "--simulate" or "--skip-download" options, with yt-dlp bailing out on undownloadable videos without printing any information. This issue makes extracting information from scheduled livestreams/premieres or membership videos impossible, as no information is returned. This PR allows such information to be extracted and the videos filterable similar to uploads and archived livestreams. Specifically, we continue processing when no formats are found so that json output and other possbile extractions work.

We also add "is_upcoming", "live_starttime", and "live_endtime" to the info dict, as they are useful for livestreams and premieres (especially is_upcoming) and no other equivalent exists.

