### PR TITLE
[servus] extractor reimplementation due to new url schema

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1251,6 +1251,7 @@ from .senateisvp import SenateISVPIE
 from .sendtonews import SendtoNewsIE
 from .servus import (
     ServusTVIE,
+    ServusSearchIE,
     PmWissenIE,
 )
 from .sevenplus import SevenPlusIE

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1249,7 +1249,10 @@ from .scte import (
 from .seeker import SeekerIE
 from .senateisvp import SenateISVPIE
 from .sendtonews import SendtoNewsIE
-from .servus import ServusIE
+from .servus import (
+    ServusTVIE,
+    PmWissenIE,
+)
 from .sevenplus import SevenPlusIE
 from .sexu import SexuIE
 from .seznamzpravy import (

--- a/yt_dlp/extractor/servus.py
+++ b/yt_dlp/extractor/servus.py
@@ -26,7 +26,7 @@ class ServusTVIE(InfoExtractor):
                         /[\w-]+/(?:v|[bp]/[\w-]+)
                         /(?P<id>[A-Za-z0-9-]+)
                     '''
-    _GEO_COUNTRIES = ['AT', 'DE', 'CH', 'LI', 'IT']
+    _GEO_COUNTRIES = ['AT', 'DE']
     _API_URL = 'https://api-player.redbull.com/stv/servus-tv'
     _QUERY_API_URL = 'https://backend.servustv.com/wp-json/rbmh/v2/query-filters/query/'
     _LIVE_URLS = {
@@ -68,7 +68,7 @@ class ServusTVIE(InfoExtractor):
 
     def __init__(self, downloader=None):
         super().__init__(downloader=downloader)
-        self.country_code = 'AT'
+        self.country_code = self._GEO_COUNTRIES[0]
         self.timezone = 'Europe/Vienna'
 
     def _entry_by_id(self, video_id, video_url=None, is_live=False):

--- a/yt_dlp/extractor/servus.py
+++ b/yt_dlp/extractor/servus.py
@@ -107,6 +107,10 @@ class ServusTVIE(InfoExtractor):
             'duration': None if is_live else info.get('duration'),
             'timestamp': parse_iso8601(info.get('currentSunrise')),
             'is_live': is_live,
+            'categories': [info['label']] if info.get('label') else [],
+            'age_limit': int(
+                self._search_regex(r'(?:^|\s)(\d\d?)(?:\s|$)', info.get('maturityRating', '0'),
+                'age_limit', default='0')),
             'formats': formats,
             'subtitles': subtitles,
         }

--- a/yt_dlp/extractor/servus.py
+++ b/yt_dlp/extractor/servus.py
@@ -1,148 +1,236 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import json
+from operator import itemgetter
+
 from .common import InfoExtractor
+from ..compat import (
+    compat_urllib_parse_urlparse,
+    compat_parse_qs,
+)
 from ..utils import (
-    determine_ext,
-    float_or_none,
-    int_or_none,
-    unified_timestamp,
-    urlencode_postdata,
-    url_or_none,
+    get_element_by_id,
+    parse_iso8601,
+    traverse_obj,
+    ExtractorError,
+    OnDemandPagedList,
 )
 
 
-class ServusIE(InfoExtractor):
+class ServusTVIE(InfoExtractor):
+    IE_NAME = 'servustv'
     _VALID_URL = r'''(?x)
                     https?://
-                        (?:www\.)?
-                        (?:
-                            servus\.com/(?:(?:at|de)/p/[^/]+|tv/videos)|
-                            (?:servustv|pm-wissen)\.com/videos
-                        )
-                        /(?P<id>[aA]{2}-\w+|\d+-\d+)
+                        (?:www\.)?servustv.com
+                        /[\w-]+/(?:v|[bp]/[\w-]+)
+                        /(?P<id>[A-Za-z0-9-]+)
                     '''
+    _API_URL = 'https://api-player.redbull.com/stv/servus-tv'
+    _QUERY_API_URL = 'https://backend.servustv.com/wp-json/rbmh/v2/query-filters/query/'
+    _LIVE_URLS = {
+        'AT': 'https://dms.redbull.tv/v4/destination/stv/stv-linear'
+              '/personal_computer/chrome/at/de_AT/playlist.m3u8',
+        'DE': 'https://dms.redbull.tv/v4/destination/stv/stv-linear'
+              '/personal_computer/chrome/de/de_DE/playlist.m3u8',
+    }
+
     _TESTS = [{
         # new URL schema
-        'url': 'https://www.servustv.com/videos/aa-1t6vbu5pw1w12/',
-        'md5': '60474d4c21f3eb148838f215c37f02b9',
+        'url': 'https://www.servustv.com/volkskultur/v/aa-28jq9b51h1w11/',
         'info_dict': {
-            'id': 'AA-1T6VBU5PW1W12',
+            'id': 'aa-28jq9b51h1w11',
             'ext': 'mp4',
-            'title': 'Die Grünen aus Sicht des Volkes',
-            'alt_title': 'Talk im Hangar-7 Voxpops Gruene',
-            'description': 'md5:1247204d85783afe3682644398ff2ec4',
+            'title': 'Der Hof meines Vertrauens',
+            'description': 'Rinder, Gemüse, Schnecken - drei Selbstvermarkter zeigen ihren Hof.',
             'thumbnail': r're:^https?://.*\.jpg',
-            'duration': 62.442,
-            'timestamp': 1605193976,
-            'upload_date': '20201112',
-            'series': 'Talk im Hangar-7',
-            'season': 'Season 9',
-            'season_number': 9,
-            'episode': 'Episode 31 - September 14',
-            'episode_number': 31,
+            'timestamp': 1635538309,
+            'upload_date': '20211029',
+        },
+        'params': {'skip_download': True, 'format': 'bestvideo'},
+    }, {
+        # playlist
+        'url': 'https://www.servustv.com/volkskultur/b/ich-bauer/aa-1qcy94h3s1w11/',
+        'info_dict': {
+            'id': '116155',
+            'title': 'Ich, Bauer',
+            'description': 'md5:04cd98226e5c07ca50d0dc90f4a27ea1',
+        },
+        'playlist_mincount': 10,
+    }, {
+        'url': 'https://www.servustv.com/allgemein/v/aagevnv3syv5kuu8cpfq/',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.servustv.com/allgemein/p/jetzt-live/119753/',
+        'only_matching': True,
+    }]
+
+    def __init__(self, downloader=None):
+        super().__init__(downloader=downloader)
+        self.country_code = 'AT'
+        self.timezone = 'Europe/Vienna'
+
+    def _entry_by_id(self, video_id, video_url=None, is_live=False):
+        info = self._download_json(
+            self._API_URL, query={'videoId': video_id.upper(), 'timeZone': self.timezone},
+            video_id=video_id, fatal=False, expected_status=(400, 404, 500)) \
+            or {'message': 'Bad JSON Response'}
+
+        if 'message' in info:
+            raise ExtractorError(info['message'], video_id=video_id, expected=True)
+
+        info.setdefault('videoUrl', video_url)
+        errors = ", ".join(info.get('playabilityErrors', ()))
+        if errors and info.get('videoUrl') is None:
+            raise ExtractorError(
+                f'{info.get("title", "Unknown")} - {errors}', video_id=video_id, expected=True)
+
+        try:
+            formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+                info['videoUrl'], video_id=video_id,
+                entry_protocol='m3u8' if is_live else 'm3u8_native',
+                errnote='Stream not available')
+        except ExtractorError as exc:
+            raise ExtractorError(exc.msg, video_id=video_id, expected=True)
+
+        self._sort_formats(formats)
+        for fmt in formats:
+            if 'height' in fmt:
+                fmt['format_id'] = f"{fmt['height']}p"
+
+        return {
+            'id': video_id,
+            'title': info.get('title'),
+            'description': info.get('description'),
+            'thumbnail': info.get('poster'),
+            'duration': None if is_live else info.get('duration'),
+            'timestamp': parse_iso8601(info.get('currentSunrise')),
+            'is_live': is_live,
+            'formats': formats,
+            'subtitles': subtitles,
         }
-    }, {
-        # old URL schema
-        'url': 'https://www.servus.com/de/p/Die-Gr%C3%BCnen-aus-Sicht-des-Volkes/AA-1T6VBU5PW1W12/',
-        'only_matching': True,
-    }, {
-        'url': 'https://www.servus.com/at/p/Wie-das-Leben-beginnt/1309984137314-381415152/',
-        'only_matching': True,
-    }, {
-        'url': 'https://www.servus.com/tv/videos/aa-1t6vbu5pw1w12/',
-        'only_matching': True,
-    }, {
-        'url': 'https://www.servus.com/tv/videos/1380889096408-1235196658/',
-        'only_matching': True,
-    }, {
+
+    def _live_stream_from_schedule(self, schedule):
+        for item in sorted(schedule, key=lambda x: x.get('is_live', False), reverse=True):
+            is_live = item.get('is_live', False)
+            video_url = self._LIVE_URLS.get(self.country_code) if is_live else None
+            return self._entry_by_id(item['aa_id'].lower(), video_url=video_url, is_live=is_live)
+
+    def _paged_playlist_entries(self, query_id, query_type, page_size=20):
+        query = {query_type: query_id}
+        query.update(dict(
+            geo_override=self.country_code, post_type='media_asset', per_page=page_size,
+            filter_playability='true', order='desc', orderby='rbmh_playability'))
+
+        def fetch_page(page_number):
+            query.update({'page': page_number + 1})
+            info = self._download_json(
+                self._QUERY_API_URL,
+                query=query,
+                video_id=f'{query_type}-{query_id}',
+                note=f"Downloading entries "
+                     f"{page_number * page_size + 1}-{(page_number + 1) * page_size}")
+
+            for item in info['posts']:
+                if not traverse_obj(item, ('stv_duration', 'raw')):
+                    continue
+                video_id, title, url = itemgetter('slug', 'stv_short_title', 'link')(item)
+                yield self.url_result(
+                    url,
+                    ie=self.ie_key(),
+                    video_id=video_id,
+                    video_title=title
+                )
+
+        return OnDemandPagedList(fetch_page, page_size)
+
+    @staticmethod
+    def _page_id(json_obj):
+        for key, value in traverse_obj(json_obj, ('source', 'data'), default={}).items():
+            if isinstance(value, dict) and 'id' in value:
+                return value['id']
+        return None
+
+    def _json_extract(self, webpage, video_id):
+        json_string = get_element_by_id('__FRONTITY_CONNECT_STATE__', webpage)
+        if not json_string:
+            raise ExtractorError('Missing HTML metadata', video_id=video_id, expected=True)
+
+        try:
+            return json.loads(json_string or '{}')
+        except json.JSONDecodeError:
+            raise ExtractorError('Bad JSON metadata', video_id=video_id, expected=False)
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        parsed_url = compat_urllib_parse_urlparse(url)
+        url_query = {key.lower(): value[0] for key, value in compat_parse_qs(parsed_url.query).items()}
+        if 'timezone' in url_query:
+            self.timezone = url_query['timezone']
+            self.to_screen(f'Set timezone to {self.timezone!r}')
+
+        # single video
+        if '/v/' in parsed_url.path:
+            return self._entry_by_id(video_id)
+
+        webpage = self._download_webpage(url, video_id=video_id)
+        json_obj = self._json_extract(webpage, video_id=video_id)
+        self.country_code = traverse_obj(
+            json_obj, ('geolocation', 'countryCode'), default='AT', expected_type=str)
+
+        # find livestreams
+        live_schedule = traverse_obj(
+            json_obj, ('source', 'page', video_id, 'stv_live_player_schedule'), default=None)
+        if live_schedule:
+            return self._live_stream_from_schedule(live_schedule)
+
+        # create playlist
+        page_id = self._page_id(json_obj)
+        if page_id is None:
+            raise ExtractorError('Missing page id', video_id=video_id)
+
+        asset_paths = (
+            ('source', 'media_asset', str(page_id), 'categories'),
+            # ('source', 'page', str(page_id), 'asset_content_color'),
+        )
+
+        for *path, asset_name in asset_paths:
+            asset_ids = traverse_obj(json_obj, (*path, asset_name), default=())
+            if asset_ids:
+                query_id, query_type = asset_ids[0], asset_name
+                break
+        else:
+            raise ExtractorError('Website contains no supported playlists',
+                                 video_id=page_id, expected=True)
+
+        site_name = self._og_search_property('site_name', webpage, default=None)
+        playlist_title = self._og_search_title(webpage, default=None)
+        if site_name and playlist_title:
+            playlist_title = playlist_title.replace(f' - {site_name}', '', 1)
+        playlist_description = self._og_search_description(webpage, default=None)
+
+        return self.playlist_result(
+            self._paged_playlist_entries(query_id=query_id, query_type=query_type),
+            playlist_id=str(page_id),
+            playlist_title=playlist_title,
+            playlist_description=playlist_description
+        )
+
+
+class PmWissenIE(ServusTVIE):
+    IE_NAME = 'pm-wissen'
+    _VALID_URL = r'''(?x)
+                    https?://
+                        (?:www\.)?pm-wissen.com
+                        /videos
+                        /(?P<id>[aA]{2}-\w+)
+                    '''
+
+    _TESTS = [{
         'url': 'https://www.pm-wissen.com/videos/aa-24mus4g2w2112/',
         'only_matching': True,
     }]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url).upper()
-
-        token = self._download_json(
-            'https://auth.redbullmediahouse.com/token', video_id,
-            'Downloading token', data=urlencode_postdata({
-                'grant_type': 'client_credentials',
-            }), headers={
-                'Authorization': 'Basic SVgtMjJYNEhBNFdEM1cxMTpEdDRVSkFLd2ZOMG5IMjB1NGFBWTBmUFpDNlpoQ1EzNA==',
-            })
-        access_token = token['access_token']
-        token_type = token.get('token_type', 'Bearer')
-
-        video = self._download_json(
-            'https://sparkle-api.liiift.io/api/v1/stv/channels/international/assets/%s' % video_id,
-            video_id, 'Downloading video JSON', headers={
-                'Authorization': '%s %s' % (token_type, access_token),
-            })
-
-        formats = []
-        thumbnail = None
-        for resource in video['resources']:
-            if not isinstance(resource, dict):
-                continue
-            format_url = url_or_none(resource.get('url'))
-            if not format_url:
-                continue
-            extension = resource.get('extension')
-            type_ = resource.get('type')
-            if extension == 'jpg' or type_ == 'reference_keyframe':
-                thumbnail = format_url
-                continue
-            ext = determine_ext(format_url)
-            if type_ == 'dash' or ext == 'mpd':
-                formats.extend(self._extract_mpd_formats(
-                    format_url, video_id, mpd_id='dash', fatal=False))
-            elif type_ == 'hls' or ext == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(
-                    format_url, video_id, 'mp4', entry_protocol='m3u8_native',
-                    m3u8_id='hls', fatal=False))
-            elif extension == 'mp4' or ext == 'mp4':
-                formats.append({
-                    'url': format_url,
-                    'format_id': type_,
-                    'width': int_or_none(resource.get('width')),
-                    'height': int_or_none(resource.get('height')),
-                })
-        self._sort_formats(formats)
-
-        attrs = {}
-        for attribute in video['attributes']:
-            if not isinstance(attribute, dict):
-                continue
-            key = attribute.get('fieldKey')
-            value = attribute.get('fieldValue')
-            if not key or not value:
-                continue
-            attrs[key] = value
-
-        title = attrs.get('title_stv') or video_id
-        alt_title = attrs.get('title')
-        description = attrs.get('long_description') or attrs.get('short_description')
-        series = attrs.get('label')
-        season = attrs.get('season')
-        episode = attrs.get('chapter')
-        duration = float_or_none(attrs.get('duration'), scale=1000)
-        season_number = int_or_none(self._search_regex(
-            r'Season (\d+)', season or '', 'season number', default=None))
-        episode_number = int_or_none(self._search_regex(
-            r'Episode (\d+)', episode or '', 'episode number', default=None))
-
-        return {
-            'id': video_id,
-            'title': title,
-            'alt_title': alt_title,
-            'description': description,
-            'thumbnail': thumbnail,
-            'duration': duration,
-            'timestamp': unified_timestamp(video.get('lastPublished')),
-            'series': series,
-            'season': season,
-            'season_number': season_number,
-            'episode': episode,
-            'episode_number': episode_number,
-            'formats': formats,
-        }
+        video_id = self._match_id(url)
+        return self._entry_by_id(video_id)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Closes #1490
Current servustv.com platform seems to have an API which is easy to implement.
Since I don't know the old one I left the ServusIE class untouched.

Open questions:
- video and audio streams are separated - can we provide a default merge?