### PR TITLE
[Viafree] Fix extractor and extract subtitles

### DIFF
--- a/yt_dlp/extractor/tvplay.py
+++ b/yt_dlp/extractor/tvplay.py
@@ -356,7 +356,6 @@ class ViafreeIE(InfoExtractor):
             'skip_download': True,
         },
     }, {
-        # TODO: fix
         'url': 'https://www.viafree.dk/programmer/humor/comedy-central-roast-of-charlie-sheen/film/1047660',
         'info_dict': {
             'id': '1047660',
@@ -369,6 +368,9 @@ class ViafreeIE(InfoExtractor):
             'timestamp': 1608246060,
             'upload_date': '20201217'
         },
+        'params': {
+            'format': 'bestvideo'
+        }
     }, {
         # with relatedClips
         'url': 'http://www.viafree.se/program/reality/sommaren-med-youtube-stjarnorna/sasong-1/avsnitt-1',
@@ -386,8 +388,7 @@ class ViafreeIE(InfoExtractor):
     }, {
         'url': 'http://www.viafree.se/program/underhallning/i-like-radio-live/sasong-1/676869',
         'only_matching': True,
-        },
-    ]
+    }]
     _GEO_BYPASS = False
 
     @classmethod

--- a/yt_dlp/extractor/tvplay.py
+++ b/yt_dlp/extractor/tvplay.py
@@ -34,8 +34,8 @@ class TVPlayIE(InfoExtractor):
                                 tvplay(?:\.skaties)?\.lv(?:/parraides)?|
                                 (?:tv3play|play\.tv3)\.lt(?:/programos)?|
                                 tv3play(?:\.tv3)?\.ee/sisu|
-                                (?:tv(?:3|6|8|10)play|viafree)\.se/program|
-                                (?:(?:tv3play|viasat4play|tv6play|viafree)\.no|(?:tv3play|viafree)\.dk)/programmer|
+                                (?:tv(?:3|6|8|10)play)\.se/program|
+                                (?:(?:tv3play|viasat4play|tv6play)\.no|(?:tv3play)\.dk)/programmer|
                                 play\.nova(?:tv)?\.bg/programi
                             )
                             /(?:[^/]+/)+
@@ -224,10 +224,6 @@ class TVPlayIE(InfoExtractor):
             'only_matching': True,
         },
         {
-            'url': 'http://www.viafree.se/program/underhallning/i-like-radio-live/sasong-1/676869',
-            'only_matching': True,
-        },
-        {
             'url': 'mtg:418113',
             'only_matching': True,
         }
@@ -360,6 +356,20 @@ class ViafreeIE(InfoExtractor):
             'skip_download': True,
         },
     }, {
+        # TODO: fix
+        'url': 'https://www.viafree.dk/programmer/humor/comedy-central-roast-of-charlie-sheen/film/1047660',
+        'info_dict': {
+            'id': '1047660',
+            'ext': 'mp4',
+            'title': 'Comedy Central Roast of Charlie Sheen - Comedy Central Roast of Charlie Sheen',
+            'description': 'md5:ec956d941ae9fd7c65a48fd64951dc6d',
+            'series': 'Comedy Central Roast of Charlie Sheen',
+            'season_number': 1,
+            'duration': 3747,
+            'timestamp': 1608246060,
+            'upload_date': '20201217'
+        },
+    }, {
         # with relatedClips
         'url': 'http://www.viafree.se/program/reality/sommaren-med-youtube-stjarnorna/sasong-1/avsnitt-1',
         'only_matching': True,
@@ -373,7 +383,11 @@ class ViafreeIE(InfoExtractor):
     }, {
         'url': 'http://www.viafree.dk/programmer/reality/paradise-hotel/saeson-7/episode-5',
         'only_matching': True,
-    }]
+    }, {
+        'url': 'http://www.viafree.se/program/underhallning/i-like-radio-live/sasong-1/676869',
+        'only_matching': True,
+        },
+    ]
     _GEO_BYPASS = False
 
     @classmethod
@@ -398,16 +412,16 @@ class ViafreeIE(InfoExtractor):
                 self.raise_geo_restricted(countries=[country])
             raise
 
-        formats = self._extract_m3u8_formats(stream_href, guid, 'mp4')
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(stream_href, guid, 'mp4')
         self._sort_formats(formats)
         episode = program.get('episode') or {}
-
         return {
             'id': guid,
             'title': title,
             'thumbnail': meta.get('image'),
             'description': meta.get('description'),
             'series': episode.get('seriesTitle'),
+            'subtitles': subtitles,
             'episode_number': int_or_none(episode.get('episodeNumber')),
             'season_number': int_or_none(episode.get('seasonNumber')),
             'duration': int_or_none(try_get(program, lambda x: x['video']['duration']['milliseconds']), 1000),

--- a/yt_dlp/extractor/tvplay.py
+++ b/yt_dlp/extractor/tvplay.py
@@ -392,10 +392,6 @@ class ViafreeIE(InfoExtractor):
     }]
     _GEO_BYPASS = False
 
-    @classmethod
-    def suitable(cls, url):
-        return False if TVPlayIE.suitable(url) else super(ViafreeIE, cls).suitable(url)
-
     def _real_extract(self, url):
         country, path = self._match_valid_url(url).groups()
         content = self._download_json(

--- a/yt_dlp/extractor/tvplay.py
+++ b/yt_dlp/extractor/tvplay.py
@@ -369,7 +369,8 @@ class ViafreeIE(InfoExtractor):
             'upload_date': '20201217'
         },
         'params': {
-            'format': 'bestvideo'
+            'format': 'bestvideo',
+            'skip_download': True
         }
     }, {
         # with relatedClips


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes #820 
Appears that some Viafree urls were being picked up by the TVPlay/mtg extractor. These no longer with such extractor, however, do work with the existing Viafree extractor.

This PR also adds support for subtitles.