### PR TITLE
[telemundo] Fix invalid '# coding' encoding tag format

### DIFF
--- a/yt_dlp/extractor/telemundo.py
+++ b/yt_dlp/extractor/telemundo.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# coding: utf-8
 from __future__ import unicode_literals
 
 from .common import InfoExtractor


### PR DESCRIPTION
Fix a `# coding: utf8` tag that has an invalid format in the first line of the 'telemundo' extractor.