### PR TITLE
[BravoTV] Improve metadata extraction

### DIFF
--- a/yt_dlp/extractor/bravotv.py
+++ b/yt_dlp/extractor/bravotv.py
@@ -10,6 +10,7 @@ from ..utils import (
     int_or_none,
     float_or_none,
     try_get,
+    dict_get,
 )
 
 
@@ -97,21 +98,17 @@ class BravoTVIE(AdobePassIE):
                 'title': tp_metadata.get('title'),
                 'description': tp_metadata.get('description'),
                 'duration': float_or_none(tp_metadata.get('duration'), 1000),
-                'season_number': (
-                    int_or_none(tp_metadata.get('pl1$seasonNumber'))
-                    or int_or_none(tp_metadata.get('nbcu$seasonNumber'))),
-                'episode_number': (
-                    int_or_none(tp_metadata.get('pl1$episodeNumber'))
-                    or int_or_none(tp_metadata.get('nbcu$episodeNumber'))),
+                'season_number': int_or_none(
+                    dict_get(tp_metadata, ('pl1$seasonNumber', 'nbcu$seasonNumber'))),
+                'episode_number': int_or_none(
+                    dict_get(tp_metadata, ('pl1$episodeNumber', 'nbcu$episodeNumber'))),
                 # For some reason the series is sometimes wrapped into a single element array.
                 'series': try_get(
-                    tp_metadata.get('pl1$show') or tp_metadata.get('nbcu$show'),
+                    dict_get(tp_metadata, ('pl1$show', 'nbcu$show')),
                     lambda x: x[0] if isinstance(x, list) else x,
                     expected_type=str),
-                'episode': (
-                    tp_metadata.get('pl1$episodeName')
-                    or tp_metadata.get('nbcu$episodeName')
-                    or tp_metadata.get('title')),
+                'episode': dict_get(
+                    tp_metadata, ('pl1$episodeName', 'nbcu$episodeName', 'title')),
             })
 
         info.update({

--- a/yt_dlp/extractor/bravotv.py
+++ b/yt_dlp/extractor/bravotv.py
@@ -8,6 +8,8 @@ from ..utils import (
     smuggle_url,
     update_url_query,
     int_or_none,
+    float_or_none,
+    try_get,
 )
 
 
@@ -24,6 +26,11 @@ class BravoTVIE(AdobePassIE):
             'uploader': 'NBCU-BRAV',
             'upload_date': '20190314',
             'timestamp': 1552591860,
+            'season_number': 16,
+            'episode_number': 15,
+            'series': 'Top Chef',
+            'episode': 'The Top Chef Season 16 Winner Is...',
+            'duration': 190.0,
         }
     }, {
         'url': 'http://www.bravotv.com/below-deck/season-3/ep-14-reunion-part-1',
@@ -79,12 +86,38 @@ class BravoTVIE(AdobePassIE):
                 'episode_number': int_or_none(metadata.get('episode_num')),
             })
             query['switch'] = 'progressive'
+
+        tp_url = 'http://link.theplatform.com/s/%s/%s' % (account_pid, tp_path)
+
+        tp_metadata = self._download_json(
+            update_url_query(tp_url, {'format': 'preview'}),
+            display_id, fatal=False)
+        if tp_metadata:
+            info.update({
+                'title': tp_metadata.get('title'),
+                'description': tp_metadata.get('description'),
+                'duration': float_or_none(tp_metadata.get('duration'), 1000),
+                'season_number': (
+                    int_or_none(tp_metadata.get('pl1$seasonNumber'))
+                    or int_or_none(tp_metadata.get('nbcu$seasonNumber'))),
+                'episode_number': (
+                    int_or_none(tp_metadata.get('pl1$episodeNumber'))
+                    or int_or_none(tp_metadata.get('nbcu$episodeNumber'))),
+                # For some reason the series is sometimes wrapped into a single element array.
+                'series': try_get(
+                    tp_metadata.get('pl1$show') or tp_metadata.get('nbcu$show'),
+                    lambda x: x[0] if isinstance(x, list) else x,
+                    expected_type=str),
+                'episode': (
+                    tp_metadata.get('pl1$episodeName')
+                    or tp_metadata.get('nbcu$episodeName')
+                    or tp_metadata.get('title')),
+            })
+
         info.update({
             '_type': 'url_transparent',
             'id': release_pid,
-            'url': smuggle_url(update_url_query(
-                'http://link.theplatform.com/s/%s/%s' % (account_pid, tp_path),
-                query), {'force_smil_url': True}),
+            'url': smuggle_url(update_url_query(tp_url, query), {'force_smil_url': True}),
             'ie_key': 'ThePlatform',
         })
         return info


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Download and parse ThePlatform metadata to get more metadata about the content including runtime, series name, season number, and episode number.

The only quirk is that I found that the series name is sometimes nested into a single element array so I added a handler for that.

I updated the existing test to also test these extra attributes.