### PR TITLE
[XHamster] fix: extract uploader_id

### DIFF
--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -245,14 +245,16 @@ class XHamsterIE(InfoExtractor):
             else:
                 categories = None
 
+            uploader = try_get(video, lambda x: x['author']['name'], compat_str)
+
             return {
                 'id': video_id,
                 'display_id': display_id,
                 'title': title,
                 'description': video.get('description'),
                 'timestamp': int_or_none(video.get('created')),
-                'uploader': try_get(
-                    video, lambda x: x['author']['name'], compat_str),
+                'uploader': uploader,
+                'uploader_id': uploader,
                 'thumbnail': video.get('thumbURL'),
                 'duration': int_or_none(video.get('duration')),
                 'view_count': int_or_none(video.get('views')),
@@ -352,6 +354,7 @@ class XHamsterIE(InfoExtractor):
             'description': description,
             'upload_date': upload_date,
             'uploader': uploader,
+            'uploader_id': uploader,
             'thumbnail': thumbnail,
             'duration': duration,
             'view_count': view_count,

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -245,7 +245,7 @@ class XHamsterIE(InfoExtractor):
             else:
                 categories = None
 
-            uploader = try_get(video, lambda x: x['author']['name'], compat_str)
+            uploader_url = url_or_none(try_get(video, lambda x: x['author']['pageURL']))
 
             return {
                 'id': video_id,
@@ -253,8 +253,10 @@ class XHamsterIE(InfoExtractor):
                 'title': title,
                 'description': video.get('description'),
                 'timestamp': int_or_none(video.get('created')),
-                'uploader': uploader,
-                'uploader_id': uploader,
+                'uploader': try_get(
+                    video, lambda x: x['author']['name'], compat_str),
+                'uploader_url': uploader_url,
+                'uploader_id': uploader_url.split('/')[-1] if uploader_url else None,
                 'thumbnail': video.get('thumbURL'),
                 'duration': int_or_none(video.get('duration')),
                 'view_count': int_or_none(video.get('views')),
@@ -354,7 +356,7 @@ class XHamsterIE(InfoExtractor):
             'description': description,
             'upload_date': upload_date,
             'uploader': uploader,
-            'uploader_id': uploader,
+            'uploader_id': uploader.lower() if uploader else None,
             'thumbnail': thumbnail,
             'duration': duration,
             'view_count': view_count,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature
