### PR TITLE
Add Win32 Edge Canary support for browser cookies

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -190,7 +190,7 @@ def _get_chromium_based_browser_settings(browser_name):
             'chrome': os.path.join(appdata, 'Google/Chrome'),
             'chromium': os.path.join(appdata, 'Chromium'),
             'edge': os.path.join(appdata, 'Microsoft Edge'),
-            'edgesxs': os.path.join(config, 'microsoft-edge'),
+            'edgesxs': os.path.join(appdata, 'Microsoft Edge'),
             'opera': os.path.join(appdata, 'com.operasoftware.Opera'),
             'vivaldi': os.path.join(appdata, 'Vivaldi'),
         }[browser_name]

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -54,7 +54,7 @@ except Exception as _err:
     KEYRING_UNAVAILABLE_REASON = 'as the `keyring` module could not be initialized: %s' % _err
 
 
-CHROMIUM_BASED_BROWSERS = {'brave', 'chrome', 'chromium', 'edge', 'opera', 'vivaldi'}
+CHROMIUM_BASED_BROWSERS = {'brave', 'chrome', 'chromium', 'edge', 'edgesxs', 'opera', 'vivaldi'}
 SUPPORTED_BROWSERS = CHROMIUM_BASED_BROWSERS | {'firefox', 'safari'}
 
 
@@ -165,6 +165,7 @@ def _get_chromium_based_browser_settings(browser_name):
             'chrome': os.path.join(config, 'google-chrome'),
             'chromium': os.path.join(config, 'chromium'),
             'edge': os.path.join(config, 'microsoft-edge'),
+            'edgesxs': os.path.join(config, 'microsoft-edge'),
             'opera': os.path.join(config, 'opera'),
             'vivaldi': os.path.join(config, 'vivaldi'),
         }[browser_name]
@@ -177,6 +178,7 @@ def _get_chromium_based_browser_settings(browser_name):
             'chrome': os.path.join(appdata_local, r'Google\Chrome\User Data'),
             'chromium': os.path.join(appdata_local, r'Chromium\User Data'),
             'edge': os.path.join(appdata_local, r'Microsoft\Edge\User Data'),
+            'edgesxs': os.path.join(appdata_local, r'Microsoft\Edge SxS\User Data'),
             'opera': os.path.join(appdata_roaming, r'Opera Software\Opera Stable'),
             'vivaldi': os.path.join(appdata_local, r'Vivaldi\User Data'),
         }[browser_name]
@@ -188,6 +190,7 @@ def _get_chromium_based_browser_settings(browser_name):
             'chrome': os.path.join(appdata, 'Google/Chrome'),
             'chromium': os.path.join(appdata, 'Chromium'),
             'edge': os.path.join(appdata, 'Microsoft Edge'),
+            'edgesxs': os.path.join(config, 'microsoft-edge'),
             'opera': os.path.join(appdata, 'com.operasoftware.Opera'),
             'vivaldi': os.path.join(appdata, 'Vivaldi'),
         }[browser_name]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Microsoft Edge Canary installs in a side-by-side configuration with production Edge, storing the profile data in a different place.  This means that someone using Canary as a daily driver can't pull in cookies.

I have no Mac or Linux access at the moment, so the entries for those OSes are not really right - they are something as a placeholder, to avoid a crash, but it's not right, either.  This should be fixed before going live, I think.

This may be opening a bad path because this leads to "why not Beta channel" and "why not Dev channel" and "why not [something] on [other browser]" and that would also be a reasonable cause to kick this - it's not like someone can't bring up production if necessary.  (Just trying to be realistic about the situation.)  So rejecting for that would be perfectly reasonable, if that's the case.