### PR TITLE
[SovietsCloset] Fix finding playlists for games with only named categories

### DIFF
--- a/yt_dlp/extractor/sovietscloset.py
+++ b/yt_dlp/extractor/sovietscloset.py
@@ -167,6 +167,14 @@ class SovietsClosetPlaylistIE(SovietsClosetBaseIE):
             },
             'playlist_mincount': 3,
         },
+        {
+            'url': 'https://sovietscloset.com/Total-War-Warhammer',
+            'info_dict': {
+                'id': 'Total-War-Warhammer',
+                'title': 'Total War: Warhammer - Greenskins',
+            },
+            'playlist_mincount': 33,
+        },
     ]
 
     def _real_extract(self, url):
@@ -188,7 +196,12 @@ class SovietsClosetPlaylistIE(SovietsClosetBaseIE):
             category_slug = 'misc'
 
         game = next(game for game in sovietscloset if game['slug'].lower() == game_slug)
-        category = next(cat for cat in game['subcategories'] if cat['slug'].lower() == category_slug)
+        category = game['subcategories'][0]
+        for cat in game['subcategories']:
+            if cat['slug'].lower() == category_slug:
+                category = cat
+        category_slug = category.get('slug') or category_slug
+        category_slug = category_slug.lower()
         playlist_title = game.get('name') or game_slug
         if category_slug != 'misc':
             playlist_title += f' - {category.get("name") or category_slug}'

--- a/yt_dlp/extractor/sovietscloset.py
+++ b/yt_dlp/extractor/sovietscloset.py
@@ -196,12 +196,9 @@ class SovietsClosetPlaylistIE(SovietsClosetBaseIE):
             category_slug = 'misc'
 
         game = next(game for game in sovietscloset if game['slug'].lower() == game_slug)
-        category = game['subcategories'][0]
-        for cat in game['subcategories']:
-            if cat['slug'].lower() == category_slug:
-                category = cat
-        category_slug = category.get('slug') or category_slug
-        category_slug = category_slug.lower()
+        category = next((cat for cat in game['subcategories'] if cat['slug'].lower() == category_slug),
+                        game['subcategories'][0])
+        category_slug = category.get('slug', '').lower() or category_slug
         playlist_title = game.get('name') or game_slug
         if category_slug != 'misc':
             playlist_title += f' - {category.get("name") or category_slug}'

--- a/yt_dlp/extractor/sovietscloset.py
+++ b/yt_dlp/extractor/sovietscloset.py
@@ -196,7 +196,7 @@ class SovietsClosetPlaylistIE(SovietsClosetBaseIE):
             category_slug = 'misc'
 
         game = next(game for game in sovietscloset if game['slug'].lower() == game_slug)
-        category = next((cat for cat in game['subcategories'] if cat['slug'].lower() == category_slug),
+        category = next((cat for cat in game['subcategories'] if cat.get('slug', '').lower() == category_slug),
                         game['subcategories'][0])
         category_slug = category.get('slug', '').lower() or category_slug
         playlist_title = game.get('name') or game_slug


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes a crash when loading playlists for games that don't have the default "Misc" category and no category is specified.
The new behavior is to search for the "Misc" category but if it can't be found use the first category instead.
