### PR TITLE
[youtube] Add age-unverified account age-gate bypass (EU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,7 +1356,7 @@ Some extractors accept additional arguments which can be passed using `--extract
 The following extractors use this feature:
 * **youtube**
     * `skip`: `hls` or `dash` (or both) to skip download of the respective manifests
-    * `player_client`: Clients to extract video data from. The main clients are `web`, `android`, `ios`, `mweb`. These also have `_music`, `_embedded`, `_agegate`, and `_creator` variants (Eg: `web_embedded`) (`mweb` has only `_agegate`). By default, `android,web` is used, but the agegate and creator variants are added as required for age-gated videos. Similarly the music variants are added for `music.youtube.com` urls.
+    * `player_client`: Clients to extract video data from. The main clients are `web`, `android`, `ios`, `mweb`. These also have `_music`, `_embedded`, `_agegate`, and `_creator` variants (Eg: `web_embedded`) (`mweb` has only `_agegate`). By default, `android,web` is used, but the agegate and creator variants are added as required for age-gated videos. Similarly the music variants are added for `music.youtube.com` urls. You can also use `all` to use all the clients
     * `player_skip`: `configs` - skip any requests for client configs and use defaults
     * `comment_sort`: `top` or `new` (default) - choose comment sorting mode (on YouTube's side).
     * `max_comments`: maximum amount of comments to download (default all).

--- a/README.md
+++ b/README.md
@@ -1356,7 +1356,7 @@ Some extractors accept additional arguments which can be passed using `--extract
 The following extractors use this feature:
 * **youtube**
     * `skip`: `hls` or `dash` (or both) to skip download of the respective manifests
-    * `player_client`: Clients to extract video data from - one or more of `web`, `android`, `ios`, `mweb`, `web_music`, `android_music`, `ios_music`, `web_embedded`, `android_embedded`, `ios_embedded`, `web_agegate`, `android_agegate`, `ios_agegate`, `mweb_agegate` or `all`. By default, `android,web` is used. If the URL is from `music.youtube.com`, `android,web,android_music,web_music` is used. If age-gate is detected, the `_agegate` variants are automatically added.
+    * `player_client`: Clients to extract video data from. The main clients are `web`, `android`, `ios`, `mweb`. These also have `_music`, `_embedded`, `_agegate`, and `_creator` variants (Eg: `web_embedded`) (`mweb` has only `_agegate`). By default, `android,web` is used, but the agegate and creator variants are added as required for age-gated videos. Similarly the music variants are added for `music.youtube.com` urls.
     * `player_skip`: `configs` - skip any requests for client configs and use defaults
     * `comment_sort`: `top` or `new` (default) - choose comment sorting mode (on YouTube's side).
     * `max_comments`: maximum amount of comments to download (default all).

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -100,6 +100,17 @@ INNERTUBE_CLIENTS = {
         },
         'INNERTUBE_CONTEXT_CLIENT_NAME': 67,
     },
+    'web_studio': {
+        'INNERTUBE_API_KEY': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
+        'INNERTUBE_HOST': 'studio.youtube.com',
+        'INNERTUBE_CONTEXT': {
+            'client': {
+                'clientName': 62,
+                'clientVersion': '1.20210621.00.00',
+            }
+        },
+        'INNERTUBE_CONTEXT_CLIENT_NAME': 1,
+    },
     'android': {
         'INNERTUBE_API_KEY': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
         'INNERTUBE_CONTEXT': {
@@ -2441,8 +2452,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 requested_clients.extend(allowed_clients)
             else:
                 self.report_warning(f'Skipping unsupported client {client}')
+
         if not requested_clients:
             requested_clients = ['android', 'web']
+
+            # Try web studio client if session cookies provided (bypass for "AGE_VERIFICATION_REQUIRED")
+            if self._get_cookies('https://www.youtube.com').get("__Secure-3PAPISID") is not None:
+                requested_clients.append("web_studio")
 
         if smuggled_data.get('is_music_url') or self.is_music_url(url):
             requested_clients.extend(

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2469,7 +2469,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 requested_clients.extend(allowed_clients)
             else:
                 self.report_warning(f'Skipping unsupported client {client}')
-
         if not requested_clients:
             requested_clients = ['android', 'web']
 
@@ -2498,7 +2497,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         original_clients = clients
         clients = clients[::-1]
-
         while clients:
             client = clients.pop()
             player_ytcfg = master_ytcfg if client == 'web' else {}

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2498,7 +2498,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         original_clients = clients
         clients = clients[::-1]
-        creator_client_appended = False
 
         while clients:
             client = clients.pop()
@@ -2521,7 +2520,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     client = '%s_creator' % client.remove_end('_agegate')
                 else:
                     client = f'{client}_agegate'
-                if bypass_client in INNERTUBE_CLIENTS and bypass_client not in original_clients:
+                if client in INNERTUBE_CLIENTS and client not in original_clients:
                     clients.append(client)
 
         # Android player_response does not have microFormats which are needed for

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2514,14 +2514,15 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 yield pr
 
             if self._is_agegated(pr):
-                client = f'{client}_agegate'
-                if client in INNERTUBE_CLIENTS and client not in original_clients:
+                if client.endswith('_agegate'):
+                    # _creator clients can bypass AGE_VERIFICATION_REQUIRED if logged in
+                    if not self._generate_sapisidhash_header():
+                        continue
+                    client = '%s_creator' % client.remove_end('_agegate')
+                else:
+                    client = f'{client}_agegate'
+                if bypass_client in INNERTUBE_CLIENTS and bypass_client not in original_clients:
                     clients.append(client)
-
-                # Try web creator (studio) client if session cookies provided (bypass for "AGE_VERIFICATION_REQUIRED")
-                if self._generate_sapisidhash_header() is not None and not creator_client_appended:
-                    clients.append("web_creator")
-                    creator_client_appended = True
 
         # Android player_response does not have microFormats which are needed for
         # extraction of some data. So we return the initial_pr with formats

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2475,7 +2475,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         if smuggled_data.get('is_music_url') or self.is_music_url(url):
             requested_clients.extend(
-                f'{client}_music' for client in requested_clients if not client.endswith('_music'))
+                f'{client}_music' for client in requested_clients if f'{client}_music' in INNERTUBE_CLIENTS)
 
         return orderedSet(requested_clients)
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2419,7 +2419,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'racyCheckOk': True
         }
 
-    def _is_agegated(self, player_response):
+    @staticmethod
+    def _is_agegated(player_response):
         if traverse_obj(player_response, ('playabilityStatus', 'desktopLegacyAgeGateReason')):
             return True
 
@@ -2432,8 +2433,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         )
         return any(expected in reason for expected in AGE_GATE_REASONS for reason in reasons)
 
-    def _is_unplayable(self, player_response):
-        return traverse_obj(player_response, ('playabilityStatus', 'status')) == "UNPLAYABLE"
+    @staticmethod
+    def _is_unplayable(player_response):
+        return traverse_obj(player_response, ('playabilityStatus', 'status')) == 'UNPLAYABLE'
 
     def _extract_player_response(self, client, video_id, master_ytcfg, player_ytcfg, identity_token, player_url, initial_pr):
 
@@ -2512,8 +2514,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 yield pr
 
             # _creator clients can bypass AGE_VERIFICATION_REQUIRED if logged in
-            if client.endswith("_agegate") and self._is_unplayable(pr) and self._generate_sapisidhash_header() is not None:
-                append_client(client.replace("_agegate", "_creator"))
+            if client.endswith('_agegate') and self._is_unplayable(pr) and self._generate_sapisidhash_header() is not None:
+                append_client(client.replace('_agegate', '_creator'))
             elif self._is_agegated(pr):
                 append_client(f'{client}_agegate')
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -141,6 +141,15 @@ INNERTUBE_CLIENTS = {
         },
         'INNERTUBE_CONTEXT_CLIENT_NAME': 21,
     },
+    'android_creator': {
+        'INNERTUBE_CONTEXT': {
+            'client': {
+                'clientName': 'ANDROID_CREATOR',
+                'clientVersion': '21.24.100',
+            },
+        },
+        'INNERTUBE_CONTEXT_CLIENT_NAME': 14
+    },
     # ios has HLS live streams
     # See: https://github.com/TeamNewPipe/NewPipeExtractor/issues/680
     'ios': {
@@ -173,6 +182,15 @@ INNERTUBE_CLIENTS = {
             },
         },
         'INNERTUBE_CONTEXT_CLIENT_NAME': 26
+    },
+    'ios_creator': {
+        'INNERTUBE_CONTEXT': {
+            'client': {
+                'clientName': 'IOS_CREATOR',
+                'clientVersion': '21.24.100',
+            },
+        },
+        'INNERTUBE_CONTEXT_CLIENT_NAME': 15
     },
     # mweb has 'ultralow' formats
     # See: https://github.com/yt-dlp/yt-dlp/pull/557

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2493,6 +2493,11 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         original_clients = clients
         clients = clients[::-1]
+
+        def append_client(client_name):
+            if client_name in INNERTUBE_CLIENTS and client_name not in original_clients:
+                clients.append(client_name)
+
         while clients:
             client = clients.pop()
             player_ytcfg = master_ytcfg if client == 'web' else {}
@@ -2505,10 +2510,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     client, video_id, player_ytcfg or master_ytcfg, player_ytcfg, identity_token, player_url, initial_pr))
             if pr:
                 yield pr
-
-            def append_client(client_name):
-                if client_name in INNERTUBE_CLIENTS and client_name not in original_clients:
-                    clients.append(client_name)
 
             # _creator clients can bypass AGE_VERIFICATION_REQUIRED if logged in
             if client.endswith("_agegate") and self._is_unplayable(pr) and self._generate_sapisidhash_header() is not None:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2428,8 +2428,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         AGE_GATE_REASONS = (
             'confirm your age', 'age-restricted', 'inappropriate',  # reason
             'age_verification_required', 'age_check_required',  # status
-            # If the agegate client gives this message, we should fallback to creator
-            'playback on other websites has been disabled',
         )
         return any(expected in reason for expected in AGE_GATE_REASONS for reason in reasons)
 
@@ -2513,8 +2511,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             if pr:
                 yield pr
 
-            # _creator clients can bypass AGE_VERIFICATION_REQUIRED if logged in
-            if client.endswith('_agegate') and self._is_unplayable(pr) and self._generate_sapisidhash_header() is not None:
+            # creator clients can bypass AGE_VERIFICATION_REQUIRED if logged in
+            if client.endswith('_agegate') and self._is_unplayable(pr) and self._generate_sapisidhash_header():
                 append_client(client.replace('_agegate', '_creator'))
             elif self._is_agegated(pr):
                 append_client(f'{client}_agegate')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Currently, age-restricted + non-embeddable videos do not work when trying to download them from the EU, because the `clientScreen`: `EMBED` bypass cannot be used for non-embeddable videos. Even with Cookies, users from the EU receive the `AGE_VERIFICATION_REQUIRED` status. Today I searched for more clientName's. I found the clientName `62`, which is used by YouTube Studio (Web). This client requires a user session, but no age verification. Furthermore, non-embeddable videos work.

Example Video from existing Unit Test: https://youtube.com/watch?v=Cr381pDsSsA (Test note: 'Non-bypassable age-gated video')

Without this bypass:

```
PS E:\repos\yt-dlp\yt_dlp> python __main__.py https://youtube.com/watch?v=Cr381pDsSsA --cookies "C:\Users\David\Downloads\youtube.com_cookies.txt"
[youtube] Cr381pDsSsA: Downloading webpage
[youtube] Cr381pDsSsA: Downloading android player API JSON
[youtube] Cr381pDsSsA: Downloading android agegate player API JSON
[youtube] Cr381pDsSsA: Downloading web agegate player API JSON
ERROR: Playback on other websites has been disabled by the video owner.
```

With this bypass:
```
PS E:\repos\yt-dlp\yt_dlp> python __main__.py https://youtube.com/watch?v=Cr381pDsSsA --cookies "C:\Users\David\Downloads\youtube.com_cookies.txt"
[youtube] Cr381pDsSsA: Downloading webpage
[youtube] Cr381pDsSsA: Downloading android player API JSON
[youtube] Cr381pDsSsA: Downloading android agegate player API JSON
[youtube] Cr381pDsSsA: Downloading web agegate player API JSON
[youtube] Cr381pDsSsA: Downloading web studio player API JSON
[info] Cr381pDsSsA: Downloading 1 format(s): 22
[download] Destination: Some Girls from Equestria have a Fall Formal Fuck-up [Cr381pDsSsA].mp4
[download]  18.2% of 219.63MiB at 12.23MiB/s ETA 00:14
```

Account Type: Age Unverified
Location: EU

The position where the bypass was implemented by me might be incorrect. I had some problems to understand the code. Feel free to correct this.