### PR TITLE
Revert erroneous use of the Content-Length header

### DIFF
--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -238,7 +238,7 @@ class HttpFD(FileDownloader):
             while True:
                 try:
                     # Download and write
-                    data_block = ctx.data.read(block_size if data_len is None else min(block_size, data_len - byte_counter))
+                    data_block = ctx.data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
                 # socket.timeout is a subclass of socket.error but may not have
                 # errno set
                 except socket.timeout as e:


### PR DESCRIPTION
<details>
<summary>Boilerplate (not own code, bug fix)</summary>

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- **I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)**

### What is the purpose of your *pull request*?
- **Bug fix**
</details>

The commit reverted here uses the value obtained from the `Content-Length` header to determine the length of data that will be downloaded in the HTTP request. The problem with this is that `Content-Length` is the size of the data *after* it has been processed by the encoding scheme specified in the `Content-Encoding` header, not of the raw bytestream, while the `urllib` library undoes the encoding transparently and operates on the decoded bytestream. (<https://stackoverflow.com/a/3819303/> contains references to the relevant specifications.) If the encoded length is smaller than the raw data length (e.g. when `Content-Encoding: gzip` does its job well), this results in a truncated download.

This bug probably wasn’t hit very often, for multiple reasons:
- gzip compression is usually used as `Transfer-Encoding` and not `Content-Encoding`, and the former has no bearing on `Content-Length`;
- multimedia data that have already been processed by a lossy codec don’t compress well, so gzip compression is usually ineffective;
- non-multimedia endpoints requested by yt-dlp (e.g. HTML and JSON pages) tend to be dynamically generated, and the response bodies for those don’t usually contain a `Content-Length` header.

Nevertheless, this issue has been implicated in <https://github.com/yt-dlp/yt-dlp/issues/631#issuecomment-893338552>, and may have led to silent data corruption in other places. It is only thanks to a strict WebVTT parser that this issue has been noticed. (It does [pay off to be strict](https://datatracker.ietf.org/doc/html/draft-iab-protocol-maintenance-05#section-7), it seems.)

Other uses of the `data_len` variable may need to be audited as well, to ensure it’s not assumed to exactly correspond to the raw bytestream length elsewhere where it matters (mere uses in the UI may be tolerable).