### PR TITLE
[adobepass] Fix Verizon SAML login error

### DIFF
--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1509,7 +1509,7 @@ class AdobePassIE(InfoExtractor):
                     # you will not actually pass your credentials.
                     provider_redirect_page, urlh = provider_redirect_page_res
                     # From non-Verizon IP, still gave 'Please wait', but noticed N==Y; will need to try on Verizon IP
-                    if 'Please wait ...' in provider_redirect_page and "'N'== \"Y\"" not in provider_redirect_page:
+                    if 'Please wait ...' in provider_redirect_page and '\'N\'== "Y"' not in provider_redirect_page:
                         saml_redirect_url = self._html_search_regex(
                             r'self\.parent\.location=(["\'])(?P<url>.+?)\1',
                             provider_redirect_page,

--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1529,7 +1529,6 @@ class AdobePassIE(InfoExtractor):
                             raise ExtractorError(
                                 'We\'re sorry, but either the User ID or Password entered is not correct.')
                     else:
-                        # elif 'Please wait ...' in provider_redirect_page and "'N'== \"Y\"" in provider_redirect_page:
                         # ABC from non-Verizon IP
                         saml_redirect_url = self._html_search_regex(
                             r'var\surl\s*=\s*(["\'])(?P<url>.+?)\1',

--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1541,15 +1541,14 @@ class AdobePassIE(InfoExtractor):
                         saml_login_page = self._download_webpage(
                             saml_redirect_url, video_id,
                             'Downloading SAML Login Page')
-                        saml_login_page_res = post_form(
+                        saml_login_page, urlh = post_form(
                             [saml_login_page, saml_redirect_url], 'Logging in', {
                                 mso_info['username_field']: username,
                                 mso_info['password_field']: password,
                             })
-                        saml_login_page, urlh = saml_login_page_res
                         if 'Please try again.' in saml_login_page:
                             raise ExtractorError(
-                                'We\'re sorry, but either the User ID or Password entered is not correct.')
+                                'Failed to login, incorrect User ID or Password.')
                     saml_login_url = self._search_regex(
                         r'xmlHttp\.open\("POST"\s*,\s*(["\'])(?P<url>.+?)\1',
                         saml_login_page, 'SAML Login URL', group='url')

--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1508,7 +1508,8 @@ class AdobePassIE(InfoExtractor):
                     # In general, if you're connecting from a Verizon-assigned IP,
                     # you will not actually pass your credentials.
                     provider_redirect_page, urlh = provider_redirect_page_res
-                    if 'Please wait ...' in provider_redirect_page:
+                    # From non-Verizon IP, still gave 'Please wait', but noticed N==Y; will need to try on Verizon IP
+                    if 'Please wait ...' in provider_redirect_page and "'N'== \"Y\"" not in provider_redirect_page:
                         saml_redirect_url = self._html_search_regex(
                             r'self\.parent\.location=(["\'])(?P<url>.+?)\1',
                             provider_redirect_page,
@@ -1516,9 +1517,32 @@ class AdobePassIE(InfoExtractor):
                         saml_login_page = self._download_webpage(
                             saml_redirect_url, video_id,
                             'Downloading SAML Login Page')
-                    else:
+                    elif 'Verizon FiOS - sign in' in provider_redirect_page:
+                        # FXNetworks from non-Verizon IP
                         saml_login_page_res = post_form(
                             provider_redirect_page_res, 'Logging in', {
+                                mso_info['username_field']: username,
+                                mso_info['password_field']: password,
+                            })
+                        saml_login_page, urlh = saml_login_page_res
+                        if 'Please try again.' in saml_login_page:
+                            raise ExtractorError(
+                                'We\'re sorry, but either the User ID or Password entered is not correct.')
+                    else:
+                        # elif 'Please wait ...' in provider_redirect_page and "'N'== \"Y\"" in provider_redirect_page:
+                        # ABC from non-Verizon IP
+                        saml_redirect_url = self._html_search_regex(
+                            r'var\surl\s*=\s*(["\'])(?P<url>.+?)\1',
+                            provider_redirect_page,
+                            'SAML Redirect URL', group='url')
+                        saml_redirect_url = saml_redirect_url.replace(r'\/', '/')
+                        saml_redirect_url = saml_redirect_url.replace(r'\-', '-')
+                        saml_redirect_url = saml_redirect_url.replace(r'\x26', '&')
+                        saml_login_page = self._download_webpage(
+                            saml_redirect_url, video_id,
+                            'Downloading SAML Login Page')
+                        saml_login_page_res = post_form(
+                            [saml_login_page, saml_redirect_url], 'Logging in', {
                                 mso_info['username_field']: username,
                                 mso_info['password_field']: password,
                             })


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

This was originally submitted as ytdl-org/youtube-dl#19136, and originates from a public fork at https://bitbucket.org/ParadoxGBB/youtube-dl/commits/64bddfe15c1458a1b3461875bf9afd0a17ebeea0 with the LICENSE file still containing the Unlicense.

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes AdobePass login using `--ap-mso Verizon`. I have personally verified that this fix works on DisneyNOW at least.