### PR TITLE
[ABC] Add extractor for latest episode of an iView show

### DIFF
--- a/yt_dlp/extractor/abc.py
+++ b/yt_dlp/extractor/abc.py
@@ -8,6 +8,7 @@ import time
 from .common import InfoExtractor
 from ..compat import compat_str
 from ..utils import (
+    dict_get,
     ExtractorError,
     js_to_json,
     int_or_none,
@@ -266,10 +267,10 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         'url': 'https://iview.abc.net.au/show/upper-middle-bogan',
         'info_dict': {
             'id': '124870-1',
-            'title': "Series 1",
+            'title': 'Series 1',
             'description': 'md5:93119346c24a7c322d446d8eece430ff',
             'series': 'Upper Middle Bogan',
-            'season': "Series 1",
+            'season': 'Series 1',
             'thumbnail': r're:^https?://cdn\.iview\.abc\.net\.au/thumbs/.*\.jpg$'
         },
         'playlist_count': 8,
@@ -278,7 +279,7 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         'info_dict': {
             'id': 'CO1108V001S00',
             'ext': 'mp4',
-            'title': "Series 1 Ep 1 I'm A Swan",
+            'title': 'Series 1 Ep 1 I\'m A Swan',
             'description': 'md5:7b676758c1de11a30b79b4d301e8da93',
             'series': 'Upper Middle Bogan',
             'uploader_id': 'abc1',
@@ -287,7 +288,7 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         },
         'params': {
             'noplaylist': True,
-            'skip_download': 'md5 changes for every download'
+            'skip_download': 'm3u8',
         },
     }]
 
@@ -295,26 +296,26 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         show_id = self._match_id(url)
         webpage = self._download_webpage(url, show_id)
         webpage_data = self._search_regex(
-            r'''window\.__INITIAL_STATE__\s*=\s*['"](.+)['"]\s*;''',
+            r'window\.__INITIAL_STATE__\s*=\s*[\'"](.+?)[\'"]\s*;',
             webpage, 'initial state')
         video_data = self._parse_json(
             unescapeHTML(webpage_data).encode('utf-8').decode('unicode_escape'), show_id)
         video_data = video_data['route']['pageData']['_embedded']
-        if not self.get_param('noplaylist') and 'selectedSeries' in video_data:
-            series = video_data['selectedSeries']
-            episodes = series['_embedded']['videoEpisodes']
-            entries = [self.url_result(episode['shareUrl']) for episode in episodes]
-            return self.playlist_result(
-                entries,
-                series.get('id'),
-                series.get('title', series.get('displaySubtitle')),
-                series.get('description'),
-                series=series.get('showTitle', series.get('displayTitle')),
-                season=series.get('title', series.get('displaySubtitle')),
-                thumbnail=series.get('thumbnail'),
-            )
-        elif self.get_param('noplaylist') or 'highlightVideo' in video_data:
-            url = video_data['highlightVideo']['shareUrl']
-            return self.url_result(url)
-        else:
-            ExtractorError('No videos found')
+
+        if self.get_param('noplaylist') and 'highlightVideo' in video_data:
+            self.to_screen('Downloading just the highlight video because of --no-playlist')
+            return self.url_result(video_data['highlightVideo']['shareUrl'], ie=ABCIViewIE.ie_key())
+
+        self.to_screen(f'Downloading playlist {show_id} - add --no-playlist to just download the highlight video')
+        series = video_data['selectedSeries']
+        return {
+            '_type': 'playlist',
+            'entries': [self.url_result(episode['shareUrl'])
+                        for episode in series['_embedded']['videoEpisodes']],
+            'id': series.get('id'),
+            'title': dict_get(series, ('title', 'displaySubtitle')),
+            'description': series.get('description'),
+            'series': dict_get(series, ('showTitle', 'displayTitle')),
+            'season': dict_get(series, ('title', 'displaySubtitle')),
+            'thumbnail': series.get('thumbnail'),
+        }

--- a/yt_dlp/extractor/abc.py
+++ b/yt_dlp/extractor/abc.py
@@ -255,3 +255,37 @@ class ABCIViewIE(InfoExtractor):
             'subtitles': subtitles,
             'is_live': is_live,
         }
+
+
+class ABCIViewShowLatestEpisodeIE(InfoExtractor):
+    IE_NAME = 'abc.net.au:iview:show:latest-episode'
+    _VALID_URL = r'https?://iview\.abc\.net\.au/show/(?P<id>[^/]+)$'
+    _DATA = r'window\.__INITIAL_STATE__\s*=\s*"(.+)"\s*;'
+    _GEO_COUNTRIES = ['AU']
+
+    _TESTS = [{
+        'url': 'https://iview.abc.net.au/show/upper-middle-bogan',
+        'md5': '764e4d496957407d36fd442f3207dafc',
+        'info_dict': {
+            'id': 'CO1108V001S00',
+            'ext': 'mp4',
+            'title': "Series 1 Ep 1 I'm A Swan",
+            'description': 'md5:7b676758c1de11a30b79b4d301e8da93',
+            'series': 'Upper Middle Bogan',
+            'uploader_id': 'abc1',
+            'upload_date': '20210630',
+            'timestamp': 1625036400,
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }]
+
+    def _real_extract(self, url):
+        show_id = self._match_id(url)
+        webpage = self._download_webpage(url, show_id)
+        webpage_data = self._search_regex(self._DATA, webpage, 'initial state')
+        json_data = unescapeHTML(webpage_data).encode('utf-8').decode('unicode_escape')
+        video_data = self._parse_json(json_data, show_id)
+        url = video_data['route']['pageData']['_embedded']['highlightVideo']['shareUrl']
+        return self.url_result(url)

--- a/yt_dlp/extractor/abc.py
+++ b/yt_dlp/extractor/abc.py
@@ -311,7 +311,7 @@ class ABCIViewShowSeriesIE(InfoExtractor):
                 series.get('id'),
                 series.get('title', series.get('displaySubtitle')),
                 series.get('description'),
-                series = series.get('showTitle', series.get('displayTitle')),
-                season = series.get('title', series.get('displaySubtitle')),
-                thumbnail = series.get('thumbnail'),
+                series=series.get('showTitle', series.get('displayTitle')),
+                season=series.get('title', series.get('displaySubtitle')),
+                thumbnail=series.get('thumbnail'),
             )

--- a/yt_dlp/extractor/abc.py
+++ b/yt_dlp/extractor/abc.py
@@ -295,7 +295,7 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         show_id = self._match_id(url)
         webpage = self._download_webpage(url, show_id)
         webpage_data = self._search_regex(
-            r'window\.__INITIAL_STATE__\s*=\s*"(.+)"\s*;',
+            r'''window\.__INITIAL_STATE__\s*=\s*['"](.+)['"]\s*;''',
             webpage, 'initial state')
         video_data = self._parse_json(
             unescapeHTML(webpage_data).encode('utf-8').decode('unicode_escape'), show_id)

--- a/yt_dlp/extractor/abc.py
+++ b/yt_dlp/extractor/abc.py
@@ -275,7 +275,6 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         'playlist_count': 8,
     }, {
         'url': 'https://iview.abc.net.au/show/upper-middle-bogan',
-        # The md5 changes for every download
         'info_dict': {
             'id': 'CO1108V001S00',
             'ext': 'mp4',
@@ -288,6 +287,7 @@ class ABCIViewShowSeriesIE(InfoExtractor):
         },
         'params': {
             'noplaylist': True,
+            'skip_download': 'md5 changes for every download'
         },
     }]
 

--- a/yt_dlp/extractor/abc.py
+++ b/yt_dlp/extractor/abc.py
@@ -299,11 +299,9 @@ class ABCIViewShowSeriesIE(InfoExtractor):
             webpage, 'initial state')
         video_data = self._parse_json(
             unescapeHTML(webpage_data).encode('utf-8').decode('unicode_escape'), show_id)
-        if self.get_param('noplaylist'):
-            url = video_data['route']['pageData']['_embedded']['highlightVideo']['shareUrl']
-            return self.url_result(url)
-        else:
-            series = video_data['route']['pageData']['_embedded']['selectedSeries']
+        video_data = video_data['route']['pageData']['_embedded']
+        if not self.get_param('noplaylist') and 'selectedSeries' in video_data:
+            series = video_data['selectedSeries']
             episodes = series['_embedded']['videoEpisodes']
             entries = [self.url_result(episode['shareUrl']) for episode in episodes]
             return self.playlist_result(
@@ -315,3 +313,8 @@ class ABCIViewShowSeriesIE(InfoExtractor):
                 season=series.get('title', series.get('displaySubtitle')),
                 thumbnail=series.get('thumbnail'),
             )
+        elif self.get_param('noplaylist') or 'highlightVideo' in video_data:
+            url = video_data['highlightVideo']['shareUrl']
+            return self.url_result(url)
+        else:
+            ExtractorError('No videos found')

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from .abc import (
     ABCIE,
     ABCIViewIE,
+    ABCIViewShowLatestEpisodeIE,
 )
 from .abcnews import (
     AbcNewsIE,

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from .abc import (
     ABCIE,
     ABCIViewIE,
-    ABCIViewShowLatestEpisodeIE,
+    ABCIViewShowSeriesIE,
 )
 from .abcnews import (
     AbcNewsIE,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
 - [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests 
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Add extractor for latest episode of an ABC iView show.

This allows to download using only the show URL instead of
having to find out the latest episode URL manually.