### PR TITLE
Nrk updates

### DIFF
--- a/yt_dlp/extractor/nrk.py
+++ b/yt_dlp/extractor/nrk.py
@@ -188,7 +188,7 @@ class NRKIE(NRKBaseIE):
         title = titles['title']
         alt_title = titles.get('subtitle')
 
-        description = preplay.get('description').replace('\r', '\n')
+        description = try_get(preplay, lambda x: x['description'].replace('\r', '\n'))
         duration = parse_duration(playable.get('duration')) or parse_duration(data.get('duration'))
 
         thumbnails = []


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

#### Fix 1

NRK has changed an endpoint. It's set up to redirect (301), so nothing fails, but there are no guarantees that can be removed. Also fixing the endpoint saves an HTTP request

```sh
> curl -i https://psapi.nrk.no/playback/manifest/MSUI38004414

HTTP/2 301
server: nginx
date: Fri, 22 Oct 2021 15:20:16 GMT
content-length: 0
x-varnish: 202009202
vary: Origin, Accept-Encoding
cache-control: public, max-age=3600
location: /playback/manifest/program/MSUI38004414
```
#### Fix 2

NRK descriptions sometimes has the char `\r` which will mess up the output. Removing this char from the description will fix this

This `\r` (Return Carriage) might be some left-over from an employee just
copying text. It will mess up the description when using
--get-description

Example:
https://tv.nrk.no/serie/petter-kanin/sesong/2/episode/4/avspiller
```
{ .. 'description': 'Britisk animasjonsserie. Eventyret om Gamle Brun
sin nye vagl.  \rNår Gamle Brun flyttar frå Ugleøya for å finne ein
rolegare vagl, finn Petter, Lily og Benjamin ut at han kanskje flyttar
litt for nær dei!\t\r\r' .. }
```

Removing this character fixes this problem