### PR TITLE
[soundcloud] disable login, require oauth token instead

### DIFF
--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -321,20 +321,21 @@ class SoundcloudIE(InfoExtractor):
         if username is None:
             return
 
-        if username == 'oauth':
-            if password:
-                self._access_token = password
-                query = self._API_AUTH_QUERY_TEMPLATE % self._CLIENT_ID
-                payload = {'session': {'access_token': self._access_token}}
-                token_verification = sanitized_Request(self._API_VERIFY_AUTH_TOKEN % query, json.dumps(payload).encode('utf-8'))
-                response = self._download_json(token_verification, None, note='Verifying login token...', fatal=False)
-                if response is not False:
-                    self._HEADERS = {'Authorization': 'OAuth ' + self._access_token}
-                    self.report_login()
-                else:
-                    self.report_warning('Provided authorization token seems to be invalid. Continue as guest.')
+        if username == 'oauth' and password is not None:
+            self._access_token = password
+            query = self._API_AUTH_QUERY_TEMPLATE % self._CLIENT_ID
+            payload = {'session': {'access_token': self._access_token}}
+            token_verification = sanitized_Request(self._API_VERIFY_AUTH_TOKEN % query, json.dumps(payload).encode('utf-8'))
+            response = self._download_json(token_verification, None, note='Verifying login token...', fatal=False)
+            if response is not False:
+                self._HEADERS = {'Authorization': 'OAuth ' + self._access_token}
+                self.report_login()
             else:
-                self.report_warning('No token for authentication provided!')
+                self.report_warning('Provided authorization token seems to be invalid. Continue as guest')
+        elif username is not None:
+            self.report_warning(
+                'Login using username and password is not currently supported. '
+                'Use "--user oauth --password <oauth_token>" to login using an oauth token')
 
         r'''
         def genDevId():

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import itertools
 import re
 import json
-import random
+# import random
 
 from .common import (
     InfoExtractor,
@@ -164,23 +164,11 @@ class SoundcloudIE(InfoExtractor):
         },
         # downloadable song
         {
-            'url': 'https://soundcloud.com/oddsamples/bus-brakes',
-            'md5': '7624f2351f8a3b2e7cd51522496e7631',
+            'url': 'https://soundcloud.com/the80m/the-following',
+            'md5': '9ffcddb08c87d74fb5808a3c183a1d04',
             'info_dict': {
-                'id': '128590877',
-                'ext': 'mp3',
-                'title': 'Bus Brakes',
-                'description': 'md5:0053ca6396e8d2fd7b7e1595ef12ab66',
-                'uploader': 'oddsamples',
-                'uploader_id': '73680509',
-                'timestamp': 1389232924,
-                'upload_date': '20140109',
-                'duration': 17.346,
-                'license': 'cc-by-sa',
-                'view_count': int,
-                'like_count': int,
-                'comment_count': int,
-                'repost_count': int,
+                'id': '343609555',
+                'ext': 'wav',
             },
         },
         # private link, downloadable format
@@ -317,21 +305,39 @@ class SoundcloudIE(InfoExtractor):
                 raise
 
     def _real_initialize(self):
-        self._CLIENT_ID = self._downloader.cache.load('soundcloud', 'client_id') or "T5R4kgWS2PRf6lzLyIravUMnKlbIxQag"  # 'EXLwg5lHTO2dslU5EePe3xkw0m1h86Cd' # 'YUKXoArFcqrlQn9tfNHvvyfnDISj04zk'
+        self._CLIENT_ID = self._downloader.cache.load('soundcloud', 'client_id') or "fXuVKzsVXlc6tzniWWS31etd7VHWFUuN"  # persistent `client_id`
         self._login()
 
     _USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
     _API_AUTH_QUERY_TEMPLATE = '?client_id=%s'
     _API_AUTH_URL_PW = 'https://api-auth.soundcloud.com/web-auth/sign-in/password%s'
+    _API_VERIFY_AUTH_TOKEN = 'https://api-auth.soundcloud.com/connect/session%s'
     _access_token = None
     _HEADERS = {}
     _NETRC_MACHINE = 'soundcloud'
+    _reserved_usernames = ['token', 'auth', 'oauth', 'bearer', 'authorization']
 
     def _login(self):
         username, password = self._get_login_info()
         if username is None:
             return
 
+        if username in self._reserved_usernames:
+            if password:
+                self._access_token = password
+                query = self._API_AUTH_QUERY_TEMPLATE % self._CLIENT_ID
+                payload = {'session': {'access_token': self._access_token}}
+                token_verification = sanitized_Request(self._API_VERIFY_AUTH_TOKEN % query, json.dumps(payload).encode('utf-8'))
+                response = self._download_json(token_verification, None, note='Verifying login token...', fatal=False)
+                if response is not False:
+                    self._HEADERS = {'Authorization': 'OAuth ' + self._access_token}
+                    self.report_login()
+                else:
+                    self.report_warning('Provided authorization token seems to be invalid. Continue as guest.')
+            else:
+                self.report_warning('No token for authentication provided!')
+
+        '''
         def genDevId():
             def genNumBlock():
                 return ''.join([str(random.randrange(10)) for i in range(6)])
@@ -352,12 +358,14 @@ class SoundcloudIE(InfoExtractor):
 
         query = self._API_AUTH_QUERY_TEMPLATE % self._CLIENT_ID
         login = sanitized_Request(self._API_AUTH_URL_PW % query, json.dumps(payload).encode('utf-8'))
-        response = self._download_json(login, None)
-        self._access_token = response.get('session').get('access_token')
+        response = self._download_json(login, None, fatal=False)
+        if response is not False:
+            self._access_token = response.get('session').get('access_token')
         if not self._access_token:
-            self.report_warning('Unable to get access token, login may has failed')
+            self.report_warning('Unable to get access token, login may has failed. Try cookies/authorization header instead')
         else:
             self._HEADERS = {'Authorization': 'OAuth ' + self._access_token}
+        '''
 
     # signature generation
     def sign(self, user, pw, clid):
@@ -480,6 +488,7 @@ class SoundcloudIE(InfoExtractor):
             format_urls.add(stream_url)
             stream_format = t.get('format') or {}
             protocol = stream_format.get('protocol')
+            # https://api-v2.soundcloud.com/media/soundcloud:tracks:<trackID>/<transcodingIdentifier>/stream/hls
             if protocol != 'hls' and '/hls' in format_url:
                 protocol = 'hls'
             ext = None

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -305,10 +305,10 @@ class SoundcloudIE(InfoExtractor):
                 raise
 
     def _real_initialize(self):
-        self._CLIENT_ID = self._downloader.cache.load('soundcloud', 'client_id') or "fXuVKzsVXlc6tzniWWS31etd7VHWFUuN"  # persistent `client_id`
+        self._CLIENT_ID = self._downloader.cache.load('soundcloud', 'client_id') or 'fXuVKzsVXlc6tzniWWS31etd7VHWFUuN'  # persistent `client_id`
         self._login()
 
-    _USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+    _USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36'
     _API_AUTH_QUERY_TEMPLATE = '?client_id=%s'
     _API_AUTH_URL_PW = 'https://api-auth.soundcloud.com/web-auth/sign-in/password%s'
     _API_VERIFY_AUTH_TOKEN = 'https://api-auth.soundcloud.com/connect/session%s'
@@ -377,9 +377,9 @@ class SoundcloudIE(InfoExtractor):
         b = 37
         k = 37
         c = 5
-        n = "0763ed7314c69015fd4a0dc16bbf4b90"  # _KEY
-        y = "8"  # _REV
-        r = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"  # _USER_AGENT
+        n = '0763ed7314c69015fd4a0dc16bbf4b90'  # _KEY
+        y = '8'  # _REV
+        r = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36'  # _USER_AGENT
         e = user  # _USERNAME
         t = clid  # _CLIENT_ID
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Disabled login by api since it needs a rework. Instead added the option to use one of these `['token', 'auth', 'oauth', 'bearer', 'authorization']` as a username to let the extractor know the password will be an `oauth/access token`. You still can add `--add-header "Authorization: OAuth <access_token>"` as usual. However this patch allows you to use netrc to save your token.
I will try to see how long a token is valid exactly (from experience I used the same token once for at least a week). There is also `_soundcloud_session` which can be used to retrieve the token you got when you signed in. I assume it got a shorter time span but never glimpsed on it so I will try the one I've saved in a week or so. 
This workaround patch is rather for convenience

For simplicity use e.g. chrome devtools -> Application -> Storage -> Cookies
click on soundcloud.com and filter for oauth
![image](https://user-images.githubusercontent.com/4406639/124538799-86fb5180-de1c-11eb-8cfd-393a7ab853d3.png)


~#265~
~#465~