### PR TITLE
[southpark] Fix SouthParkDE extractor

### DIFF
--- a/yt_dlp/extractor/mtv.py
+++ b/yt_dlp/extractor/mtv.py
@@ -44,7 +44,7 @@ class MTVServicesInfoExtractor(InfoExtractor):
         # Remove the templates, like &device={device}
         return re.sub(r'&[^=]*?={.*?}(?=(&|$))', '', url)
 
-    def _get_feed_url(self, uri):
+    def _get_feed_url(self, uri, url=None):
         return self._FEED_URL
 
     def _get_thumbnail_url(self, uri, itemdoc):
@@ -229,9 +229,9 @@ class MTVServicesInfoExtractor(InfoExtractor):
             data['lang'] = self._LANG
         return data
 
-    def _get_videos_info(self, uri, use_hls=True):
+    def _get_videos_info(self, uri, use_hls=True, url=None):
         video_id = self._id_from_uri(uri)
-        feed_url = self._get_feed_url(uri)
+        feed_url = self._get_feed_url(uri, url)
         info_url = update_url_query(feed_url, self._get_feed_query(uri))
         return self._get_videos_info_from_url(info_url, video_id, use_hls)
 
@@ -319,7 +319,7 @@ class MTVServicesInfoExtractor(InfoExtractor):
         title = url_basename(url)
         webpage = self._download_webpage(url, title)
         mgid = self._extract_mgid(webpage)
-        videos_info = self._get_videos_info(mgid)
+        videos_info = self._get_videos_info(mgid, url=url)
         return videos_info
 
 
@@ -348,7 +348,7 @@ class MTVServicesEmbeddedIE(MTVServicesInfoExtractor):
         if mobj:
             return mobj.group('url')
 
-    def _get_feed_url(self, uri):
+    def _get_feed_url(self, uri, url=None):
         video_id = self._id_from_uri(uri)
         config = self._download_json(
             'http://media.mtvnservices.com/pmt/e1/access/index.html?uri=%s&configtype=edge' % uri, video_id)

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -73,7 +73,7 @@ class SouthParkDeIE(SouthParkIE):
             'id': 'e99d45ea-ed00-11e0-aca6-0026b9414f30',
             'ext': 'mp4',
             'title': 'Tooth Fairy Cartman',
-            'description': 'Cartman dresses up as the Tooth Fairy to steal Butters\' tooth from underneath his pillow. Cartman gets $4 for this tooth, feeding the drive for more teeth.',
+            'description': 'md5:db02e23818b4dc9cb5f0c5a7e8833a68',
         },
     }, {
         # episode
@@ -82,7 +82,7 @@ class SouthParkDeIE(SouthParkIE):
             'id': 'f5fbd823-04bc-11eb-9b1b-0e40cf2fc285',
             'ext': 'mp4',
             'title': 'South Park',
-            'description': 'Randy comes to terms with his role in the COVID-19 outbreak as the on-going pandemic presents continued challenges to the citizens of South Park.',
+            'description': 'md5:ae0d875eff169dcbed16b21531857ac1',
         },
     }, {
         # clip
@@ -91,7 +91,7 @@ class SouthParkDeIE(SouthParkIE):
             'id': 'e99d45ea-ed00-11e0-aca6-0026b9414f30',
             'ext': 'mp4',
             'title': 'Zahnfee Cartman',
-            'description': 'Cartman verkleidet sich als Zahnfee, um Butters unter dem Kissen liegenden Zahn zu stehlen. Cartman bekommt 4$ für diesen Zahn, was das Streben nach mehr Zähnen nährt'
+            'description': 'md5:b917eec991d388811d911fd1377671ac'
         },
     }, {
         # episode
@@ -99,15 +99,15 @@ class SouthParkDeIE(SouthParkIE):
         'info_dict': {
             'id': '607115f3-496f-40c3-8647-2b0bcff486c0',
             'ext': 'mp4',
-            'title': 'South Park | Pink Eye | E 0107 | HDSS0107X deu | Version: 634312 | Comedy Central S1',
+            'title': 'md5:0d2ce7daf98eb9504c7a3276697ad666',
         },
     }]
 
     def _get_feed_url(self, uri, url=None):
         video_id = self._id_from_uri(uri)
         config = self._download_json(
-            f'http://media.mtvnservices.com/pmt/e1/access/index.html?uri={uri}&configtype=edge&ref={url}', video_id)
-        return self._remove_template_parameter(config.get('feedWithQueryParams'))
+            'http://media.mtvnservices.com/pmt/e1/access/index.html?uri=%s&configtype=edge&ref=%s' % (uri, url), video_id)
+        return self._remove_template_parameter(config['feedWithQueryParams'])
 
     def _get_feed_query(self, uri):
         return

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -56,9 +56,7 @@ class SouthParkEsIE(SouthParkIE):
 
 class SouthParkDeIE(SouthParkIE):
     IE_NAME = 'southpark.de'
-    _VALID_URL = r'https?://(?:www\.)?(?P<url>southpark\.de/(?:(en/(videoclip|collections|episodes))|(videoclip|collections|folgen))/(?P<id>(?P<unique_id>.+?)/.+?)(?:\?|#|$))'
-    # _FEED_URL = 'http://feeds.mtvnservices.com/od/feed/intl-mrss-player-feed'
-
+    _VALID_URL = r'https?://(?:www\.)?(?P<url>southpark\.de/(?:(en/(videoclip|collections|episodes|video-clips))|(videoclip|collections|folgen))/(?P<id>(?P<unique_id>.+?)/.+?)(?:\?|#|$))'
     _TESTS = [{
         'url': 'https://www.southpark.de/videoclip/rsribv/south-park-rueckzug-zum-gummibonbon-wald',
         'only_matching': True,
@@ -68,13 +66,51 @@ class SouthParkDeIE(SouthParkIE):
     }, {
         'url': 'https://www.southpark.de/collections/zzno5a/south-park-good-eats/7q26gp',
         'only_matching': True,
+    }, {
+        # clip
+        'url': 'https://www.southpark.de/en/video-clips/ct46op/south-park-tooth-fairy-cartman',
+        'info_dict': {
+            'id': 'e99d45ea-ed00-11e0-aca6-0026b9414f30',
+            'ext': 'mp4',
+            'title': 'Tooth Fairy Cartman',
+            'description': 'Cartman dresses up as the Tooth Fairy to steal Butters\' tooth from underneath his pillow. Cartman gets $4 for this tooth, feeding the drive for more teeth.',
+        },
+    }, {
+        # episode
+        'url': 'https://www.southpark.de/en/episodes/yy0vjs/south-park-the-pandemic-special-season-24-ep-1',
+        'info_dict': {
+            'id': 'f5fbd823-04bc-11eb-9b1b-0e40cf2fc285',
+            'ext': 'mp4',
+            'title': 'South Park',
+            'description': 'Randy comes to terms with his role in the COVID-19 outbreak as the on-going pandemic presents continued challenges to the citizens of South Park.',
+        },
+    }, {
+        # clip
+        'url': 'https://www.southpark.de/videoclip/ct46op/south-park-zahnfee-cartman',
+        'info_dict': {
+            'id': 'e99d45ea-ed00-11e0-aca6-0026b9414f30',
+            'ext': 'mp4',
+            'title': 'Zahnfee Cartman',
+            'description': 'Cartman verkleidet sich als Zahnfee, um Butters unter dem Kissen liegenden Zahn zu stehlen. Cartman bekommt 4$ für diesen Zahn, was das Streben nach mehr Zähnen nährt'
+        },
+    }, {
+        # episode
+        'url': 'https://www.southpark.de/folgen/242csn/south-park-her-mit-dem-hirn-staffel-1-ep-7',
+        'info_dict': {
+            'id': '607115f3-496f-40c3-8647-2b0bcff486c0',
+            'ext': 'mp4',
+            'title': 'South Park | Pink Eye | E 0107 | HDSS0107X deu | Version: 634312 | Comedy Central S1',
+        },
     }]
 
     def _get_feed_url(self, uri, url=None):
         video_id = self._id_from_uri(uri)
         config = self._download_json(
-            'http://media.mtvnservices.com/pmt/e1/access/index.html?uri=%s&configtype=edge&ref=%s' % (uri, url), video_id)
-        return self._remove_template_parameter(config['feedWithQueryParams'])
+            f'http://media.mtvnservices.com/pmt/e1/access/index.html?uri={uri}&configtype=edge&ref={url}', video_id)
+        return self._remove_template_parameter(config.get('feedWithQueryParams'))
+
+    def _get_feed_query(self, uri):
+        return
 
 
 class SouthParkNlIE(SouthParkIE):

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -99,7 +99,7 @@ class SouthParkDeIE(SouthParkIE):
         'info_dict': {
             'id': '607115f3-496f-40c3-8647-2b0bcff486c0',
             'ext': 'mp4',
-            'title': 'md5:0d2ce7daf98eb9504c7a3276697ad666',
+            'title': 'md5:South Park | Pink Eye | E 0107 | HDSS0107X deu | Version: 634312 | Comedy Central S1',
         },
     }]
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [X] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Related upstream PR: https://github.com/ytdl-org/youtube-dl/pull/28442

I notice youtube-dlc still worked with southpark.de and southpark.de/en, but https://github.com/yt-dlp/yt-dlp/commit/ee1e05581e32114c52e75e90983a66fb25fbc730#diff-170b237e5ae15340b8b6aae302f30b85bd4b59e85c365aab7290ea524ba0ce3b broke that support.

(youtube-dlc PR: https://github.com/blackjack4494/youtube-dlc/pull/188)

Changes:
- return `url` parameter in `mtv.py` from youtube-dlc (~~hopefully without breaking mtv~~ looks fine)
- implement more detailed tests from https://github.com/ytdl-org/youtube-dl/pull/28442
- support `en/video-clips` urls

Related issues: https://github.com/ytdl-org/youtube-dl/issues/26763,  https://github.com/bumbummen99/southparkdownloader/issues/13

Note: site is geo-restricted to Germany
