### PR TITLE
[bbc] Get all available formats, deprioritize audio description

### DIFF
--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -5,7 +5,6 @@ import functools
 import itertools
 import json
 import re
-from collections import defaultdict
 
 from .common import InfoExtractor
 from ..compat import (
@@ -453,7 +452,7 @@ class BBCCoUkIE(InfoExtractor):
                 'http://www.bbc.co.uk/programmes/%s/playlist.json' % playlist_id,
                 playlist_id, 'Downloading playlist JSON')
             formats = []
-            subtitles = defaultdict(list)
+            subtitles = {}
 
             for version in playlist.get('allAvailableVersions', []):
                 smp_config = version['smpConfig']
@@ -470,9 +469,10 @@ class BBCCoUkIE(InfoExtractor):
                     for f in version_formats:
                         f['format_note'] = ', '.join(types)
                         if any('AudioDescribed' in x for x in types):
-                            f['preference'] = -10
+                            f['language_preference'] = -10
                     formats += version_formats
                     for tag, subformats in (version_subtitles or {}).items():
+                        subtitles.setdefault(tag, [])
                         subtitles[tag] += subformats
 
             return programme_id, title, description, duration, formats, subtitles


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Audio description is available in a separate manifest which is (at least sometimes) SD only. Sometimes BBC iPlayer will mistakenly mark it as the default format too.

Example:
```
yt-dlp --playlist-items 1 -F "https://www.bbc.co.uk/iplayer/episodes/p09twdp8/showtrial?seriesId=p09twdth"
```

I've changed the extractor to return all available formats, add the `types` field to format notes, and deprioritize audio described tracks.

Note: In this example audio description is tagged as `DubbedAudioDescribed`, but I check if the type contains `AudioDescribed` anywhere like get_iplayer does just in case.