### PR TITLE
[afreecatv] Fix adult (19+) VODs

### DIFF
--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -237,6 +237,7 @@ class AfreecaTVIE(InfoExtractor):
             r'nTitleNo\s*=\s*(\d+)', webpage, 'title', default=video_id)
 
         partial_view = False
+        adult_view = False
         for _ in range(2):
             query = {
                 'nTitleNo': video_id,
@@ -245,6 +246,8 @@ class AfreecaTVIE(InfoExtractor):
             }
             if partial_view:
                 query['partialView'] = 'SKIP_ADULT'
+            if adult_view:
+                query['adultView'] = 'ADULT_VIEW'
             video_xml = self._download_xml(
                 'http://afbbs.afreecatv.com:8080/api/video/get_video_info.php',
                 video_id, 'Downloading video info XML%s'
@@ -264,6 +267,9 @@ class AfreecaTVIE(InfoExtractor):
                 partial_view = True
                 continue
             elif flag == 'ADULT':
+                if not adult_view:
+                    adult_view = True
+                    continue
                 error = 'Only users older than 19 are able to watch this video. Provide account credentials to download this content.'
             else:
                 error = flag


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

AfreecaTV marks segments of VODs, or entire VODs, as adult content. When accessing a VOD with adult segments from an underage account or when not logged in, the first request fails with a `PARTIAL_ADULT` error flag, and we retry with the `partialView=SKIP_ADULT` query parameter. This allows us to download the segments of the video that are not marked as adult.

Now, when accessing a VOD that is entirely marked as adult content, the first request fails with an `ADULT` error flag, *even if logged in to an adult account*. The web client presents a click-through warning, and refetches the XML with `adultView=ADULT_VIEW`.

This commit adjusts the existing retry logic for `PARTIAL_ADULT` to also support retrying `ADULT` VODs with the required parameter.

If the same `ADULT` error is returned on the second attempt, we raise the same error as before. This will occur if we are not logged in to an adult account.

At this time it does not appear that the click-through warning has been added to `PARTIAL_ADULT` VODs, so if we are logged in, our first request is still successful. Therefore, the `PARTIAL_ADULT` logic does not need to be changed.

The VODs mentioned in the below tickets are both now private, so I cannot test the given URLs, but I believe that this:

Fixes https://github.com/ytdl-org/youtube-dl/issues/26622
Fixes https://github.com/ytdl-org/youtube-dl/issues/26926

This pull request also appeared at https://github.com/ytdl-org/youtube-dl/pull/28405