### PR TITLE
[youtube:tab] Add availability metadata for playlists

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2966,17 +2966,17 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             is_membersonly = False
             is_premium = False
             contents = try_get(initial_data, lambda x: x['contents']['twoColumnWatchNextResults']['results']['results']['contents'], list) or []
-            badge_lbls = set()
+            badge_labels = set()
             for content in contents:
                 if not isinstance(content, dict):
                     continue
-                badge_lbls.update(self._extract_badges(content.get('videoPrimaryInfoRenderer')))
-            for badge_lbl in badge_lbls:
-                if badge_lbl.lower() == 'members only':
+                badge_labels.update(self._extract_badges(content.get('videoPrimaryInfoRenderer')))
+            for badge_label in badge_labels:
+                if badge_label.lower() == 'members only':
                     is_membersonly = True
-                elif badge_lbl.lower() == 'premium':
+                elif badge_label.lower() == 'premium':
                     is_premium = True
-                elif badge_lbl.lower() == 'unlisted':
+                elif badge_label.lower() == 'unlisted':
                     is_unlisted = True
 
         info['availability'] = self._availability(
@@ -3923,7 +3923,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
     def _extract_availability(self, data):
         is_private = is_unlisted = None
         renderer = self._extract_sidebar_info_renderer(data, 'playlistSidebarPrimaryInfoRenderer') or {}
-        badge_lbls = self._extract_badges(renderer)
+        badge_labels = self._extract_badges(renderer)
 
         # Personal playlists when auth given have a dropdown selector rather a badge
         privacy_dropdown_entries = try_get(
@@ -3936,15 +3936,15 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             label = self._join_text_entries(
                 try_get(renderer_dict, lambda x: x['privacyDropdownItemRenderer']['label']['runs'], list) or [])
             if label:
-                badge_lbls.add(label.lower())
+                badge_labels.add(label.lower())
                 break
 
-        for badge_lbl in badge_lbls:
-            if badge_lbl == 'unlisted':
+        for badge_label in badge_labels:
+            if badge_label == 'unlisted':
                 is_unlisted = True
-            elif badge_lbl == 'private':
+            elif badge_label == 'private':
                 is_private = True
-            elif badge_lbl == 'public':
+            elif badge_label == 'public':
                 return self._availability(*itertools.repeat(False, 5))
         return self._availability(
             is_private=is_private,

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2965,23 +2965,18 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         if initial_data and is_private is not None:
             is_membersonly = False
             is_premium = False
-            contents = try_get(initial_data, lambda x: x['contents']['twoColumnWatchNextResults']['results']['results']['contents'], list)
-            for content in contents or []:
-                badges = try_get(content, lambda x: x['videoPrimaryInfoRenderer']['badges'], list)
-                for badge in badges or []:
-                    label = try_get(badge, lambda x: x['metadataBadgeRenderer']['label']) or ''
-                    if label.lower() == 'members only':
-                        is_membersonly = True
-                        break
-                    elif label.lower() == 'premium':
-                        is_premium = True
-                        break
-                    elif label.lower() == 'unlisted':
-                        is_unlisted = True
-                if is_membersonly or is_premium:
-                    break
+            contents = try_get(initial_data, lambda x: x['contents']['twoColumnWatchNextResults']['results']['results']['contents'], list) or []
+            badge_lbls = set()
+            for content in contents:
+                badge_lbls.update(self._extract_badges(content.get('videoPrimaryInfoRenderer')))
+            for badge_lbl in badge_lbls:
+                if badge_lbl.lower() == 'members only':
+                    is_membersonly = True
+                elif badge_lbl.lower() == 'premium':
+                    is_premium = True
+                elif badge_lbl.lower() == 'unlisted':
+                    is_unlisted = True
 
-        # TODO: Add this for playlists
         info['availability'] = self._availability(
             is_private=is_private,
             needs_premium=is_premium,

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3811,8 +3811,8 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             thumbnails_list = (
                 try_get(renderer, lambda x: x['avatar']['thumbnails'], list)
                 or try_get(
-                    data,
-                    lambda x: x['sidebar']['playlistSidebarRenderer']['items'][0]['playlistSidebarPrimaryInfoRenderer']['thumbnailRenderer']['playlistVideoThumbnailRenderer']['thumbnail']['thumbnails'],
+                    self._extract_sidebar_info_renderer(data, 'playlistSidebarPrimaryInfoRenderer'),
+                    lambda x: x['thumbnailRenderer']['playlistVideoThumbnailRenderer']['thumbnail']['thumbnails'],
                     list)
                 or [])
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2968,6 +2968,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             contents = try_get(initial_data, lambda x: x['contents']['twoColumnWatchNextResults']['results']['results']['contents'], list) or []
             badge_lbls = set()
             for content in contents:
+                if not isinstance(content, dict):
+                    continue
                 badge_lbls.update(self._extract_badges(content.get('videoPrimaryInfoRenderer')))
             for badge_lbl in badge_lbls:
                 if badge_lbl.lower() == 'members only':

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -665,6 +665,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                     continue
                 text += sub_text
         return text
+
     def _extract_response(self, item_id, query, note='Downloading API JSON', headers=None,
                           ytcfg=None, check_get_keys=None, ep='browse', fatal=True, api_hostname=None,
                           default_client='WEB'):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3965,36 +3965,37 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         """
         browse_id = params = None
         renderer = self._extract_sidebar_info_renderer(data, 'playlistSidebarPrimaryInfoRenderer')
-        menu_renderer = try_get(
-            renderer, lambda x: x['menu']['menuRenderer']['items'], list) or []
-        for menu_item in menu_renderer:
-            if not isinstance(menu_item, dict):
-                continue
-            nav_item_renderer = menu_item.get('menuNavigationItemRenderer')
-            text = try_get(
-                nav_item_renderer, lambda x: x['text']['simpleText'], compat_str)
-            if not text or text.lower() != 'show unavailable videos':
-                continue
-            browse_endpoint = try_get(
-                nav_item_renderer, lambda x: x['navigationEndpoint']['browseEndpoint'], dict) or {}
-            browse_id = browse_endpoint.get('browseId')
-            params = browse_endpoint.get('params')
-            break
+        if renderer:
+            menu_renderer = try_get(
+                renderer, lambda x: x['menu']['menuRenderer']['items'], list) or []
+            for menu_item in menu_renderer:
+                if not isinstance(menu_item, dict):
+                    continue
+                nav_item_renderer = menu_item.get('menuNavigationItemRenderer')
+                text = try_get(
+                    nav_item_renderer, lambda x: x['text']['simpleText'], compat_str)
+                if not text or text.lower() != 'show unavailable videos':
+                    continue
+                browse_endpoint = try_get(
+                    nav_item_renderer, lambda x: x['navigationEndpoint']['browseEndpoint'], dict) or {}
+                browse_id = browse_endpoint.get('browseId')
+                params = browse_endpoint.get('params')
+                break
 
-        ytcfg = self._extract_ytcfg(item_id, webpage)
-        headers = self._generate_api_headers(
-            ytcfg, account_syncid=self._extract_account_syncid(ytcfg),
-            identity_token=self._extract_identity_token(webpage, item_id=item_id),
-            visitor_data=try_get(
-                self._extract_context(ytcfg), lambda x: x['client']['visitorData'], compat_str))
-        query = {
-            'params': params or 'wgYCCAA=',
-            'browseId': browse_id or 'VL%s' % item_id
-        }
-        return self._extract_response(
-            item_id=item_id, headers=headers, query=query,
-            check_get_keys='contents', fatal=False,
-            note='Downloading API JSON with unavailable videos')
+            ytcfg = self._extract_ytcfg(item_id, webpage)
+            headers = self._generate_api_headers(
+                ytcfg, account_syncid=self._extract_account_syncid(ytcfg),
+                identity_token=self._extract_identity_token(webpage, item_id=item_id),
+                visitor_data=try_get(
+                    self._extract_context(ytcfg), lambda x: x['client']['visitorData'], compat_str))
+            query = {
+                'params': params or 'wgYCCAA=',
+                'browseId': browse_id or 'VL%s' % item_id
+            }
+            return self._extract_response(
+                item_id=item_id, headers=headers, query=query,
+                check_get_keys='contents', fatal=False,
+                note='Downloading API JSON with unavailable videos')
 
     def _extract_webpage(self, url, item_id):
         retries = self.get_param('extractor_retries', 3)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -647,8 +647,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def _extract_badges(self, renderer: dict):
         badges = set()
         for badge in try_get(renderer, lambda x: x['badges'], list) or []:
-            label = try_get(badge, lambda x: x['metadataBadgeRenderer']['label']) or ''
-            if label != '':
+            label = try_get(badge, lambda x: x['metadataBadgeRenderer']['label'], compat_str)
+            if label:
                 badges.add(label.lower())
         return badges
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [X] New feature

---

### Description of your *pull request* and other information

- Adds `availability` key support for playlists.
- Adds fallback for `is_unlisted` in `YouTubeIE` (related: #501) (Note: without `microformat` we won't be able to detect if a video is public since unlisted will be None)
 
Currently only supports public, unlisted and private availability forms for playlists. I'm not aware of any other examples of the other types.

Note: as of writing, the `public` availability is only possible when the playlist is a personal public playlist and auth is given.

TODO: 
- [X] Can probably add a test of some sort