### PR TITLE
Fix a crash for WAV files

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -391,7 +391,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
         self._nopostoverwrites = nopostoverwrites
 
     def _quality_args(self, codec):
-        if self._preferredquality is None:
+        if self._preferredquality is None or codec is None:
             return []
         elif self._preferredquality > 10:
             return ['-b:a', f'{self._preferredquality}k']


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Reproduction

```
$ yt-dlp --extract-audio --audio-format wav --output test.wav https://www.youtube.com/watch?v=dQw4w9WgXcQ
[youtube] dQw4w9WgXcQ: Downloading webpage
[youtube] dQw4w9WgXcQ: Downloading android player API JSON
[info] dQw4w9WgXcQ: Downloading 1 format(s): 251
[download] Destination: test.wav
[download] 100% of 3.28MiB in 00:00                 
ERROR: None
```

### Description

This regression seems to have been introduced in https://github.com/yt-dlp/yt-dlp/commit/31c49255bf647373734c2c7f917e0d24ab81ac95 a couple of days ago.

`ACODECS` maps `"wav"` to `None`, but that breaks `_quality_args()`, which does not expect `codec=None`. This patch fixes it.