### PR TITLE
[blogger] Add support for videos and embeds

### DIFF
--- a/yt_dlp/extractor/blogger.py
+++ b/yt_dlp/extractor/blogger.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from ..utils import mimetype2ext, parse_duration, parse_qs, str_or_none, traverse_obj
+from .common import InfoExtractor
+
+
+class BloggerIE(InfoExtractor):
+    IE_NAME = 'blogger.com'
+    _VALID_URL = r'https?://(?:www\.)?blogger\.com/video\.g\?token=(?P<id>.+)'
+    _VALID_EMBED = r'''<iframe[^>]+src=["']((?:https?:)?//(?:www\.)?blogger\.com/video\.g\?token=[^"']+)["']'''
+    _TESTS = [{
+        'url': 'https://www.blogger.com/video.g?token=AD6v5dzEe9hfcARr5Hlq1WTkYy6t-fXH3BBahVhGvVHe5szdEUBEloSEDSTA8-b111089KbfWuBvTN7fnbxMtymsHhXAXwVvyzHH4Qch2cfLQdGxKQrrEuFpC1amSl_9GuLWODjPgw',
+        'md5': 'f1bc19b6ea1b0fd1d81e84ca9ec467ac',
+        'info_dict': {
+            'id': 'BLOGGER-video-3c740e3a49197e16-796',
+            'title': 'BLOGGER-video-3c740e3a49197e16-796',
+            'ext': 'mp4',
+            'thumbnail': r're:^https?://.*',
+        }
+    }]
+
+    @staticmethod
+    def _extract_urls(webpage):
+        return re.findall(BloggerIE._VALID_EMBED, webpage)
+
+    def _real_extract(self, url):
+        token_id = self._match_id(url)
+        webpage = self._download_webpage(url, token_id)
+        data_json = self._search_regex(r'var\s+VIDEO_CONFIG\s*=\s*(\{.*)', webpage, 'JSON data')
+        data_json = data_json.encode('utf-8').decode('unicode_escape')
+        data = self._parse_json(data_json, token_id)
+        streams = data['streams']
+        formats = [{
+            'ext': mimetype2ext(traverse_obj(parse_qs(stream['play_url']), ('mime', 0))),
+            'url': stream['play_url'],
+            'format_id': str_or_none(stream.get('format_id')),
+            'duration': parse_duration(traverse_obj(parse_qs(stream['play_url']), ('dur', 0))),
+        } for stream in streams]
+
+        return {
+            'id': data.get('iframe_id', token_id),
+            'title': data.get('iframe_id', token_id),
+            'formats': formats,
+            'thumbnail': data.get('thumbnail'),
+            'duration': streams[0].get('duration'),
+        }

--- a/yt_dlp/extractor/blogger.py
+++ b/yt_dlp/extractor/blogger.py
@@ -25,6 +25,7 @@ class BloggerIE(InfoExtractor):
             'title': 'BLOGGER-video-3c740e3a49197e16-796',
             'ext': 'mp4',
             'thumbnail': r're:^https?://.*',
+            'duration': 76.068,
         }
     }]
 
@@ -42,7 +43,6 @@ class BloggerIE(InfoExtractor):
             'ext': mimetype2ext(traverse_obj(parse_qs(stream['play_url']), ('mime', 0))),
             'url': stream['play_url'],
             'format_id': str_or_none(stream.get('format_id')),
-            'duration': parse_duration(traverse_obj(parse_qs(stream['play_url']), ('dur', 0))),
         } for stream in streams]
 
         return {
@@ -50,5 +50,5 @@ class BloggerIE(InfoExtractor):
             'title': data.get('iframe_id', token_id),
             'formats': formats,
             'thumbnail': data.get('thumbnail'),
-            'duration': streams[0].get('duration'),
+            'duration': parse_duration(traverse_obj(parse_qs(streams[0]['play_url']), ('dur', 0))),
         }

--- a/yt_dlp/extractor/blogger.py
+++ b/yt_dlp/extractor/blogger.py
@@ -3,7 +3,13 @@ from __future__ import unicode_literals
 
 import re
 
-from ..utils import mimetype2ext, parse_duration, parse_qs, str_or_none, traverse_obj
+from ..utils import (
+    mimetype2ext,
+    parse_duration,
+    parse_qs,
+    str_or_none,
+    traverse_obj,
+)
 from .common import InfoExtractor
 
 
@@ -30,8 +36,7 @@ class BloggerIE(InfoExtractor):
         token_id = self._match_id(url)
         webpage = self._download_webpage(url, token_id)
         data_json = self._search_regex(r'var\s+VIDEO_CONFIG\s*=\s*(\{.*)', webpage, 'JSON data')
-        data_json = data_json.encode('utf-8').decode('unicode_escape')
-        data = self._parse_json(data_json, token_id)
+        data = self._parse_json(data_json.encode('utf-8').decode('unicode_escape'), token_id)
         streams = data['streams']
         formats = [{
             'ext': mimetype2ext(traverse_obj(parse_qs(stream['play_url']), ('mime', 0))),

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -166,6 +166,7 @@ from .bleacherreport import (
     BleacherReportIE,
     BleacherReportCMSIE,
 )
+from .blogger import BloggerIE
 from .bloomberg import BloombergIE
 from .bokecc import BokeCCIE
 from .bongacams import BongaCamsIE

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -136,6 +136,7 @@ from .medialaan import MedialaanIE
 from .simplecast import SimplecastIE
 from .wimtv import WimTVIE
 from .tvp import TVPEmbedIE
+from .blogger import BloggerIE
 
 
 class GenericIE(InfoExtractor):
@@ -2173,6 +2174,17 @@ class GenericIE(InfoExtractor):
                 'skip_download': True,
             },
         },
+        {
+            # blogger embed
+            'url': 'https://blog.tomeuvizoso.net/2019/01/a-panfrost-milestone.html',
+            'md5': 'f1bc19b6ea1b0fd1d81e84ca9ec467ac',
+            'info_dict': {
+                'id': 'BLOGGER-video-3c740e3a49197e16-796',
+                'ext': 'mp4',
+                'title': 'Blogger',
+                'thumbnail': r're:^https?://.*',
+            },
+        },
         # {
         #     # TODO: find another test
         #     # http://schema.org/VideoObject
@@ -3215,6 +3227,11 @@ class GenericIE(InfoExtractor):
         onionstudios_url = OnionStudiosIE._extract_url(webpage)
         if onionstudios_url:
             return self.url_result(onionstudios_url)
+
+        # Look for Blogger embeds
+        blogger_urls = BloggerIE._extract_urls(webpage)
+        if blogger_urls:
+            return self.playlist_from_matches(blogger_urls, video_id, video_title, ie=BloggerIE.ie_key())
 
         # Look for ViewLift embeds
         viewlift_url = ViewLiftEmbedIE._extract_url(webpage)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adds support for blogger videos and embeds.

There is no discernable title field in any of the JSON or URLs,
and the title is mandatory so 'Blogger' is used as a substitute.