### PR TITLE
[Nova] fix extractor

### DIFF
--- a/yt_dlp/extractor/nova.py
+++ b/yt_dlp/extractor/nova.py
@@ -39,7 +39,7 @@ class NovaEmbedIE(InfoExtractor):
 
         player = self._parse_json(
             self._search_regex(
-                r'Player\.init\s*\([^,]+,\s*({.+?})\s*,\s*{.+?}\s*\)\s*;',
+                r'Player\.init\s*\([^,]+,\s*(?:\w+\s*\?\s*{.+?}\s*:\s*)?({.+})\s*,\s*{.+?}\s*\)\s*;',
                 webpage, 'player', default='{}'), video_id, fatal=False)
         if player:
             for format_id, format_list in player['tracks'].items():


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

partially fixes https://github.com/ytdl-org/youtube-dl/issues/27840, but there are caveats:

Nova seems to have introduced DRM for downloads (SAMPLE-AES) that were published more than 7 days ago. Newer downloads are DRM free and work just fine. The NovaEmbedIE test still doesn't pass since it contains a very old episode and I haven't edited it because it'd get outdated very quickly.

Here's an example of downloading a recent episode:

with current master
```
[Nova] 76963-4094-dil: Downloading webpage
[debug] [Nova] Extracting URL: https://novaplus.nova.cz/porad/ulice/epizoda/76963-4094-dil
[debug] [NovaEmbed] Extracting URL: https://media.cms.nova.cz/embed/CTuvVACgTdR
[NovaEmbed] CTuvVACgTdR: Downloading webpage
ERROR: [NovaEmbed] CTuvVACgTdR: Unable to extract formats; please report this issue on  https://github.com/yt-dlp/yt-dlp .
```

with my commit
```
[Nova] 76963-4094-dil: Downloading webpage
[debug] [Nova] Extracting URL: https://novaplus.nova.cz/porad/ulice/epizoda/76963-4094-dil
[NovaEmbed] CTuvVACgTdR: Downloading webpage
[debug] [NovaEmbed] Extracting URL: https://media.cms.nova.cz/embed/CTuvVACgTdR
[NovaEmbed] CTuvVACgTdR: Downloading m3u8 information
[NovaEmbed] CTuvVACgTdR: Downloading MPD manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] CTuvVACgTdR: Downloading 1 format(s): dash-p0va0br5000440+dash-p0aa0br128424
[debug] Invoking downloader on "https://nova-ott-vod-prep-sec.ssl.cdn.cra.cz/Y572KFdQKS-4BRs_8ILjOQ==,1630177187/vod_Nova/_definst_/0127/5317/cze-sd1-sd2-sd3-sd4-hd1-hd2-yDOV8vxE.smil/manifest.mpd"
[dashsegments] Total fragments: 863
[download] Destination:  Ulice 337. cyklus, díl, 4094 B101774 [CTuvVACgTdR].fdash-p0va0br5000440.mp4
```

I realize this isn't a comprehensive fix but it's better than nothing so I thought I should upstream this.

Note: the greediness (removal of ? in the matched group) is intentional and makes the extraction (but not the download) succeed even for DRM-protected videos such as the one in the unit test.