### PR TITLE
[youtube:api] Extract error messages from HTTPError response

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -38,6 +38,7 @@ from ..utils import (
     format_field,
     int_or_none,
     intlist_to_bytes,
+    is_html,
     mimetype2ext,
     network_exceptions,
     orderedSet,
@@ -793,7 +794,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                     note='%s%s' % (note, ' (retry #%d)' % count if count else ''))
             except ExtractorError as e:
                 if isinstance(e.cause, network_exceptions):
-                    if isinstance(e.cause, compat_HTTPError):
+                    if isinstance(e.cause, compat_HTTPError) and not is_html(e.cause.read(512)):
+                        e.cause.seek(0)
                         yt_error = try_get(
                             self._parse_json(e.cause.read().decode(), item_id, fatal=False),
                             lambda x: x['error']['message'], compat_str)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -795,9 +795,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 if isinstance(e.cause, network_exceptions):
                     if isinstance(e.cause, compat_HTTPError):
                         yt_error = try_get(
-                            self._parse_json(e.cause.read(), item_id, fatal=False),
+                            self._parse_json(e.cause.read().decode(), item_id, fatal=False),
                             lambda x: x['error']['message'], compat_str)
-                        e.cause.seek(0)
                         if yt_error:
                             self._report_alerts([('ERROR', yt_error)], fatal=False)
                     # Downloading page may result in intermittent 5xx HTTP error

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -723,11 +723,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 if message:
                     yield alert_type, message
 
-    def _report_alerts(self, alerts, expected=True):
+    def _report_alerts(self, alerts, expected=True, fatal=True):
         errors = []
         warnings = []
         for alert_type, alert_message in alerts:
-            if alert_type.lower() == 'error':
+            if alert_type.lower() == 'error' and fatal:
                 errors.append([alert_type, alert_message])
             else:
                 warnings.append([alert_type, alert_message])
@@ -797,6 +797,13 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                     # Sometimes a 404 is also recieved. See: https://github.com/ytdl-org/youtube-dl/issues/28289
                     # We also want to catch all other network exceptions since errors in later pages can be troublesome
                     # See https://github.com/yt-dlp/yt-dlp/issues/507#issuecomment-880188210
+                    if isinstance(e.cause, compat_HTTPError):
+                        yt_error = try_get(
+                            self._parse_json(e.cause.file.read(), item_id, fatal=False),
+                            lambda x: x['error']['message'], compat_str)
+                        if yt_error:
+                            self._report_alerts([('ERROR', yt_error)], fatal=False)
+
                     if not isinstance(e.cause, compat_HTTPError) or e.cause.code not in (403, 429):
                         last_error = error_to_compat_str(e.cause or e)
                         if count < retries:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

The Innertube API appears to give useful error messages in the response payload for an HTTP Error. So, this PR attempts to extract such error and raise a warning. This might be useful for debugging future issues relating to the API.

The current implementation is to report the error as a non-fatal alert.

Example:
```
$ yt-dlp --flat-playlist ytsearchall:youtube-dl
[download] Downloading playlist: youtube-dl
[youtube:search] query "youtube-dl" page 1: Downloading API JSON
WARNING: [youtube:search] YouTube said: ERROR - API key not valid. Please pass a valid API key.
WARNING: [youtube:search] HTTP Error 400: Bad Request. Retrying ...
[youtube:search] query "youtube-dl" page 1: Downloading API JSON (retry #1)
WARNING: [youtube:search] YouTube said: ERROR - API key not valid. Please pass a valid API key.
WARNING: [youtube:search] HTTP Error 400: Bad Request. Retrying ...
[youtube:search] query "youtube-dl" page 1: Downloading API JSON (retry #2)
WARNING: [youtube:search] YouTube said: ERROR - API key not valid. Please pass a valid API key.
WARNING: [youtube:search] HTTP Error 400: Bad Request. Retrying ...
[youtube:search] query "youtube-dl" page 1: Downloading API JSON (retry #3)
WARNING: [youtube:search] YouTube said: ERROR - API key not valid. Please pass a valid API key.
ERROR: Unable to download API page: HTTP Error 400: Bad Request (caused by <HTTPError 400: 'Bad Request'>); please report this issue on  https://github.com/yt-dlp/yt-dlp . Make sure you are using the latest version; see  https://github.com/yt-dlp/yt-dlp  on how to update. Be sure to call yt-dlp with the --verbose flag and include its complete output.
[youtube:search] playlist youtube-dl: Downloading 0 videos
[download] Finished downloading playlist: youtube-dl
```

TODO:
- [ ] Catch possible errors that can arise from reading/seeking the file object
- [ ] Test other errors (rate-limit behaviour)?
