### PR TITLE
[hls] Improve DRM checks

### DIFF
--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -80,7 +80,7 @@ class HlsFD(FragmentFD):
             has_drm = re.search('|'.join([
                 r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
                 r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
-            ], s)
+            ]), s)
             if has_drm and not self.params.get('allow_unplayable_formats'):
                 self.report_error(
                     'This video is DRM protected; Try selecting another format with --format or '

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -77,11 +77,10 @@ class HlsFD(FragmentFD):
                 message = ('The stream has AES-128 encryption and neither ffmpeg nor pycryptodomex are available; '
                            'Decryption will be performed natively, but will be extremely slow')
         if not can_download:
-            # NOTE: '#' needs to be escaped since it's a comment character in multiline regex ('\#' doesn't work)
-            has_drm = re.search(r'''(?x)(?:
-                                [#]EXT-X-FAXS-CM:|                        # Adobe Flash Access
-                                [#]EXT-X-(?:SESSION-)?KEY:.*?URI="skd://  # Apple FairPlay
-                                )''', s)
+            has_drm = re.search('|'.join([
+                r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
+                r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
+            ], s)
             if has_drm and not self.params.get('allow_unplayable_formats'):
                 self.report_error(
                     'This video is DRM protected; Try selecting another format with --format or '

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -87,11 +87,10 @@ class HlsFD(FragmentFD):
                     'This video is DRM protected; Try selecting another format with --format or '
                     'add --check-formats to automatically fallback to the next best format')
                 return False
-            else:
-                message = message or 'Unsupported features have been detected'
-                fd = FFmpegFD(self.ydl, self.params)
-                self.report_warning(f'{message}; extraction will be delegated to {fd.get_basename()}')
-                return fd.real_download(filename, info_dict)
+            message = message or 'Unsupported features have been detected'
+            fd = FFmpegFD(self.ydl, self.params)
+            self.report_warning(f'{message}; extraction will be delegated to {fd.get_basename()}')
+            return fd.real_download(filename, info_dict)
         elif message:
             self.report_warning(message)
 

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -83,7 +83,9 @@ class HlsFD(FragmentFD):
                                 [#]EXT-X-(?:SESSION-)?KEY:.*?URI="skd://  # Apple FairPlay
                                 )''', s)
             if has_drm and not self.params.get('allow_unplayable_formats'):
-                self.report_error('This video is DRM protected')
+                self.report_error(
+                    'This video is DRM protected; Try selecting another format with --format or '
+                    'add --check-formats to automatically fallback to the next best format')
                 return False
             else:
                 message = message or 'Unsupported features have been detected'

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -77,10 +77,19 @@ class HlsFD(FragmentFD):
                 message = ('The stream has AES-128 encryption and neither ffmpeg nor pycryptodomex are available; '
                            'Decryption will be performed natively, but will be extremely slow')
         if not can_download:
-            message = message or 'Unsupported features have been detected'
-            fd = FFmpegFD(self.ydl, self.params)
-            self.report_warning(f'{message}; extraction will be delegated to {fd.get_basename()}')
-            return fd.real_download(filename, info_dict)
+            # NOTE: '#' needs to be escaped since it's a comment character in multiline regex ('\#' doesn't work)
+            has_drm = re.search(r'''(?x)(?:
+                                [#]EXT-X-FAXS-CM:|                        # Adobe Flash Access
+                                [#]EXT-X-(?:SESSION-)?KEY:.*?URI="skd://  # Apple FairPlay
+                                )''', s)
+            if has_drm and not self.params.get('allow_unplayable_formats'):
+                self.report_error('This video is DRM protected')
+                return False
+            else:
+                message = message or 'Unsupported features have been detected'
+                fd = FFmpegFD(self.ydl, self.params)
+                self.report_warning(f'{message}; extraction will be delegated to {fd.get_basename()}')
+                return fd.real_download(filename, info_dict)
         elif message:
             self.report_warning(message)
 

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2035,10 +2035,11 @@ class InfoExtractor(object):
             video_id=None):
         formats, subtitles = [], {}
 
-        if '#EXT-X-FAXS-CM:' in m3u8_doc:  # Adobe Flash Access
-            return formats, subtitles
-
-        has_drm = re.search(r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://', m3u8_doc)
+        # NOTE: '#' needs to be escaped since it's a comment character in multiline regex ('\#' doesn't work)
+        has_drm = re.search(r'''(?x)(?:
+                            [#]EXT-X-FAXS-CM:|                        # Adobe Flash Access
+                            [#]EXT-X-(?:SESSION-)?KEY:.*?URI="skd://  # Apple FairPlay
+                            )''', m3u8_doc)
 
         def format_url(url):
             return url if re.match(r'^https?://', url) else compat_urlparse.urljoin(m3u8_url, url)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2038,7 +2038,7 @@ class InfoExtractor(object):
         has_drm = re.search('|'.join([
             r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
             r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
-        ], m3u8_doc)
+        ]), m3u8_doc)
 
         def format_url(url):
             return url if re.match(r'^https?://', url) else compat_urlparse.urljoin(m3u8_url, url)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2035,11 +2035,10 @@ class InfoExtractor(object):
             video_id=None):
         formats, subtitles = [], {}
 
-        # NOTE: '#' needs to be escaped since it's a comment character in multiline regex ('\#' doesn't work)
-        has_drm = re.search(r'''(?x)(?:
-                            [#]EXT-X-FAXS-CM:|                        # Adobe Flash Access
-                            [#]EXT-X-(?:SESSION-)?KEY:.*?URI="skd://  # Apple FairPlay
-                            )''', m3u8_doc)
+        has_drm = re.search('|'.join([
+            r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
+            r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
+        ], m3u8_doc)
 
         def format_url(url):
             return url if re.match(r'^https?://', url) else compat_urlparse.urljoin(m3u8_url, url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request does two things:

* Report Adobe Flash Access as DRM instead of "No video formats found"
* Detect FairPlay/FlashAccess DRM when only specified HLS variant playlists rather than the master playlist (closes #1658)