### PR TITLE
Fix VRV Extractor

### DIFF
--- a/yt_dlp/extractor/vrv.py
+++ b/yt_dlp/extractor/vrv.py
@@ -217,7 +217,7 @@ class VRVIE(VRVBaseIE):
                 })
 
         thumbnails = []
-        for thumbnail in video_data.get('images', {}).get('thumbnails', []):
+        for thumbnail in video_data.get('images', {}).get('thumbnail', [])[0]:
             thumbnail_url = thumbnail.get('source')
             if not thumbnail_url:
                 continue

--- a/yt_dlp/extractor/vrv.py
+++ b/yt_dlp/extractor/vrv.py
@@ -19,6 +19,7 @@ from ..utils import (
     ExtractorError,
     float_or_none,
     int_or_none,
+    traverse_obj,
 )
 
 
@@ -217,7 +218,7 @@ class VRVIE(VRVBaseIE):
                 })
 
         thumbnails = []
-        for thumbnail in video_data.get('images', {}).get('thumbnail', [])[0]:
+        for thumbnail in traverse_obj(video_data, ('images', 'thumbnail', ..., ...)):
             thumbnail_url = thumbnail.get('source')
             if not thumbnail_url:
                 continue


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The VRV CMS API seems to have changed slightly since the release of the module, and the thumbnail part of the extractor has stopped working. The `video_data` now looks like [this.](https://gist.github.com/funniray/70edeed626ac98032b1a6ef74704e4a6)  
It appears that there may be able to be multiple thumbnails, however I was unable to find any episodes that have multiple thumbnails.
