### PR TITLE
[youtube] Retry on 'Unknown Error' and do not repeat unimportant alerts

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -818,15 +818,14 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 try:
                     self._extract_and_report_alerts(response, expected=False, only_once=True)
                 except ExtractorError as e:
-                    err_str = error_to_compat_str(e)
                     # YouTube servers may return errors we want to retry on in a 200 OK response
                     # See: https://github.com/yt-dlp/yt-dlp/issues/839
-                    if 'unknown error' in err_str.lower():
-                        last_error = remove_end(err_str, bug_reports_message())
+                    if 'unknown error' in e.msg.lower():
+                        last_error = e.msg
                         continue
                     if fatal:
                         raise
-                    self.report_warning(err_str)
+                    self.report_warning(error_to_compat_str(e))
                     return
                 if not check_get_keys or dict_get(response, check_get_keys):
                     break

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -29,7 +29,6 @@ from ..compat import (
 from ..jsinterp import JSInterpreter
 from ..utils import (
     bytes_to_intlist,
-    bug_reports_message,
     clean_html,
     datetime_from_str,
     dict_get,

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -29,6 +29,7 @@ from ..compat import (
 from ..jsinterp import JSInterpreter
 from ..utils import (
     bytes_to_intlist,
+    bug_reports_message,
     clean_html,
     datetime_from_str,
     dict_get,
@@ -48,6 +49,7 @@ from ..utils import (
     parse_iso8601,
     parse_qs,
     qualities,
+    remove_end,
     remove_start,
     smuggle_url,
     str_or_none,
@@ -720,7 +722,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 if message:
                     yield alert_type, message
 
-    def _report_alerts(self, alerts, expected=True, fatal=True):
+    def _report_alerts(self, alerts, expected=True, fatal=True, only_once=False):
         errors = []
         warnings = []
         for alert_type, alert_message in alerts:
@@ -730,7 +732,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 warnings.append([alert_type, alert_message])
 
         for alert_type, alert_message in (warnings + errors[:-1]):
-            self.report_warning('YouTube said: %s - %s' % (alert_type, alert_message))
+            self.report_warning('YouTube said: %s - %s' % (alert_type, alert_message), only_once=only_once)
         if errors:
             raise ExtractorError('YouTube said: %s' % errors[-1][1], expected=expected)
 
@@ -779,7 +781,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         while count < retries:
             count += 1
             if last_error:
-                self.report_warning('%s. Retrying ...' % last_error)
+                self.report_warning('%s. Retrying ...' % remove_end(last_error, '.'))
             try:
                 response = self._call_api(
                     ep=ep, fatal=True, headers=headers,
@@ -814,11 +816,17 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             else:
                 # Youtube may send alerts if there was an issue with the continuation page
                 try:
-                    self._extract_and_report_alerts(response, expected=False)
+                    self._extract_and_report_alerts(response, expected=False, only_once=True)
                 except ExtractorError as e:
+                    err_str = error_to_compat_str(e)
+                    # YouTube servers may return errors we want to retry on in a 200 OK response
+                    # See: https://github.com/yt-dlp/yt-dlp/issues/839
+                    if 'unknown error' in err_str.lower():
+                        last_error = remove_end(err_str, bug_reports_message())
+                        continue
                     if fatal:
                         raise
-                    self.report_warning(error_to_compat_str(e))
+                    self.report_warning(err_str)
                     return
                 if not check_get_keys or dict_get(response, check_get_keys):
                     break
@@ -4285,7 +4293,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         # YouTube sometimes provides a button to reload playlist with unavailable videos.
         if 'no-youtube-unavailable-videos' not in compat_opts:
             data = self._reload_with_unavailable_videos(item_id, data, webpage) or data
-        self._extract_and_report_alerts(data)
+        self._extract_and_report_alerts(data, only_once=True)
         tabs = try_get(
             data, lambda x: x['contents']['twoColumnBrowseResultsRenderer']['tabs'], list)
         if tabs:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Retries on the 'Unknown Error' error sometimes received in an 200 OK response. (Fixes #839)

Also adds `only_once` to (unimportant) alert extraction. This fixes an issue where YouTube is displaying a different message regarding unavailable videos on every playlist page, regardless of if we are showing unavailable videos.
Might be worth investigating whether this may cause any issues with other messages.
