### PR TITLE
Implemented TBS live streams

### DIFF
--- a/yt_dlp/extractor/tbs.py
+++ b/yt_dlp/extractor/tbs.py
@@ -16,7 +16,7 @@ from ..utils import (
 
 
 class TBSIE(TurnerBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?(?P<site>tbs|tntdrama)\.com(?P<path>/(?:movies|watchtnt|shows/[^/]+/(?:clips|season-\d+/episode-\d+))/(?P<id>[^/?#]+))'
+    _VALID_URL = r'https?://(?:www\.)?(?P<site>tbs|tntdrama)\.com(?P<path>/(?:movies|watchtnt|watchtbs|shows/[^/]+/(?:clips|season-\d+/episode-\d+))/(?P<id>[^/?#]+))'
     _TESTS = [{
         'url': 'http://www.tntdrama.com/shows/the-alienist/clips/monster',
         'info_dict': {
@@ -45,7 +45,7 @@ class TBSIE(TurnerBaseIE):
         drupal_settings = self._parse_json(self._search_regex(
             r'<script[^>]+?data-drupal-selector="drupal-settings-json"[^>]*?>({.+?})</script>',
             webpage, 'drupal setting'), display_id)
-        isLive = 'watchtnt' in path
+        isLive = 'watchtnt' in path or 'watchtbs' in path
         video_data = next(v for v in drupal_settings['turner_playlist'] if isLive or v.get('url') == path)
 
         media_id = video_data['mediaID']


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Add support for TBS live streams. Basically the same as #448.
 
Log:
```
./yt-dlp.cmd "https://www.tbs.com/watchtbs/east" --proxy "localhost:8888" --ignore-config -vF
[debug] Command-line config: ['https://www.tbs.com/watchtbs/east', '--proxy', 'localhost:8888', '--ignore-config', '-vF']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] yt-dlp version 2021.09.25 (source)
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: e8b80769c
[debug] Python version 3.9.6 (CPython 64bit) - Windows-10-10.0.19043-SP0
[debug] exe versions: ffmpeg n4.3.2-163-g6c414cf8f7, ffprobe n4.3.2-163-g6c414cf8f7
[debug] Optional libraries: Crypto, mutagen, sqlite, websockets
[debug] Proxy map: {'http': 'localhost:8888', 'https': 'localhost:8888'}
[debug] [TBS] Extracting URL: https://www.tbs.com/watchtbs/east
[TBS] east: Downloading webpage
[TBS] tbs-east: Downloading JSON metadata
[debug] Loading ap-mvpd.TBS from cache
[TBS] tbs-east: Retrieving Media Token
[TBS] tbs-east: Downloading XML
[TBS] tbs-east: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for tbs-east:
ID    EXT RESOLUTION FPS |   TBR PROTO  | VCODEC        VBR ACODEC     ABR
----- --- ---------- --- - ----- ------ - ----------- ----- --------- ----
hls-0 mp4 768x432    29  | 2011k m3u8_n | avc1.4d401e 2011k mp4a.40.2   0k
hls-1 mp4 768x432    29  | 2011k m3u8_n | avc1.4d401e 2011k mp4a.40.2   0k
hls-2 mp4 960x540    29  | 2727k m3u8_n | avc1.4d401f 2727k mp4a.40.2   0k
hls-3 mp4 960x540    29  | 2727k m3u8_n | avc1.4d401f 2727k mp4a.40.2   0k
hls-4 mp4 1280x720   29  | 5281k m3u8_n | avc1.4d401f 5281k mp4a.40.2   0k
hls-5 mp4 1280x720   29  | 5281k m3u8_n | avc1.4d401f 5281k mp4a.40.2   0k
```