### PR TITLE
[rtve] Add support for audio only

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1239,6 +1239,7 @@ from .rts import RTSIE
 from .rtve import (
         RTVEALaCartaIE,
         RTVELiveIE,
+        RTVEAudioIE,
         RTVEInfantilIE,
         RTVETelevisionIE,
 )

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1236,7 +1236,12 @@ from .rtl2 import (
 from .rtp import RTPIE
 from .rtrfm import RTRFMIE
 from .rts import RTSIE
-from .rtve import RTVEALaCartaIE, RTVELiveIE, RTVEInfantilIE, RTVELiveIE, RTVETelevisionIE
+from .rtve import (
+        RTVEALaCartaIE,
+        RTVELiveIE,
+        RTVEInfantilIE,
+        RTVETelevisionIE,
+)
 from .rtvnh import RTVNHIE
 from .rtvs import RTVSIE
 from .ruhd import RUHDIE

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1237,11 +1237,11 @@ from .rtp import RTPIE
 from .rtrfm import RTRFMIE
 from .rts import RTSIE
 from .rtve import (
-        RTVEALaCartaIE,
-        RTVELiveIE,
-        RTVEAudioIE,
-        RTVEInfantilIE,
-        RTVETelevisionIE,
+    RTVEALaCartaIE,
+    RTVEAudioIE,
+    RTVELiveIE,
+    RTVEInfantilIE,
+    RTVETelevisionIE,
 )
 from .rtvnh import RTVNHIE
 from .rtvs import RTVSIE

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -178,6 +178,40 @@ class RTVEALaCartaIE(InfoExtractor):
             for s in subs)
 
 
+class RTVEAudioIE(RTVEALaCartaIE):
+    IE_NAME = 'rtve.es:audio'
+    IE_DESC = 'RTVE audio'
+    _VALID_URL = r'https?://(?:www\.)?rtve\.es/alacarta/audios/[^/]+/[^/]+/(?P<id>[0-9]+)/'
+
+    _TESTS = [{
+        'url': 'https://www.rtve.es/alacarta/audios/a-hombros-de-gigantes/palabra-ingeniero-codigos-informaticos-27-04-21/5889192/',
+        'md5': 'ae06d27bff945c4e87a50f89f6ce48ce',
+        'info_dict': {
+            'id': '5889192',
+            'ext': 'mp3',
+            'title': 'Códigos informáticos',
+            'thumbnail': r're:https?://.+/1598856591583.jpg',
+            'duration': 349.440,
+        },
+    }]
+
+    def _real_extract(self, url):
+        audio_id = self._match_id(url)
+        info = self._download_json(
+            'https://www.rtve.es/api/audios/%s.json' % audio_id,
+            audio_id)['page']['items'][0]
+        title = info['title'].strip()
+
+        return {
+            'id': audio_id,
+            'title': title,
+            'thumbnail': info.get('thumbnail'),
+            'duration': float_or_none(info.get('duration'), 1000),
+            'series': info.get('programInfo').get('title'),
+            'url': info.get('qualities')[0].get('filePath'),
+        }
+
+
 class RTVEInfantilIE(RTVEALaCartaIE):
     IE_NAME = 'rtve.es:infantil'
     IE_DESC = 'RTVE infantil'

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -224,7 +224,6 @@ class RTVEAudioIE(RTVEALaCartaIE):
         formats = []
         for quality, audio_url in self._decrypt_url(png):
             ext = determine_ext(audio_url)
-            print(quality, audio_url, ext)
             if ext == 'm3u8':
                 formats.extend(self._extract_m3u8_formats(
                     audio_url, audio_id, 'mp4', 'm3u8_native',
@@ -246,16 +245,14 @@ class RTVEAudioIE(RTVEALaCartaIE):
         info = self._download_json(
             'https://www.rtve.es/api/audios/%s.json' % audio_id,
             audio_id)['page']['items'][0]
-        title = info['title'].strip()
-        formats = self._extract_png_formats(audio_id)
 
         return {
             'id': audio_id,
-            'title': title,
+            'title': info['title'].strip(),
             'thumbnail': info.get('thumbnail'),
             'duration': float_or_none(info.get('duration'), 1000),
-            'series': try_get(info, lambda x: x['programInfo']['title']),
-            'formats': formats,
+            'series': try_get(info, ('programInfo').get('title'),
+            'formats': self._extract_png_formats(audio_id),
         }
 
 

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -182,7 +182,7 @@ class RTVEALaCartaIE(InfoExtractor):
 class RTVEAudioIE(RTVEALaCartaIE):
     IE_NAME = 'rtve.es:audio'
     IE_DESC = 'RTVE audio'
-    _VALID_URL = r'https?://(?:www\.)?rtve\.es/(alacarta|play)/audios/[^/]+/[^/]+/(?P<id>[0-9]+)/'
+    _VALID_URL = r'https?://(?:www\.)?rtve\.es/(alacarta|play)/audios/[^/]+/[^/]+/(?P<id>[0-9]+)'
 
     _TESTS = [{
         'url': 'https://www.rtve.es/alacarta/audios/a-hombros-de-gigantes/palabra-ingeniero-codigos-informaticos-27-04-21/5889192/',

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -217,6 +217,12 @@ class RTVEAudioIE(RTVEALaCartaIE):
     }]
 
     def _extract_png_formats(self, audio_id):
+        """
+        This function retrieves media related png thumbnail which obfuscate
+        valuable information about the media. This information is decrypted
+        via base class _decrypt_url function providing media quality and
+        media url
+        """
         png = self._download_webpage(
             'http://www.rtve.es/ztnr/movil/thumbnail/%s/audios/%s.png' %
             (self._manager, audio_id),

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -252,7 +252,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': info['title'].strip(),
             'thumbnail': info.get('thumbnail'),
             'duration': float_or_none(info.get('duration'), 1000),
-            'series': try_get(info, ('programInfo').get('title')),
+            'series': try_get(info, lambda x: x['programInfo']['title']),
             'formats': self._extract_png_formats(audio_id),
         }
 

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -193,6 +193,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': 'Códigos informáticos',
             'thumbnail': r're:https?://.+/1598856591583.jpg',
             'duration': 349.440,
+            'series': 'A hombros de gigantes',
         },
     }, {
         'url': 'https://www.rtve.es/play/audios/en-radio-3/ignatius-farray/5791165/',
@@ -203,6 +204,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': 'Ignatius Farray',
             'thumbnail': r're:https?://.+/1613243011863.jpg',
             'duration': 3559.559,
+            'series': 'En Radio 3'
         },
     }, {
         'url': 'https://www.rtve.es/play/audios/frankenstein-o-el-moderno-prometeo/capitulo-26-ultimo-muerte-victor-juan-jose-plans-mary-shelley/6082623/',
@@ -213,6 +215,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': 'Capítulo 26 y último: La muerte de Victor',
             'thumbnail': r're:https?://.+/1632147445707.jpg',
             'duration': 3174.086,
+            'series': 'Frankenstein o el moderno Prometeo'
         },
     }]
 

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -203,7 +203,43 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'thumbnail': r're:https?://.+/1613243011863.jpg',
             'duration': 3559.559,
         },
+    }, {
+        'url': 'https://www.rtve.es/play/audios/frankenstein-o-el-moderno-prometeo/capitulo-26-ultimo-muerte-victor-juan-jose-plans-mary-shelley/6082623/',
+        'md5': '0eadab248cc8dd193fa5765712e84d5c',
+        'info_dict': {
+            'id': '6082623',
+            'ext': 'mp3',
+            'title': 'Capítulo 26 y último: La muerte de Victor',
+            'thumbnail': r're:https?://.+/1632147445707.jpg',
+            'duration': 3174.086,
+        },
     }]
+
+    def _extract_png_formats(self, audio_id):
+        png = self._download_webpage(
+            'http://www.rtve.es/ztnr/movil/thumbnail/%s/audios/%s.png' %
+            (self._manager, audio_id),
+            audio_id, 'Downloading url information', query={'q': 'v2'})
+        q = qualities(['Media', 'Alta', 'HQ', 'HD_READY', 'HD_FULL'])
+        formats = []
+        for quality, audio_url in self._decrypt_url(png):
+            ext = determine_ext(audio_url)
+            print(quality, audio_url, ext)
+            if ext == 'm3u8':
+                formats.extend(self._extract_m3u8_formats(
+                    audio_url, audio_id, 'mp4', 'm3u8_native',
+                    m3u8_id='hls', fatal=False))
+            elif ext == 'mpd':
+                formats.extend(self._extract_mpd_formats(
+                    audio_url, audio_id, 'dash', fatal=False))
+            else:
+                formats.append({
+                    'format_id': quality,
+                    'quality': q(quality),
+                    'url': audio_url,
+                })
+        self._sort_formats(formats)
+        return formats
 
     def _real_extract(self, url):
         audio_id = self._match_id(url)
@@ -211,6 +247,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'https://www.rtve.es/api/audios/%s.json' % audio_id,
             audio_id)['page']['items'][0]
         title = info['title'].strip()
+        formats = self._extract_png_formats(audio_id)
 
         return {
             'id': audio_id,
@@ -218,7 +255,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'thumbnail': info.get('thumbnail'),
             'duration': float_or_none(info.get('duration'), 1000),
             'series': info.get('programInfo').get('title'),
-            'url': info.get('qualities')[0].get('filePath'),
+            'formats': formats,
         }
 
 

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -181,7 +181,7 @@ class RTVEALaCartaIE(InfoExtractor):
 class RTVEAudioIE(RTVEALaCartaIE):
     IE_NAME = 'rtve.es:audio'
     IE_DESC = 'RTVE audio'
-    _VALID_URL = r'https?://(?:www\.)?rtve\.es/alacarta/audios/[^/]+/[^/]+/(?P<id>[0-9]+)/'
+    _VALID_URL = r'https?://(?:www\.)?rtve\.es/(alacarta|play)/audios/[^/]+/[^/]+/(?P<id>[0-9]+)/'
 
     _TESTS = [{
         'url': 'https://www.rtve.es/alacarta/audios/a-hombros-de-gigantes/palabra-ingeniero-codigos-informaticos-27-04-21/5889192/',
@@ -192,6 +192,16 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': 'Códigos informáticos',
             'thumbnail': r're:https?://.+/1598856591583.jpg',
             'duration': 349.440,
+        },
+    }, {
+        'url': 'https://www.rtve.es/play/audios/en-radio-3/ignatius-farray/5791165/',
+        'md5': '072855ab89a9450e0ba314c717fa5ebc',
+        'info_dict': {
+            'id': '5791165',
+            'ext': 'mp3',
+            'title': 'Ignatius Farray',
+            'thumbnail': r're:https?://.+/1613243011863.jpg',
+            'duration': 3559.559,
         },
     }]
 

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -18,6 +18,7 @@ from ..utils import (
     remove_end,
     remove_start,
     std_headers,
+    try_get,
 )
 
 _bytes_to_chr = (lambda x: x) if sys.version_info[0] == 2 else (lambda x: map(chr, x))
@@ -251,7 +252,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': info['title'].strip(),
             'thumbnail': info.get('thumbnail'),
             'duration': float_or_none(info.get('duration'), 1000),
-            'series': try_get(info, ('programInfo').get('title'),
+            'series': try_get(info, ('programInfo').get('title')),
             'formats': self._extract_png_formats(audio_id),
         }
 

--- a/yt_dlp/extractor/rtve.py
+++ b/yt_dlp/extractor/rtve.py
@@ -254,7 +254,7 @@ class RTVEAudioIE(RTVEALaCartaIE):
             'title': title,
             'thumbnail': info.get('thumbnail'),
             'duration': float_or_none(info.get('duration'), 1000),
-            'series': info.get('programInfo').get('title'),
+            'series': try_get(info, lambda x: x['programInfo']['title']),
             'formats': formats,
         }
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [X] New feature

---

### Description of your *pull request* and other information

This adds support to audio only urls to the rtve extractor. So far this extractor did not support urls like Audio only episode . With this extension such audio only url is supported.

The class supporting the above mentioned url includes a test case which runs successfully here.

Taken over from https://github.com/ytdl-org/youtube-dl/pull/29023