### PR TITLE
[plugins] support plugins from external python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The major new features from the latest release of [blackjack4494/yt-dlc](https:/
 
 * **Improvements**: Regex and other operators in `--match-filter`, multiple `--postprocessor-args` and `--downloader-args`, faster archive checking, more [format selection options](#format-selection) etc
 
-* **Plugin extractors**: Extractors can be loaded from an external file. See [plugins](#plugins) for details
+* **Plugin extractors**: Extractors can be loaded from an external file or package. See [plugins](#plugins) for details
 
 * **Self-updater**: The releases can be updated using `yt-dlp -U`
 
@@ -1541,9 +1541,11 @@ NOTE: These options may be changed/removed in the future without concern for bac
 
 # PLUGINS
 
-Plugins are loaded from `<root-dir>/ytdlp_plugins/<type>/__init__.py`; where `<root-dir>` is the directory of the binary (`<root-dir>/yt-dlp`), or the root directory of the module if you are running directly from source-code (`<root dir>/yt_dlp/__main__.py`). Plugins are currently not supported for the `pip` version
+Plugins are loaded from namespace-package `ytdlp_plugins.extractor` and `ytdlp_plugins.postprocessor`. They can also be installed via `pip`.
 
-Plugins can be of `<type>`s `extractor` or `postprocessor`. Extractor plugins do not need to be enabled from the CLI and are automatically invoked when the input URL is suitable for it. Postprocessor plugins can be invoked using `--use-postprocessor NAME`.
+E.g. you can create a file `<root-dir>/ytdlp_plugins/<type>/myplugin.py`; where `<root-dir>` is the directory of the binary (`<root-dir>/yt-dlp`), or the root directory of the module if you are running directly from source-code (`<root dir>/yt_dlp/__main__.py`).
+
+Extractor plugins do not need to be enabled from the CLI and are automatically invoked when the input URL is suitable for it. Postprocessor plugins can be invoked using `--use-postprocessor NAME`.
 
 See [ytdlp_plugins](ytdlp_plugins) for example plugins.
 

--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -13,17 +13,11 @@ lazy_extractors_filename = sys.argv[1] if len(sys.argv) > 1 else 'yt_dlp/extract
 if os.path.exists(lazy_extractors_filename):
     os.remove(lazy_extractors_filename)
 
-# Block plugins from loading
-plugins_dirname = 'ytdlp_plugins'
-plugins_blocked_dirname = 'ytdlp_plugins_blocked'
-if os.path.exists(plugins_dirname):
-    os.rename(plugins_dirname, plugins_blocked_dirname)
-
-from yt_dlp.extractor import _ALL_CLASSES
+from yt_dlp.extractor import _ALL_CLASSES as _ALL_CLASSES_TMP
 from yt_dlp.extractor.common import InfoExtractor, SearchInfoExtractor
 
-if os.path.exists(plugins_blocked_dirname):
-    os.rename(plugins_blocked_dirname, plugins_dirname)
+# Filter out plugins
+_ALL_CLASSES = [cls for cls in _ALL_CLASSES_TMP if not cls.__module__.startswith('ytdlp_plugins.')]
 
 with open('devscripts/lazy_load_template.py', 'rt') as f:
     module_template = f.read()

--- a/pyinst.py
+++ b/pyinst.py
@@ -35,6 +35,9 @@ def main():
               '"devscripts/make_lazy_extractors.py"  to build lazy extractors', file=sys.stderr)
     print(f'Destination: {final_file}\n')
 
+    # Note: to package the plugin directory
+    # add  the following line to opts:
+    # f'--add-data=ytdlp_plugins{os.pathsep}ytdlp_plugins',
     opts = [
         f'--name=yt-dlp{suffix}',
         '--icon=devscripts/logo.ico',

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+import sys
+import unittest
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parents[1].absolute()
+sys.path.insert(0, str(ROOT_DIR))
+
+from yt_dlp.plugins import PACKAGE_NAME, directories, load_plugins
+
+
+class TestPlugins(unittest.TestCase):
+    SAMPLE_PLUGIN_DIR = ROOT_DIR / PACKAGE_NAME
+
+    def test_plugin_directory_structure(self):
+        self.assertFalse(self.SAMPLE_PLUGIN_DIR.joinpath("__init__.py").exists())
+        self.assertTrue(self.SAMPLE_PLUGIN_DIR.joinpath("extractor").is_dir())
+        self.assertFalse(self.SAMPLE_PLUGIN_DIR.joinpath("extractor", "__init__.py").exists())
+        self.assertTrue(self.SAMPLE_PLUGIN_DIR.joinpath("postprocessor").is_dir())
+        self.assertFalse(self.SAMPLE_PLUGIN_DIR.joinpath("postprocessor", "__init__.py").exists())
+
+    def test_directories_containing_plugins(self):
+        plugin_dirs = {Path(path) for path in directories()}
+        self.assertIn(self.SAMPLE_PLUGIN_DIR, plugin_dirs)
+
+    def test_extractor_classes(self):
+        plugins_ie = load_plugins("extractor", "IE", {})
+        self.assertIn("SamplePluginIE", plugins_ie.keys())
+
+    def test_postprocessor_classes(self):
+        plugins_pp = load_plugins("postprocessor", "PP", {})
+        self.assertIn("SamplePluginPP", plugins_pp.keys())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,7 +1,11 @@
 # coding: utf-8
+import importlib
 import sys
 import unittest
+from importlib import invalidate_caches
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 
 ROOT_DIR = Path(__file__).parents[1].absolute()
 sys.path.insert(0, str(ROOT_DIR))
@@ -30,6 +34,23 @@ class TestPlugins(unittest.TestCase):
     def test_postprocessor_classes(self):
         plugins_pp = load_plugins("postprocessor", "PP", {})
         self.assertIn("SamplePluginPP", plugins_pp.keys())
+
+    def test_importing_zipped_module(self):
+        """
+        create a zip file with plugins and check if it can be imported
+        """
+        with TemporaryDirectory() as tmp:
+            zipmodule_path = Path(tmp, "plugins.zip")
+            with ZipFile(zipmodule_path, mode="w") as zipmodule:
+                for file in self.SAMPLE_PLUGIN_DIR.rglob("*.py"):
+                    zipmodule.write(file, arcname=file.relative_to(self.SAMPLE_PLUGIN_DIR.parent))
+
+            sys.path.append(str(zipmodule_path))  # add zip to search paths
+            invalidate_caches()  # reset the import caches
+
+            for plugin_type in ("extractor", "postprocessor"):
+                package = importlib.import_module(f"{PACKAGE_NAME}.{plugin_type}")
+                self.assertIn(zipmodule_path / PACKAGE_NAME / plugin_type, map(Path, package.__path__))
 
 
 if __name__ == "__main__":

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -31,6 +31,7 @@ import unicodedata
 from enum import Enum
 from string import ascii_letters
 
+from .plugins import directories as plugin_directories
 from .compat import (
     compat_basestring,
     compat_get_terminal_size,
@@ -3327,6 +3328,7 @@ class YoutubeDL(object):
             write_debug('Plugins: %s' % [
                 '%s%s' % (klass.__name__, '' if klass.__name__ == name else f' as {name}')
                 for name, klass in itertools.chain(plugin_extractors.items(), plugin_postprocessors.items())])
+            write_debug('Plugin directories: %s\n' % plugin_directories())
         if self.params.get('compat_opts'):
             write_debug('Compatibility options: %s' % ', '.join(self.params.get('compat_opts')))
         try:

--- a/yt_dlp/extractor/__init__.py
+++ b/yt_dlp/extractor/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from ..utils import load_plugins
+from ..plugins import load_plugins
 
 _LAZY_LOADER = False
 if not os.environ.get('YTDLP_NO_LAZY_EXTRACTORS'):

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -2,7 +2,7 @@ import importlib
 import sys
 import traceback
 from contextlib import suppress
-from importlib.abc import MetaPathFinder
+from importlib.abc import MetaPathFinder, Loader
 from importlib.machinery import ModuleSpec
 from importlib.util import module_from_spec, find_spec
 from inspect import getmembers, isclass
@@ -17,23 +17,18 @@ PACKAGE_NAME = 'ytdlp_plugins'
 _INITIALIZED = False
 
 
-class PluginLoader:
-    ''' Dummy loader for virtual namespace packages '''
-    @classmethod
-    def create_module(cls, spec):
-        pass
-
-    @classmethod
-    def exec_module(cls, module):
-        pass
+class PluginLoader(Loader):
+    """ Dummy loader for virtual namespace packages """
+    def exec_module(self, module):
+        return None
 
 
 class PluginFinder(MetaPathFinder):
-    '''
+    """
     This class provides one or multiple namespace packages
     it searches in sys.path for the existing subdirectories
     from which the modules can be imported
-    '''
+    """
     @staticmethod
     def partition(name):
         yield from accumulate(name.split('.'), lambda a, b: '.'.join((a, b)))
@@ -70,7 +65,7 @@ class PluginFinder(MetaPathFinder):
         if not search_locations:
             return None
 
-        spec = ModuleSpec(fullname, PluginLoader, is_package=True)
+        spec = ModuleSpec(fullname, PluginLoader(), is_package=True)
         spec.submodule_search_locations = search_locations
         return spec
 

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -1,0 +1,150 @@
+import importlib
+import sys
+import traceback
+from contextlib import suppress
+from inspect import getmembers, isclass
+from itertools import accumulate
+from pathlib import Path
+from pkgutil import iter_modules as pkgutil_iter_modules
+from shutil import copytree
+from zipfile import ZipFile
+from zipimport import zipimporter
+
+PACKAGE_NAME = 'ytdlp_plugins'
+_INITIALIZED = False
+
+
+class PluginLoader:
+    ''' Dummy loader for virtual namespace packages '''
+    @classmethod
+    def create_module(cls, spec):
+        pass
+
+    @classmethod
+    def exec_module(cls, module):
+        pass
+
+
+class PluginFinder(importlib.abc.MetaPathFinder):
+    '''
+    This class provides one or multiple namespace packages
+    it searches in sys.path for the existing subdirectories
+    from which the modules can be imported
+    '''
+    @staticmethod
+    def partition(name):
+        yield from accumulate(name.split('.'), lambda a, b: '.'.join((a, b)))
+
+    def __init__(self, *packages):
+        self.packages = set()
+        for name in packages:
+            self.packages.update(self.partition(name))
+
+    @staticmethod
+    def search_locations(fullname):
+        parts = fullname.split('.')
+        loc = []
+        for path in map(Path, sys.path):
+            candidate = path.joinpath(*parts)
+            if candidate.is_dir():
+                loc.append(str(candidate))
+            elif path.is_file() and path.suffix in {'.zip', '.egg', '.whl'}:
+                with suppress(FileNotFoundError):
+                    zipfile = ZipFile(path, 'r')
+                    if any(
+                        name.startswith('/'.join((*parts, '')))
+                        for name in zipfile.namelist()
+                    ):
+                        loc.append(str(candidate))
+
+        return loc
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname not in self.packages:
+            return None
+
+        search_locations = self.search_locations(fullname)
+        if not search_locations:
+            return None
+
+        spec = importlib.machinery.ModuleSpec(fullname, PluginLoader, is_package=True)
+        spec.submodule_search_locations = search_locations
+        return spec
+
+
+def initialize():
+    global _INITIALIZED
+    if _INITIALIZED:
+        return
+
+    # are we running from PyInstaller single executable?
+    # then copy the plugin directory if exist
+    root = Path(sys.executable).parent
+    meipass = Path(getattr(sys, '_MEIPASS', '.'))
+    if getattr(sys, 'frozen', False) and root != meipass:
+        try:
+            copytree(root / PACKAGE_NAME, meipass / PACKAGE_NAME, dirs_exist_ok=False)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            print(exc, file=sys.stderr)
+
+    sys.meta_path.insert(
+        0, PluginFinder(f'{PACKAGE_NAME}.extractor', f'{PACKAGE_NAME}.postprocessor'))
+    _INITIALIZED = True
+
+
+def iter_modules(subpackage):
+    fullname = f'{PACKAGE_NAME}.{subpackage}'
+    with suppress(ModuleNotFoundError):
+        pkg = importlib.import_module(fullname)
+        yield from pkgutil_iter_modules(path=pkg.__path__, prefix=f'{fullname}.')
+
+
+def load_plugins(name, suffix, namespace):
+    classes = {}
+
+    def predicate(package_name):
+        def check_pred(obj):
+            return (isclass(obj)
+                    and obj.__name__.endswith(suffix)
+                    and obj.__module__.startswith(package_name))
+
+        return check_pred
+
+    for finder, module_name, is_pkg in iter_modules(name):
+        try:
+            if isinstance(finder, zipimporter):
+                module = finder.load_module(module_name)
+            else:
+                spec = finder.find_spec(module_name)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+        except Exception:
+            print(f"Error while importing module '{module_name}'", file=sys.stderr)
+            traceback.print_exc(limit=-1)
+            continue
+
+        sys.modules[module_name] = module
+        module_classes = dict(getmembers(module, predicate(module_name)))
+        name_collisons = (set(classes.keys()) | set(namespace.keys())) & set(
+            module_classes.keys()
+        )
+        classes.update(
+            {
+                key: value
+                for key, value in module_classes.items()
+                if key not in name_collisons
+            }
+        )
+
+    namespace.update(classes)
+    return classes
+
+
+def directories():
+    spec = importlib.util.find_spec(PACKAGE_NAME)
+    return spec.submodule_search_locations if spec else []
+
+
+initialize()

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -2,6 +2,9 @@ import importlib
 import sys
 import traceback
 from contextlib import suppress
+from importlib.abc import MetaPathFinder
+from importlib.machinery import ModuleSpec
+from importlib.util import module_from_spec, find_spec
 from inspect import getmembers, isclass
 from itertools import accumulate
 from pathlib import Path
@@ -25,7 +28,7 @@ class PluginLoader:
         pass
 
 
-class PluginFinder(importlib.abc.MetaPathFinder):
+class PluginFinder(MetaPathFinder):
     '''
     This class provides one or multiple namespace packages
     it searches in sys.path for the existing subdirectories
@@ -67,7 +70,7 @@ class PluginFinder(importlib.abc.MetaPathFinder):
         if not search_locations:
             return None
 
-        spec = importlib.machinery.ModuleSpec(fullname, PluginLoader, is_package=True)
+        spec = ModuleSpec(fullname, PluginLoader, is_package=True)
         spec.submodule_search_locations = search_locations
         return spec
 
@@ -118,7 +121,7 @@ def load_plugins(name, suffix, namespace):
                 module = finder.load_module(module_name)
             else:
                 spec = finder.find_spec(module_name)
-                module = importlib.util.module_from_spec(spec)
+                module = module_from_spec(spec)
                 spec.loader.exec_module(module)
         except Exception:
             print(f"Error while importing module '{module_name}'", file=sys.stderr)
@@ -143,7 +146,7 @@ def load_plugins(name, suffix, namespace):
 
 
 def directories():
-    spec = importlib.util.find_spec(PACKAGE_NAME)
+    spec = find_spec(PACKAGE_NAME)
     return spec.submodule_search_locations if spec else []
 
 

--- a/yt_dlp/postprocessor/__init__.py
+++ b/yt_dlp/postprocessor/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa: F401
 
-from ..utils import load_plugins
+from ..plugins import load_plugins
 
 from .embedthumbnail import EmbedThumbnailPP
 from .exec import ExecPP, ExecAfterDownloadPP

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -18,7 +18,6 @@ import functools
 import gzip
 import hashlib
 import hmac
-import importlib.util
 import io
 import itertools
 import json
@@ -6344,26 +6343,6 @@ def get_executable_path():
     else:
         path = os.path.join(os.path.dirname(__file__), '..')
     return os.path.abspath(path)
-
-
-def load_plugins(name, suffix, namespace):
-    classes = {}
-    try:
-        plugins_spec = importlib.util.spec_from_file_location(
-            name, os.path.join(get_executable_path(), 'ytdlp_plugins', name, '__init__.py'))
-        plugins = importlib.util.module_from_spec(plugins_spec)
-        sys.modules[plugins_spec.name] = plugins
-        plugins_spec.loader.exec_module(plugins)
-        for name in dir(plugins):
-            if name in namespace:
-                continue
-            if not name.endswith(suffix):
-                continue
-            klass = getattr(plugins, name)
-            classes[name] = namespace[name] = klass
-    except FileNotFoundError:
-        pass
-    return classes
 
 
 def traverse_obj(

--- a/ytdlp_plugins/extractor/__init__.py
+++ b/ytdlp_plugins/extractor/__init__.py
@@ -1,4 +1,0 @@
-# flake8: noqa: F401
-
-# ℹ️ The imported name must end in "IE"
-from .sample import SamplePluginIE

--- a/ytdlp_plugins/postprocessor/__init__.py
+++ b/ytdlp_plugins/postprocessor/__init__.py
@@ -1,4 +1,0 @@
-# flake8: noqa: F401
-
-# ℹ️ The imported name must end in "PP" and is the name to be used in --use-postprocessor
-from .sample import SamplePluginPP


### PR DESCRIPTION
### Before submitting this *pull request* I have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description

This PR enhances the capability to find and load plugin modules. (Closes #1389)
- uses namespace packages for extractor and postprocessor plugins
- zip-safe solution, which works with .whl, .egg and PyInstaller
- supports editable packages (pip install -e <path>)
- report all plugin directories in verbose mode
- update plugin documentation in README
