### PR TITLE
add support for python interpreters compiled without sqlite3 support. fixes #544

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -27,7 +27,7 @@ try:
     SQLITE_AVAILABLE = True
 except ImportError:
     # although sqlite3 is part of the standard library, it is possible to compile python without
-    # sqlite support, in which case importing fails
+    # sqlite support. See: https://github.com/yt-dlp/yt-dlp/issues/544
     SQLITE_AVAILABLE = False
 
 

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -2,7 +2,6 @@ import ctypes
 import json
 import os
 import shutil
-import sqlite3
 import struct
 import subprocess
 import sys
@@ -22,6 +21,15 @@ from yt_dlp.utils import (
     process_communicate_or_kill,
     YoutubeDLCookieJar,
 )
+
+try:
+    import sqlite3
+    SQLITE_AVAILABLE = True
+except ImportError:
+    # although sqlite3 is part of the standard library, it is possible to compile python without
+    # sqlite support, in which case importing fails
+    SQLITE_AVAILABLE = False
+
 
 try:
     from Crypto.Cipher import AES
@@ -90,6 +98,10 @@ def extract_cookies_from_browser(browser_name, profile=None, logger=YDLLogger())
 
 def _extract_firefox_cookies(profile, logger):
     logger.info('Extracting cookies from firefox')
+    if not SQLITE_AVAILABLE:
+        logger.warning('Cannot extract cookies from firefox without sqlite3 support. '
+                       'Please use a python interpreter compiled with sqlite3 support')
+        return YoutubeDLCookieJar()
 
     if profile is None:
         search_root = _firefox_browser_dir()
@@ -195,6 +207,12 @@ def _get_chromium_based_browser_settings(browser_name):
 
 def _extract_chrome_cookies(browser_name, profile, logger):
     logger.info('Extracting cookies from {}'.format(browser_name))
+
+    if not SQLITE_AVAILABLE:
+        logger.warning(('Cannot extract cookies from {} without sqlite3 support. '
+                        'Please use a python interpreter compiled with sqlite3 support').format(browser_name))
+        return YoutubeDLCookieJar()
+
     config = _get_chromium_based_browser_settings(browser_name)
 
     if profile is None:


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Prevent crashing when running with a python interpreter compiled without sqlite3 support (see #544)