### PR TITLE
[soundcloud] Add related tracks extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1284,6 +1284,7 @@ from .soundcloud import (
     SoundcloudEmbedIE,
     SoundcloudIE,
     SoundcloudSetIE,
+    SoundcloudRelatedIE,
     SoundcloudUserIE,
     SoundcloudTrackStationIE,
     SoundcloudPlaylistIE,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

## Description

examples:
- https://soundcloud.com/wajang/sexapil-pingers-5/recommended
- https://soundcloud.com/wajang/sexapil-pingers-5/sets
- https://soundcloud.com/wajang/sexapil-pingers-5/albums

This is an initial patch for another soundcloud extractor. I still need to add some test values (only manual probing, i will look at test results tomorrow).

Specifically i'm requesting comments about:

- the regex change at line 75-77 (i don't know what a token is nor tested with one)
- the playlist id i'm giving at line 852 is just the id of the track, not the real id of the playlist, but that is consistent with other uses of `SoundcloudPagedPlaylistBaseIE`. Btw the whole style is imho a bit wrong (inconsistent checking of the `id` field, invented id where it could be gotten from first page response i think), but should be fixed consistently on all usages of this base-class.

Kudos for keeping the beast working.