### PR TITLE
Fix cc extractor (which references mtv extractor)

### DIFF
--- a/yt_dlp/extractor/mtv.py
+++ b/yt_dlp/extractor/mtv.py
@@ -320,8 +320,7 @@ class MTVServicesInfoExtractor(InfoExtractor):
             main_container = self._extract_child_with_type(data, 'MainContainer')
             ab_testing = self._extract_child_with_type(main_container, 'ABTesting')
             video_player = self._extract_child_with_type(ab_testing or main_container, 'VideoPlayer')
-            if video_player:
-                mgid = video_player['props']['media']['video']['config']['uri']
+            mgid = try_get(video_player, lambda x: x['props']['media']['video']['config']['uri'])
 
         if not mgid:
             mgid = self._search_regex(

--- a/yt_dlp/extractor/mtv.py
+++ b/yt_dlp/extractor/mtv.py
@@ -322,7 +322,7 @@ class MTVServicesInfoExtractor(InfoExtractor):
             video_player = self._extract_child_with_type(ab_testing or main_container, 'VideoPlayer')
             if video_player:
                 mgid = video_player['props']['media']['video']['config']['uri']
-        
+
         if not mgid:
             mgid = self._search_regex(
                 r'"videoId":"(mgid:.*?)"', webpage, 'mgid', default=None)

--- a/yt_dlp/extractor/mtv.py
+++ b/yt_dlp/extractor/mtv.py
@@ -278,7 +278,7 @@ class MTVServicesInfoExtractor(InfoExtractor):
     @staticmethod
     def _extract_child_with_type(parent, t):
         for c in parent['children']:
-            if c.get('type') == t:
+            if c.get('type') and c.get('type') == t:
                 return c
 
     def _extract_mgid(self, webpage):
@@ -320,7 +320,12 @@ class MTVServicesInfoExtractor(InfoExtractor):
             main_container = self._extract_child_with_type(data, 'MainContainer')
             ab_testing = self._extract_child_with_type(main_container, 'ABTesting')
             video_player = self._extract_child_with_type(ab_testing or main_container, 'VideoPlayer')
-            mgid = video_player['props']['media']['video']['config']['uri']
+            if video_player:
+                mgid = video_player['props']['media']['video']['config']['uri']
+        
+        if not mgid:
+            mgid = self._search_regex(
+                r'"videoId":"(mgid:.*?)"', webpage, 'mgid', default=None)
 
         return mgid
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Recent changes to cc.com causes failures for downloading videos. I added some additional checking and regex checks for the extractor to address these changes.

