### PR TITLE
Use markers instead of names to filter pytest tests in discovery

### DIFF
--- a/devscripts/run_tests.bat
+++ b/devscripts/run_tests.bat
@@ -3,14 +3,14 @@
 cd /d %~dp0..
 
 if ["%~1"]==[""] (
-    set "test_set="
+    set "test_set="test""
 ) else if ["%~1"]==["core"] (
-    set "test_set="not download""
+    set "test_set="-m not download""
 ) else if ["%~1"]==["download"] (
-    set "test_set="download"
+    set "test_set="-m "download""
 ) else (
     echo.Invalid test type "%~1". Use "core" ^| "download"
     exit /b 1
 )
 
-pytest -m %test_set%
+pytest %test_set%

--- a/devscripts/run_tests.sh
+++ b/devscripts/run_tests.sh
@@ -3,12 +3,12 @@
 if [ -z $1 ]; then
     test_set='test'
 elif [ $1 = 'core' ]; then
-    test_set='not download'
+    test_set="-m not download"
 elif [ $1 = 'download' ]; then
-    test_set='download'
+    test_set="-m download"
 else
     echo 'Invalid test type "'$1'". Use "core" | "download"'
     exit 1
 fi
 
-python3 -m pytest -m "$test_set"
+python3 -m pytest "$test_set"


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:  ###
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:  ###
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? ###
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information  ###

https://docs.pytest.org/en/6.2.x/example/markers.html

> You can use the -k command line option to specify an expression which implements a substring match on the test names instead of the exact match on markers that -m provides.

note:
https://github.com/yt-dlp/yt-dlp/blob/ecdc9049c0d8c00ad9ea5218126eefb1e7049385/test/helper.py#L25-L30

### Untested: ###
Looks good in matrix, tho: `run_tests.bat`