### PR TITLE
Implemented TNT live streams

### DIFF
--- a/yt_dlp/extractor/tbs.py
+++ b/yt_dlp/extractor/tbs.py
@@ -16,7 +16,7 @@ from ..utils import (
 
 
 class TBSIE(TurnerBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?(?P<site>tbs|tntdrama)\.com(?P<path>/(?:movies|shows/[^/]+/(?:clips|season-\d+/episode-\d+))/(?P<id>[^/?#]+))'
+    _VALID_URL = r'https?://(?:www\.)?(?P<site>tbs|tntdrama)\.com(?P<path>/(?:movies|watchtnt|shows/[^/]+/(?:clips|season-\d+/episode-\d+))/(?P<id>[^/?#]+))'
     _TESTS = [{
         'url': 'http://www.tntdrama.com/shows/the-alienist/clips/monster',
         'info_dict': {
@@ -45,7 +45,8 @@ class TBSIE(TurnerBaseIE):
         drupal_settings = self._parse_json(self._search_regex(
             r'<script[^>]+?data-drupal-selector="drupal-settings-json"[^>]*?>({.+?})</script>',
             webpage, 'drupal setting'), display_id)
-        video_data = next(v for v in drupal_settings['turner_playlist'] if v.get('url') == path)
+        isLive = "watchtnt" in path
+        video_data = next(v for v in drupal_settings['turner_playlist'] if isLive or v.get('url') == path)
 
         media_id = video_data['mediaID']
         title = video_data['title']
@@ -56,7 +57,8 @@ class TBSIE(TurnerBaseIE):
             media_id, tokenizer_query, {
                 'url': url,
                 'site_name': site[:3].upper(),
-                'auth_required': video_data.get('authRequired') == '1',
+                'auth_required': video_data.get('authRequired') == '1' or isLive,
+                'is_live': isLive
             })
 
         thumbnails = []
@@ -85,5 +87,6 @@ class TBSIE(TurnerBaseIE):
             'season_number': int_or_none(video_data.get('season')),
             'episode_number': int_or_none(video_data.get('episode')),
             'thumbnails': thumbnails,
+            'is_live': isLive
         })
         return info

--- a/yt_dlp/extractor/tbs.py
+++ b/yt_dlp/extractor/tbs.py
@@ -45,7 +45,7 @@ class TBSIE(TurnerBaseIE):
         drupal_settings = self._parse_json(self._search_regex(
             r'<script[^>]+?data-drupal-selector="drupal-settings-json"[^>]*?>({.+?})</script>',
             webpage, 'drupal setting'), display_id)
-        isLive = "watchtnt" in path
+        isLive = 'watchtnt' in path
         video_data = next(v for v in drupal_settings['turner_playlist'] if isLive or v.get('url') == path)
 
         media_id = video_data['mediaID']

--- a/yt_dlp/extractor/turner.py
+++ b/yt_dlp/extractor/turner.py
@@ -246,12 +246,12 @@ class TurnerBaseIE(AdobePassIE):
                 for chapter in stream_data.get('contentSegments', []):
                     start_time = float_or_none(chapter.get('start'))
                     chapter_duration = float_or_none(chapter.get('duration'))
-                if start_time is None or chapter_duration is None:
-                    continue
-                chapters.append({
-                    'start_time': start_time,
-                    'end_time': start_time + chapter_duration,
-                })
+                    if start_time is None or chapter_duration is None:
+                        continue
+                    chapters.append({
+                        'start_time': start_time,
+                        'end_time': start_time + chapter_duration,
+                    })
         self._sort_formats(formats)
 
         return {

--- a/yt_dlp/extractor/turner.py
+++ b/yt_dlp/extractor/turner.py
@@ -221,6 +221,7 @@ class TurnerBaseIE(AdobePassIE):
         }
 
     def _extract_ngtv_info(self, media_id, tokenizer_query, ap_data=None):
+        is_live = ap_data.get('is_live')
         streams_data = self._download_json(
             'http://medium.ngtv.io/media/%s/tv' % media_id,
             media_id)['media']['tv']
@@ -237,20 +238,20 @@ class TurnerBaseIE(AdobePassIE):
                     'http://token.ngtv.io/token/token_spe',
                     m3u8_url, media_id, ap_data or {}, tokenizer_query)
             formats.extend(self._extract_m3u8_formats(
-                m3u8_url, media_id, 'mp4', m3u8_id='hls', fatal=False))
+                m3u8_url, media_id, 'mp4', m3u8_id='hls', live=is_live, fatal=False))
 
             duration = float_or_none(stream_data.get('totalRuntime'))
 
-            if not chapters:
+            if not chapters and not is_live:
                 for chapter in stream_data.get('contentSegments', []):
                     start_time = float_or_none(chapter.get('start'))
                     chapter_duration = float_or_none(chapter.get('duration'))
-                    if start_time is None or chapter_duration is None:
-                        continue
-                    chapters.append({
-                        'start_time': start_time,
-                        'end_time': start_time + chapter_duration,
-                    })
+                if start_time is None or chapter_duration is None:
+                    continue
+                chapters.append({
+                    'start_time': start_time,
+                    'end_time': start_time + chapter_duration,
+                })
         self._sort_formats(formats)
 
         return {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Add support for TNT live streams. Hard coded that MVPD auth required because ~~I'm bad at coding~~ it's required to authenticate to view the live stream. Example log with this patch: 
```
 ./yt-dlp.cmd --ignore-config --proxy "http://localhost:8888" "https://www.tntdrama.com/watchtnt/east" --ap-mso Comcast_SSO --ap-username f --ap-password f
[TBS] east: Downloading webpage
[TBS] tnt-east: Downloading JSON metadata
[TBS] tnt-east: Downloading Provider Redirect Page
[TBS] tnt-east: Confirming auto login
[TBS] tnt-east: Retrieving Session
[TBS] tnt-east: Retrieving Authorization Token
[TBS] tnt-east: Retrieving Media Token
[TBS] tnt-east: Downloading XML
[TBS] tnt-east: Downloading m3u8 information
[info] tnt-east: Downloading 1 format(s): hls-2
[download] Destination: 2260268 [tnt-east].mp4
[hls @ 000002458a384fc0] Skip ('#EXT-X-VERSION:3')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PUBLISHED-TIME:2021-06-25T23:15:17.418Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-DISCONTINUITY-SEQUENCE:4')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:14.808Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:20.814Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:26.82Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:32.826Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:38.832Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:44.838Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:50.844Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:05:56.85Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:02.856Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:08.862Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:14.868Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:20.874Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:26.88Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:32.886Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:38.892Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:44.898Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:50.904Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:06:56.91Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:02.916Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:08.922Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:14.928Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:20.934Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:26.94Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:32.946Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:38.952Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:44.958Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:50.964Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:07:56.97Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:02.976Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:08.982Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:14.988Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:20.994Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:27Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:33.006Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:39.012Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:45.018Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:51.024Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:08:57.03Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:03.036Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:09.042Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:15.048Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:21.054Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:27.06Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:33.066Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:39.072Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:45.078Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:51.084Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:09:57.09Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:03.096Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:09.102Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:15.108Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:21.114Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:27.12Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:33.126Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:39.132Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:45.138Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:51.144Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:10:57.15Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:03.156Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:09.162Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:15.168Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:21.174Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:27.18Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:33.186Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:39.192Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:45.198Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:51.204Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:11:57.21Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:03.216Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:09.222Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:15.228Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:21.234Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:27.24Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:33.246Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:39.252Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:45.258Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:51.264Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:12:57.27Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:03.276Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:06.513Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:12.519Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:18.525Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:24.531Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:30.537Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:36.543Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:42.549Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:48.555Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:13:54.561Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:00.567Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:06.573Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:12.579Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:18.585Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:24.591Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:30.597Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:36.603Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:42.609Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:48.615Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:14:54.621Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:15:00.627Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:15:06.633Z')
[hls @ 000002458a384fc0] Skip ('#EXT-X-PROGRAM-DATE-TIME:2021-06-25T23:15:07.3Z')
[hls @ 000002458a384fc0] Opening 'https://turnerlive.akamaized.net/hls/live/2023169/tnteast/noslate/keys/47a19527c1540a848bb9f13c861fbcde04687728.key' for reading
[hls @ 000002458a384fc0] Opening 'crypto+https://tve-live-lln.warnermediacdn.com/hls/live/2023169/tnteast/noslate/1624474212_video_720p-30fps-5000kbps/video_31789.ts' for reading
Input #0, hls, from 'https://tve-live-lln.warnermediacdn.com/hls/live/2023169/tnteast/noslate/VIDEO_1_5128000.m3u8':
  Duration: N/A, start: 19938.127167, bitrate: N/A
  Program 0
    Metadata:
      variant_bitrate : 0
    Stream #0:0: Video: h264 (Main) ([27][0][0][0] / 0x001B), yuv420p, 1280x720, Closed Captions, 29.97 fps, 29.97 tbr, 90k tbn, 59.94 tbc
    Metadata:
      variant_bitrate : 0
    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp
    Metadata:
      variant_bitrate : 0
Output #0, mpegts, to 'file:2260268 [tnt-east].mp4.part':
  Metadata:
    encoder         : Lavf58.45.100
    Stream #0:0: Video: h264 (Main) ([27][0][0][0] / 0x001B), yuv420p, 1280x720, q=2-31, 29.97 fps, 29.97 tbr, 90k tbn, 90k tbc
    Metadata:
      variant_bitrate : 0
    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp
    Metadata:
      variant_bitrate : 0
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
frame=   33 fps=0.0 q=-1.0 Lsize=     813kB time=00:00:01.03 bitrate=6415.7kbits/s speed=  84x
video:770kB audio:16kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 3.385775%
[ffmpeg] Interrupted by user
Exiting normally, received signal 2.
[ffmpeg] Downloaded 832088 bytes
[download] 100% of 812.59KiB in 00:01
Terminate batch job (Y/N)? Y
```

Formats:

```
./yt-dlp.cmd --ignore-config --proxy "http://localhost:8888" "https://www.tntdrama.com/watchtnt/east" --ap-mso Comcast_SSO --ap-username f --ap-password f3e -F
[TBS] east: Downloading webpage
[TBS] tnt-east: Downloading JSON metadata
[TBS] tnt-east: Retrieving Media Token
[TBS] tnt-east: Downloading XML
[TBS] tnt-east: Downloading m3u8 information
[info] Available formats for tnt-east:
ID    EXT RESOLUTION FPS |   TBR PROTO  | VCODEC        VBR ACODEC     ABR
----- --- ---------- --- - ----- ------ - ----------- ----- --------- ----
hls-0 mp4 768x432    29  | 2011k m3u8_n | avc1.4d401e 2011k mp4a.40.2   0k
hls-1 mp4 768x432    29  | 2011k m3u8_n | avc1.4d401e 2011k mp4a.40.2   0k
hls-2 mp4 960x540    29  | 2727k m3u8_n | avc1.4d401f 2727k mp4a.40.2   0k
hls-3 mp4 960x540    29  | 2727k m3u8_n | avc1.4d401f 2727k mp4a.40.2   0k
hls-4 mp4 1280x720   29  | 5281k m3u8_n | avc1.4d401f 5281k mp4a.40.2   0k
hls-5 mp4 1280x720   29  | 5281k m3u8_n | avc1.4d401f 5281k mp4a.40.2   0k
```

Traffic log:
![image](https://user-images.githubusercontent.com/16567977/123493369-bc799100-d60b-11eb-96f8-f9cf278a67a9.png)



