### PR TITLE
Preserve sponsorblock_chapters when downloading multiple formats of the same video

### DIFF
--- a/yt_dlp/postprocessor/modify_chapters.py
+++ b/yt_dlp/postprocessor/modify_chapters.py
@@ -1,7 +1,6 @@
 import copy
 import heapq
 import os
-from copy import deepcopy
 
 from .common import PostProcessor
 from .ffmpeg import (
@@ -31,10 +30,10 @@ class ModifyChaptersPP(FFmpegPostProcessor):
 
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
-        # sponsorblock_chapters must be preserved intact
-        # when downloading multiple formats of the same video.
+        # Chapters must be preserved intact when downloading multiple formats of the same video.
         chapters, sponsor_chapters = self._mark_chapters_to_remove(
-            info.get('chapters') or [], deepcopy(info.get('sponsorblock_chapters')) or [])
+            copy.deepcopy(info.get('chapters')) or [],
+            copy.deepcopy(info.get('sponsorblock_chapters')) or [])
         if not chapters and not sponsor_chapters:
             return [], info
 


### PR DESCRIPTION
Fixes https://github.com/yt-dlp/yt-dlp/issues/1295.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When downloading multiple formats of the same video, each format gets it's own `info['chapters']`, but `info['sponsor_chapters']` is shared. When first format gets processed, it modifies `info['sponsor_chapters']` making it ineligible for the second run. `deepcopy` preserves `sponsor_chapters`. + Better assertions.

May be there is a different way to preserve `sponsor_chapters` akin to what is being used for ordinary `chapters`, but I'm not aware of it.