### PR TITLE
[eroprofile] fix page skipping in albums

### DIFF
--- a/yt_dlp/extractor/eroprofile.py
+++ b/yt_dlp/extractor/eroprofile.py
@@ -113,12 +113,15 @@ class EroProfileAlbumIE(InfoExtractor):
     def _entries(self, playlist_id, first_page):
         yield from self._extract_from_page(first_page)
 
+        # using the url of the last page, find the biggest page number
         page_urls = re.findall(rf'href=".*?(/m/videos/album/{playlist_id}\?pnum=(\d+))"', first_page)
+        max_page = max(int(n) for _, n in page_urls)
 
-        for url, n in page_urls[1:]:
-            yield from self._extract_from_page(self._download_webpage(
-                f'https://www.eroprofile.com{url}',
-                playlist_id, note=f'Downloading playlist page {int(n) - 1}'))
+        for n in range(2, max_page + 1):
+            url = f"https://www.eroprofile.com/m/videos/album/{playlist_id}?pnum={n}"
+            yield from self._extract_from_page(
+                    self._download_webpage(url, playlist_id,
+                                           note=f'Downloading playlist page {int(n) - 1}'))
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)

--- a/yt_dlp/extractor/eroprofile.py
+++ b/yt_dlp/extractor/eroprofile.py
@@ -120,8 +120,8 @@ class EroProfileAlbumIE(InfoExtractor):
         for n in range(2, max_page + 1):
             url = f"https://www.eroprofile.com/m/videos/album/{playlist_id}?pnum={n}"
             yield from self._extract_from_page(
-                    self._download_webpage(url, playlist_id,
-                                           note=f'Downloading playlist page {int(n) - 1}'))
+                self._download_webpage(url, playlist_id,
+                                       note=f'Downloading playlist page {int(n) - 1}'))
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)

--- a/yt_dlp/extractor/eroprofile.py
+++ b/yt_dlp/extractor/eroprofile.py
@@ -113,7 +113,6 @@ class EroProfileAlbumIE(InfoExtractor):
     def _entries(self, playlist_id, first_page):
         yield from self._extract_from_page(first_page)
 
-        # using the url of the last page, find the biggest page number
         page_urls = re.findall(rf'href=".*?(/m/videos/album/{playlist_id}\?pnum=(\d+))"', first_page)
         max_page = max(int(n) for _, n in page_urls)
 

--- a/yt_dlp/extractor/eroprofile.py
+++ b/yt_dlp/extractor/eroprofile.py
@@ -118,7 +118,7 @@ class EroProfileAlbumIE(InfoExtractor):
         max_page = max(int(n) for _, n in page_urls)
 
         for n in range(2, max_page + 1):
-            url = f"https://www.eroprofile.com/m/videos/album/{playlist_id}?pnum={n}"
+            url = f'https://www.eroprofile.com/m/videos/album/{playlist_id}?pnum={n}'
             yield from self._extract_from_page(
                 self._download_webpage(url, playlist_id,
                                        note=f'Downloading playlist page {int(n) - 1}'))


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix

---

### Description of your *pull request* and other information

It seems that the refactor done to my code in #658  skips pages. Running the test fails on current master:
```
[EroProfile:album] ...: Downloading playlist page 1
[EroProfile:album] ...: Downloading playlist page 2
[EroProfile:album] ...: Downloading playlist page 3
[...]
[EroProfile:album] ...: Downloading playlist page 8
[EroProfile:album] ...: Downloading playlist page 1
[EroProfile:album] ...: Downloading playlist page 27
[info] Writing playlist metadata as JSON to: ...

AssertionError: False is not true : Expected at least 486 in playlist, but got only 193

```

This seems to happen, because the new code presumes all page links are on page one. However, this is is not the case. Instead, page one contains a couple pages near it, but then "Next" and "Last" buttons.

This PR restores the original behavior: use the links to find the _last page number_, and then iterate all the way to it by generating the page URLs.