### PR TITLE
Remove mutable default from keyword arguments of function definition

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -567,7 +567,8 @@ class TestYoutubeDL(unittest.TestCase):
             'webpage_url': 'http://example.com/watch?v=shenanigans',
         }
 
-        def get_info(params={}):
+        def get_info(params=None):
+            params = {} if params is None else params
             params.setdefault('simulate', True)
             ydl = YDL(params)
             ydl.report_warning = lambda *args, **kargs: None

--- a/yt_dlp/downloader/__init__.py
+++ b/yt_dlp/downloader/__init__.py
@@ -7,7 +7,8 @@ from ..utils import (
 )
 
 
-def get_suitable_downloader(info_dict, params={}, default=NO_DEFAULT, protocol=None, to_stdout=False):
+def get_suitable_downloader(info_dict, params=None, default=NO_DEFAULT, protocol=None, to_stdout=False):
+    params = {} if params is None else params
     info_dict['protocol'] = determine_protocol(info_dict)
     info_copy = info_dict.copy()
     if protocol:

--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1381,8 +1381,10 @@ class AdobePassIE(InfoExtractor):
             token_expires = unified_timestamp(re.sub(r'[_ ]GMT', '', xml_text(token, date_ele)))
             return token_expires and token_expires <= int(time.time())
 
-        def post_form(form_page_res, note, data={}):
+        def post_form(form_page_res, note, data=None):
+            data = {} if data is None else data
             form_page, urlh = form_page_res
+
             post_url = self._html_search_regex(r'<form[^>]+action=(["\'])(?P<url>.+?)\1', form_page, 'post url', group='url')
             if not re.match(r'https?://', post_url):
                 post_url = compat_urlparse.urljoin(urlh.geturl(), post_url)

--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1384,7 +1384,6 @@ class AdobePassIE(InfoExtractor):
         def post_form(form_page_res, note, data=None):
             data = {} if data is None else data
             form_page, urlh = form_page_res
-
             post_url = self._html_search_regex(r'<form[^>]+action=(["\'])(?P<url>.+?)\1', form_page, 'post url', group='url')
             if not re.match(r'https?://', post_url):
                 post_url = compat_urlparse.urljoin(urlh.geturl(), post_url)

--- a/yt_dlp/extractor/brightcove.py
+++ b/yt_dlp/extractor/brightcove.py
@@ -468,7 +468,8 @@ class BrightcoveNewIE(AdobePassIE):
 
         return entries
 
-    def _parse_brightcove_metadata(self, json_data, video_id, headers={}):
+    def _parse_brightcove_metadata(self, json_data, video_id, headers=None):
+        headers = {} if headers is None else headers
         title = json_data['name'].strip()
 
         num_drm_sources = 0

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -907,12 +907,15 @@ class InfoExtractor(object):
             self, url_or_request, video_id,
             note='Downloading XML', errnote='Unable to download XML',
             transform_source=None, fatal=True, encoding=None,
-            data=None, headers={}, query={}, expected_status=None):
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return the xml as an compat_etree_Element.
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_xml_handle(
             url_or_request, video_id, note=note, errnote=errnote,
             transform_source=transform_source, fatal=fatal, encoding=encoding,
@@ -3201,7 +3204,7 @@ class InfoExtractor(object):
 
         return formats, subtitles
 
-    def _extract_wowza_formats(self, url, video_id, m3u8_entry_protocol='m3u8_native', skip_protocols=[]):
+    def _extract_wowza_formats(self, url, video_id, m3u8_entry_protocol='m3u8_native', skip_protocols=()):
         query = compat_urlparse.urlparse(url).query
         url = re.sub(r'/(?:manifest|playlist|jwplayer)\.(?:m3u8|f4m|mpd|smil)', '', url)
         mobj = re.search(

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1790,7 +1790,7 @@ class InfoExtractor(object):
 
             return tuple(self._calculate_field_preference(format, field) for field in self._order)
 
-    def _sort_formats(self, formats, field_preference=[]):
+    def _sort_formats(self, formats, field_preference=()):
         if not formats:
             return
         format_sort = self.FormatSort()  # params and to_screen are taken from the downloader

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1790,7 +1790,8 @@ class InfoExtractor(object):
 
             return tuple(self._calculate_field_preference(format, field) for field in self._order)
 
-    def _sort_formats(self, formats, field_preference=[]):
+    def _sort_formats(self, formats, field_preference=None):
+        field_preference = [] if field_preference is None else field_preference
         if not formats:
             return
         format_sort = self.FormatSort()  # params and to_screen are taken from the downloader

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -651,12 +651,17 @@ class InfoExtractor(object):
         else:
             return err.code in variadic(expected_status)
 
-    def _request_webpage(self, url_or_request, video_id, note=None, errnote=None, fatal=True, data=None, headers={}, query={}, expected_status=None):
+    def _request_webpage(
+            self, url_or_request, video_id, note=None, errnote=None, fatal=True,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return the response handle.
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         if not self._downloader._first_webpage_request:
             sleep_interval = float_or_none(self.get_param('sleep_interval_requests')) or 0
             if sleep_interval > 0:
@@ -714,12 +719,17 @@ class InfoExtractor(object):
                 self.report_warning(errmsg)
                 return False
 
-    def _download_webpage_handle(self, url_or_request, video_id, note=None, errnote=None, fatal=True, encoding=None, data=None, headers={}, query={}, expected_status=None):
+    def _download_webpage_handle(
+            self, url_or_request, video_id, note=None, errnote=None, fatal=True, encoding=None,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return a tuple (page content as string, URL handle).
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         # Strip hashes from the URL (#1038)
         if isinstance(url_or_request, (compat_str, str)):
             url_or_request = url_or_request.partition('#')[0]
@@ -814,9 +824,8 @@ class InfoExtractor(object):
         return content
 
     def _download_webpage(
-            self, url_or_request, video_id, note=None, errnote=None,
-            fatal=True, tries=1, timeout=5, encoding=None, data=None,
-            headers={}, query={}, expected_status=None):
+            self, url_or_request, video_id, note=None, errnote=None, fatal=True, tries=1, timeout=5,
+            encoding=None, data=None, headers=None, query=None, expected_status=None):
         """
         Return the data of the page as a string.
 
@@ -850,6 +859,8 @@ class InfoExtractor(object):
             Note that this argument does not affect success status codes (2xx)
             which are always accepted.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
 
         success = False
         try_count = 0
@@ -872,15 +883,17 @@ class InfoExtractor(object):
             return content
 
     def _download_xml_handle(
-            self, url_or_request, video_id, note='Downloading XML',
-            errnote='Unable to download XML', transform_source=None,
-            fatal=True, encoding=None, data=None, headers={}, query={},
-            expected_status=None):
+            self, url_or_request, video_id, note='Downloading XML', errnote='Unable to download XML',
+            transform_source=None, fatal=True, encoding=None,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return a tuple (xml as an compat_etree_Element, URL handle).
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_webpage_handle(
             url_or_request, video_id, note, errnote, fatal=fatal,
             encoding=encoding, data=data, headers=headers, query=query,
@@ -922,15 +935,18 @@ class InfoExtractor(object):
                 self.report_warning(errmsg + str(ve))
 
     def _download_json_handle(
-            self, url_or_request, video_id, note='Downloading JSON metadata',
-            errnote='Unable to download JSON metadata', transform_source=None,
-            fatal=True, encoding=None, data=None, headers={}, query={},
-            expected_status=None):
+            self, url_or_request, video_id,
+            note='Downloading JSON metadata',errnote='Unable to download JSON metadata',
+            transform_source=None, fatal=True, encoding=None,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return a tuple (JSON object, URL handle).
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_webpage_handle(
             url_or_request, video_id, note, errnote, fatal=fatal,
             encoding=encoding, data=data, headers=headers, query=query,
@@ -943,15 +959,18 @@ class InfoExtractor(object):
             fatal=fatal), urlh
 
     def _download_json(
-            self, url_or_request, video_id, note='Downloading JSON metadata',
-            errnote='Unable to download JSON metadata', transform_source=None,
-            fatal=True, encoding=None, data=None, headers={}, query={},
-            expected_status=None):
+            self, url_or_request, video_id,
+            note='Downloading JSON metadata', errnote='Unable to download JSON metadata',
+            transform_source=None, fatal=True, encoding=None,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return the JSON object as a dict.
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_json_handle(
             url_or_request, video_id, note=note, errnote=errnote,
             transform_source=transform_source, fatal=fatal, encoding=encoding,
@@ -977,15 +996,17 @@ class InfoExtractor(object):
             video_id, transform_source, fatal)
 
     def _download_socket_json_handle(
-            self, url_or_request, video_id, note='Polling socket',
-            errnote='Unable to poll socket', transform_source=None,
-            fatal=True, encoding=None, data=None, headers={}, query={},
-            expected_status=None):
+            self, url_or_request, video_id, note='Polling socket', errnote='Unable to poll socket',
+            transform_source=None, fatal=True, encoding=None,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return a tuple (JSON object, URL handle).
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_webpage_handle(
             url_or_request, video_id, note, errnote, fatal=fatal,
             encoding=encoding, data=data, headers=headers, query=query,
@@ -998,15 +1019,17 @@ class InfoExtractor(object):
             fatal=fatal), urlh
 
     def _download_socket_json(
-            self, url_or_request, video_id, note='Polling socket',
-            errnote='Unable to poll socket', transform_source=None,
-            fatal=True, encoding=None, data=None, headers={}, query={},
-            expected_status=None):
+            self, url_or_request, video_id, note='Polling socket', errnote='Unable to poll socket',
+            transform_source=None, fatal=True, encoding=None,
+            data=None, headers=None, query=None, expected_status=None):
         """
         Return the JSON object as a dict.
 
         See _download_webpage docstring for arguments specification.
         """
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_socket_json_handle(
             url_or_request, video_id, note=note, errnote=errnote,
             transform_source=transform_source, fatal=fatal, encoding=encoding,
@@ -1794,7 +1817,9 @@ class InfoExtractor(object):
                 unique_formats.append(f)
         formats[:] = unique_formats
 
-    def _is_valid_url(self, url, video_id, item='video', headers={}):
+    def _is_valid_url(self, url, video_id, item='video', headers=None):
+        headers = {} if headers is None else headers
+
         url = self._proto_relative_url(url, scheme='http:')
         # For now assume non HTTP(S) URLs always valid
         if not (url.startswith('http://') or url.startswith('https://')):
@@ -1832,9 +1857,13 @@ class InfoExtractor(object):
         self.to_screen(msg)
         time.sleep(timeout)
 
-    def _extract_f4m_formats(self, manifest_url, video_id, preference=None, quality=None, f4m_id=None,
-                             transform_source=lambda s: fix_xml_ampersands(s).strip(),
-                             fatal=True, m3u8_id=None, data=None, headers={}, query={}):
+    def _extract_f4m_formats(
+            self, manifest_url, video_id, preference=None, quality=None, f4m_id=None,
+            transform_source=lambda s: fix_xml_ampersands(s).strip(), fatal=True, m3u8_id=None,
+            data=None, headers=None, query=None):
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         manifest = self._download_xml(
             manifest_url, video_id, 'Downloading f4m manifest',
             'Unable to download f4m manifest',
@@ -1976,8 +2005,9 @@ class InfoExtractor(object):
     def _extract_m3u8_formats_and_subtitles(
             self, m3u8_url, video_id, ext=None, entry_protocol='m3u8_native',
             preference=None, quality=None, m3u8_id=None, note=None,
-            errnote=None, fatal=True, live=False, data=None, headers={},
-            query={}):
+            errnote=None, fatal=True, live=False, data=None, headers=None, query=None):
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
 
         res = self._download_webpage_handle(
             m3u8_url, video_id,
@@ -2000,8 +2030,10 @@ class InfoExtractor(object):
     def _parse_m3u8_formats_and_subtitles(
             self, m3u8_doc, m3u8_url, ext=None, entry_protocol='m3u8_native',
             preference=None, quality=None, m3u8_id=None, live=False, note=None,
-            errnote=None, fatal=True, data=None, headers={}, query={},
-            video_id=None):
+            errnote=None, fatal=True, data=None, headers=None, query=None, video_id=None):
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         formats, subtitles = [], {}
 
         if '#EXT-X-FAXS-CM:' in m3u8_doc:  # Adobe Flash Access
@@ -2483,7 +2515,10 @@ class InfoExtractor(object):
 
     def _extract_mpd_formats_and_subtitles(
             self, mpd_url, video_id, mpd_id=None, note=None, errnote=None,
-            fatal=True, data=None, headers={}, query={}):
+            fatal=True, data=None, headers=None, query=None):
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_xml_handle(
             mpd_url, video_id,
             note='Downloading MPD manifest' if note is None else note,
@@ -2837,7 +2872,12 @@ class InfoExtractor(object):
             ))
         return fmts
 
-    def _extract_ism_formats_and_subtitles(self, ism_url, video_id, ism_id=None, note=None, errnote=None, fatal=True, data=None, headers={}, query={}):
+    def _extract_ism_formats_and_subtitles(
+            self, ism_url, video_id, ism_id=None, note=None, errnote=None, fatal=True,
+            data=None, headers=None, query=None):
+        headers = {} if headers is None else headers
+        query = {} if query is None else query
+
         res = self._download_xml_handle(
             ism_url, video_id,
             note='Downloading ISM manifest' if note is None else note,
@@ -2983,7 +3023,9 @@ class InfoExtractor(object):
                 return f
             return {}
 
-        def _media_formats(src, cur_media_type, type_info={}):
+        def _media_formats(src, cur_media_type, type_info=None):
+            type_info = {} if type_info is None else type_info
+
             full_url = absolute_url(src)
             ext = type_info.get('ext') or determine_ext(full_url)
             if ext == 'm3u8':
@@ -3100,7 +3142,9 @@ class InfoExtractor(object):
             ))
         return fmts
 
-    def _extract_akamai_formats_and_subtitles(self, manifest_url, video_id, hosts={}):
+    def _extract_akamai_formats_and_subtitles(self, manifest_url, video_id, hosts=None):
+        hosts = {} if hosts is None else hosts
+
         signed = 'hdnea=' in manifest_url
         if not signed:
             # https://learn.akamai.com/en-us/webhelp/media-services-on-demand/stream-packaging-user-guide/GUID-BE6C0F73-1E06-483B-B0EA-57984B91B7F9.html
@@ -3393,7 +3437,9 @@ class InfoExtractor(object):
         return res
 
     def _set_cookie(self, domain, name, value, expire_time=None, port=None,
-                    path='/', secure=False, discard=False, rest={}, **kwargs):
+                    path='/', secure=False, discard=False, rest=None, **kwargs):
+        rest = {} if rest is None else rest
+
         cookie = compat_cookiejar_Cookie(
             0, name, value, port, port is not None, domain, True,
             domain.startswith('.'), path, True, secure, expire_time,

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -651,9 +651,7 @@ class InfoExtractor(object):
         else:
             return err.code in variadic(expected_status)
 
-    def _request_webpage(
-            self, url_or_request, video_id, note=None, errnote=None, fatal=True,
-            data=None, headers=None, query=None, expected_status=None):
+    def _request_webpage(self, url_or_request, video_id, note=None, errnote=None, fatal=True, data=None, headers=None, query=None, expected_status=None):
         """
         Return the response handle.
 
@@ -719,9 +717,7 @@ class InfoExtractor(object):
                 self.report_warning(errmsg)
                 return False
 
-    def _download_webpage_handle(
-            self, url_or_request, video_id, note=None, errnote=None, fatal=True, encoding=None,
-            data=None, headers=None, query=None, expected_status=None):
+    def _download_webpage_handle(self, url_or_request, video_id, note=None, errnote=None, fatal=True, encoding=None, data=None, headers=None, query=None, expected_status=None):
         """
         Return a tuple (page content as string, URL handle).
 
@@ -824,8 +820,9 @@ class InfoExtractor(object):
         return content
 
     def _download_webpage(
-            self, url_or_request, video_id, note=None, errnote=None, fatal=True, tries=1, timeout=5,
-            encoding=None, data=None, headers=None, query=None, expected_status=None):
+            self, url_or_request, video_id, note=None, errnote=None,
+            fatal=True, tries=1, timeout=5, encoding=None, data=None,
+            headers=None, query=None, expected_status=None):
         """
         Return the data of the page as a string.
 
@@ -883,9 +880,10 @@ class InfoExtractor(object):
             return content
 
     def _download_xml_handle(
-            self, url_or_request, video_id, note='Downloading XML', errnote='Unable to download XML',
-            transform_source=None, fatal=True, encoding=None,
-            data=None, headers=None, query=None, expected_status=None):
+            self, url_or_request, video_id, note='Downloading XML',
+            errnote='Unable to download XML', transform_source=None,
+            fatal=True, encoding=None, data=None, headers=None, query=None,
+            expected_status=None):
         """
         Return a tuple (xml as an compat_etree_Element, URL handle).
 
@@ -935,10 +933,10 @@ class InfoExtractor(object):
                 self.report_warning(errmsg + str(ve))
 
     def _download_json_handle(
-            self, url_or_request, video_id,
-            note='Downloading JSON metadata',errnote='Unable to download JSON metadata',
-            transform_source=None, fatal=True, encoding=None,
-            data=None, headers=None, query=None, expected_status=None):
+            self, url_or_request, video_id, note='Downloading JSON metadata',
+            errnote='Unable to download JSON metadata', transform_source=None,
+            fatal=True, encoding=None, data=None, headers=None, query=None,
+            expected_status=None):
         """
         Return a tuple (JSON object, URL handle).
 
@@ -959,10 +957,10 @@ class InfoExtractor(object):
             fatal=fatal), urlh
 
     def _download_json(
-            self, url_or_request, video_id,
-            note='Downloading JSON metadata', errnote='Unable to download JSON metadata',
-            transform_source=None, fatal=True, encoding=None,
-            data=None, headers=None, query=None, expected_status=None):
+            self, url_or_request, video_id, note='Downloading JSON metadata',
+            errnote='Unable to download JSON metadata', transform_source=None,
+            fatal=True, encoding=None, data=None, headers=None, query=None,
+            expected_status=None):
         """
         Return the JSON object as a dict.
 
@@ -996,9 +994,10 @@ class InfoExtractor(object):
             video_id, transform_source, fatal)
 
     def _download_socket_json_handle(
-            self, url_or_request, video_id, note='Polling socket', errnote='Unable to poll socket',
-            transform_source=None, fatal=True, encoding=None,
-            data=None, headers=None, query=None, expected_status=None):
+            self, url_or_request, video_id, note='Polling socket',
+            errnote='Unable to poll socket', transform_source=None,
+            fatal=True, encoding=None, data=None, headers=None, query=None,
+            expected_status=None):
         """
         Return a tuple (JSON object, URL handle).
 
@@ -1019,9 +1018,10 @@ class InfoExtractor(object):
             fatal=fatal), urlh
 
     def _download_socket_json(
-            self, url_or_request, video_id, note='Polling socket', errnote='Unable to poll socket',
-            transform_source=None, fatal=True, encoding=None,
-            data=None, headers=None, query=None, expected_status=None):
+            self, url_or_request, video_id, note='Polling socket',
+            errnote='Unable to poll socket', transform_source=None,
+            fatal=True, encoding=None, data=None, headers=None, query=None,
+            expected_status=None):
         """
         Return the JSON object as a dict.
 
@@ -1857,10 +1857,9 @@ class InfoExtractor(object):
         self.to_screen(msg)
         time.sleep(timeout)
 
-    def _extract_f4m_formats(
-            self, manifest_url, video_id, preference=None, quality=None, f4m_id=None,
-            transform_source=lambda s: fix_xml_ampersands(s).strip(), fatal=True, m3u8_id=None,
-            data=None, headers=None, query=None):
+    def _extract_f4m_formats(self, manifest_url, video_id, preference=None, quality=None, f4m_id=None,
+                             transform_source=lambda s: fix_xml_ampersands(s).strip(),
+                             fatal=True, m3u8_id=None, data=None, headers=None, query=None):
         headers = {} if headers is None else headers
         query = {} if query is None else query
 
@@ -2005,7 +2004,8 @@ class InfoExtractor(object):
     def _extract_m3u8_formats_and_subtitles(
             self, m3u8_url, video_id, ext=None, entry_protocol='m3u8_native',
             preference=None, quality=None, m3u8_id=None, note=None,
-            errnote=None, fatal=True, live=False, data=None, headers=None, query=None):
+            errnote=None, fatal=True, live=False, data=None, headers=None,
+            query=None):
         headers = {} if headers is None else headers
         query = {} if query is None else query
 
@@ -2030,7 +2030,8 @@ class InfoExtractor(object):
     def _parse_m3u8_formats_and_subtitles(
             self, m3u8_doc, m3u8_url, ext=None, entry_protocol='m3u8_native',
             preference=None, quality=None, m3u8_id=None, live=False, note=None,
-            errnote=None, fatal=True, data=None, headers=None, query=None, video_id=None):
+            errnote=None, fatal=True, data=None, headers=None, query=None,
+            video_id=None):
         headers = {} if headers is None else headers
         query = {} if query is None else query
 
@@ -2872,9 +2873,7 @@ class InfoExtractor(object):
             ))
         return fmts
 
-    def _extract_ism_formats_and_subtitles(
-            self, ism_url, video_id, ism_id=None, note=None, errnote=None, fatal=True,
-            data=None, headers=None, query=None):
+    def _extract_ism_formats_and_subtitles(self, ism_url, video_id, ism_id=None, note=None, errnote=None, fatal=True, data=None, headers=None, query=None):
         headers = {} if headers is None else headers
         query = {} if query is None else query
 

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1790,8 +1790,7 @@ class InfoExtractor(object):
 
             return tuple(self._calculate_field_preference(format, field) for field in self._order)
 
-    def _sort_formats(self, formats, field_preference=None):
-        field_preference = [] if field_preference is None else field_preference
+    def _sort_formats(self, formats, field_preference=[]):
         if not formats:
             return
         format_sort = self.FormatSort()  # params and to_screen are taken from the downloader

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -22,11 +22,15 @@ class MildomBaseIE(InfoExtractor):
     _GUEST_ID = None
     _DISPATCHER_CONFIG = None
 
-    def _call_api(self, url, video_id, query={}, note='Downloading JSON metadata', init=False):
+    def _call_api(self, url, video_id, query=None, note='Downloading JSON metadata', init=False):
+        query = {} if query is None else query
+
         url = update_url_query(url, self._common_queries(query, init=init))
         return self._download_json(url, video_id, note=note)['body']
 
-    def _common_queries(self, query={}, init=False):
+    def _common_queries(self, query=None, init=False):
+        query = {} if query is None else query
+
         dc = self._fetch_dispatcher_config()
         r = {
             'timestamp': self.iso_timestamp(),

--- a/yt_dlp/extractor/naver.py
+++ b/yt_dlp/extractor/naver.py
@@ -29,7 +29,9 @@ class NaverBaseIE(InfoExtractor):
         formats = []
         get_list = lambda x: try_get(video_data, lambda y: y[x + 's']['list'], list) or []
 
-        def extract_formats(streams, stream_type, query={}):
+        def extract_formats(streams, stream_type, query=None):
+            query = {} if query is None else query
+
             for stream in streams:
                 stream_url = stream.get('source')
                 if not stream_url:

--- a/yt_dlp/extractor/nexx.py
+++ b/yt_dlp/extractor/nexx.py
@@ -146,7 +146,9 @@ class NexxIE(InfoExtractor):
             '%s said: %s' % (self.IE_NAME, response['metadata']['errorhint']),
             expected=True)
 
-    def _call_api(self, domain_id, path, video_id, data=None, headers={}):
+    def _call_api(self, domain_id, path, video_id, data=None, headers=None):
+        headers = {} if headers is None else headers
+
         headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
         result = self._download_json(
             'https://api.nexx.cloud/v3/%s/%s' % (domain_id, path), video_id,

--- a/yt_dlp/extractor/nuevo.py
+++ b/yt_dlp/extractor/nuevo.py
@@ -10,7 +10,9 @@ from ..utils import (
 
 
 class NuevoBaseIE(InfoExtractor):
-    def _extract_nuevo(self, config_url, video_id, headers={}):
+    def _extract_nuevo(self, config_url, video_id, headers=None):
+        headers = {} if headers is None else headers
+
         config = self._download_xml(
             config_url, video_id, transform_source=lambda s: s.strip(),
             headers=headers)

--- a/yt_dlp/extractor/openload.py
+++ b/yt_dlp/extractor/openload.py
@@ -161,7 +161,8 @@ class PhantomJSwrapper(object):
                 cookie['expire_time'] = cookie['expiry']
             self.extractor._set_cookie(**compat_kwargs(cookie))
 
-    def get(self, url, html=None, video_id=None, note=None, note2='Executing JS on webpage', headers={}, jscode='saveAndExit();'):
+    def get(self, url, html=None, video_id=None, note=None, note2='Executing JS on webpage',
+            headers=None, jscode='saveAndExit();'):
         """
         Downloads webpage (if needed) and executes JS
 
@@ -197,6 +198,8 @@ class PhantomJSwrapper(object):
             });
             check();
         """
+        headers = {} if headers is None else headers
+
         if 'saveAndExit();' not in jscode:
             raise ExtractorError('`saveAndExit();` not found in `jscode`')
         if not html:

--- a/yt_dlp/extractor/openload.py
+++ b/yt_dlp/extractor/openload.py
@@ -161,8 +161,7 @@ class PhantomJSwrapper(object):
                 cookie['expire_time'] = cookie['expiry']
             self.extractor._set_cookie(**compat_kwargs(cookie))
 
-    def get(self, url, html=None, video_id=None, note=None, note2='Executing JS on webpage',
-            headers=None, jscode='saveAndExit();'):
+    def get(self, url, html=None, video_id=None, note=None, note2='Executing JS on webpage', headers=None, jscode='saveAndExit();'):
         """
         Downloads webpage (if needed) and executes JS
 

--- a/yt_dlp/extractor/rcti.py
+++ b/yt_dlp/extractor/rcti.py
@@ -254,7 +254,9 @@ class RCTIPlusSeriesIE(RCTIPlusBaseIE):
     def suitable(cls, url):
         return False if RCTIPlusIE.suitable(url) else super(RCTIPlusSeriesIE, cls).suitable(url)
 
-    def _entries(self, url, display_id=None, note='Downloading entries JSON', metadata={}):
+    def _entries(self, url, display_id=None, note='Downloading entries JSON', metadata=None):
+        metadata = {} if metadata is None else metadata
+
         total_pages = 0
         try:
             total_pages = self._call_api(

--- a/yt_dlp/extractor/theplatform.py
+++ b/yt_dlp/extractor/theplatform.py
@@ -340,7 +340,11 @@ class ThePlatformFeedIE(ThePlatformBaseIE):
         'only_matching': True,
     }]
 
-    def _extract_feed_info(self, provider_id, feed_id, filter_query, video_id, custom_fields=None, asset_types_query={}, account_id=None):
+    def _extract_feed_info(
+            self, provider_id, feed_id, filter_query, video_id,
+            custom_fields=None, asset_types_query=None, account_id=None):
+        asset_types_query = {} if asset_types_query is None else asset_types_query
+
         real_url = self._URL_TEMPLATE % (self.http_scheme(), provider_id, feed_id, filter_query)
         entry = self._download_json(real_url, video_id)['entries'][0]
         main_smil_url = 'http://link.theplatform.com/s/%s/media/guid/%d/%s' % (provider_id, account_id, entry['guid']) if account_id else entry.get('plmedia$publicUrl')

--- a/yt_dlp/extractor/theplatform.py
+++ b/yt_dlp/extractor/theplatform.py
@@ -340,9 +340,7 @@ class ThePlatformFeedIE(ThePlatformBaseIE):
         'only_matching': True,
     }]
 
-    def _extract_feed_info(
-            self, provider_id, feed_id, filter_query, video_id,
-            custom_fields=None, asset_types_query=None, account_id=None):
+    def _extract_feed_info(self, provider_id, feed_id, filter_query, video_id, custom_fields=None, asset_types_query=None, account_id=None):
         asset_types_query = {} if asset_types_query is None else asset_types_query
 
         real_url = self._URL_TEMPLATE % (self.http_scheme(), provider_id, feed_id, filter_query)

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -87,7 +87,9 @@ class TikTokBaseIE(InfoExtractor):
 
         known_resolutions = {}
 
-        def extract_addr(addr, add_meta={}):
+        def extract_addr(addr, add_meta=None):
+            add_meta = {} if add_meta is None else add_meta
+
             parsed_meta, res = parse_url_key(addr.get('url_key', ''))
             if res:
                 known_resolutions.setdefault(res, {}).setdefault('height', add_meta.get('height'))

--- a/yt_dlp/extractor/turner.py
+++ b/yt_dlp/extractor/turner.py
@@ -50,7 +50,10 @@ class TurnerBaseIE(AdobePassIE):
             self._AKAMAI_SPE_TOKEN_CACHE[secure_path] = token
         return video_url + '?hdnea=' + token
 
-    def _extract_cvp_info(self, data_src, video_id, path_data={}, ap_data={}, fatal=False):
+    def _extract_cvp_info(self, data_src, video_id, path_data=None, ap_data=None, fatal=False):
+        path_data = {} if path_data is None else path_data
+        ap_data = {} if ap_data is None else ap_data
+
         video_data = self._download_xml(
             data_src, video_id,
             transform_source=lambda s: fix_xml_ampersands(s).strip(),

--- a/yt_dlp/extractor/tvnow.py
+++ b/yt_dlp/extractor/tvnow.py
@@ -287,7 +287,9 @@ class TVNowFilmIE(TVNowBaseIE):
 
 
 class TVNowNewBaseIE(InfoExtractor):
-    def _call_api(self, path, video_id, query={}):
+    def _call_api(self, path, video_id, query=None):
+        query = {} if query is None else query
+
         result = self._download_json(
             'https://apigw.tvnow.de/module/' + path, video_id, query=query)
         error = result.get('error')

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -84,7 +84,9 @@ class TwitterBaseIE(InfoExtractor):
                 'height': int(m.group('height')),
             })
 
-    def _call_api(self, path, video_id, query={}):
+    def _call_api(self, path, video_id, query=None):
+        query = {} if query is None else query
+
         headers = {
             'Authorization': 'Bearer AAAAAAAAAAAAAAAAAAAAAPYXBAAAAAAACLXUNDekMxqa8h%2F40K4moUkGsoc%3DTYfbDKbT3jJPCEVnMYqilB28NHfOPqkca3qaAxGfsyKCs0wRbw',
         }

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -52,7 +52,8 @@ def _hide_login_info(opts):
 
 
 def parseOpts(overrideArguments=None):
-    def _readOptions(filename_bytes, default=[]):
+    def _readOptions(filename_bytes, default=None):
+        default = [] if default is None else default
         try:
             optionf = open(filename_bytes)
         except IOError:
@@ -67,7 +68,8 @@ def parseOpts(overrideArguments=None):
             optionf.close()
         return res
 
-    def _readUserConf(package_name, default=[]):
+    def _readUserConf(package_name, default=None):
+        default = [] if default is None else default
         # .config
         xdg_config_home = compat_getenv('XDG_CONFIG_HOME') or compat_expanduser('~/.config')
         userConfFile = os.path.join(xdg_config_home, package_name, 'config')

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -52,8 +52,7 @@ def _hide_login_info(opts):
 
 
 def parseOpts(overrideArguments=None):
-    def _readOptions(filename_bytes, default=None):
-        default = [] if default is None else default
+    def _readOptions(filename_bytes, default=[]):
         try:
             optionf = open(filename_bytes)
         except IOError:
@@ -68,8 +67,7 @@ def parseOpts(overrideArguments=None):
             optionf.close()
         return res
 
-    def _readUserConf(package_name, default=None):
-        default = [] if default is None else default
+    def _readUserConf(package_name, default=[]):
         # .config
         xdg_config_home = compat_getenv('XDG_CONFIG_HOME') or compat_expanduser('~/.config')
         userConfFile = os.path.join(xdg_config_home, package_name, 'config')

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -52,7 +52,7 @@ def _hide_login_info(opts):
 
 
 def parseOpts(overrideArguments=None):
-    def _readOptions(filename_bytes, default=[]):
+    def _readOptions(filename_bytes, default=()):
         try:
             optionf = open(filename_bytes)
         except IOError:
@@ -67,7 +67,7 @@ def parseOpts(overrideArguments=None):
             optionf.close()
         return res
 
-    def _readUserConf(package_name, default=[]):
+    def _readUserConf(package_name, default=()):
         # .config
         xdg_config_home = compat_getenv('XDG_CONFIG_HOME') or compat_expanduser('~/.config')
         userConfFile = os.path.join(xdg_config_home, package_name, 'config')

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -125,8 +125,10 @@ def parseOpts(overrideArguments=None):
             current + value if append is True else value + current)
 
     def _set_from_options_callback(
-            option, opt_str, value, parser, delim=',', allowed_values=None, aliases={},
+            option, opt_str, value, parser, delim=',', allowed_values=None, aliases=None,
             process=lambda x: x.lower().strip()):
+        aliases = {} if aliases is None else aliases
+
         current = getattr(parser.values, option.dest)
         values = [process(value)] if delim is None else list(map(process, value.split(delim)[::-1]))
         while values:

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -204,7 +204,8 @@ class FFmpegPostProcessor(PostProcessor):
                 return mobj.group(1)
         return None
 
-    def get_metadata_object(self, path, opts=[]):
+    def get_metadata_object(self, path, opts=None):
+        opts = [] if opts is None else opts
         if self.probe_basename != 'ffprobe':
             if self.probe_available:
                 self.report_warning('Only ffprobe is supported for metadata extraction')

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -204,8 +204,7 @@ class FFmpegPostProcessor(PostProcessor):
                 return mobj.group(1)
         return None
 
-    def get_metadata_object(self, path, opts=None):
-        opts = [] if opts is None else opts
+    def get_metadata_object(self, path, opts=[]):
         if self.probe_basename != 'ffprobe':
             if self.probe_available:
                 self.report_warning('Only ffprobe is supported for metadata extraction')

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -220,7 +220,8 @@ class FFmpegPostProcessor(PostProcessor):
             encodeArgument('json'),
         ]
 
-        cmd += opts
+        if opts:
+            cmd += opts
         cmd.append(encodeFilename(self._ffmpeg_filename_argument(path), True))
         self.write_debug('ffprobe command line: %s' % shell_quote(cmd))
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -204,7 +204,7 @@ class FFmpegPostProcessor(PostProcessor):
                 return mobj.group(1)
         return None
 
-    def get_metadata_object(self, path, opts=[]):
+    def get_metadata_object(self, path, opts=()):
         if self.probe_basename != 'ffprobe':
             if self.probe_available:
                 self.report_warning('Only ffprobe is supported for metadata extraction')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5007,7 +5007,7 @@ def cli_configuration_args(argdict, keys, default=(), use_compat=True):
     return default
 
 
-def _configuration_args(main_key, argdict, exe, keys=None, default=[], use_compat=True):
+def _configuration_args(main_key, argdict, exe, keys=None, default=(), use_compat=True):
     main_key, exe = main_key.lower(), exe.lower()
     root_key = exe if main_key == exe else f'{main_key}+{exe}'
     keys = [f'{root_key}{k}' for k in (keys or [''])]

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3933,7 +3933,7 @@ def check_executable(exe, args=()):
     args can be a list of arguments for a short output (like -version) """
     try:
         process_communicate_or_kill(subprocess.Popen(
-            [exe] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE))
+            [exe] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE))
     except OSError:
         return False
     return exe
@@ -3948,7 +3948,7 @@ def get_exe_version(exe, args=('--version',),
         # SIGTTOU if yt-dlp is run in the background.
         # See https://github.com/ytdl-org/youtube-dl/issues/955#issuecomment-209789656
         out, _ = process_communicate_or_kill(subprocess.Popen(
-            [encodeArgument(exe)] + args,
+            [encodeArgument(exe)] + list(args),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
     except OSError:
@@ -4987,14 +4987,14 @@ def cli_valueless_option(params, command_option, param, expected_value=True):
     return [command_option] if param == expected_value else []
 
 
-def cli_configuration_args(argdict, keys, default=(), use_compat=True):
+def cli_configuration_args(argdict, keys, default=None, use_compat=True):
     if isinstance(argdict, (list, tuple)):  # for backward compatibility
         if use_compat:
             return argdict
         else:
             argdict = None
     if argdict is None:
-        return default
+        return [] if default is None else default
     assert isinstance(argdict, dict)
 
     assert isinstance(keys, (list, tuple))
@@ -5004,10 +5004,10 @@ def cli_configuration_args(argdict, keys, default=(), use_compat=True):
             [argdict.get(key.lower()) for key in variadic(key_list)]))
         if arg_list:
             return [arg for args in arg_list for arg in args]
-    return default
+    return [] if default is None else default
 
 
-def _configuration_args(main_key, argdict, exe, keys=None, default=(), use_compat=True):
+def _configuration_args(main_key, argdict, exe, keys=None, default=None, use_compat=True):
     main_key, exe = main_key.lower(), exe.lower()
     root_key = exe if main_key == exe else f'{main_key}+{exe}'
     keys = [f'{root_key}{k}' for k in (keys or [''])]

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3928,7 +3928,8 @@ def replace_extension(filename, ext, expected_real_ext=None):
         ext)
 
 
-def check_executable(exe, args=[]):
+def check_executable(exe, args=None):
+    args = [] if args is None else args
     """ Checks if the given binary is installed somewhere in PATH, and returns its name.
     args can be a list of arguments for a short output (like -version) """
     try:
@@ -3939,10 +3940,11 @@ def check_executable(exe, args=[]):
     return exe
 
 
-def get_exe_version(exe, args=['--version'],
+def get_exe_version(exe, args=None,
                     version_re=None, unrecognized='present'):
     """ Returns the version of the specified executable,
     or False if the executable is not present """
+    args = ['--version'] if args is None else args
     try:
         # STDIN should be redirected too. On UNIX-like systems, ffmpeg triggers
         # SIGTTOU if yt-dlp is run in the background.
@@ -4987,7 +4989,8 @@ def cli_valueless_option(params, command_option, param, expected_value=True):
     return [command_option] if param == expected_value else []
 
 
-def cli_configuration_args(argdict, keys, default=[], use_compat=True):
+def cli_configuration_args(argdict, keys, default=None, use_compat=True):
+    default = [] if default is None else default
     if isinstance(argdict, (list, tuple)):  # for backward compatibility
         if use_compat:
             return argdict

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3928,7 +3928,7 @@ def replace_extension(filename, ext, expected_real_ext=None):
         ext)
 
 
-def check_executable(exe, args=[]):
+def check_executable(exe, args=()):
     """ Checks if the given binary is installed somewhere in PATH, and returns its name.
     args can be a list of arguments for a short output (like -version) """
     try:
@@ -3939,7 +3939,7 @@ def check_executable(exe, args=[]):
     return exe
 
 
-def get_exe_version(exe, args=['--version'],
+def get_exe_version(exe, args=('--version',),
                     version_re=None, unrecognized='present'):
     """ Returns the version of the specified executable,
     or False if the executable is not present """
@@ -4987,7 +4987,7 @@ def cli_valueless_option(params, command_option, param, expected_value=True):
     return [command_option] if param == expected_value else []
 
 
-def cli_configuration_args(argdict, keys, default=[], use_compat=True):
+def cli_configuration_args(argdict, keys, default=(), use_compat=True):
     if isinstance(argdict, (list, tuple)):  # for backward compatibility
         if use_compat:
             return argdict

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3928,8 +3928,7 @@ def replace_extension(filename, ext, expected_real_ext=None):
         ext)
 
 
-def check_executable(exe, args=None):
-    args = [] if args is None else args
+def check_executable(exe, args=[]):
     """ Checks if the given binary is installed somewhere in PATH, and returns its name.
     args can be a list of arguments for a short output (like -version) """
     try:
@@ -3940,11 +3939,10 @@ def check_executable(exe, args=None):
     return exe
 
 
-def get_exe_version(exe, args=None,
+def get_exe_version(exe, args=['--version'],
                     version_re=None, unrecognized='present'):
     """ Returns the version of the specified executable,
     or False if the executable is not present """
-    args = ['--version'] if args is None else args
     try:
         # STDIN should be redirected too. On UNIX-like systems, ffmpeg triggers
         # SIGTTOU if yt-dlp is run in the background.
@@ -4989,8 +4987,7 @@ def cli_valueless_option(params, command_option, param, expected_value=True):
     return [command_option] if param == expected_value else []
 
 
-def cli_configuration_args(argdict, keys, default=None, use_compat=True):
-    default = [] if default is None else default
+def cli_configuration_args(argdict, keys, default=[], use_compat=True):
     if isinstance(argdict, (list, tuple)):  # for backward compatibility
         if use_compat:
             return argdict

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4218,7 +4218,10 @@ def update_url_query(url, query):
         query=compat_urllib_parse_urlencode(qs, True)))
 
 
-def update_Request(req, url=None, data=None, headers={}, query={}):
+def update_Request(req, url=None, data=None, headers=None, query=None):
+    headers = {} if headers is None else headers
+    query = {} if query is None else query
+
     req_headers = req.headers.copy()
     req_headers.update(headers)
     req_data = data or req.data
@@ -4375,7 +4378,9 @@ def strip_jsonp(code):
         r'\g<callback_data>', code)
 
 
-def js_to_json(code, vars={}):
+def js_to_json(code, vars=None):
+    vars = {} if vars is None else vars
+
     # vars is a dict of var, val pairs to substitute
     COMMENT_RE = r'/\*(?:(?!\*/).)*?\*/|//[^\n]*\n'
     SKIP_RE = r'\s*(?:{comment})?\s*'.format(comment=COMMENT_RE)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature


### Description of your *pull request* and other information

> Do not use mutable default arguments in Python, unless you have a REALLY good reason to do so.
> Why? Because it can lead to all sorts of nasty and horrible bugs, give you headaches and waste everyone's time.
> Instead, default to None and assign the mutable value inside the function.

I can't bother to copy-paste the [whole](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/) thing, so above is the tl;dr; part.

If you wish to discuss this further, there's an issue #1021 for it. Please keep this strictly about the change.

### TODO
- [x] find and change all dictionarys
- [x] find and change all lists 
- [x] find and change all sets (there's probably none, since it's much finicky to create an empty set)
- [x] do all the above for non-empty ones
