### PR TITLE
[trovo] [trivial] replace tab character with space

### DIFF
--- a/yt_dlp/extractor/trovo.py
+++ b/yt_dlp/extractor/trovo.py
@@ -36,7 +36,7 @@ class TrovoIE(TrovoBaseIE):
                 'query': '''{
   getLiveInfo(params: {userName: "%s"}) {
     isLive
-    programInfo	{
+    programInfo {
       coverUrl
       id
       streamInfo {


### PR DESCRIPTION
Replace 1 tab character `\x09` with space `\x20`.