### PR TITLE
Workaround for bug in `ssl.SSLContext.load_default_certs`

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2353,11 +2353,12 @@ def formatSeconds(secs, delim=':', msec=False):
 
 
 def make_HTTPS_handler(params, **kwargs):
-    opts_no_check_certificate = params.get('nocheckcertificate', False)
-    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    if opts_no_check_certificate:
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
+    opts_check_certificate = not params.get('nocheckcertificate')
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = opts_check_certificate
+    context.verify_mode = ssl.CERT_REQUIRED if opts_check_certificate else ssl.CERT_NONE
+    if opts_check_certificate:
+        context.load_default_certs(ssl.Purpose.SERVER_AUTH)
     return YoutubeDLHTTPSHandler(params, context=context, **kwargs)
 
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2354,27 +2354,11 @@ def formatSeconds(secs, delim=':', msec=False):
 
 def make_HTTPS_handler(params, **kwargs):
     opts_no_check_certificate = params.get('nocheckcertificate', False)
-    if hasattr(ssl, 'create_default_context'):  # Python >= 3.4 or 2.7.9
-        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        if opts_no_check_certificate:
-            context.check_hostname = False
-            context.verify_mode = ssl.CERT_NONE
-        try:
-            return YoutubeDLHTTPSHandler(params, context=context, **kwargs)
-        except TypeError:
-            # Python 2.7.8
-            # (create_default_context present but HTTPSHandler has no context=)
-            pass
-
-    if sys.version_info < (3, 2):
-        return YoutubeDLHTTPSHandler(params, **kwargs)
-    else:  # Python < 3.4
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-        context.verify_mode = (ssl.CERT_NONE
-                               if opts_no_check_certificate
-                               else ssl.CERT_REQUIRED)
-        context.set_default_verify_paths()
-        return YoutubeDLHTTPSHandler(params, context=context, **kwargs)
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    if opts_no_check_certificate:
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    return YoutubeDLHTTPSHandler(params, context=context, **kwargs)
 
 
 def bug_reports_message(before=';'):


### PR DESCRIPTION
When there are bad certificates in windows store, `ssl.SSLContext.load_default_certs()` and therefore `ssl.create_default_context()` throws error without loading any certificate. This works around the issue by loading the certificates one by one instead

Closes https://github.com/yt-dlp/yt-dlp/issues/1060
See https://bugs.python.org/issue35665, https://bugs.python.org/issue4531

@MDM-79, please test this code and let me know