### PR TITLE
10Play: Add 'MA15+' as a valid age classification.

### DIFF
--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -41,6 +41,7 @@ class TenPlayIE(InfoExtractor):
         'PG': 15,
         'M': 15,
         'MA': 15,
+        'MA15+': 15,
         'R': 18,
         'X': 18
     }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

10Play appears to return 'MA15+' as an age classification on some shows. For example, see this log:

<details>

```
[debug] Command-line config: ['--username', 'PRIVATE', '--password', 'PRIVATE', 'https://10play.com.au/comedy/episodes/2021/nath-valvo-show-pony-live/tpv210221fnpws', '--verbose']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, pref UTF-8
[debug] yt-dlp version 2021.07.07 
[debug] Python version 3.9.5 (CPython 64bit) - Linux-4.14.24-qnap-x86_64-with
[debug] exe versions: ffmpeg 4.4, ffprobe 4.4
[debug] Proxy map: {}
[debug] [TenPlay] Extracting URL: https://10play.com.au/comedy/episodes/2021/nath-valvo-show-pony-live/tpv210221fnpws
[TenPlay] tpv210221fnpws: Getting bearer token
[TenPlay] tpv210221fnpws: Downloading JSON metadata
[TenPlay] tpv210221fnpws: Downloading video JSON
[TenPlay] tpv210221fnpws: Downloading webpage
[TenPlay] tpv210221fnpws: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
ERROR: An extractor error has occurred. (caused by KeyError('MA15+')); please report this issue on  https://github.com/yt-dlp/yt-dlp . Make sure you are using the latest version; see  https://github.com/yt-dlp/yt-dlp  on how to update. Be sure to call yt-dlp with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/yt_dlp/extractor/common.py", line 569, in extract
    ie_result = self._real_extract(url)
  File "/usr/lib/python3.9/site-packages/yt_dlp/extractor/tenplay.py", line 82, in _real_extract
    'age_limit': self._AUS_AGES[data.get('classification')],
KeyError: 'MA15+'
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/yt_dlp/extractor/common.py", line 569, in extract
    ie_result = self._real_extract(url)
  File "/usr/lib/python3.9/site-packages/yt_dlp/extractor/tenplay.py", line 82, in _real_extract
    'age_limit': self._AUS_AGES[data.get('classification')],
KeyError: 'MA15+'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 1142, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 1167, in __extract_info
    ie_result = ie.extract(url)
  File "/usr/lib/python3.9/site-packages/yt_dlp/extractor/common.py", line 588, in extract
    raise ExtractorError('An extractor error has occurred.', cause=e)
yt_dlp.utils.ExtractorError: An extractor error has occurred. (caused by KeyError('MA15+')); please report this issue on  https://github.com/yt-dlp/yt-dlp . Make sure you are using the latest version; see  https://github.com/yt-dlp/yt-dlp  on how to update. Be sure to call yt-dlp with the --verbose flag and include its complete output.
```

</details>

This PR adds `MA15+` as a valid age rating.