### PR TITLE
Add optional iwara.tv extractor fields

### DIFF
--- a/yt_dlp/extractor/iwara.py
+++ b/yt_dlp/extractor/iwara.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
+import re
 
 from .common import InfoExtractor
 from ..compat import compat_urllib_parse_urlparse
@@ -21,6 +22,7 @@ class IwaraIE(InfoExtractor):
             'ext': 'mp4',
             'title': '【MMD R-18】ガールフレンド carry_me_off',
             'age_limit': 18,
+            'thumbnail': 'https://i.iwara.tv/sites/default/files/videos/thumbnails/7951/thumbnail-7951_0001.png',
         },
     }, {
         'url': 'http://ecchi.iwara.tv/videos/Vb4yf2yZspkzkBO',
@@ -73,8 +75,18 @@ class IwaraIE(InfoExtractor):
             r'<title>([^<]+)</title>', webpage, 'title'), ' | Iwara')
 
         thumbnail = self._html_search_regex(
-            r'<video[^>]+id=[\'"]video-player[\'"][^>]+poster=[\'"]([^\'"]+)',
-            webpage, 'thumbnail', default=None)
+            r'poster=[\'"]([^\'"]+)', webpage, 'thumbnail', default=None)
+
+        uploader = self._html_search_regex(
+            r'class="username">([^<]+)', webpage, 'uploader', fatal=False)
+
+        upload_date = self._html_search_regex(
+            r'作成日:([^\s]+)', webpage, 'upload_date', fatal=False).replace("-", "")
+
+        description = self._search_regex(
+            r'<p>(.+?(?=</div))', webpage, 'description', fatal=False,
+            flags=re.DOTALL).strip()
+
 
         formats = []
         for a_format in video_data:
@@ -101,4 +113,7 @@ class IwaraIE(InfoExtractor):
             'age_limit': age_limit,
             'formats': formats,
             'thumbnail': self._proto_relative_url(thumbnail, 'https:'),
+            'uploader': uploader,
+            'upload_date': upload_date,
+            'description': description,
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Added the InfoExtractor fields `uploader`, `upload_date`, and `description` for the website iwara.tv

I've also fixed the old `thumbnail` extractor. I think the site updated and broke the old one
