### PR TITLE
[MxplayerIE]Add H265 format extraction.

### DIFF
--- a/yt_dlp/extractor/mxplayer.py
+++ b/yt_dlp/extractor/mxplayer.py
@@ -110,6 +110,11 @@ class MxplayerIE(InfoExtractor):
                 for frmt in dash_formats:
                     frmt['quality'] = get_quality(quality)
                 formats.extend(dash_formats)
+                dash_formats_h265 = self._extract_mpd_formats(
+                    format_url.replace('h264_high', 'h265_main'), video_id, mpd_id='dash-%s' % quality, headers={'Referer': url}, fatal=False)
+                for frmt in dash_formats_h265:
+                    frmt['quality'] = get_quality(quality)
+                formats.extend(dash_formats_h265)
             elif stream_type == 'hls':
                 formats.extend(self._extract_m3u8_formats(
                     format_url, video_id, fatal=False,

--- a/yt_dlp/extractor/mxplayer.py
+++ b/yt_dlp/extractor/mxplayer.py
@@ -118,7 +118,7 @@ class MxplayerIE(InfoExtractor):
             elif stream_type == 'hls':
                 formats.extend(self._extract_m3u8_formats(
                     format_url, video_id, fatal=False,
-                    m3u8_id='hls-%s' % quality, quality=get_quality(quality)))
+                    m3u8_id='hls-%s' % quality, quality=get_quality(quality), ext='mp4'))
 
         self._sort_formats(formats)
         return {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

```
[info] Available formats for 4b481d9c589e5aa4ea92bacc35949ebf:
ID                        EXT  RESOLUTION |   TBR  PROTO  | VCODEC             VBR  ACODEC     ABR  ASR    MORE INFO
------------------------- ---- ---------- - ------ ------ - ---------------- ------ --------- ---- ------- --------------------
hls-high-audio-stream_2-0 m3u8 audio only |        m3u8_n |                         unknown                stream_2
hls-high-audio-stream_2-1 m3u8 audio only |        m3u8_n |                         unknown                stream_2
dash-high-3-0             m4a  audio only |   67k  dash   |                         mp4a.40.2  67k 48000Hz DASH audio, m4a_dash
dash-high-4-0             m4a  audio only |   67k  dash   |                         mp4a.40.2  67k 48000Hz DASH audio, m4a_dash
dash-high-2-0             mp4  256x144    |  340k  dash   | avc1.640828       340k                         DASH video, mp4_dash
hls-high-353              mp4  256x144    |  353k  m3u8_n | avc1.640828       353k                         
dash-high-4-1             mp4  256x144    |  276k  dash   | hev1.1.6.L60.90   276k                         DASH video, mp4_dash
hls-high-446              mp4  320x180    |  446k  m3u8_n | avc1.640828       446k                         
dash-high-9-0             mp4  320x180    |  717k  dash   | avc1.640828       717k                         DASH video, mp4_dash
dash-high-5-0             mp4  320x180    |  580k  dash   | hev1.1.6.L60.90   580k                         DASH video, mp4_dash
hls-high-513              mp4  384x216    |  513k  m3u8_n | avc1.640828       513k                         
dash-high-7-0             mp4  384x216    |  846k  dash   | avc1.640828       846k                         DASH video, mp4_dash
dash-high-8-0             mp4  384x216    |  698k  dash   | hev1.1.6.L60.90   698k                         DASH video, mp4_dash
hls-high-611              mp4  480x270    |  611k  m3u8_n | avc1.640828       611k                         
dash-high-8-1             mp4  480x270    | 1057k  dash   | avc1.640828      1057k                         DASH video, mp4_dash
dash-high-6-0             mp4  480x270    |  902k  dash   | hev1.1.6.L63.90   902k                         DASH video, mp4_dash
hls-high-876              mp4  640x360    |  876k  m3u8_n | avc1.640828       876k                         
dash-high-10-0            mp4  640x360    | 1824k  dash   | avc1.640828      1824k                         DASH video, mp4_dash
dash-high-10-1            mp4  640x360    | 1414k  dash   | hev1.1.6.L63.90  1414k                         DASH video, mp4_dash
hls-high-1273             mp4  853x480    | 1273k  m3u8_n | avc1.640828      1273k                         
dash-high-5-1             mp4  854x480    | 2946k  dash   | avc1.640828      2946k                         DASH video, mp4_dash
dash-high-7-1             mp4  854x480    | 2045k  dash   | hev1.1.6.L90.90  2045k                         DASH video, mp4_dash
hls-high-2073             mp4  1280x720   | 2073k  m3u8_n | avc1.640828      2073k                         
dash-high-6-1             mp4  1280x720   | 5498k  dash   | avc1.640828      5498k                         DASH video, mp4_dash
dash-high-9-1             mp4  1280x720   | 3340k  dash   | hev1.1.6.L93.90  3340k                         DASH video, mp4_dash
hls-high-4821             mp4  1920x1080  | 4821k  m3u8_n | avc1.640828      4821k                         
dash-high-3-1             mp4  1920x1080  | 13843k dash   | avc1.640828      13843k                        DASH video, mp4_dash
dash-high-2-1             mp4  1920x1080  | 7298k  dash   | hev1.1.6.L120.90 7298k                         DASH video, mp4_dash

```