### PR TITLE
[afreecatv] Tolerate failure to parse date string

### DIFF
--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -10,6 +10,7 @@ from ..utils import (
     determine_ext,
     ExtractorError,
     int_or_none,
+    unified_strdate,
     url_or_none,
     urlencode_postdata,
     xpath_text,
@@ -310,17 +311,14 @@ class AfreecaTVIE(InfoExtractor):
                 if not file_url:
                     continue
                 key = file_element.get('key', '')
-                upload_date = self._search_regex(
-                    r'^(\d{8})_', key, 'upload date', default=None)
+                upload_date = unified_strdate(self._search_regex(
+                    r'^(\d{8})_', key, 'upload date', default=None))
                 if upload_date is not None:
-                    try:
-                        # sometimes the upload date isn't included in the file name
-                        # instead, another random ID is, which may not parse as a date
-                        # or may be wildly out of a reasonable range
-                        parsed_date = date_from_str(upload_date)
-                        if parsed_date.year < 2000 or parsed_date.year >= 2100:
-                            upload_date = None
-                    except ValueError:
+                    # sometimes the upload date isn't included in the file name
+                    # instead, another random ID is, which may parse as a valid
+                    # date but be wildly out of a reasonable range
+                    parsed_date = date_from_str(upload_date)
+                    if parsed_date.year < 2000 or parsed_date.year >= 2100:
                         upload_date = None
                 file_duration = int_or_none(file_element.get('duration'))
                 format_id = key if key else '%s_%s' % (video_id, file_num)

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -6,6 +6,7 @@ import re
 from .common import InfoExtractor
 from ..compat import compat_xpath
 from ..utils import (
+    date_from_str,
     determine_ext,
     ExtractorError,
     int_or_none,
@@ -311,6 +312,16 @@ class AfreecaTVIE(InfoExtractor):
                 key = file_element.get('key', '')
                 upload_date = self._search_regex(
                     r'^(\d{8})_', key, 'upload date', default=None)
+                if upload_date is not None:
+                    try:
+                        # sometimes the upload date isn't included in the file name
+                        # instead, another random ID is, which may not parse as a date
+                        # or may be wildly out of a reasonable range
+                        parsed_date = date_from_str(upload_date)
+                        if parsed_date.year < 2000 or parsed_date.year >= 2100:
+                            upload_date = None
+                    except ValueError:
+                        upload_date = None
                 file_duration = int_or_none(file_element.get('duration'))
                 format_id = key if key else '%s_%s' % (video_id, file_num)
                 if determine_ext(file_url) == 'm3u8':


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The AfreecaTV extractor currently relies on the fact that video filenames contain the upload date. Unfortunately, there appear to be some videos where this is not the case (I would cite examples, but all that I have encountered have since been deleted or made private). For these videos, the extractor puts junk data into the upload date field, which later causes a parse error that fails the download.

This commit adjusts the extractor's logic for parsing the upload date, so that after it extracts a candidate date value:

1. if the value does not parse as a valid date, the upload date is set to `None`, and
2. if the value *does* parse as a valid date, but the date is outside a reasonable range (currently defined as "the 21st century"), the upload date is set to `None`.

I'm open to suggestions on other sanity checks; this commit represents only the bare minimum necessary to avoid failures on certain videos.

At this time, it seems that a very large majority of video files *do* have the upload date in their filenames, so the filename heuristic isn't entirely without merit - i.e. it can probably stay, until and unless someone implements a more robust way to look up the upload date.