### PR TITLE
Lookup order of .netrc on windows

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1166,14 +1166,13 @@ class InfoExtractor(object):
 
         if self.get_param('usenetrc', False):
             try:
-                try:
-                    netrc_file = os.path.join(self.get_param('config_location', None), ".netrc")
-                    if not os.path.exists(netrc_file):
-                        netrc_file = os.path.join(os.environ.get('HOME'), ".netrc")
-                        if not os.path.exists(netrc_file):
-                            netrc_file = None
-                except TypeError:
-                    netrc_file = None
+                location = self.get_param('config_location', None)
+                netrc_file = os.path.join(location, ".netrc") if location is not None else None
+                if netrc_file is None or not os.path.exists(netrc_file):
+                    location = os.environ.get('HOME')
+                    netrc_file = os.path.join(location, ".netrc") if location is not None else None
+                    if netrc_file is None or not os.path.exists(netrc_file):
+                        netrc_file = None
                 # if file is None looks for it in %HOMEDRIVE%\%HOMEPROFILE%
                 info = netrc.netrc(file=netrc_file).authenticators(netrc_machine)
                 if info is not None:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1173,7 +1173,7 @@ class InfoExtractor(object):
                     netrc_file = os.path.join(location, ".netrc") if location is not None else None
                     if netrc_file is None or not os.path.exists(netrc_file):
                         netrc_file = None
-                # if file is None looks for it in %HOMEDRIVE%\%HOMEPROFILE%
+                # if file is None looks for it in %USERPROFILE% if set otherwise in %HOMEDRIVE%\%HOMEPATH%
                 info = netrc.netrc(file=netrc_file).authenticators(netrc_machine)
                 if info is not None:
                     username = info[0]

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1167,11 +1167,14 @@ class InfoExtractor(object):
         if self.get_param('usenetrc', False):
             try:
                 try:
-                    netrc_file = os.path.join(os.environ.get('HOME'), ".netrc")
+                    netrc_file = os.path.join(self.get_param('config_location', None), ".netrc")
                     if not os.path.exists(netrc_file):
-                        netrc_file = None
+                        netrc_file = os.path.join(os.environ.get('HOME'), ".netrc")
+                        if not os.path.exists(netrc_file):
+                            netrc_file = None
                 except TypeError:
                     netrc_file = None
+                # if file is None looks for it in %HOMEDRIVE%\%HOMEPROFILE%
                 info = netrc.netrc(file=netrc_file).authenticators(netrc_machine)
                 if info is not None:
                     username = info[0]

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1166,7 +1166,9 @@ class InfoExtractor(object):
 
         if self.get_param('usenetrc', False):
             try:
-                info = netrc.netrc().authenticators(netrc_machine)
+                home = os.environ.get('HOME')
+                netrc_file = None if home is None else os.path.join(home, ".netrc")
+                info = netrc.netrc(file=netrc_file).authenticators(netrc_machine)
                 if info is not None:
                     username = info[0]
                     password = info[2]

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1166,8 +1166,12 @@ class InfoExtractor(object):
 
         if self.get_param('usenetrc', False):
             try:
-                home = os.environ.get('HOME')
-                netrc_file = None if home is None else os.path.join(home, ".netrc")
+                try:
+                    netrc_file = os.path.join(os.environ.get('HOME'), ".netrc")
+                    if not os.path.exists(netrc_file):
+                        netrc_file = None
+                except TypeError:
+                    netrc_file = None
                 info = netrc.netrc(file=netrc_file).authenticators(netrc_machine)
                 if info is not None:
                     username = info[0]


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Due to changes introduced in python 3.8, it no longer uses "%HOME%". 
For required compatibility first existence of "%HOME%\.netrc" is checked.

No upstream solution.

This is untested!

closes #792 