### PR TITLE
Raiplayradio

### DIFF
--- a/supportedsites.md
+++ b/supportedsites.md
@@ -867,8 +867,6 @@
  - **RaiPlay**
  - **RaiPlayLive**
  - **RaiPlayPlaylist**
- - **RaiPlayRadio**
- - **RaiPlayRadioPlaylist**
  - **RayWenderlich**
  - **RayWenderlichCourse**
  - **RBMARadio**

--- a/supportedsites.md
+++ b/supportedsites.md
@@ -867,6 +867,8 @@
  - **RaiPlay**
  - **RaiPlayLive**
  - **RaiPlayPlaylist**
+ - **RaiPlayRadio**
+ - **RaiPlayRadioPlaylist**
  - **RayWenderlich**
  - **RayWenderlichCourse**
  - **RBMARadio**

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1153,6 +1153,8 @@ from .rai import (
     RaiPlayLiveIE,
     RaiPlayPlaylistIE,
     RaiIE,
+    RaiPlayRadioIE,
+    RaiPlayRadioPlaylistIE,
 )
 from .raywenderlich import (
     RayWenderlichIE,

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -667,4 +667,5 @@ class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
             })
 
         return self.playlist_result(
-            entries, playlist_id, playlist_title, playlist_description)
+            entries, playlist_id, playlist_title, playlist_description,
+            creator=playlist_creator)

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -619,32 +619,35 @@ class RaiPlayRadioBaseIE(InfoExtractor):
         for attrs in self.parse_list(webpage):
             title = attrs['data-title'].strip()
             webpage = urljoin(url, attrs['data-mediapolis'])
-            audio_url = compat_str(self._request_webpage(webpage, title).geturl())
+            audio_url = compat_str(self._request_webpage(
+                webpage, title).geturl())
             yield {
                 'url': audio_url,
                 'id': attrs['data-uniquename'].lstrip('ContentItem-'),
                 'title': title,
                 'ext': determine_ext(audio_url),
                 'thumbnail': urljoin(url, attrs['data-image']),
-                'language': 'it',
-            }
+                'language': 'it'}
 
     def get_playlist(self, *args, **kwargs):
         return list(self.get_playlist_iter(*args, **kwargs))
 
 
 class RaiPlayRadioIE(RaiPlayRadioBaseIE):
-    _VALID_URL = r'%s/audio/.+?-(?P<id>%s)\.html' % (RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
+    _VALID_URL = r'%s/audio/.+?-(?P<id>%s)\.html' % (
+        RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
     _TEST = {
-        'url': 'https://www.raiplayradio.it/audio/2019/07/RADIO3---LEZIONI-DI-MUSICA-36b099ff-4123-4443-9bf9-38e43ef5e025.html',
+        'url': 'https://www.raiplayradio.it/audio/2019/07/'
+               'RADIO3---LEZIONI-DI-MUSICA-'
+               '36b099ff-4123-4443-9bf9-38e43ef5e025.html',
         'info_dict': {
             'id': '36b099ff-4123-4443-9bf9-38e43ef5e025',
             'ext': 'mp3',
-            'title': 'Dal "Chiaro di luna" al  "Clair de lune", prima parte con Giovanni Bietti',
-            'thumbnail': 'https://www.raiplayradio.it/cropgd/400x400/dl/img/2019/07/08/1562590329054_luna.jpg',
-            'language': 'it',
-        }
-    }
+            'title': 'Dal "Chiaro di luna" al  "Clair de lune", '
+                     'prima parte con Giovanni Bietti',
+            'thumbnail': 'https://www.raiplayradio.it/cropgd/400x400/dl/'
+                         'img/2019/07/08/1562590329054_luna.jpg',
+            'language': 'it'}}
 
     def _real_extract(self, url):
         list_url = url.replace('.html', '-list.html')
@@ -654,25 +657,30 @@ class RaiPlayRadioIE(RaiPlayRadioBaseIE):
 
 
 class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
-    _VALID_URL = r'%s/playlist/.+?-(?P<id>%s)\.html' % (RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
+    _VALID_URL = r'%s/playlist/.+?-(?P<id>%s)\.html' % (
+        RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
     _TEST = {
-        'url': 'https://www.raiplayradio.it/playlist/2017/12/Alice-nel-paese-delle-meraviglie-72371d3c-d998-49f3-8860-d168cfdf4966.html',
+        'url': 'https://www.raiplayradio.it/playlist/2017/12/'
+               'Alice-nel-paese-delle-meraviglie-'
+               '72371d3c-d998-49f3-8860-d168cfdf4966.html',
         'info_dict': {
             'id': '72371d3c-d998-49f3-8860-d168cfdf4966',
             'title': "Alice nel paese delle meraviglie",
-            'description': "di Lewis Carrol letto da Aldo Busi",
-        },
-        'playlist_count': 11,
-    }
+            'description': "di Lewis Carrol letto da Aldo Busi"},
+        'playlist_count': 11}
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)
         playlist_webpage = self._download_webpage(url, playlist_id)
-        playlist_title = unescapeHTML(self._html_search_regex(r'data-playlist-title="(.+?)"', playlist_webpage, 'title'))
-        playlist_creator = self._html_search_meta('nomeProgramma', playlist_webpage)
-        playlist_description = get_element_by_class('textDescriptionProgramma', playlist_webpage)
+        playlist_title = unescapeHTML(self._html_search_regex(
+            r'data-playlist-title="(.+?)"', playlist_webpage, 'title'))
+        playlist_creator = self._html_search_meta(
+            'nomeProgramma', playlist_webpage)
+        playlist_description = get_element_by_class(
+            'textDescriptionProgramma', playlist_webpage)
 
-        player_href = self._html_search_regex(r'data-player-href="(.+?)"', playlist_webpage, 'href')
+        player_href = self._html_search_regex(
+            r'data-player-href="(.+?)"', playlist_webpage, 'href')
         list_url = urljoin(url, player_href)
 
         entries = self.get_playlist(list_url)
@@ -681,7 +689,7 @@ class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
                 'track': entry['title'],
                 'track_number': index,
                 'album': playlist_title,
-                'artist': playlist_creator,
-            })
+                'artist': playlist_creator})
 
-        return self.playlist_result(entries, playlist_id, playlist_title, playlist_description)
+        return self.playlist_result(
+            entries, playlist_id, playlist_title, playlist_description)

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -5,6 +5,7 @@ import re
 
 from .common import InfoExtractor
 from ..compat import (
+    compat_HTMLParser,
     compat_str,
     compat_urlparse,
 )
@@ -14,12 +15,14 @@ from ..utils import (
     find_xpath_attr,
     fix_xml_ampersands,
     GeoRestrictedError,
+    get_element_by_class,
     HEADRequest,
     int_or_none,
     parse_duration,
     remove_start,
     strip_or_none,
     try_get,
+    unescapeHTML,
     unified_strdate,
     unified_timestamp,
     update_url_query,
@@ -585,3 +588,100 @@ class RaiIE(RaiBaseIE):
         info.update(relinker_info)
 
         return info
+
+
+class HTMLListAttrsParser(compat_HTMLParser):
+    def __init__(self):
+        compat_HTMLParser.__init__(self)
+        self.items = []
+        self._level = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'li' and self._level == 0:
+            self.items.append(dict(attrs))
+        self._level += 1
+
+    def handle_endtag(self, tag):
+        self._level -= 1
+
+
+class RaiPlayRadioBaseIE(InfoExtractor):
+    _BASE = 'https://www.raiplayradio.it'
+
+    def parse_list(self, webpage):
+        parser = HTMLListAttrsParser()
+        parser.feed(webpage)
+        parser.close()
+        return parser.items
+
+    def get_playlist_iter(self, url):
+        webpage = self._download_webpage(url, url)
+        for attrs in self.parse_list(webpage):
+            title = attrs['data-title'].strip()
+            webpage = urljoin(url, attrs['data-mediapolis'])
+            audio_url = compat_str(self._request_webpage(webpage, title).geturl())
+            yield {
+                'url': audio_url,
+                'id': attrs['data-uniquename'].lstrip('ContentItem-'),
+                'title': title,
+                'ext': determine_ext(audio_url),
+                'thumbnail': urljoin(url, attrs['data-image']),
+                'language': 'it',
+            }
+
+    def get_playlist(self, *args, **kwargs):
+        return list(self.get_playlist_iter(*args, **kwargs))
+
+
+class RaiPlayRadioIE(RaiPlayRadioBaseIE):
+    _VALID_URL = r'%s/audio/.+?-(?P<id>%s)\.html' % (RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
+    _TEST = {
+        'url': 'https://www.raiplayradio.it/audio/2019/07/RADIO3---LEZIONI-DI-MUSICA-36b099ff-4123-4443-9bf9-38e43ef5e025.html',
+        'info_dict': {
+            'id': '36b099ff-4123-4443-9bf9-38e43ef5e025',
+            'ext': 'mp3',
+            'title': 'Dal "Chiaro di luna" al  "Clair de lune", prima parte con Giovanni Bietti',
+            'thumbnail': 'https://www.raiplayradio.it/cropgd/400x400/dl/img/2019/07/08/1562590329054_luna.jpg',
+            'language': 'it',
+        }
+    }
+
+    def _real_extract(self, url):
+        list_url = url.replace('.html', '-list.html')
+        for entry in self.get_playlist_iter(list_url):
+            if entry['id'] == self._match_id(url):
+                return entry
+
+
+class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
+    _VALID_URL = r'%s/playlist/.+?-(?P<id>%s)\.html' % (RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
+    _TEST = {
+        'url': 'https://www.raiplayradio.it/playlist/2017/12/Alice-nel-paese-delle-meraviglie-72371d3c-d998-49f3-8860-d168cfdf4966.html',
+        'info_dict': {
+            'id': '72371d3c-d998-49f3-8860-d168cfdf4966',
+            'title': "Alice nel paese delle meraviglie",
+            'description': "di Lewis Carrol letto da Aldo Busi",
+        },
+        'playlist_count': 11,
+    }
+
+    def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        playlist_webpage = self._download_webpage(url, playlist_id)
+        playlist_title = unescapeHTML(self._html_search_regex(r'data-playlist-title="(.+?)"', playlist_webpage, 'title'))
+        playlist_creator = self._html_search_meta('nomeProgramma', playlist_webpage)
+        playlist_description = get_element_by_class('textDescriptionProgramma', playlist_webpage)
+
+        player_href = self._html_search_regex(r'data-player-href="(.+?)"', playlist_webpage, 'href')
+        list_url = urljoin(url, player_href)
+
+        entries = self.get_playlist(list_url)
+        for index, entry in enumerate(entries, start=1):
+            entry.update({
+                'track': entry['title'],
+                'track_number': index,
+                'album': playlist_title,
+                'artist': playlist_creator,
+            })
+
+        return self.playlist_result(entries, playlist_id, playlist_title, playlist_description)

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -5,7 +5,6 @@ import re
 
 from .common import InfoExtractor
 from ..compat import (
-    compat_HTMLParser,
     compat_str,
     compat_urlparse,
 )
@@ -17,6 +16,7 @@ from ..utils import (
     GeoRestrictedError,
     get_element_by_class,
     HEADRequest,
+    HTMLListAttrsParser,
     int_or_none,
     parse_duration,
     remove_start,
@@ -588,21 +588,6 @@ class RaiIE(RaiBaseIE):
         info.update(relinker_info)
 
         return info
-
-
-class HTMLListAttrsParser(compat_HTMLParser):
-    def __init__(self):
-        compat_HTMLParser.__init__(self)
-        self.items = []
-        self._level = 0
-
-    def handle_starttag(self, tag, attrs):
-        if tag == 'li' and self._level == 0:
-            self.items.append(dict(attrs))
-        self._level += 1
-
-    def handle_endtag(self, tag):
-        self._level -= 1
 
 
 class RaiPlayRadioBaseIE(InfoExtractor):

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -618,14 +618,12 @@ class RaiPlayRadioBaseIE(InfoExtractor):
         webpage = self._download_webpage(url, uid)
         for attrs in self.parse_list(webpage):
             title = attrs['data-title'].strip()
-            webpage = urljoin(url, attrs['data-mediapolis'])
-            audio_url = compat_str(self._request_webpage(
-                webpage, title).geturl())
+            audio_url = urljoin(url, attrs['data-mediapolis'])
             yield {
                 'url': audio_url,
                 'id': attrs['data-uniquename'].lstrip('ContentItem-'),
                 'title': title,
-                'ext': determine_ext(audio_url),
+                'ext': 'mp3',
                 'thumbnail': urljoin(url, attrs['data-image']),
                 'language': 'it'}
 

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -635,17 +635,15 @@ class RaiPlayRadioIE(RaiPlayRadioBaseIE):
     _VALID_URL = r'%s/audio/.+?-(?P<id>%s)\.html' % (
         RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
     _TEST = {
-        'url': 'https://www.raiplayradio.it/audio/2019/07/'
-               'RADIO3---LEZIONI-DI-MUSICA-'
-               '36b099ff-4123-4443-9bf9-38e43ef5e025.html',
+        'url': 'https://www.raiplayradio.it/audio/2019/07/RADIO3---LEZIONI-DI-MUSICA-36b099ff-4123-4443-9bf9-38e43ef5e025.html',
         'info_dict': {
             'id': '36b099ff-4123-4443-9bf9-38e43ef5e025',
             'ext': 'mp3',
             'title': 'Dal "Chiaro di luna" al  "Clair de lune", '
                      'prima parte con Giovanni Bietti',
-            'thumbnail': 'https://www.raiplayradio.it/cropgd/400x400/dl/'
-                         'img/2019/07/08/1562590329054_luna.jpg',
-            'language': 'it'}}
+            'thumbnail': 'https://www.raiplayradio.it/cropgd/400x400/dl/img/2019/07/08/1562590329054_luna.jpg',
+            'language': 'it',
+    }}
 
     def _real_extract(self, url):
         audio_id = self._match_id(url)
@@ -659,14 +657,14 @@ class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
     _VALID_URL = r'%s/playlist/.+?-(?P<id>%s)\.html' % (
         RaiPlayRadioBaseIE._BASE, RaiBaseIE._UUID_RE)
     _TEST = {
-        'url': 'https://www.raiplayradio.it/playlist/2017/12/'
-               'Alice-nel-paese-delle-meraviglie-'
-               '72371d3c-d998-49f3-8860-d168cfdf4966.html',
+        'url': 'https://www.raiplayradio.it/playlist/2017/12/Alice-nel-paese-delle-meraviglie-72371d3c-d998-49f3-8860-d168cfdf4966.html',
         'info_dict': {
             'id': '72371d3c-d998-49f3-8860-d168cfdf4966',
             'title': "Alice nel paese delle meraviglie",
-            'description': "di Lewis Carrol letto da Aldo Busi"},
-        'playlist_count': 11}
+            'description': "di Lewis Carrol letto da Aldo Busi",
+        },
+        'playlist_count': 11,
+    }
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -646,7 +646,8 @@ class RaiPlayRadioIE(RaiPlayRadioBaseIE):
                      'prima parte con Giovanni Bietti',
             'thumbnail': r're:^https?://.*\.jpg$',
             'language': 'it',
-    }}
+        }
+    }
 
     def _real_extract(self, url):
         audio_id = self._match_id(url)

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -678,7 +678,8 @@ class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
             r'data-player-href="(.+?)"', playlist_webpage, 'href')
         list_url = urljoin(url, player_href)
 
-        for index, entry in enumerate(self.get_playlist_iter(list_url, playlist_id), start=1):
+        entries = list(self.get_playlist_iter(list_url, playlist_id))
+        for index, entry in enumerate(entries, start=1):
             entry.update({
                 'track': entry['title'],
                 'track_number': index,

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -644,7 +644,7 @@ class RaiPlayRadioIE(RaiPlayRadioBaseIE):
             'ext': 'mp3',
             'title': 'Dal "Chiaro di luna" al  "Clair de lune", '
                      'prima parte con Giovanni Bietti',
-            'thumbnail': 'https://www.raiplayradio.it/cropgd/400x400/dl/img/2019/07/08/1562590329054_luna.jpg',
+            'thumbnail': r're:^https?://.*\.jpg$',
             'language': 'it',
     }}
 

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -614,8 +614,8 @@ class RaiPlayRadioBaseIE(InfoExtractor):
         parser.close()
         return parser.items
 
-    def get_playlist_iter(self, url):
-        webpage = self._download_webpage(url, url)
+    def get_playlist_iter(self, url, uid):
+        webpage = self._download_webpage(url, uid)
         for attrs in self.parse_list(webpage):
             title = attrs['data-title'].strip()
             webpage = urljoin(url, attrs['data-mediapolis'])
@@ -650,9 +650,10 @@ class RaiPlayRadioIE(RaiPlayRadioBaseIE):
             'language': 'it'}}
 
     def _real_extract(self, url):
+        audio_id = self._match_id(url)
         list_url = url.replace('.html', '-list.html')
-        for entry in self.get_playlist_iter(list_url):
-            if entry['id'] == self._match_id(url):
+        for entry in self.get_playlist_iter(list_url, audio_id):
+            if entry['id'] == audio_id:
                 return entry
 
 
@@ -683,7 +684,7 @@ class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
             r'data-player-href="(.+?)"', playlist_webpage, 'href')
         list_url = urljoin(url, player_href)
 
-        entries = self.get_playlist(list_url)
+        entries = self.get_playlist(list_url, playlist_id)
         for index, entry in enumerate(entries, start=1):
             entry.update({
                 'track': entry['title'],

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -619,13 +619,16 @@ class RaiPlayRadioBaseIE(InfoExtractor):
         for attrs in self.parse_list(webpage):
             title = attrs['data-title'].strip()
             audio_url = urljoin(url, attrs['data-mediapolis'])
-            yield {
+            entry = {
                 'url': audio_url,
                 'id': attrs['data-uniquename'].lstrip('ContentItem-'),
                 'title': title,
                 'ext': 'mp3',
-                'thumbnail': urljoin(url, attrs['data-image']),
-                'language': 'it'}
+                'language': 'it',
+            }
+            if 'data-image' in attrs:
+                entry['thumbnail'] = urljoin(url, attrs['data-image'])
+            yield entry
 
     def get_playlist(self, *args, **kwargs):
         return list(self.get_playlist_iter(*args, **kwargs))

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -687,8 +687,10 @@ class RaiPlayRadioPlaylistIE(RaiPlayRadioBaseIE):
             entry.update({
                 'track': entry['title'],
                 'track_number': index,
-                'album': playlist_title,
-                'artist': playlist_creator})
+                'artist': playlist_creator,
+            })
+            if playlist_title:
+                entry['album'] = playlist_title
 
         return self.playlist_result(
             entries, playlist_id, playlist_title, playlist_description)

--- a/yt_dlp/extractor/rai.py
+++ b/yt_dlp/extractor/rai.py
@@ -16,9 +16,9 @@ from ..utils import (
     GeoRestrictedError,
     get_element_by_class,
     HEADRequest,
-    HTMLListAttrsParser,
     int_or_none,
     parse_duration,
+    parse_list,
     remove_start,
     strip_or_none,
     try_get,
@@ -593,15 +593,9 @@ class RaiIE(RaiBaseIE):
 class RaiPlayRadioBaseIE(InfoExtractor):
     _BASE = 'https://www.raiplayradio.it'
 
-    def parse_list(self, webpage):
-        parser = HTMLListAttrsParser()
-        parser.feed(webpage)
-        parser.close()
-        return parser.items
-
     def get_playlist_iter(self, url, uid):
         webpage = self._download_webpage(url, uid)
-        for attrs in self.parse_list(webpage):
+        for attrs in parse_list(webpage):
             title = attrs['data-title'].strip()
             audio_url = urljoin(url, attrs['data-mediapolis'])
             entry = {

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2006,6 +2006,23 @@ class HTMLAttributeParser(compat_HTMLParser):
         self.attrs = dict(attrs)
 
 
+class HTMLListAttrsParser(compat_HTMLParser):
+    """HTML parser to gather the attributes for the elements of a list"""
+
+    def __init__(self):
+        compat_HTMLParser.__init__(self)
+        self.items = []
+        self._level = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'li' and self._level == 0:
+            self.items.append(dict(attrs))
+        self._level += 1
+
+    def handle_endtag(self, tag):
+        self._level -= 1
+
+
 def extract_attributes(html_element):
     """Given a string for an HTML element such as
     <el

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2049,6 +2049,15 @@ def extract_attributes(html_element):
     return parser.attrs
 
 
+def parse_list(webpage):
+    """Given a string for an series of HTML <li> elements,
+    return a dictionary of their attributes"""
+    parser = HTMLListAttrsParser()
+    parser.feed(webpage)
+    parser.close()
+    return parser.items
+
+
 def clean_html(html):
     """Clean an HTML snippet into a readable string"""
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [X] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Description of your pull request and other information

Support for www.raiplayradio.it added.

Notes:

- Using `--embed-thumbnail` produces ERROR: Conversion failed! on some links, like the one in the tests: I have no idea why that is happening, but the downloaded temporary image has a .jpg extension but it is encoded in webp (the URL is correct). The resolution and ratio are also different.

Here is an example:

`./yt-dlp --add-metadata -o '%(artist)s/%(album)s/%(title)s.%(ext)s' https://www.raiplayradio.it/playlist/2017/12/Alice-nel-paese-delle-meraviglie-72371d3c-d998-49f3-8860-d168cfdf4966.html`

Other pages to test can be found at: https://www.raiplayradio.it/programmi/adaltavoce/archivio/audiolibri/tutte/1

This is a port of my previous PR on youtube-dl: https://github.com/ytdl-org/youtube-dl/pull/21837