### PR TITLE
[SovietsCloset] Add duration from m3u8

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2214,6 +2214,35 @@ class InfoExtractor(object):
                 last_stream_inf = {}
         return formats, subtitles
 
+    def _extract_m3u8_vod_duration(
+            self, m3u8_vod_url, video_id, note=None, errnote=None, fatal=True,
+            data=None, headers={}, query={}):
+
+        res = self._download_webpage_handle(
+            m3u8_vod_url, video_id,
+            note='Downloading m3u8 VOD manifest' if note is None else note,
+            errnote='Failed to download VOD manifest' if errnote is None else errnote,
+            fatal=fatal, data=data, headers=headers, query=query)
+
+        if res is False:
+            return None
+
+        m3u8_vod, urlh = res
+
+        return self._parse_m3u8_vod_duration(m3u8_vod, video_id)
+
+    def _parse_m3u8_vod_duration(self, m3u8_vod, video_id):
+        if '#EXT-X-PLAYLIST-TYPE:VOD' not in m3u8_vod:
+            return None
+
+        duration = 0
+        for line in m3u8_vod.splitlines():
+            if line.startswith('#EXTINF:'):
+                segment_duration = float(line.split("#EXTINF:")[1].split(",")[0])
+                duration += int(segment_duration)
+
+        return duration
+
     @staticmethod
     def _xpath_ns(path, namespace=None):
         if not namespace:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2215,33 +2215,23 @@ class InfoExtractor(object):
         return formats, subtitles
 
     def _extract_m3u8_vod_duration(
-            self, m3u8_vod_url, video_id, note=None, errnote=None, fatal=True,
-            data=None, headers={}, query={}):
+            self, m3u8_vod_url, video_id, note=None, errnote=None, data=None, headers={}, query={}):
 
-        res = self._download_webpage_handle(
+        m3u8_vod = self._download_webpage(
             m3u8_vod_url, video_id,
             note='Downloading m3u8 VOD manifest' if note is None else note,
             errnote='Failed to download VOD manifest' if errnote is None else errnote,
-            fatal=fatal, data=data, headers=headers, query=query)
+            fatal=False, data=data, headers=headers, query=query)
 
-        if res is False:
-            return None
-
-        m3u8_vod, urlh = res
-
-        return self._parse_m3u8_vod_duration(m3u8_vod, video_id)
+        return self._parse_m3u8_vod_duration(m3u8_vod or '', video_id)
 
     def _parse_m3u8_vod_duration(self, m3u8_vod, video_id):
         if '#EXT-X-PLAYLIST-TYPE:VOD' not in m3u8_vod:
             return None
 
-        duration = 0
-        for line in m3u8_vod.splitlines():
-            if line.startswith('#EXTINF:'):
-                segment_duration = float(line.split("#EXTINF:")[1].split(",")[0])
-                duration += int(segment_duration)
-
-        return duration
+        return int(sum(
+            float(line[len('#EXTINF:'):].split(',')[0])
+            for line in m3u8_vod.splitlines() if line.startswith('#EXTINF:'))) or None
 
     @staticmethod
     def _xpath_ns(path, namespace=None):

--- a/yt_dlp/extractor/sovietscloset.py
+++ b/yt_dlp/extractor/sovietscloset.py
@@ -122,7 +122,7 @@ class SovietsClosetIE(SovietsClosetBaseIE):
             duration = None
         else:
             duration = self._extract_m3u8_vod_duration(
-                m3u8_formats[0]["url"], video_id, headers=self.MEDIADELIVERY_REFERER)
+                m3u8_formats[0]['url'], video_id, headers=self.MEDIADELIVERY_REFERER)
 
         return {
             'formats': m3u8_formats,

--- a/yt_dlp/extractor/sovietscloset.py
+++ b/yt_dlp/extractor/sovietscloset.py
@@ -72,6 +72,7 @@ class SovietsClosetIE(SovietsClosetBaseIE):
                 'upload_date': '20170413',
                 'uploader_id': 'SovietWomble',
                 'uploader_url': 'https://www.twitch.tv/SovietWomble',
+                'duration': 7007,
                 'was_live': True,
                 'availability': 'public',
                 'series': 'The Witcher',
@@ -96,6 +97,7 @@ class SovietsClosetIE(SovietsClosetBaseIE):
                 'upload_date': '20160420',
                 'uploader_id': 'SovietWomble',
                 'uploader_url': 'https://www.twitch.tv/SovietWomble',
+                'duration': 8804,
                 'was_live': True,
                 'availability': 'public',
                 'series': 'Arma 3',
@@ -116,9 +118,16 @@ class SovietsClosetIE(SovietsClosetBaseIE):
         m3u8_formats = self._extract_m3u8_formats(m3u8_url, video_id, headers=self.MEDIADELIVERY_REFERER)
         self._sort_formats(m3u8_formats)
 
+        if not m3u8_formats:
+            duration = None
+        else:
+            duration = self._extract_m3u8_vod_duration(
+                m3u8_formats[0]["url"], video_id, headers=self.MEDIADELIVERY_REFERER)
+
         return {
             'formats': m3u8_formats,
             'thumbnail': thumbnail_url,
+            'duration': duration,
         }
 
     def _real_extract(self, url):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adds helper methods that add up m3u8 VOD segment durations and adds duration for SovietsCloset videos.
