### PR TITLE
Add MuseScoreIE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.conf
 *.spec
 cookies
-cookies.txt
+*cookies.txt
 
 # Downloaded
 *.srt

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -801,6 +801,7 @@ from .mtv import (
     MTVItaliaProgrammaIE,
 )
 from .muenchentv import MuenchenTVIE
+from .musescore import MuseScoreIE
 from .mwave import MwaveIE, MwaveMeetGreetIE
 from .mxplayer import (
     MxplayerIE,

--- a/yt_dlp/extractor/musescore.py
+++ b/yt_dlp/extractor/musescore.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class MuseScoreIE(InfoExtractor):
+    _VALID_URL = r'(?:https?://)(?:www\.)?musescore\.com/(?:user/\d+|[^/]+)(?:/scores)?/(?P<id>[^#&?]+)'
+    _TESTS = [{
+        'url': 'https://musescore.com/minh_cuteee/scores/6555384',
+        'info_dict': {
+            'id': '6555384',
+            'ext': 'mp3',
+            'title': 'Waltz No. 2 (The Second Waltz) by Dmitri Shostakovich for Piano',
+            'description': 'md5:4632f2a04d34311292c3fd89211c5d7c',
+            'thumbnail': r're:(?:https?://)(?:www\.)?musescore\.com/.*\.png[^$]+',
+            'uploader': 'Minh_Cuteee',
+            'creator': 'Dmaitri Shostakovich',
+        }
+    }, {
+        'url': 'https://musescore.com/user/12461571/scores/3291706',
+        'info_dict': {
+            'id': '3291706',
+            'ext': 'mp3',
+            'title': 'River Flows In You',
+            'description': 'md5:148c03afb5b1d237bca46458e225f4fd',
+            'thumbnail': r're:(?:https?://)(?:www\.)?musescore\.com/.*\.png[^$]+',
+            'uploader': 'emmy langevin',
+            'creator': 'YIRUMA',
+        }
+    }, {
+        'url': 'https://musescore.com/classicman/fur-elise',
+        'info_dict': {
+            'id': '33816',
+            'ext': 'mp3',
+            'title': 'Für Elise – Beethoven',
+            'description': 'md5:49515a3556d5ecaf9fa4b2514064ac34',
+            'thumbnail': r're:(?:https?://)(?:www\.)?musescore\.com/.*\.png[^$]+',
+            'uploader': 'ClassicMan',
+            'creator': 'Ludwig van Beethoven (1770–1827)',
+        }
+    }]
+
+    def _real_extract(self, url):
+        webpage = self._download_webpage(url, None)
+        url = self._og_search_url(webpage) or url
+        id = self._match_id(url)
+        mp3_url = self._download_json(f'https://musescore.com/api/jmuse?id={id}&index=0&type=mp3&v2=1', id,
+                                      headers={'authorization': '63794e5461e4cfa046edfbdddfccc1ac16daffd2'})['info']['url']
+        formats = [{
+            'url': mp3_url,
+            'ext': 'mp3',
+            'vcodec': 'none',
+        }]
+
+        return {
+            'id': id,
+            'formats': formats,
+            'title': self._og_search_title(webpage),
+            'description': self._og_search_description(webpage),
+            'thumbnail': self._og_search_thumbnail(webpage),
+            'uploader': self._html_search_meta('musescore:author', webpage, 'uploader'),
+            'creator': self._html_search_meta('musescore:composer', webpage, 'composer'),
+        }

--- a/yt_dlp/extractor/musescore.py
+++ b/yt_dlp/extractor/musescore.py
@@ -7,26 +7,26 @@ from .common import InfoExtractor
 class MuseScoreIE(InfoExtractor):
     _VALID_URL = r'(?:https?://)(?:www\.)?musescore\.com/(?:user/\d+|[^/]+)(?:/scores)?/(?P<id>[^#&?]+)'
     _TESTS = [{
-        'url': 'https://musescore.com/minh_cuteee/scores/6555384',
+        'url': 'https://musescore.com/user/73797/scores/142975',
         'info_dict': {
-            'id': '6555384',
+            'id': '142975',
             'ext': 'mp3',
-            'title': 'Waltz No. 2 (The Second Waltz) by Dmitri Shostakovich for Piano',
-            'description': 'md5:4632f2a04d34311292c3fd89211c5d7c',
+            'title': 'WA Mozart Marche Turque (Turkish March fingered)',
+            'description': 'md5:7ede08230e4eaabd67a4a98bb54d07be',
             'thumbnail': r're:(?:https?://)(?:www\.)?musescore\.com/.*\.png[^$]+',
-            'uploader': 'Minh_Cuteee',
-            'creator': 'Dmaitri Shostakovich',
+            'uploader': 'PapyPiano',
+            'creator': 'Wolfgang Amadeus Mozart',
         }
     }, {
-        'url': 'https://musescore.com/user/12461571/scores/3291706',
+        'url': 'https://musescore.com/user/36164500/scores/6837638',
         'info_dict': {
-            'id': '3291706',
+            'id': '6837638',
             'ext': 'mp3',
-            'title': 'River Flows In You',
-            'description': 'md5:148c03afb5b1d237bca46458e225f4fd',
+            'title': 'Sweet Child O\' Mine  – Guns N\' Roses sweet child',
+            'description': 'md5:4dca71191c14abc312a0a4192492eace',
             'thumbnail': r're:(?:https?://)(?:www\.)?musescore\.com/.*\.png[^$]+',
-            'uploader': 'emmy langevin',
-            'creator': 'YIRUMA',
+            'uploader': 'roxbelviolin',
+            'creator': 'Guns N´Roses Arr. Roxbel Violin',
         }
     }, {
         'url': 'https://musescore.com/classicman/fur-elise',
@@ -39,6 +39,9 @@ class MuseScoreIE(InfoExtractor):
             'uploader': 'ClassicMan',
             'creator': 'Ludwig van Beethoven (1770–1827)',
         }
+    }, {
+        'url': 'https://musescore.com/minh_cuteee/scores/6555384',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Closes https://github.com/yt-dlp/yt-dlp/issues/911

Ln 46-47 is such that ln 48 it will break if id is matched from user provided url instead of url from webpage, this is intended.
mp3_url is also extracted in such way that it should break if json is irregular.