### PR TITLE
[itv] Merged ITVBTCCIE into new ITVNewsIE extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -601,7 +601,7 @@ from .iqiyi import IqiyiIE
 from .ir90tv import Ir90TvIE
 from .itv import (
     ITVIE,
-    ITVNewsIE,
+    ITVBTCCIE,
 )
 from .ivi import (
     IviIE,

--- a/yt_dlp/extractor/itv.py
+++ b/yt_dlp/extractor/itv.py
@@ -219,7 +219,7 @@ class ITVIE(InfoExtractor):
         }, info)
 
 
-class ITVNewsIE(InfoExtractor):
+class ITVBTCCIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?itv\.com/(?:news|btcc)/(?:[^/]+/)*(?P<id>[^/?#&]+)'
     _TESTS = [{
         'url': 'https://www.itv.com/btcc/articles/btcc-2019-brands-hatch-gp-race-action',
@@ -249,20 +249,21 @@ class ITVNewsIE(InfoExtractor):
 
         entries = []
         for video in json_map:
-            if any(video['data'].get(attr) == 'Brightcove' for attr in ('name', 'type')):
-                video_id = video['data']['id']
-                account_id = video['data']['accountId']
-                player_id = video['data']['playerId']
-                entries.append(self.url_result(
-                    smuggle_url(self.BRIGHTCOVE_URL_TEMPLATE % (account_id, player_id, video_id), {
-                        # ITV does not like some GB IP ranges, so here are some
-                        # IP blocks it accepts
-                        'geo_ip_blocks': [
-                            '193.113.0.0/16', '54.36.162.0/23', '159.65.16.0/21'
-                        ],
-                        'referrer': url,
-                    }),
-                    ie=BrightcoveNewIE.ie_key(), video_id=video_id))
+            if not any(video['data'].get(attr) == 'Brightcove' for attr in ('name', 'type')):
+                continue
+            video_id = video['data']['id']
+            account_id = video['data']['accountId']
+            player_id = video['data']['playerId']
+            entries.append(self.url_result(
+                smuggle_url(self.BRIGHTCOVE_URL_TEMPLATE % (account_id, player_id, video_id), {
+                    # ITV does not like some GB IP ranges, so here are some
+                    # IP blocks it accepts
+                    'geo_ip_blocks': [
+                        '193.113.0.0/16', '54.36.162.0/23', '159.65.16.0/21'
+                    ],
+                    'referrer': url,
+                }),
+                ie=BrightcoveNewIE.ie_key(), video_id=video_id))
 
         title = self._og_search_title(webpage, fatal=False)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

There was no extractor for ITV news pages, so I modified ITVBTCCIE and created a new ITVNewsIE extractor which can now extract from both news & BTCC articles. Therefore the old ITVBTCCIE can be removed.
