### PR TITLE
[bbc] Respect --no-playlist

### DIFF
--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -1411,6 +1411,8 @@ class BBCCoUkIPlayerPlaylistBaseIE(InfoExtractor):
         pid = self._match_id(url)
         qs = parse_qs(url)
         series_id = qs.get('seriesId', [None])[0]
+        if self.get_param('noplaylist'):
+            series_id = None
         page = qs.get('page', [None])[0]
         per_page = 36 if page else self._PAGE_SIZE
         fetch_page = functools.partial(self._fetch_page, pid, per_page, series_id)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

If `--no-playlist` was used on a URL containing the seriesId parameter, the option was not respected before.

Example:
```
yt-dlp --no-playlist -F "https://www.bbc.co.uk/iplayer/episodes/p09twdp8/showtrial?seriesId=p09twdth"
```