### PR TITLE
[mediaset] Fix #365

### DIFF
--- a/yt_dlp/extractor/mediaset.py
+++ b/yt_dlp/extractor/mediaset.py
@@ -30,20 +30,20 @@ class MediasetIE(ThePlatformBaseIE):
                     '''
     _TESTS = [{
         # full episode
-        'url': 'https://www.mediasetplay.mediaset.it/video/hellogoodbye/quarta-puntata_FAFU000000661824',
-        'md5': '9b75534d42c44ecef7bf1ffeacb7f85d',
+        'url': 'https://www.mediasetplay.mediaset.it/video/mrwronglezionidamore/episodio-1_F310575103000102',
+        'md5': 'a7e75c6384871f322adb781d3bd72c26',
         'info_dict': {
-            'id': 'FAFU000000661824',
+            'id': 'F310575103000102',
             'ext': 'mp4',
-            'title': 'Quarta puntata',
+            'title': 'Episodio 1',
             'description': 'md5:d41d8cd98f00b204e9800998ecf8427e',
             'thumbnail': r're:^https?://.*\.jpg$',
-            'duration': 1414.26,
-            'upload_date': '20161107',
-            'series': 'Hello Goodbye',
-            'timestamp': 1478532900,
-            'uploader': 'Rete 4',
-            'uploader_id': 'R4',
+            'duration': 2682.0,
+            'upload_date': '20210530',
+            'series': 'Mr Wrong - Lezioni d\'amore',
+            'timestamp': 1622413946,
+            'uploader': 'Canale 5',
+            'uploader_id': 'C5',
         },
     }, {
         'url': 'https://www.mediasetplay.mediaset.it/video/matrix/puntata-del-25-maggio_F309013801000501',
@@ -54,10 +54,10 @@ class MediasetIE(ThePlatformBaseIE):
             'title': 'Puntata del 25 maggio',
             'description': 'md5:d41d8cd98f00b204e9800998ecf8427e',
             'thumbnail': r're:^https?://.*\.jpg$',
-            'duration': 6565.007,
-            'upload_date': '20180526',
+            'duration': 6565.008,
+            'upload_date': '20200903',
             'series': 'Matrix',
-            'timestamp': 1527326245,
+            'timestamp': 1599172492,
             'uploader': 'Canale 5',
             'uploader_id': 'C5',
         },
@@ -135,36 +135,38 @@ class MediasetIE(ThePlatformBaseIE):
         formats = []
         subtitles = {}
         first_e = None
-        for asset_type in ('SD', 'HD'):
-            # TODO: fixup ISM+none manifest URLs
-            for f in ('MPEG4', 'MPEG-DASH+none', 'M3U+none'):
-                try:
-                    tp_formats, tp_subtitles = self._extract_theplatform_smil(
-                        update_url_query('http://link.theplatform.%s/s/%s' % (self._TP_TLD, tp_path), {
-                            'mbr': 'true',
-                            'formats': f,
-                            'assetTypes': asset_type,
-                        }), guid, 'Downloading %s %s SMIL data' % (f.split('+')[0], asset_type))
-                except ExtractorError as e:
-                    if not first_e:
-                        first_e = e
-                    break
-                for tp_f in tp_formats:
-                    tp_f['quality'] = 1 if asset_type == 'HD' else 0
-                formats.extend(tp_formats)
-                subtitles = self._merge_subtitles(subtitles, tp_subtitles)
+        asset_type = 'HD,browser,geoIT|SD,browser,geoIT|geoNo:HD,browser,geoIT|geoNo:SD,browser,geoIT|geoNo'
+        # TODO: fixup ISM+none manifest URLs
+        for f in ('MPEG4', 'MPEG-DASH+none', 'M3U+none'):
+            try:
+                tp_formats, tp_subtitles = self._extract_theplatform_smil(
+                    update_url_query('http://link.theplatform.%s/s/%s' % (self._TP_TLD, tp_path), {
+                        'mbr': 'true',
+                        'formats': f,
+                        'assetTypes': asset_type,
+                    }), guid, 'Downloading %s SMIL data' % (f.split('+')[0]))
+            except ExtractorError as e:
+                if not first_e:
+                    first_e = e
+                break
+            formats.extend(tp_formats)
+            subtitles = self._merge_subtitles(subtitles, tp_subtitles)
         if first_e and not formats:
             raise first_e
         self._sort_formats(formats)
 
-        fields = []
-        for templ, repls in (('tvSeason%sNumber', ('', 'Episode')), ('mediasetprogram$%s', ('brandTitle', 'numberOfViews', 'publishInfo'))):
-            fields.extend(templ % repl for repl in repls)
         feed_data = self._download_json(
-            'https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-all-programs/guid/-/' + guid,
-            guid, fatal=False, query={'fields': ','.join(fields)})
+            'https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-all-programs-v2/guid/-/' + guid,
+            guid, fatal=False)
         if feed_data:
             publish_info = feed_data.get('mediasetprogram$publishInfo') or {}
+            thumbnails = feed_data.get('thumbnails') or {}
+            thumbnail = None
+            for key, value in thumbnails.items():
+                if key.startswith('image_keyframe_poster-'):
+                    thumbnail = value.get('url')
+                    break
+
             info.update({
                 'episode_number': int_or_none(feed_data.get('tvSeasonEpisodeNumber')),
                 'season_number': int_or_none(feed_data.get('tvSeasonNumber')),
@@ -172,6 +174,7 @@ class MediasetIE(ThePlatformBaseIE):
                 'uploader': publish_info.get('description'),
                 'uploader_id': publish_info.get('channel'),
                 'view_count': int_or_none(feed_data.get('mediasetprogram$numberOfViews')),
+                'thumbnail': thumbnail,
             })
 
         info.update({


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement

---

### Description of your *pull request* and other information

As title, fixes #365 by creating cleaner http requests, more similar to the ones done by a web browser and not the ones done by apps or similar (where I think the previous method was taken)

- fixed video request
- fixed tests
- thumbnail extraction (can be improved)