### PR TITLE
[nebula] Rewrite extractor with channel support / fix #1690 "Unable to extract API key"

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -882,7 +882,10 @@ from .ndr import (
     NJoyEmbedIE,
 )
 from .ndtv import NDTVIE
-from .nebula import NebulaIE
+from .nebula import (
+    NebulaIE,
+    NebulaCollectionIE,
+)
 from .nerdcubed import NerdCubedFeedIE
 from .netzkino import NetzkinoIE
 from .neteasemusic import (

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -6,92 +6,26 @@ import time
 
 from urllib.error import HTTPError
 from .common import InfoExtractor
-from ..compat import compat_str, compat_urllib_parse_unquote, compat_urllib_parse_quote
+from ..compat import compat_str, compat_urllib_parse_unquote, compat_urllib_parse_quote, compat_urllib_request
 from ..utils import (
     ExtractorError,
     parse_iso8601,
     try_get,
-    urljoin,
 )
 
 
-class NebulaIE(InfoExtractor):
-
-    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/videos/(?P<id>[-\w]+)'
-    _TESTS = [
-        {
-            'url': 'https://nebula.app/videos/that-time-disney-remade-beauty-and-the-beast',
-            'md5': 'fe79c4df8b3aa2fea98a93d027465c7e',
-            'info_dict': {
-                'id': '5c271b40b13fd613090034fd',
-                'ext': 'mp4',
-                'title': 'That Time Disney Remade Beauty and the Beast',
-                'description': 'Note: this video was originally posted on YouTube with the sponsor read included. We weren’t able to remove it without reducing video quality, so it’s presented here in its original context.',
-                'upload_date': '20180731',
-                'timestamp': 1533009600,
-                'channel': 'Lindsay Ellis',
-                'uploader': 'Lindsay Ellis',
-            },
-            'params': {
-                'usenetrc': True,
-            },
-            'skip': 'All Nebula content requires authentication',
-        },
-        {
-            'url': 'https://nebula.app/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
-            'md5': '6d4edd14ce65720fa63aba5c583fb328',
-            'info_dict': {
-                'id': '5e7e78171aaf320001fbd6be',
-                'ext': 'mp4',
-                'title': 'Landing Craft - How The Allies Got Ashore',
-                'description': r're:^In this episode we explore the unsung heroes of D-Day, the landing craft.',
-                'upload_date': '20200327',
-                'timestamp': 1585348140,
-                'channel': 'The Logistics of D-Day',
-                'uploader': 'The Logistics of D-Day',
-            },
-            'params': {
-                'usenetrc': True,
-            },
-            'skip': 'All Nebula content requires authentication',
-        },
-        {
-            'url': 'https://nebula.app/videos/money-episode-1-the-draw',
-            'md5': '8c7d272910eea320f6f8e6d3084eecf5',
-            'info_dict': {
-                'id': '5e779ebdd157bc0001d1c75a',
-                'ext': 'mp4',
-                'title': 'Episode 1: The Draw',
-                'description': r'contains:There’s free money on offer… if the players can all work together.',
-                'upload_date': '20200323',
-                'timestamp': 1584980400,
-                'channel': 'Tom Scott Presents: Money',
-                'uploader': 'Tom Scott Presents: Money',
-            },
-            'params': {
-                'usenetrc': True,
-            },
-            'skip': 'All Nebula content requires authentication',
-        },
-        {
-            'url': 'https://watchnebula.com/videos/money-episode-1-the-draw',
-            'only_matching': True,
-        },
-    ]
+class NebulaBaseIE(InfoExtractor):
     _NETRC_MACHINE = 'watchnebula'
 
-    _nebula_token = None
+    _nebula_api_token = None
+    _nebula_bearer_token = None
+    _zype_access_token = None
 
     def _retrieve_nebula_auth(self):
-        """
-        Log in to Nebula, and returns a Nebula API token
-        """
-
         username, password = self._get_login_info()
         if not (username and password):
             self.raise_login_required()
 
-        self.report_login()
         data = json.dumps({'email': username, 'password': password}).encode('utf8')
         response = self._download_json(
             'https://api.watchnebula.com/api/v1/auth/login/',
@@ -101,7 +35,7 @@ class NebulaIE(InfoExtractor):
                 # Submitting the 'sessionid' cookie always causes a 403 on auth endpoint
                 'cookie': ''
             },
-            note='Authenticating to Nebula with supplied credentials',
+            note='Logging in to Nebula with supplied credentials',
             errnote='Authentication failed or rejected')
         if not response or not response.get('key'):
             self.raise_login_required()
@@ -120,50 +54,25 @@ class NebulaIE(InfoExtractor):
 
         return response['key']
 
-    def _retrieve_zype_api_key(self, page_url, display_id):
-        """
-        Retrieves the Zype API key
-        """
+    def _call_nebula_api(self, url, video_id=None, method='GET', auth_type='api', note=''):
+        assert method in ('GET', 'POST',)
+        assert auth_type in ('api', 'bearer',)
+        authorization = 'Token {api_token}'.format(api_token=self._nebula_api_token) \
+            if auth_type == 'api' \
+            else 'Bearer {bearer_token}'.format(bearer_token=self._nebula_bearer_token)
+        url_or_request = url \
+            if method == 'GET' \
+            else compat_urllib_request.Request(url, method='POST', data={})
+        return self._download_json(url_or_request, video_id, headers={'Authorization': authorization}, note=note)
 
-        # Find the js that has the API key from the webpage and download it
-        webpage = self._download_webpage(page_url, video_id=display_id)
-        main_script_relpath = self._search_regex(
-            r'<script[^>]*src="(?P<script_relpath>[^"]*main.[0-9a-f]*.chunk.js)"[^>]*>', webpage,
-            group='script_relpath', name='script relative path', fatal=True)
-        main_script_abspath = urljoin(page_url, main_script_relpath)
-        main_script = self._download_webpage(main_script_abspath, video_id=display_id,
-                                             note='Retrieving Zype API key')
-
-        api_key = self._search_regex(
-            r'REACT_APP_ZYPE_API_KEY\s*:\s*"(?P<api_key>[\w-]*)"', main_script,
-            group='api_key', name='API key', fatal=True)
-
-        return api_key
-
-    def _call_zype_api(self, path, params, video_id, api_key, note):
-        """
-        A helper for making calls to the Zype API.
-        """
-        query = {'api_key': api_key, 'per_page': 1}
-        query.update(params)
-        return self._download_json('https://api.zype.com' + path, video_id, query=query, note=note)
-
-    def _call_nebula_api(self, path, video_id, access_token, note):
-        """
-        A helper for making calls to the Nebula API.
-        """
-        return self._download_json('https://api.watchnebula.com/api/v1' + path, video_id, headers={
-            'Authorization': 'Token {access_token}'.format(access_token=access_token)
-        }, note=note)
-
-    def _fetch_zype_access_token(self, video_id):
+    def _fetch_zype_access_token(self):
         try:
-            user_object = self._call_nebula_api('/auth/user/', video_id, self._nebula_token, note='Retrieving Zype access token')
+            user_object = self._call_nebula_api('https://api.watchnebula.com/api/v1/auth/user/', note='Retrieving Zype access token')
         except ExtractorError as exc:
             # if 401, attempt credential auth and retry
             if exc.cause and isinstance(exc.cause, HTTPError) and exc.cause.code == 401:
-                self._nebula_token = self._retrieve_nebula_auth()
-                user_object = self._call_nebula_api('/auth/user/', video_id, self._nebula_token, note='Retrieving Zype access token')
+                self._nebula_api_token = self._retrieve_nebula_auth()
+                user_object = self._call_nebula_api('https://api.watchnebula.com/api/v1/auth/user/', note='Retrieving Zype access token')
             else:
                 raise
 
@@ -179,14 +88,38 @@ class NebulaIE(InfoExtractor):
             raise ExtractorError('Unable to extract Zype access token from Nebula API authentication endpoint')
         return access_token
 
-    def _extract_channel_title(self, video_meta):
-        # TODO: Implement the API calls giving us the channel list,
-        # so that we can do the title lookup and then figure out the channel URL
-        categories = video_meta.get('categories', []) if video_meta else []
-        # the channel name is the value of the first category
-        for category in categories:
-            if category.get('value'):
-                return category['value'][0]
+    def _fetch_nebula_bearer_token(self):
+        response = self._call_nebula_api('https://api.watchnebula.com/api/v1/authorization/',
+                                         method='POST',
+                                         note='Authorizing to Nebula')
+        return response['token']
+
+    def _build_video_info(self, episode):
+        zype_video_url = 'https://player.zype.com/embed/%s.html?access_token=%s' % (episode['zype_id'], self._zype_access_token)
+        return {
+            'id': episode['zype_id'],
+            'display_id': episode['slug'],
+            '_type': 'url_transparent',
+            'ie_key': 'Zype',
+            'url': zype_video_url,
+            'title': episode['title'],
+            'description': episode['description'],
+            'timestamp': parse_iso8601(episode['published_at']),
+            'thumbnails': [{
+                # 'id': tn.get('name'),  # this appears to be null
+                'url': tn['original'],
+                'height': key,
+            } for key, tn in episode['assets']['thumbnail'].items()],
+            'duration': episode['duration'],
+            'channel': episode['channel_title'],
+            'channel_id': episode['channel_slug'],
+            'channel_url': 'https://nebula.app/{channel_slug}'.format(channel_slug=episode['channel_slug']),
+            'uploader': episode['channel_title'],
+            'uploader_id': episode['channel_slug'],
+            'uploader_url': 'https://nebula.app/{channel_slug}'.format(channel_slug=episode['channel_slug']),
+            'series': episode['channel_title'],
+            'creator': episode['channel_title'],
+        }
 
     def _real_initialize(self):
         # check cookie jar for valid token
@@ -195,44 +128,156 @@ class NebulaIE(InfoExtractor):
         if nebula_cookie:
             self.to_screen('Authenticating to Nebula with token from cookie jar')
             nebula_cookie_value = compat_urllib_parse_unquote(nebula_cookie.value)
-            self._nebula_token = self._parse_json(nebula_cookie_value, None).get('apiToken')
+            self._nebula_api_token = self._parse_json(nebula_cookie_value, None).get('apiToken')
 
         # try to authenticate using credentials if no valid token has been found
-        if not self._nebula_token:
-            self._nebula_token = self._retrieve_nebula_auth()
+        if not self._nebula_api_token:
+            self._nebula_api_token = self._retrieve_nebula_auth()
+
+        # get a Bearer token for the Nebula API, that we need to fetch meta data
+        self._nebula_bearer_token = self._fetch_nebula_bearer_token()
+
+        # get a Zype access token which is required to access video streams (for us: to generate video URLs)
+        self._zype_access_token = self._fetch_zype_access_token()
+
+
+class NebulaIE(NebulaBaseIE):
+    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/videos/(?P<id>[-\w]+)'
+    _TESTS = [
+        {
+            'url': 'https://nebula.app/videos/that-time-disney-remade-beauty-and-the-beast',
+            'md5': 'fe79c4df8b3aa2fea98a93d027465c7e',
+            'info_dict': {
+                'id': '5c271b40b13fd613090034fd',
+                'ext': 'mp4',
+                'title': 'That Time Disney Remade Beauty and the Beast',
+                'description': 'Note: this video was originally posted on YouTube with the sponsor read included. We weren’t able to remove it without reducing video quality, so it’s presented here in its original context.',
+                'upload_date': '20180731',
+                'timestamp': 1533009600,
+                'channel': 'Lindsay Ellis',
+                'channel_id': 'lindsayellis',
+                'uploader': 'Lindsay Ellis',
+                'uploader_id': 'lindsayellis',
+            },
+            'params': {
+                'usenetrc': True,
+            },
+            'skip': 'All Nebula content requires authentication',
+        },
+        {
+            'url': 'https://nebula.app/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
+            'md5': '6d4edd14ce65720fa63aba5c583fb328',
+            'info_dict': {
+                'id': '5e7e78171aaf320001fbd6be',
+                'ext': 'mp4',
+                'title': 'Landing Craft - How The Allies Got Ashore',
+                'description': r're:^In this episode we explore the unsung heroes of D-Day, the landing craft.',
+                'upload_date': '20200327',
+                'timestamp': 1585348140,
+                'channel': 'Real Engineering',
+                'channel_id': 'realengineering',
+                'uploader': 'Real Engineering',
+                'uploader_id': 'realengineering',
+            },
+            'params': {
+                'usenetrc': True,
+            },
+            'skip': 'All Nebula content requires authentication',
+        },
+        {
+            'url': 'https://nebula.app/videos/money-episode-1-the-draw',
+            'md5': '8c7d272910eea320f6f8e6d3084eecf5',
+            'info_dict': {
+                'id': '5e779ebdd157bc0001d1c75a',
+                'ext': 'mp4',
+                'title': 'Episode 1: The Draw',
+                'description': r'contains:There’s free money on offer… if the players can all work together.',
+                'upload_date': '20200323',
+                'timestamp': 1584980400,
+                'channel': 'Tom Scott Presents: Money',
+                'channel_id': 'tom-scott-presents-money',
+                'uploader': 'Tom Scott Presents: Money',
+                'uploader_id': 'tom-scott-presents-money',
+            },
+            'params': {
+                'usenetrc': True,
+            },
+            'skip': 'All Nebula content requires authentication',
+        },
+        {
+            'url': 'https://watchnebula.com/videos/money-episode-1-the-draw',
+            'only_matching': True,
+        },
+    ]
+
+    def _fetch_video_metadata(self, slug):
+        return self._call_nebula_api('https://content.watchnebula.com/video/{slug}/'.format(slug=slug),
+                                     video_id=slug,
+                                     auth_type='bearer',
+                                     note='Fetching video meta data')
 
     def _real_extract(self, url):
-        display_id = self._match_id(url)
-        api_key = self._retrieve_zype_api_key(url, display_id)
+        slug = self._match_id(url)
+        video = self._fetch_video_metadata(slug)
+        return self._build_video_info(video)
 
-        response = self._call_zype_api('/videos', {'friendly_title': display_id},
-                                       display_id, api_key, note='Retrieving metadata from Zype')
-        if len(response.get('response') or []) != 1:
-            raise ExtractorError('Unable to find video on Zype API')
-        video_meta = response['response'][0]
 
-        video_id = video_meta['_id']
-        zype_access_token = self._fetch_zype_access_token(display_id)
+class NebulaCollectionIE(NebulaBaseIE):
+    IE_NAME = 'nebula:collection'
+    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/(?P<id>[-\w]+)'
+    _TESTS = [
+        {
+            'url': 'https://nebula.app/tom-scott-presents-money',
+            'info_dict': {
+                'id': 'tom-scott-presents-money',
+                'title': 'Tom Scott Presents: Money',
+                'description': 'Tom Scott hosts a series all about trust, negotiation and money.',
+            },
+            'playlist_count': 5,
+            'params': {
+                'usenetrc': True,
+            },
+            'skip': 'All Nebula content requires authentication',
+        }, {
+            'url': 'https://nebula.app/lindsayellis',
+            'info_dict': {
+                'id': 'lindsayellis',
+                'title': 'Lindsay Ellis',
+                'description': 'Enjoy these hottest of takes on Disney, Transformers, and Musicals.',
+            },
+            'playlist_mincount': 100,
+            'params': {
+                'usenetrc': True,
+            },
+            'skip': 'All Nebula content requires authentication',
+        },
+    ]
 
-        channel_title = self._extract_channel_title(video_meta)
+    def _fetch_collection(self, collection_id):
+        page_nr = 1
+        next_url = 'https://content.watchnebula.com/video/channels/{collection_id}/'.format(collection_id=collection_id)
+        episodes = []
+        channel_details = None
+        while next_url:
+            channel = self._call_nebula_api(next_url, collection_id, auth_type='bearer',
+                                            note='Retrieving channel page {page_nr}'.format(page_nr=page_nr))
+            if not channel_details:
+                channel_details = channel['details']
+            episodes.extend(channel['episodes']['results'])
+            next_url = channel['episodes']['next']
+            page_nr += 1
 
-        return {
-            'id': video_id,
-            'display_id': display_id,
-            '_type': 'url_transparent',
-            'ie_key': 'Zype',
-            'url': 'https://player.zype.com/embed/%s.html?access_token=%s' % (video_id, zype_access_token),
-            'title': video_meta.get('title'),
-            'description': video_meta.get('description'),
-            'timestamp': parse_iso8601(video_meta.get('published_at')),
-            'thumbnails': [{
-                'id': tn.get('name'),  # this appears to be null
-                'url': tn['url'],
-                'width': tn.get('width'),
-                'height': tn.get('height'),
-            } for tn in video_meta.get('thumbnails', [])],
-            'duration': video_meta.get('duration'),
-            'channel': channel_title,
-            'uploader': channel_title,  # we chose uploader = channel name
-            # TODO: uploader_url, channel_id, channel_url
-        }
+        return channel_details, episodes
+
+    def _real_extract(self, url):
+        collection_id = self._match_id(url)
+        channel_details, episodes = self._fetch_collection(collection_id)
+
+        return self.playlist_result(
+            entries=[
+                self._build_video_info(episode) for episode in episodes
+            ],
+            playlist_id=collection_id,
+            playlist_title=channel_details['title'],
+            playlist_description=channel_details['description']
+        )

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -86,7 +86,7 @@ class NebulaBaseIE(InfoExtractor):
             # if 401 or 403, attempt credential re-auth and retry
             if exc.cause and isinstance(exc.cause, urllib.error.HTTPError) and exc.cause.code in (401, 403):
                 self.to_screen(f'Reauthenticating to Nebula and retrying, because last {auth_type} call resulted in error {exc.cause.code}')
-                self._real_initialize()
+                self._login()
                 return inner_call()
             else:
                 raise
@@ -148,10 +148,13 @@ class NebulaBaseIE(InfoExtractor):
             'creator': episode['channel_title'],
         }
 
-    def _real_initialize(self):
+    def _login(self):
         self._nebula_api_token = self._retrieve_nebula_api_token()
         self._nebula_bearer_token = self._fetch_nebula_bearer_token()
         self._zype_access_token = self._fetch_zype_access_token()
+
+    def _real_initialize(self):
+        self._login()
 
 
 class NebulaIE(NebulaBaseIE):

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import itertools
 import json
 import time
 import urllib
@@ -256,18 +257,16 @@ class NebulaCollectionIE(NebulaBaseIE):
     ]
 
     def _generate_playlist_entries(self, collection_id, channel):
-        page_nr = 1
         episodes = channel['episodes']['results']
-        while episodes:
+        for page_num in itertools.count(2):
             for episode in episodes:
                 yield self._build_video_info(episode)
             next_url = channel['episodes']['next']
-            if next_url:
-                page_nr += 1
-                channel = self._call_nebula_api(next_url, collection_id, auth_type='bearer', note=f'Retrieving channel page {page_nr}')
-                episodes = channel['episodes']['results']
-            else:
-                episodes = None
+            if not next_url:
+                break
+            channel = self._call_nebula_api(next_url, collection_id, auth_type='bearer',
+                                            note=f'Retrieving channel page {page_num}')
+            episodes = channel['episodes']['results']
 
     def _real_extract(self, url):
         collection_id = self._match_id(url)

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -57,9 +57,9 @@ class NebulaBaseIE(InfoExtractor):
     def _call_nebula_api(self, url, video_id=None, method='GET', auth_type='api', note=''):
         assert method in ('GET', 'POST',)
         assert auth_type in ('api', 'bearer',)
-        authorization = 'Token {api_token}'.format(api_token=self._nebula_api_token) \
+        authorization = f'Token {self._nebula_api_token}' \
             if auth_type == 'api' \
-            else 'Bearer {bearer_token}'.format(bearer_token=self._nebula_bearer_token)
+            else f'Bearer {self._nebula_bearer_token}'
         url_or_request = url \
             if method == 'GET' \
             else compat_urllib_request.Request(url, method='POST', data={})
@@ -95,7 +95,9 @@ class NebulaBaseIE(InfoExtractor):
         return response['token']
 
     def _build_video_info(self, episode):
-        zype_video_url = 'https://player.zype.com/embed/%s.html?access_token=%s' % (episode['zype_id'], self._zype_access_token)
+        zype_id = episode['zype_id']
+        zype_video_url = f'https://player.zype.com/embed/{zype_id}.html?access_token={self._zype_access_token}'
+        channel_slug = episode['channel_slug']
         return {
             'id': episode['zype_id'],
             'display_id': episode['slug'],
@@ -112,11 +114,11 @@ class NebulaBaseIE(InfoExtractor):
             } for key, tn in episode['assets']['thumbnail'].items()],
             'duration': episode['duration'],
             'channel': episode['channel_title'],
-            'channel_id': episode['channel_slug'],
-            'channel_url': 'https://nebula.app/{channel_slug}'.format(channel_slug=episode['channel_slug']),
+            'channel_id': channel_slug,
+            'channel_url': f'https://nebula.app/{channel_slug}',
             'uploader': episode['channel_title'],
-            'uploader_id': episode['channel_slug'],
-            'uploader_url': 'https://nebula.app/{channel_slug}'.format(channel_slug=episode['channel_slug']),
+            'uploader_id': channel_slug,
+            'uploader_url': f'https://nebula.app/{channel_slug}',
             'series': episode['channel_title'],
             'creator': episode['channel_title'],
         }
@@ -211,7 +213,7 @@ class NebulaIE(NebulaBaseIE):
     ]
 
     def _fetch_video_metadata(self, slug):
-        return self._call_nebula_api('https://content.watchnebula.com/video/{slug}/'.format(slug=slug),
+        return self._call_nebula_api(f'https://content.watchnebula.com/video/{slug}/',
                                      video_id=slug,
                                      auth_type='bearer',
                                      note='Fetching video meta data')
@@ -255,12 +257,12 @@ class NebulaCollectionIE(NebulaBaseIE):
 
     def _fetch_collection(self, collection_id):
         page_nr = 1
-        next_url = 'https://content.watchnebula.com/video/channels/{collection_id}/'.format(collection_id=collection_id)
+        next_url = f'https://content.watchnebula.com/video/channels/{collection_id}/'
         episodes = []
         channel_details = None
         while next_url:
             channel = self._call_nebula_api(next_url, collection_id, auth_type='bearer',
-                                            note='Retrieving channel page {page_nr}'.format(page_nr=page_nr))
+                                            note=f'Retrieving channel page {page_nr}')
             if not channel_details:
                 channel_details = channel['details']
             episodes.extend(channel['episodes']['results'])

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -226,7 +226,7 @@ class NebulaIE(NebulaBaseIE):
 
 class NebulaCollectionIE(NebulaBaseIE):
     IE_NAME = 'nebula:collection'
-    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/(?P<id>[-\w]+)'
+    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/(?!videos/)(?P<id>[-\w]+)'
     _TESTS = [
         {
             'url': 'https://nebula.app/tom-scott-presents-money',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The primary purpose of this pull request is to add channel/playlist support to the Nebula extractor:

```
$ yt-dlp --netrc "https://nebula.app/lindsayellis"
[nebula:collection] Logging in to Nebula with supplied credentials
[nebula:collection] Authorizing to Nebula
[nebula:collection] Retrieving Zype access token
[nebula:collection] lindsayellis: Retrieving channel page 1
[...]
[nebula:collection] lindsayellis: Retrieving channel page 11
[download] Downloading playlist: Lindsay Ellis
[nebula:collection] playlist Lindsay Ellis: Collected 104 videos; downloading 104 of them
[download] Downloading video 1 of 104
[Zype] 617408d3a9f9bc0001f47b3e: Downloading JSON metadata
[...]
```

However, one thing led to another and this ultimately ended up being a complete rewrite. I think the new extractor is much simpler, cleaner, and easier to read and reason about. The video and channel extractor classes inherit from a common base and I finally learned about the existance of `_real_initialize()` and therefore I'm using it now. 😉

The rewrite does not use the Zype API anymore, and therefore should also fix the Nebula extractor currently released, which is completely broken (#1690), raising a `RegexNotFoundError: Unable to extract API key` on every video.
