### PR TITLE
Fix usage of --no-config as an alias for --ignore-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,7 +919,7 @@ For example, with the following configuration file yt-dlp will always extract th
 
 Note that options in configuration file are just the same options aka switches used in regular command line calls; thus there **must be no whitespace** after `-` or `--`, e.g. `-o` or `--proxy` but not `- o` or `-- proxy`.
 
-You can use `--ignore-config` if you want to disable all configuration files for a particular yt-dlp run. If `--ignore-config` is found inside any configuration file, no further configuration will be loaded. For example, having the option in the portable configuration file prevents loading of user and system configurations. Additionally, (for backward compatibility) if `--ignore-config` is found inside the system configuration file, the user configuration is not loaded.
+You can use `--ignore-config` or `--no-config` if you want to disable all configuration files for a particular yt-dlp run. If `--ignore-config` or `--no-config` is found inside any configuration file, no further configuration will be loaded. For example, having the option in the portable configuration file prevents loading of user and system configurations. Additionally, (for backward compatibility) if `--ignore-config` or `--no-config` is found inside the system configuration file, the user configuration is not loaded.
 
 ### Authentication with `.netrc` file
 

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1547,9 +1547,9 @@ def parseOpts(overrideArguments=None):
                     configs['custom'] = []
                 else:
                     paths['custom'] = location
-            if '--ignore-config' in configs['command-line']:
+            if '--ignore-config' in configs['command-line'] or '--no-config' in configs['command-line']:
                 return
-            if '--ignore-config' in configs['custom']:
+            if '--ignore-config' in configs['custom'] or '--no-config' in configs['custom']:
                 return
 
             def read_options(path, user=False):
@@ -1567,7 +1567,7 @@ def parseOpts(overrideArguments=None):
                 return [], None
 
             configs['portable'], paths['portable'] = read_options(get_executable_path())
-            if '--ignore-config' in configs['portable']:
+            if '--ignore-config' in configs['portable'] or '--no-config' in configs['portable']:
                 return
 
             def get_home_path():
@@ -1575,15 +1575,15 @@ def parseOpts(overrideArguments=None):
                 return expand_path(opts.paths.get('home', '')).strip()
 
             configs['home'], paths['home'] = read_options(get_home_path())
-            if '--ignore-config' in configs['home']:
+            if '--ignore-config' in configs['home'] or '--no-config' in configs['home']:
                 return
 
             configs['system'], paths['system'] = read_options('/etc')
-            if '--ignore-config' in configs['system']:
+            if '--ignore-config' in configs['system'] or '--no-config' in configs['system']:
                 return
 
             configs['user'], paths['user'] = read_options('', True)
-            if '--ignore-config' in configs['user']:
+            if '--ignore-config' in configs['user'] or '--no-config' in configs['user']:
                 configs['system'], paths['system'] = [], None
 
         get_configs()


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

`--no-config` was introduced as an alias for `--ignore-config` but there were some cases where this was not reflected. This PR fixes those cases.

Fixes #912.