### PR TITLE
[mirrativ] add support for mirrativ.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The major new features from the latest release of [blackjack4494/yt-dlc](https:/
 
 * **Aria2c with HLS/DASH**: You can use `aria2c` as the external downloader for DASH(mpd) and HLS(m3u8) formats
 
-* **New extractors**: AnimeLab, Philo MSO, Spectrum MSO, SlingTV MSO, Rcs, Gedi, bitwave.tv, mildom, audius, zee5, mtv.it, wimtv, pluto.tv, niconico users, discoveryplus.in, mediathek, NFHSNetwork, nebula, ukcolumn, whowatch, MxplayerShow, parlview (au), YoutubeWebArchive, fancode, Saitosan, ShemarooMe, telemundo, VootSeries, SonyLIVSeries, HotstarSeries, VidioPremier, VidioLive, RCTIPlus, TBS Live, douyin, pornflip, ParamountPlusSeries, ScienceChannel, Utreon, OpenRec
+* **New extractors**: AnimeLab, Philo MSO, Spectrum MSO, SlingTV MSO, Rcs, Gedi, bitwave.tv, mildom, audius, zee5, mtv.it, wimtv, pluto.tv, niconico users, discoveryplus.in, mediathek, NFHSNetwork, nebula, ukcolumn, whowatch, MxplayerShow, parlview (au), YoutubeWebArchive, fancode, Saitosan, ShemarooMe, telemundo, VootSeries, SonyLIVSeries, HotstarSeries, VidioPremier, VidioLive, RCTIPlus, TBS Live, douyin, pornflip, ParamountPlusSeries, ScienceChannel, Utreon, OpenRec, Mirrativ
 
 * **Fixed/improved extractors**: archive.org, roosterteeth.com, skyit, instagram, itv, SouthparkDe, spreaker, Vlive, akamai, ina, rumble, tennistv, amcnetworks, la7 podcasts, linuxacadamy, nitter, twitcasting, viu, crackle, curiositystream, mediasite, rmcdecouverte, sonyliv, tubi, tenplay, patreon, videa, yahoo, BravoTV, crunchyroll playlist, RTP, viki, Hotstar, vidio, vimeo, mediaset, Mxplayer
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The major new features from the latest release of [blackjack4494/yt-dlc](https:/
 
 * **Aria2c with HLS/DASH**: You can use `aria2c` as the external downloader for DASH(mpd) and HLS(m3u8) formats
 
-* **New extractors**: AnimeLab, Philo MSO, Spectrum MSO, SlingTV MSO, Rcs, Gedi, bitwave.tv, mildom, audius, zee5, mtv.it, wimtv, pluto.tv, niconico users, discoveryplus.in, mediathek, NFHSNetwork, nebula, ukcolumn, whowatch, MxplayerShow, parlview (au), YoutubeWebArchive, fancode, Saitosan, ShemarooMe, telemundo, VootSeries, SonyLIVSeries, HotstarSeries, VidioPremier, VidioLive, RCTIPlus, TBS Live, douyin, pornflip, ParamountPlusSeries, ScienceChannel, Utreon, OpenRec, Mirrativ
+* **New extractors**: AnimeLab, Philo MSO, Spectrum MSO, SlingTV MSO, Rcs, Gedi, bitwave.tv, mildom, audius, zee5, mtv.it, wimtv, pluto.tv, niconico users, discoveryplus.in, mediathek, NFHSNetwork, nebula, ukcolumn, whowatch, MxplayerShow, parlview (au), YoutubeWebArchive, fancode, Saitosan, ShemarooMe, telemundo, VootSeries, SonyLIVSeries, HotstarSeries, VidioPremier, VidioLive, RCTIPlus, TBS Live, douyin, pornflip, ParamountPlusSeries, ScienceChannel, Utreon, OpenRec
 
 * **Fixed/improved extractors**: archive.org, roosterteeth.com, skyit, instagram, itv, SouthparkDe, spreaker, Vlive, akamai, ina, rumble, tennistv, amcnetworks, la7 podcasts, linuxacadamy, nitter, twitcasting, viu, crackle, curiositystream, mediasite, rmcdecouverte, sonyliv, tubi, tenplay, patreon, videa, yahoo, BravoTV, crunchyroll playlist, RTP, viki, Hotstar, vidio, vimeo, mediaset, Mxplayer
 

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -735,6 +735,10 @@ from .minds import (
 from .ministrygrid import MinistryGridIE
 from .minoto import MinotoIE
 from .miomio import MioMioIE
+from .mirrativ import (
+    MirrativIE,
+    MirrativUserIE,
+)
 from .mit import TechTVMITIE, OCWMITIE
 from .mitele import MiTeleIE
 from .mixcloud import (

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -30,7 +30,7 @@ class MirrativIE(MirrativBaseIE):
         live_response = self._download_json(self.LIVE_API_URL % video_id, video_id)
         self.assert_error(live_response)
 
-        hls_url = live_response.get('archive_url_hls') or live_response.get('streaming_url_hls')
+        hls_url = traverse_obj(live_response, 'archive_url_hls', 'streaming_url_hls')
         is_live = bool(live_response.get('is_live'))
         was_live = bool(live_response.get('is_archive'))
         if not hls_url:

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -38,7 +38,7 @@ class MirrativIE(MirrativBaseIE):
 
         formats = self._extract_m3u8_formats(
             hls_url, video_id,
-            ext='mp4', entry_protocol='m3u8',
+            ext='mp4', entry_protocol='m3u8_native',
             m3u8_id='hls', live=is_live)
         rtmp_url = live_response.get('streaming_url_edge')
         if rtmp_url:

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -1,0 +1,137 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    ExtractorError,
+    traverse_obj,
+)
+
+
+class MirrativBaseIE(InfoExtractor):
+    def assert_error(self, response):
+        error_message = traverse_obj(response, ('status', 'error'))
+        if error_message:
+            raise ExtractorError('Mirrativ says: %s' % error_message, expected=True)
+
+
+class MirrativIE(MirrativBaseIE):
+    IE_NAME = 'mirrativ'
+    _VALID_URL = r'https?://(?:www\.)?mirrativ\.com/live/(?P<id>[^/?#&]+)'
+    LIVE_API_URL = 'https://www.mirrativ.com/api/live/live?live_id=%s'
+
+    TESTS = [{
+        'url': 'https://mirrativ.com/live/POxyuG1KmW2982lqlDTuPw',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage('https://www.mirrativ.com/live/%s' % video_id, video_id)
+        live_response = self._download_json(self.LIVE_API_URL % video_id, video_id)
+        self.assert_error(live_response)
+
+        hls_url = live_response.get('archive_url_hls') or live_response.get('streaming_url_hls')
+        is_live = bool(live_response.get('is_live'))
+        was_live = bool(live_response.get('is_archive'))
+        if not hls_url:
+            raise ExtractorError('Neither archive nor live is available.', expected=True)
+
+        formats = self._extract_m3u8_formats(
+            hls_url, video_id,
+            ext='mp4', entry_protocol='m3u8',
+            m3u8_id='hls', live=is_live)
+        rtmp_url = live_response.get('streaming_url_edge')
+        if rtmp_url:
+            keys_to_copy = ('width', 'height', 'vcodec', 'acodec', 'tbr')
+            fmt = {
+                'format_id': 'rtmp',
+                'url': rtmp_url,
+                'protocol': 'rtmp',
+                'ext': 'mp4',
+            }
+            fmt.update({k: traverse_obj(formats, (0, k)) for k in keys_to_copy})
+            formats.append(fmt)
+        self._sort_formats(formats)
+
+        title = self._og_search_title(webpage, default=None) or self._search_regex(
+            r'<title>\s*(.+?) - Mirrativ\s*</title>', webpage) or live_response.get('title')
+        description = live_response.get('description')
+        thumbnail = live_response.get('image_url')
+
+        if live_response.get('started_at') and live_response.get('ended_at'):
+            duration = live_response.get('ended_at') - live_response.get('started_at')
+        else:
+            duration = None
+        view_count = live_response.get('total_viewer_num')
+        release_timestamp = live_response.get('started_at')
+        timestamp = live_response.get('created_at')
+
+        owner = live_response.get('owner', {})
+        uploader = owner.get('name')
+        uploader_id = owner.get('user_id')
+
+        return {
+            'id': video_id,
+            'title': title,
+            'is_live': is_live,
+            'description': description,
+            'formats': formats,
+            'thumbnail': thumbnail,
+            'uploader': uploader,
+            'uploader_id': uploader_id,
+            'duration': duration,
+            'view_count': view_count,
+            'release_timestamp': release_timestamp,
+            'timestamp': timestamp,
+            'was_live': was_live,
+        }
+
+
+class MirrativUserIE(MirrativBaseIE):
+    IE_NAME = 'mirrativ:user'
+    _VALID_URL = r'https?://(?:www\.)?mirrativ\.com/user/(?P<id>\d+)'
+    LIVE_HISTORY_API_URL = 'https://www.mirrativ.com/api/live/live_history?user_id=%s&page=%d'
+    USER_INFO_API_URL = 'https://www.mirrativ.com/api/user/profile?user_id=%s'
+
+    _TESTS = [{
+        # Live archive is available up to 3 days
+        # see: https://helpfeel.com/mirrativ/%E9%8C%B2%E7%94%BB-5e26d3ad7b59ef0017fb49ac (Japanese)
+        'url': 'https://www.mirrativ.com/user/110943130',
+        'note': 'multiple archives available',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        user_id = self._match_id(url)
+        user_info = self._download_json(
+            self.USER_INFO_API_URL % user_id, user_id,
+            note='Downloading user info', fatal=False)
+        self.assert_error(user_info)
+
+        if user_info:
+            uploader, description = user_info.get('name'), user_info.get('description')
+        else:
+            uploader, description = [None] * 2
+
+        entries = []
+        page = 1
+        while page is not None:
+            api_response = self._download_json(
+                self.LIVE_HISTORY_API_URL % (user_id, page), user_id,
+                note='Downloading page %d' % page)
+            self.assert_error(api_response)
+            lives = api_response.get('lives')
+            if not lives:
+                break
+            for live in lives:
+                # !(live.is_archive || live.is_live) === !live.is_archive && !live.is_live
+                if not live.get('is_archive') and not live.get('is_live'):
+                    # neither archive nor live is available, so skip it
+                    # or the service will ban your IP address for a while
+                    continue
+                live_id = live.get('live_id')
+                url = 'https://www.mirrativ.com/live/%s' % live_id
+                entries.append(self.url_result(url, 'Mirrativ', live_id, live.get('title')))
+            page = api_response.get('next_page')
+
+        return self.playlist_result(entries, user_id, uploader, description)

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -103,7 +103,6 @@ class MirrativUserIE(MirrativBaseIE):
     def _entries(self, user_id):
         page = 1
         while page is not None:
-            print(page)
             api_response = self._download_json(
                 self.LIVE_HISTORY_API_URL % (user_id, page), user_id,
                 note='Downloading page %d' % page)

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -5,6 +5,7 @@ from ..utils import (
     ExtractorError,
     dict_get,
     traverse_obj,
+    try_get,
 )
 
 
@@ -57,10 +58,7 @@ class MirrativIE(MirrativBaseIE):
         description = live_response.get('description')
         thumbnail = live_response.get('image_url')
 
-        if live_response.get('started_at') and live_response.get('ended_at'):
-            duration = live_response.get('ended_at') - live_response.get('started_at')
-        else:
-            duration = None
+        duration = try_get(live_response, lambda x: x['ended_at'] - x['started_at'])
         view_count = live_response.get('total_viewer_num')
         release_timestamp = live_response.get('started_at')
         timestamp = live_response.get('created_at')

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
-    InAdvancePagedList,
+    dict_get,
     traverse_obj,
 )
 
@@ -31,7 +31,7 @@ class MirrativIE(MirrativBaseIE):
         live_response = self._download_json(self.LIVE_API_URL % video_id, video_id)
         self.assert_error(live_response)
 
-        hls_url = traverse_obj(live_response, 'archive_url_hls', 'streaming_url_hls')
+        hls_url = dict_get(live_response, ('archive_url_hls', 'streaming_url_hls'))
         is_live = bool(live_response.get('is_live'))
         was_live = bool(live_response.get('is_archive'))
         if not hls_url:
@@ -101,6 +101,7 @@ class MirrativUserIE(MirrativBaseIE):
     }]
 
     def _entries(self, user_id):
+        page = 1
         while page is not None:
             print(page)
             api_response = self._download_json(

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -108,10 +108,8 @@ class MirrativUserIE(MirrativBaseIE):
             note='Downloading user info', fatal=False)
         self.assert_error(user_info)
 
-        if user_info:
-            uploader, description = user_info.get('name'), user_info.get('description')
-        else:
-            uploader, description = [None] * 2
+        uploader = user_info.get('name')
+        description = user_info.get('description')
 
         entries = []
         page = 1

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -50,7 +50,8 @@ class MirrativIE(MirrativBaseIE):
                 'url': rtmp_url,
                 'protocol': 'rtmp',
                 'ext': 'mp4',
-            } | {k: traverse_obj(formats, (0, k)) for k in keys_to_copy})
+                **{k: traverse_obj(formats, (0, k)) for k in keys_to_copy},
+            })
         self._sort_formats(formats)
 
         title = self._og_search_title(webpage, default=None) or self._search_regex(
@@ -109,7 +110,6 @@ class MirrativUserIE(MirrativBaseIE):
             if not lives:
                 break
             for live in lives:
-                # !(live.is_archive || live.is_live) === !live.is_archive && !live.is_live
                 if not live.get('is_archive') and not live.get('is_live'):
                     # neither archive nor live is available, so skip it
                     # or the service will ban your IP address for a while

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -43,14 +43,12 @@ class MirrativIE(MirrativBaseIE):
         rtmp_url = live_response.get('streaming_url_edge')
         if rtmp_url:
             keys_to_copy = ('width', 'height', 'vcodec', 'acodec', 'tbr')
-            fmt = {
+            formats.append({
                 'format_id': 'rtmp',
                 'url': rtmp_url,
                 'protocol': 'rtmp',
                 'ext': 'mp4',
-            }
-            fmt.update({k: traverse_obj(formats, (0, k)) for k in keys_to_copy})
-            formats.append(fmt)
+            } | {k: traverse_obj(formats, (0, k)) for k in keys_to_copy})
         self._sort_formats(formats)
 
         title = self._og_search_title(webpage, default=None) or self._search_regex(

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -45,13 +45,14 @@ class MirrativIE(MirrativBaseIE):
         rtmp_url = live_response.get('streaming_url_edge')
         if rtmp_url:
             keys_to_copy = ('width', 'height', 'vcodec', 'acodec', 'tbr')
-            formats.append({
+            fmt = {
                 'format_id': 'rtmp',
                 'url': rtmp_url,
                 'protocol': 'rtmp',
                 'ext': 'mp4',
-                **{k: traverse_obj(formats, (0, k)) for k in keys_to_copy},
-            })
+            }
+            fmt.update({k: traverse_obj(formats, (0, k)) for k in keys_to_copy})
+            formats.append(fmt)
         self._sort_formats(formats)
 
         title = self._og_search_title(webpage, default=None) or self._search_regex(

--- a/yt_dlp/extractor/mirrativ.py
+++ b/yt_dlp/extractor/mirrativ.py
@@ -129,7 +129,7 @@ class MirrativUserIE(MirrativBaseIE):
                     continue
                 live_id = live.get('live_id')
                 url = 'https://www.mirrativ.com/live/%s' % live_id
-                entries.append(self.url_result(url, 'Mirrativ', live_id, live.get('title')))
+                entries.append(self.url_result(url, video_id=live_id, video_title=live.get('title')))
             page = api_response.get('next_page')
 
         return self.playlist_result(entries, user_id, uploader, description)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

Note that the code is taken from [my fork](https://github.com/ytdl-patched/ytdl-patched/blob/ytdlp/yt_dlp/extractor/mirrativ.py), which is my own work.

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR adds support for mirrativ.com, which is a streaming service in Japan.

example URL for live: https://www.mirrativ.com/live/xvbjsvT96UFjkPqaRj9ajg (running as of writing, but you can find new one at https://mirrativ.com/ )
example URL for user: https://www.mirrativ.com/user/7077880