### PR TITLE
[postprocessor] Use libfdk_aac over FFmpeg's AAC encoder, if available.

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -100,7 +100,7 @@ class FFmpegPostProcessor(PostProcessor):
                 return
 
             # If the libfdk_aac encoder is available, it will be used instead of FFmpeg's AAC encoder.
-            self.use_fdk_aac = True if '--enable-libfdk-aac' in ffmpeg_banner else False
+            self.use_fdk_aac = True if ffmpeg_banner and '--enable-libfdk-aac' in ffmpeg_banner else False
 
         self.basename = None
         self.probe_basename = None

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -100,7 +100,7 @@ class FFmpegPostProcessor(PostProcessor):
                 return
 
             # If the libfdk_aac encoder is available, it will be used instead of FFmpeg's AAC encoder.
-            self.use_fdk_aac = True if ffmpeg_banner and '--enable-libfdk-aac' in ffmpeg_banner else False
+            self.use_fdk_aac = ffmpeg_banner and '--enable-libfdk-aac' in ffmpeg_banner
 
         self.basename = None
         self.probe_basename = None

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -437,9 +437,10 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             more_opts = []
             audio_quality_setter = '-q:a' if not self.use_fdk_aac else '-vbr'
             if self._preferredquality is not None:
-                # Quality range for FDK AAC is 1-5.
-                if self.use_fdk_aac and int(self._preferredquality) > 5:
-                    self._preferredquality = '5'
+                # The quality range for --audio-quality is 0-9 (best to worst).
+                # Re-scale this as FDK AAC uses a quality range of 1-5 (worst to best).
+                if self.use_fdk_aac:
+                    self._preferredquality = str(int(5.5 - (int(self._preferredquality) / 2)))
                 # The opus codec doesn't support the audio quality option.
                 if int(self._preferredquality) < 10 and extension != 'opus':
                     more_opts += [audio_quality_setter, self._preferredquality]

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -434,13 +434,12 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             extension = self._preferredcodec
             more_opts = []
             audio_quality_setter = '-q:a'
-            if self._preferredcodec == 'aac' or self._preferredcodec == 'm4a':
-                if self.libfdk_aac_available():
-                    acodec = 'libfdk_aac'
-                    audio_quality_setter = '-vbr'
-                    # The quality range for libfdk_aac is 1-5
-                    if int(self._preferredquality) > 5:
-                        self._preferredquality = '5'
+            if self._preferredcodec in ('aac', 'm4a') and self.libfdk_aac_available():
+                acodec = 'libfdk_aac'
+                audio_quality_setter = '-vbr'
+                # The quality range for libfdk_aac is 1-5
+                if int(self._preferredquality) > 5:
+                    self._preferredquality = '5'
             if self._preferredquality is not None:
                 # The opus codec doesn't support the audio quality option (-q:a).
                 if int(self._preferredquality) < 10 and extension != 'opus':

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4007,10 +4007,7 @@ def check_executable(exe, args=[]):
     return exe
 
 
-def get_exe_version(exe, args=['--version'],
-                    version_re=None, unrecognized='present'):
-    """ Returns the version of the specified executable,
-    or False if the executable is not present """
+def _get_exe_version_output(exe, args):
     try:
         # STDIN should be redirected too. On UNIX-like systems, ffmpeg triggers
         # SIGTTOU if yt-dlp is run in the background.
@@ -4022,7 +4019,7 @@ def get_exe_version(exe, args=['--version'],
         return False
     if isinstance(out, bytes):  # Python 2.x
         out = out.decode('ascii', 'ignore')
-    return detect_exe_version(out, version_re, unrecognized)
+    return out
 
 
 def detect_exe_version(output, version_re=None, unrecognized='present'):
@@ -4034,6 +4031,14 @@ def detect_exe_version(output, version_re=None, unrecognized='present'):
         return m.group(1)
     else:
         return unrecognized
+
+
+def get_exe_version(exe, args=['--version'],
+                    version_re=None, unrecognized='present'):
+    """ Returns the version of the specified executable,
+    or False if the executable is not present """
+    out = _get_exe_version_output(exe, args)
+    return detect_exe_version(out, version_re, unrecognized) if out else False
 
 
 class LazyList(collections.abc.Sequence):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This update checks your FFmpeg configuration to see if libfdk_aac is supported. If so, this encoder is used when `--audio-format` is set to `aac` or `m4a`.

Listening tests show FDK AAC as being superior to FFmpeg's native AAC in terms of quality:
https://hydrogenaud.io/index.php?topic=119861.0
https://hydrogenaud.io/index.php?topic=120062.0