### PR TITLE
[nebula] Support authentication via tokens from cookie jar

### DIFF
--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -2,9 +2,10 @@
 from __future__ import unicode_literals
 
 import json
+import time
 
 from .common import InfoExtractor
-from ..compat import compat_str, compat_urllib_parse_unquote
+from ..compat import compat_str, compat_urllib_parse_unquote, compat_urllib_parse_quote
 from ..utils import (
     ExtractorError,
     parse_iso8601,
@@ -111,6 +112,21 @@ class NebulaIE(InfoExtractor):
             errnote='Authentication failed or rejected')
         if not response or not response.get('key'):
             self.raise_login_required()
+        self._set_cookie(
+            'nebula.app',
+            'nebula-auth',
+            compat_urllib_parse_quote(
+              json.dumps(
+                {
+                  "apiToken":response["key"],
+                  "isLoggingIn":False,
+                  "isLoggingOut":False
+                },
+                separators=(",",":")
+              ),
+            ),
+            expire_time = int(time.time()) + 86400 * 365
+          )
         return response['key']
 
     def _retrieve_zype_api_key(self, page_url, display_id):

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import json
 
 from .common import InfoExtractor
-from ..compat import compat_str
+from ..compat import compat_str, compat_urllib_parse_unquote
 from ..utils import (
     ExtractorError,
     parse_iso8601,
@@ -85,6 +85,16 @@ class NebulaIE(InfoExtractor):
 
         username, password = self._get_login_info()
         if not (username and password):
+
+            # attempt auth via cookie jar
+            nebula_cookies = self._get_cookies('https://nebula.app')
+            nebula_cookie = nebula_cookies.get('nebula-auth')
+            if nebula_cookie:
+                self.to_screen('Authenticating to Nebula with credentials from cookie jar')
+                nebula_cookie_value = compat_urllib_parse_unquote(nebula_cookie.value)
+                nebula_token = self._parse_json(nebula_cookie_value, video_id).get('apiToken')
+                return nebula_token
+
             self.raise_login_required()
 
         self.report_login()

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -108,18 +108,13 @@ class NebulaIE(InfoExtractor):
 
         # save nebula token as cookie
         self._set_cookie(
-            'nebula.app',
-            'nebula-auth',
+            'nebula.app', 'nebula-auth',
             compat_urllib_parse_quote(
-                json.dumps(
-                    {
-                        "apiToken": response["key"],
-                        "isLoggingIn": False,
-                        "isLoggingOut": False,
-                    },
-                    separators=(",", ":")
-                ),
-            ),
+                json.dumps({
+                    "apiToken": response["key"],
+                    "isLoggingIn": False,
+                    "isLoggingOut": False,
+                }, separators=(",", ":"))),
             expire_time=int(time.time()) + 86400 * 365,
         )
 
@@ -230,13 +225,12 @@ class NebulaIE(InfoExtractor):
             'title': video_meta.get('title'),
             'description': video_meta.get('description'),
             'timestamp': parse_iso8601(video_meta.get('published_at')),
-            'thumbnails': [
-                {
-                    'id': tn.get('name'),  # this appears to be null
-                    'url': tn['url'],
-                    'width': tn.get('width'),
-                    'height': tn.get('height'),
-                } for tn in video_meta.get('thumbnails', [])],
+            'thumbnails': [{
+                'id': tn.get('name'),  # this appears to be null
+                'url': tn['url'],
+                'width': tn.get('width'),
+                'height': tn.get('height'),
+            } for tn in video_meta.get('thumbnails', [])],
             'duration': video_meta.get('duration'),
             'channel': channel_title,
             'uploader': channel_title,  # we chose uploader = channel name

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -79,30 +79,22 @@ class NebulaIE(InfoExtractor):
     ]
     _NETRC_MACHINE = 'watchnebula'
 
-    def _retrieve_nebula_auth(self, video_id):
+    _nebula_token = None
+
+    def _retrieve_nebula_auth(self):
         """
         Log in to Nebula, and returns a Nebula API token
         """
 
         username, password = self._get_login_info()
         if not (username and password):
-
-            # attempt auth via cookie jar
-            nebula_cookies = self._get_cookies('https://nebula.app')
-            nebula_cookie = nebula_cookies.get('nebula-auth')
-            if nebula_cookie:
-                self.to_screen('Authenticating to Nebula with credentials from cookie jar')
-                nebula_cookie_value = compat_urllib_parse_unquote(nebula_cookie.value)
-                nebula_token = self._parse_json(nebula_cookie_value, video_id).get('apiToken')
-                return nebula_token
-
             self.raise_login_required()
 
         self.report_login()
         data = json.dumps({'email': username, 'password': password}).encode('utf8')
         response = self._download_json(
             'https://api.watchnebula.com/api/v1/auth/login/',
-            data=data, fatal=False, video_id=video_id,
+            data=data, fatal=False, video_id=None,
             headers={
                 'content-type': 'application/json',
                 # Submitting the 'sessionid' cookie always causes a 403 on auth endpoint
@@ -112,21 +104,24 @@ class NebulaIE(InfoExtractor):
             errnote='Authentication failed or rejected')
         if not response or not response.get('key'):
             self.raise_login_required()
+
+        # save nebula token as cookie
         self._set_cookie(
             'nebula.app',
             'nebula-auth',
             compat_urllib_parse_quote(
-              json.dumps(
-                {
-                  "apiToken":response["key"],
-                  "isLoggingIn":False,
-                  "isLoggingOut":False
-                },
-                separators=(",",":")
-              ),
+                json.dumps(
+                    {
+                        "apiToken": response["key"],
+                        "isLoggingIn": False,
+                        "isLoggingOut": False,
+                    },
+                    separators=(",", ":")
+                ),
             ),
-            expire_time = int(time.time()) + 86400 * 365
-          )
+            expire_time=int(time.time()) + 86400 * 365,
+        )
+
         return response['key']
 
     def _retrieve_zype_api_key(self, page_url, display_id):
@@ -165,8 +160,8 @@ class NebulaIE(InfoExtractor):
             'Authorization': 'Token {access_token}'.format(access_token=access_token)
         }, note=note)
 
-    def _fetch_zype_access_token(self, video_id, nebula_token):
-        user_object = self._call_nebula_api('/auth/user/', video_id, nebula_token, note='Retrieving Zype access token')
+    def _fetch_zype_access_token(self, video_id):
+        user_object = self._call_nebula_api('/auth/user/', video_id, self._nebula_token, note='Retrieving Zype access token')
         access_token = try_get(user_object, lambda x: x['zype_auth_info']['access_token'], compat_str)
         if not access_token:
             if try_get(user_object, lambda x: x['is_subscribed'], bool):
@@ -188,9 +183,21 @@ class NebulaIE(InfoExtractor):
             if category.get('value'):
                 return category['value'][0]
 
+    def _real_initialize(self):
+        # check cookie jar for valid token
+        nebula_cookies = self._get_cookies('https://nebula.app')
+        nebula_cookie = nebula_cookies.get('nebula-auth')
+        if nebula_cookie:
+            self.to_screen('Authenticating to Nebula with token from cookie jar')
+            nebula_cookie_value = compat_urllib_parse_unquote(nebula_cookie.value)
+            self._nebula_token = self._parse_json(nebula_cookie_value, None).get('apiToken')
+
+        # try to authenticate using credentials if no valid token has been found
+        if not self._nebula_token:
+            self._nebula_token = self._retrieve_nebula_auth()
+
     def _real_extract(self, url):
         display_id = self._match_id(url)
-        nebula_token = self._retrieve_nebula_auth(display_id)
         api_key = self._retrieve_zype_api_key(url, display_id)
 
         response = self._call_zype_api('/videos', {'friendly_title': display_id},
@@ -200,7 +207,7 @@ class NebulaIE(InfoExtractor):
         video_meta = response['response'][0]
 
         video_id = video_meta['_id']
-        zype_access_token = self._fetch_zype_access_token(display_id, nebula_token=nebula_token)
+        zype_access_token = self._fetch_zype_access_token(display_id)
 
         channel_title = self._extract_channel_title(video_meta)
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Improvement

---

### Description of your *pull request* and other information

Main conversation on issue: https://github.com/yt-dlp/yt-dlp/issues/496

* Support authentication from cookie jar.
* Token from cookie is preferred, if no cookie present or expired, credentials auth is run against login endpoint (with credentials required in `.netrc` or supplied on command line).
* Token retrieved from login endpoint is stored in cookie jar, if available.
* [tentative] If token is rejected by Nebula backend, reauthentication with credentials is attempted.