### PR TITLE
RTP: fix extraction

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1054,6 +1054,9 @@ class TestUtil(unittest.TestCase):
         on = js_to_json('{ "040": "040" }')
         self.assertEqual(json.loads(on), {'040': '040'})
 
+        on = js_to_json('[1,//{},\n2]')
+        self.assertEqual(json.loads(on), [1, 2])
+
     def test_js_to_json_malformed(self):
         self.assertEqual(js_to_json('42a1'), '42"a1"')
         self.assertEqual(js_to_json('42a-1'), '42"a"-1')

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1111,6 +1111,8 @@ class InfoExtractor(object):
             if group is None:
                 # return the first matching group
                 return next(g for g in mobj.groups() if g is not None)
+            elif isinstance(group, tuple):
+                return tuple(mobj.group(g) for g in group)
             else:
                 return mobj.group(group)
         elif default is not NO_DEFAULT:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1111,7 +1111,7 @@ class InfoExtractor(object):
             if group is None:
                 # return the first matching group
                 return next(g for g in mobj.groups() if g is not None)
-            elif isinstance(group, tuple):
+            elif isinstance(group, (list, tuple)):
                 return tuple(mobj.group(g) for g in group)
             else:
                 return mobj.group(group)

--- a/yt_dlp/extractor/rtp.py
+++ b/yt_dlp/extractor/rtp.py
@@ -2,10 +2,11 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from ..utils import (
-    determine_ext,
-    js_to_json,
-)
+from ..utils import js_to_json
+import re
+import json
+import urllib.parse
+import base64
 
 
 class RTPIE(InfoExtractor):
@@ -25,6 +26,28 @@ class RTPIE(InfoExtractor):
         'only_matching': True,
     }]
 
+    _RX_OBFUSCATION = re.compile(r'''(?xs)
+        atob\s*\(\s*decodeURIComponent\s*\(\s*
+            (\[[0-9A-Za-z%,'"]*\])
+        \s*\.\s*join\(\s*(?:""|'')\s*\)\s*\)\s*\)
+    ''')
+
+    def __unobfuscate(self, data, *, video_id):
+        if data.startswith('{'):
+            data = self._RX_OBFUSCATION.sub(
+                lambda m: json.dumps(
+                    base64.b64decode(
+                        urllib.parse.unquote(
+                            ''.join(
+                                self._parse_json(m.group(1), video_id)
+                            )
+                        )
+                    ).decode('iso-8859-1')
+                ),
+                data
+            )
+        return js_to_json(data)
+
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
@@ -32,30 +55,52 @@ class RTPIE(InfoExtractor):
         title = self._html_search_meta(
             'twitter:title', webpage, display_name='title', fatal=True)
 
-        config = self._parse_json(self._search_regex(
-            r'(?s)RTPPlayer\(({.+?})\);', webpage,
-            'player config'), video_id, js_to_json)
-        file_url = config['file']
-        ext = determine_ext(file_url)
-        if ext == 'm3u8':
-            file_key = config.get('fileKey')
-            formats = self._extract_m3u8_formats(
-                file_url, video_id, 'mp4', 'm3u8_native',
-                m3u8_id='hls', fatal=file_key)
-            if file_key:
-                formats.append({
-                    'url': 'https://cdn-ondemand.rtp.pt' + file_key,
-                    'quality': 1,
-                })
-            self._sort_formats(formats)
+        f, config = self._search_regex(
+            r'''(?sx)
+                var\s+f\s*=\s*(?P<f>".*?"|{[^;]+?});\s*
+                var\s+player1\s+=\s+new\s+RTPPlayer\s*\((?P<config>{(?:(?!\*/).)+?})\);(?!\s*\*/)
+            ''', webpage,
+            'player config', group=('f', 'config'))
+
+        f = self._parse_json(
+            f, video_id,
+            lambda data: self.__unobfuscate(data, video_id=video_id)
+        )
+        config = self._parse_json(
+            config, video_id,
+            lambda data: self.__unobfuscate(data, video_id=video_id)
+        )
+
+        formats = []
+
+        if isinstance(f, dict):
+            f_hls = f.get('hls')
+            if f_hls is not None:
+                formats.extend(self._extract_m3u8_formats(
+                    f_hls, video_id, 'mp4', 'm3u8_native',
+                    m3u8_id='hls'))
+
+            f_dash = f.get('dash')
+            if f_dash is not None:
+                formats.extend(self._extract_mpd_formats(
+                    f_dash, video_id,
+                    mpd_id='dash'))
         else:
-            formats = [{
-                'url': file_url,
-                'ext': ext,
-            }]
-        if config.get('mediaType') == 'audio':
-            for f in formats:
-                f['vcodec'] = 'none'
+            formats.append({
+                'format_id': 'f',
+                'url': f,
+                'vcodec': 'none' if config.get('mediaType') == 'audio' else None,
+            })
+
+        subtitles = {}
+
+        vtt = config.get('vtt')
+        if vtt is not None:
+            for lcode, lname, url in vtt:
+                subtitles.setdefault(lcode, []).append({
+                    'name': lname,
+                    'url': url,
+                })
 
         return {
             'id': video_id,
@@ -63,4 +108,5 @@ class RTPIE(InfoExtractor):
             'formats': formats,
             'description': self._html_search_meta(['description', 'twitter:description'], webpage),
             'thumbnail': config.get('poster') or self._og_search_thumbnail(webpage),
+            'subtitles': subtitles,
         }

--- a/yt_dlp/extractor/rtp.py
+++ b/yt_dlp/extractor/rtp.py
@@ -36,16 +36,10 @@ class RTPIE(InfoExtractor):
         if data.startswith('{'):
             data = self._RX_OBFUSCATION.sub(
                 lambda m: json.dumps(
-                    base64.b64decode(
-                        urllib.parse.unquote(
-                            ''.join(
-                                self._parse_json(m.group(1), video_id)
-                            )
-                        )
-                    ).decode('iso-8859-1')
-                ),
-                data
-            )
+                    base64.b64decode(urllib.parse.unquote(
+                        ''.join(self._parse_json(m.group(1), video_id))
+                    )).decode('iso-8859-1')),
+                data)
         return js_to_json(data)
 
     def _real_extract(self, url):
@@ -64,27 +58,21 @@ class RTPIE(InfoExtractor):
 
         f = self._parse_json(
             f, video_id,
-            lambda data: self.__unobfuscate(data, video_id=video_id)
-        )
+            lambda data: self.__unobfuscate(data, video_id=video_id))
         config = self._parse_json(
             config, video_id,
-            lambda data: self.__unobfuscate(data, video_id=video_id)
-        )
+            lambda data: self.__unobfuscate(data, video_id=video_id))
 
         formats = []
-
         if isinstance(f, dict):
             f_hls = f.get('hls')
             if f_hls is not None:
                 formats.extend(self._extract_m3u8_formats(
-                    f_hls, video_id, 'mp4', 'm3u8_native',
-                    m3u8_id='hls'))
+                    f_hls, video_id, 'mp4', 'm3u8_native', m3u8_id='hls'))
 
             f_dash = f.get('dash')
             if f_dash is not None:
-                formats.extend(self._extract_mpd_formats(
-                    f_dash, video_id,
-                    mpd_id='dash'))
+                formats.extend(self._extract_mpd_formats(f_dash, video_id, mpd_id='dash'))
         else:
             formats.append({
                 'format_id': 'f',

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4365,7 +4365,7 @@ def strip_jsonp(code):
 
 def js_to_json(code, vars={}):
     # vars is a dict of var, val pairs to substitute
-    COMMENT_RE = r'/\*(?:(?!\*/).)*?\*/|//[^\n]*'
+    COMMENT_RE = r'/\*(?:(?!\*/).)*?\*/|//[^\n]*\n'
     SKIP_RE = r'\s*(?:{comment})?\s*'.format(comment=COMMENT_RE)
     INTEGER_TABLE = (
         (r'(?s)^(0[xX][0-9a-fA-F]+){skip}:?$'.format(skip=SKIP_RE), 16),


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- **I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)**

### What is the purpose of your *pull request*?
- **Bug fix**

---

Related to #486.

This fixes broken RTP extraction, due to obfuscation the website apparently started employing a while ago. Apart from employing URL-encoded base64, the website code contains a handful of false pieces of data that more naïve regex search might capture instead of the real data; I suspect this may be specifically to throw off scrapers like this one. Coming up with a regex that captures the real data instead of the booby traps was somewhat tricky. I worry we may need to start preparing for an obfuscation arms race, and eventually add a full JavaScript parser and evaluator.