### PR TITLE
[iPrima] Fix extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -595,7 +595,10 @@ from .instagram import (
 )
 from .internazionale import InternazionaleIE
 from .internetvideoarchive import InternetVideoArchiveIE
-from .iprima import IPrimaCNNIE
+from .iprima import (
+    IPrimaIE,
+    IPrimaCNNIE
+)
 from .iqiyi import IqiyiIE
 from .ir90tv import Ir90TvIE
 from .itv import (

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -595,7 +595,7 @@ from .instagram import (
 )
 from .internazionale import InternazionaleIE
 from .internetvideoarchive import InternetVideoArchiveIE
-from .iprima import IPrimaIE
+from .iprima import IPrimaCNNIE
 from .iqiyi import IqiyiIE
 from .ir90tv import Ir90TvIE
 from .itv import (

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -10,65 +10,20 @@ from ..utils import (
     js_to_json,
 )
 
-
-class IPrimaIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:[^/]+)\.iprima\.cz/(?:[^/]+/)*(?P<id>[^/?#&]+)'
+class IPrimaCNNIE(InfoExtractor):
+    _VALID_URL = r'https?://cnn\.iprima\.cz/(?:[^/]+/)*(?P<id>[^/?#&]+)'
     _GEO_BYPASS = False
 
     _TESTS = [{
-        'url': 'https://prima.iprima.cz/particka/92-epizoda',
+        'url': 'https://cnn.iprima.cz/porady/strunc/24072020-koronaviru-mam-plne-zuby-strasit-druhou-vlnou-je-absurdni-rika-senatorka-dernerova',
         'info_dict': {
-            'id': 'p51388',
+            'id': 'p716177',
             'ext': 'mp4',
-            'title': 'Partička (92)',
-            'description': 'md5:859d53beae4609e6dd7796413f1b6cac',
+            'title': 'Štrunc 2020 (14) - Koronaviru mám plné zuby, strašit druhou vlnou je absurdní, říká senátorka Dernerová',
         },
         'params': {
             'skip_download': True,  # m3u8 download
-        },
-    }, {
-        'url': 'https://cnn.iprima.cz/videa/70-epizoda',
-        'info_dict': {
-            'id': 'p681554',
-            'ext': 'mp4',
-            'title': 'HLAVNÍ ZPRÁVY 3.5.2020',
-        },
-        'params': {
-            'skip_download': True,  # m3u8 download
-        },
-    }, {
-        'url': 'http://play.iprima.cz/particka/particka-92',
-        'only_matching': True,
-    }, {
-        # geo restricted
-        'url': 'http://play.iprima.cz/closer-nove-pripady/closer-nove-pripady-iv-1',
-        'only_matching': True,
-    }, {
-        # iframe api.play-backend.iprima.cz
-        'url': 'https://prima.iprima.cz/my-little-pony/mapa-znameni-2-2',
-        'only_matching': True,
-    }, {
-        # iframe prima.iprima.cz
-        'url': 'https://prima.iprima.cz/porady/jak-se-stavi-sen/rodina-rathousova-praha',
-        'only_matching': True,
-    }, {
-        'url': 'http://www.iprima.cz/filmy/desne-rande',
-        'only_matching': True,
-    }, {
-        'url': 'https://zoom.iprima.cz/10-nejvetsich-tajemstvi-zahad/posvatna-mista-a-stavby',
-        'only_matching': True,
-    }, {
-        'url': 'https://krimi.iprima.cz/mraz-0/sebevrazdy',
-        'only_matching': True,
-    }, {
-        'url': 'https://cool.iprima.cz/derava-silnice-nevadi',
-        'only_matching': True,
-    }, {
-        'url': 'https://love.iprima.cz/laska-az-za-hrob/slib-dany-bratrovi',
-        'only_matching': True,
-    }, {
-        'url': 'https://autosalon.iprima.cz/motorsport/7-epizoda-1',
-        'only_matching': True,
+        }
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -178,7 +178,7 @@ class IPrimaCNNIE(InfoExtractor):
         'info_dict': {
             'id': 'p716177',
             'ext': 'mp4',
-            'title': 'Štrunc 2020 (14) - Koronaviru mám plné zuby, strašit druhou vlnou je absurdní, říká senátorka Dernerová',
+            'title': 'md5:277c6b1ed0577e51b40ddd35602ff43e',
         },
         'params': {
             'skip_download': 'm3u8'

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -9,7 +9,8 @@ from ..utils import (
     determine_ext,
     js_to_json,
     urlencode_postdata,
-    ExtractorError
+    ExtractorError,
+    parse_qs
 )
 
 
@@ -85,7 +86,7 @@ class IPrimaIE(InfoExtractor):
             self._LOGIN_URL, None, data=urlencode_postdata(login_form),
             note='Logging in')
 
-        code = parse_qs(login_handle.geturl()).get('code')
+        code = parse_qs(login_handle.geturl()).get('code')[0]
         if not code:
             raise ExtractorError('Login failed', expected=True)
 

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -20,7 +20,7 @@ class IPrimaIE(InfoExtractor):
     _NETRC_MACHINE = 'iprima'
     _LOGIN_URL = 'https://auth.iprima.cz/oauth2/login'
     _TOKEN_URL = 'https://auth.iprima.cz/oauth2/token'
-    access_token = ''
+    access_token = None
 
     _TESTS = [{
         'url': 'https://prima.iprima.cz/particka/92-epizoda',

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -91,7 +91,7 @@ class IPrimaCNNIE(InfoExtractor):
                 extract_formats(src)
 
         if not formats and '>GEO_IP_NOT_ALLOWED<' in playerpage:
-            self.raise_geo_restricted(countries=['CZ'], metadata_available=True)
+            self.raise_geo_restricted(countries=['CZ'])
 
         self._sort_formats(formats)
 

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -112,7 +112,8 @@ class IPrimaIE(InfoExtractor):
             self.raise_no_formats('Access to stream infos forbidden', expected=True)
 
     def _real_initialize(self):
-        self._login()
+        if not self.access_token:
+            self._login()
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -22,6 +22,49 @@ class IPrimaIE(InfoExtractor):
     _LOGIN_REQUIRED = True
     access_token = ''
 
+    _TESTS = [{
+        'url': 'https://prima.iprima.cz/particka/92-epizoda',
+        'info_dict': {
+            'id': 'p51388',
+            'ext': 'mp4',
+            'title': 'Partička (92)',
+            'description': 'md5:859d53beae4609e6dd7796413f1b6cac',
+            'upload_date': '20201103',
+            'timestamp': 1604437480,
+        },
+        'params': {
+            'skip_download': True,  # m3u8 download
+        },
+    }, {
+        'url': 'http://play.iprima.cz/particka/particka-92',
+        'only_matching': True,
+    }, {
+        # geo restricted
+        'url': 'http://play.iprima.cz/closer-nove-pripady/closer-nove-pripady-iv-1',
+        'only_matching': True,
+    }, {
+        'url': 'https://prima.iprima.cz/my-little-pony/mapa-znameni-2-2',
+        'only_matching': True,
+    }, {
+        'url': 'https://prima.iprima.cz/porady/jak-se-stavi-sen/rodina-rathousova-praha',
+        'only_matching': True,
+    }, {
+        'url': 'http://www.iprima.cz/filmy/desne-rande',
+        'only_matching': True,
+    }, {
+        'url': 'https://zoom.iprima.cz/10-nejvetsich-tajemstvi-zahad/posvatna-mista-a-stavby',
+        'only_matching': True,
+    }, {
+        'url': 'https://krimi.iprima.cz/mraz-0/sebevrazdy',
+        'only_matching': True,
+    }, {
+        'url': 'https://cool.iprima.cz/derava-silnice-nevadi',
+        'only_matching': True,
+    }, {
+        'url': 'https://love.iprima.cz/laska-az-za-hrob/slib-dany-bratrovi',
+        'only_matching': True,
+    }]
+
     def _login(self):
         username, password = self._get_login_info()
 

--- a/yt_dlp/extractor/iprima.py
+++ b/yt_dlp/extractor/iprima.py
@@ -20,7 +20,6 @@ class IPrimaIE(InfoExtractor):
     _NETRC_MACHINE = 'iprima'
     _LOGIN_URL = 'https://auth.iprima.cz/oauth2/login'
     _TOKEN_URL = 'https://auth.iprima.cz/oauth2/token'
-    _LOGIN_REQUIRED = True
     access_token = ''
 
     _TESTS = [{
@@ -69,7 +68,7 @@ class IPrimaIE(InfoExtractor):
     def _login(self):
         username, password = self._get_login_info()
 
-        if (username is None or password is None) and self._LOGIN_REQUIRED:
+        if username is None or password is None:
             self.raise_login_required('Login is required to access any iPrima content', method='password')
 
         login_page = self._download_webpage(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request fixes the extractor for iPrima. With the exception of [cnn.iprima.cz](https://cnn.iprima.cz) and [autosalon.iprima.cz](https://autosalon.iprima.cz), all subdomains now use a new scheme that requires users to log in. 

The support for [autosalon.iprima.cz](https://autosalon.iprima.cz) is dropped as it currently uses neither the old nor the new scheme. [cnn.iprima.cz](https://cnn.iprima.cz) is still supported by the old extractor, which is kept with only minor fixes. It is also renamed to `IPrimaCNNIE` and only used for the aforementioned subdomain. 

The new extractor addresses the need for login. Though it is possible to use cookies instead of manually logging the user in, this is not implemented. The extractor also detects geolocked content.
