### PR TITLE
[YoutubeDL] add `--redact-formats-infojson` option to remove formats and urls

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -239,7 +239,7 @@ class YoutubeDL(object):
     writedescription:  Write the video description to a .description file
     writeinfojson:     Write the video description to a .info.json file
     clean_infojson:    Remove private fields from the infojson
-    redact_formats_infojson: Remove formats and url from the infojson 
+    redact_formats_infojson: Remove formats and url from the infojson
     writecomments:     Extract video comments. This will not be written to disk
                        unless writeinfojson is also given
     writeannotations:  Write the video annotations to a .annotations.xml file

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1057,7 +1057,17 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '--no-clean-infojson',
         action='store_false', dest='clean_infojson',
-        help='Write all fields to the infojson')
+        help='Write all fields to the infojson including private fields')
+    filesystem.add_option(
+        '--redact-formats-infojson',
+        action='store_true', dest='redact_formats_infojson', default=True,
+        help=(
+            'Remove some possible sensitive information such as video URLs from the infojson. '
+            'Must be specified with --clean-infojson to work'))
+    filesystem.add_option(
+        '--no-redact-formats-infojson',
+        action='store_false', dest='redact_formats_infojson',
+        help='Write all fields to the infojson including possible sensitive information')
     filesystem.add_option(
         '--write-comments', '--get-comments',
         action='store_true', dest='getcomments', default=False,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

closes #455 

This is a implementation for #455, a suggestion to remove both formats and urls in info json.

here's comparison: https://gist.github.com/13f9b6e6b965a08255abb415fbf09250
