### PR TITLE
[web.archive:youtube] Improve extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,9 @@ The following extractors use this feature:
 #### vikichannel
 * `video_types`: Types of videos to download - one or more of `episodes`, `movies`, `clips`, `trailers`
 
+#### youtubewebarchive
+* `check_all`: Try to check more at the cost of more requests. One or more of `thumbnails`, `captures`
+
 NOTE: These options may be changed/removed in the future without concern for backward compatibility
 
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -473,10 +473,11 @@ class YoutubeWebArchiveIE(InfoExtractor):
         except ExtractorError as e:
             # HTTP Error 404 is expected if the video is not saved.
             if isinstance(e.cause, compat_HTTPError) and e.cause.code == 404:
-                raise ExtractorError(
+                self.raise_no_formats(
                     'HTTP Error %s. Most likely the video is not saved or there is an issue with web.archive.org' % e.cause.code,
                     expected=True)
-            self.raise_no_formats(str(e.cause or e.msg), expected=True)
+            else:
+                raise
 
         if video_file_url:
             video_file_url_qs = parse_qs(video_file_url)

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -8,7 +8,7 @@ from .youtube import YoutubeIE
 from ..compat import (
     compat_urllib_parse_unquote,
     compat_urllib_parse_unquote_plus,
-    compat_HTTPError,
+    compat_HTTPError
 )
 from ..utils import (
     bug_reports_message,
@@ -31,7 +31,8 @@ from ..utils import (
     try_get,
     unified_strdate,
     unified_timestamp,
-    urlhandle_detect_ext, url_or_none
+    urlhandle_detect_ext,
+    url_or_none
 )
 
 
@@ -289,8 +290,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_id': 'Zeurel',
                 'uploader_url': 'http://www.youtube.com/user/Zeurel'
             }
-        },
-        {
+        }, {
             # Internal link
             'url': 'https://web.archive.org/web/2oe/http://wayback-fakeurl.archive.org/yt/97t7Xj_iBv0',
             'info_dict': {
@@ -305,8 +305,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_id': '1veritasium',
                 'uploader_url': 'http://www.youtube.com/user/1veritasium'
             }
-        },
-        {
+        }, {
             # Video from 2012, webm format itag 45. Newest capture is deleted video, with an invalid description.
             # Should use the date in the link. Title ends with '- Youtube'. Capture has description in eow-description
             'url': 'https://web.archive.org/web/20120712231619/http://www.youtube.com/watch?v=AkhihxRKcrs&gl=US&hl=en',
@@ -320,8 +319,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_id': 'machinima',
                 'uploader_url': 'http://www.youtube.com/user/machinima'
             }
-        },
-        {
+        }, {
             # FLV video. Video file URL does not provide itag information
             'url': 'https://web.archive.org/web/20081211103536/http://www.youtube.com/watch?v=jNQXAC9IVRw',
             'info_dict': {
@@ -335,8 +333,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_id': 'jawed',
                 'uploader_url': 'http://www.youtube.com/user/jawed'
             }
-        },
-        {
+        }, {
             'url': 'https://web.archive.org/web/20110712231407/http://www.youtube.com/watch?v=lTx3G6h2xyA',
             'info_dict': {
                 'id': 'lTx3G6h2xyA',
@@ -350,8 +347,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_id': 'itsmadeon',
                 'uploader_url': 'http://www.youtube.com/user/itsmadeon'
             }
-        },
-        {
+        }, {
             # First capture is of dead video, second is the oldest from CDX response.
             'url': 'https://web.archive.org/https://www.youtube.com/watch?v=1JYutPM8O6E',
             'info_dict': {
@@ -365,8 +361,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_id': 'MachinimaETC',
                 'uploader_url': 'http://www.youtube.com/user/MachinimaETC'
             }
-        },
-        {
+        }, {
             # First capture of dead video, capture date in link links to dead capture.
             'url': 'https://web.archive.org/web/20180803221945/https://www.youtube.com/watch?v=6FPhZJGvf4E',
             'info_dict': {
@@ -383,41 +378,33 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'expected_warnings': [
                 r'unable to download capture webpage \(it may not be archived\)'
             ]
-        },
-        {   # Very old YouTube page, has - YouTube in title.
+        }, {   # Very old YouTube page, has - YouTube in title.
             'url': 'http://web.archive.org/web/20070302011044/http://youtube.com/watch?v=-06-KB9XTzg',
             'info_dict': {
                 'id': '-06-KB9XTzg',
                 'ext': 'flv',
                 'title': 'New Coin Hack!! 100% Safe!!'
             }
-        },
-        {
+        }, {
             'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
             'only_matching': True
-        },
-        {
+        }, {
             'url': 'https://web.archive.org/web/20050214000000_if/http://www.youtube.com/watch?v=0altSZ96U4M',
             'only_matching': True
-        },
-        {
+        }, {
             # Video not archived, only capture is unavailable video page
             'url': 'https://web.archive.org/web/20210530071008/https://www.youtube.com/watch?v=lHJTf93HL1s&spfreload=10',
             'only_matching': True
-        },
-        {   # Encoded url
+        }, {   # Encoded url
             'url': 'https://web.archive.org/web/20120712231619/http%3A//www.youtube.com/watch%3Fgl%3DUS%26v%3DAkhihxRKcrs%26hl%3Den',
             'only_matching': True
-        },
-        {
+        }, {
             'url': 'https://web.archive.org/web/20120712231619/http%3A//www.youtube.com/watch%3Fv%3DAkhihxRKcrs%26gl%3DUS%26hl%3Den',
             'only_matching': True
-        },
-        {
+        }, {
             'url': 'https://web.archive.org/web/20060527081937/http://www.youtube.com:80/watch.php?v=ELTFsLT73fA&amp;search=soccer',
             'only_matching': True
-        },
-        {
+        }, {
             'url': 'https://web.archive.org/http://www.youtube.com:80/watch?v=-05VVye-ffg',
             'only_matching': True
         }
@@ -544,7 +531,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         }
 
     def _extract_thumbnails(self, video_id):
-        try_all = 'thumbnails' in self._configuration_arg('checkall')
+        try_all = 'thumbnails' in self._configuration_arg('check_all')
         thumbnail_base_urls = [(ext, server, 'http://{server}/vi{webp}/{video_id}'.format(
             webp='_webp' if ext == 'webp' else '', video_id=video_id, server=server))
             for server in (self._YT_ALL_THUMB_SERVERS if try_all else self._YT_DEFAULT_THUMB_SERVERS) for ext in (('jpg', 'webp') if try_all else ('jpg',))]
@@ -587,7 +574,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         if all_captures:
             capture_dates.append(all_captures[0])
 
-        if 'captures' in self._configuration_arg('checkall'):
+        if 'captures' in self._configuration_arg('check_all'):
             capture_dates.extend(modern_captures + all_captures)
 
         # Fallbacks if any of the above fail
@@ -626,7 +613,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             # Try avoid getting deleted video metadata
             if _info_dict.get('title'):
                 info = merge_dicts(info, _info_dict)
-                if 'captures' not in self._configuration_arg('checkall'):
+                if 'captures' not in self._configuration_arg('check_all'):
                     break
 
         info['thumbnails'] = self._extract_thumbnails(video_id)

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -508,15 +508,13 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 collapse=['urlkey'], query={'matchType': 'prefix'})
             if not response:
                 continue
-
             # TODO fix sorting
             thumbnails.extend(
                 {
-                    'url': (self._WAYBACK_BASE_URL % (int_or_none(thumb.get('timestamp')) or self._EARLIEST_CAPTURE_DATE)) + thumb.get('original'),
-                    'filesize': int_or_none(thumb.get('length')),
-                    'id': int_or_none(thumb.get('length'))  # TODO. Also large filesize != best quality
-                } for thumb in response
-            )
+                    'url': (self._WAYBACK_BASE_URL % (int_or_none(thumbnail_dict.get('timestamp')) or self._EARLIEST_CAPTURE_DATE)) + thumbnail_dict.get('original'),
+                    'filesize': int_or_none(thumbnail_dict.get('length')),
+                    'id': int_or_none(thumbnail_dict.get('length'))  # TODO. Also large filesize != best quality
+                } for thumbnail_dict in response)
             if not try_all:
                 break
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -408,8 +408,6 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'only_matching': True
         }
     ]
-    # TODO:
-    # first page is 302 redirect (or bad capture), that is the only capture so fallback to video id for title
     _YT_INITIAL_DATA_RE = r'(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s' % YoutubeIE._YT_INITIAL_DATA_RE
     _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s' % YoutubeIE._YT_INITIAL_PLAYER_RESPONSE_RE
     _YT_INITIAL_BOUNDARY_RE = r'(?:(?:var\s+meta|</script|\n)|%s)' % YoutubeIE._YT_INITIAL_BOUNDARY_RE
@@ -420,7 +418,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
     _WAYBACK_BASE_URL = 'https://web.archive.org/web/%sif_/'
     _OLDEST_CAPTURE_DATE = 20050214000000
-    _NEWEST_CAPTURE_DATE = 205001010000000
+    _NEWEST_CAPTURE_DATE = 20500101000000
 
     def _call_cdx_api(self, item_id, url, filters: list = None, collapse: list = None, query: dict = None, note='Downloading CDX API JSON'):
         # CDX docs: https://github.com/internetarchive/wayback/blob/master/wayback-cdx-server/README.md
@@ -569,7 +567,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         try:
             urlh = self._request_webpage(
                 HEADRequest('https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/%s' % video_id),
-                video_id, note='Fetching video file url', expected_status=True)
+                video_id, note='Fetching archived video file url', expected_status=True)
         except ExtractorError as e:
             # HTTP Error 404 is expected if the video is not saved.
             if isinstance(e.cause, compat_HTTPError) and e.cause.code == 404:

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -533,7 +533,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             url = compat_urllib_parse_unquote(urlh.url)
             video_file_url_qs = parse_qs(url)
             # Attempt to recover any ext & format info from playback url
-            format = {'url': url}
+            format = {'url': url, 'filesize': int_or_none(urlh.headers.get('x-archive-orig-content-length'))}
             itag = try_get(video_file_url_qs, lambda x: x['itag'][0])
             if itag and itag in YoutubeIE._formats:  # Naughty access but it works
                 format.update(YoutubeIE._formats[itag])

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import re
 import json
 from .common import InfoExtractor
-from .youtube import YoutubeIE
+from .youtube import YoutubeIE, YoutubeBaseInfoExtractor
 from ..compat import (
     compat_urllib_parse_unquote,
     compat_urllib_parse_unquote_plus,
@@ -440,9 +440,9 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'only_matching': True
         }
     ]
-    _YT_INITIAL_DATA_RE = r'(?:(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s)' % YoutubeIE._YT_INITIAL_DATA_RE
-    _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s)' % YoutubeIE._YT_INITIAL_PLAYER_RESPONSE_RE
-    _YT_INITIAL_BOUNDARY_RE = r'(?:(?:var\s+meta|</script|\n)|%s)' % YoutubeIE._YT_INITIAL_BOUNDARY_RE
+    _YT_INITIAL_DATA_RE = r'(?:(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s)' % YoutubeBaseInfoExtractor._YT_INITIAL_DATA_RE
+    _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s)' % YoutubeBaseInfoExtractor._YT_INITIAL_PLAYER_RESPONSE_RE
+    _YT_INITIAL_BOUNDARY_RE = r'(?:(?:var\s+meta|</script|\n)|%s)' % YoutubeBaseInfoExtractor._YT_INITIAL_BOUNDARY_RE
 
     _YT_DEFAULT_THUMB_SERVERS = ['i.ytimg.com']  # thumbnails most likely archived on these servers
     _YT_ALL_THUMB_SERVERS = orderedSet(
@@ -503,8 +503,8 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
         video_title = (
             video_details.get('title')
-            or YoutubeIE._get_text(microformats, 'title')
-            or YoutubeIE._get_text(initial_data_video, 'title')
+            or YoutubeBaseInfoExtractor._get_text(microformats, 'title')
+            or YoutubeBaseInfoExtractor._get_text(initial_data_video, 'title')
             or self._extract_webpage_title(webpage)
             or search_meta(['og:title', 'twitter:title', 'title']))
 
@@ -523,7 +523,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             or parse_duration(search_meta('duration')))
         description = (
             video_details.get('shortDescription')
-            or YoutubeIE._get_text(microformats, 'description')
+            or YoutubeBaseInfoExtractor._get_text(microformats, 'description')
             or clean_html(get_element_by_id('eow-description', webpage))  # @9e6dd23
             or search_meta(['description', 'og:description', 'twitter:description']))
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -386,6 +386,21 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'title': 'New Coin Hack!! 100% Safe!!'
             }
         }, {
+            'url': 'web.archive.org/https://www.youtube.com/watch?v=dWW7qP423y8',
+            'info_dict': {
+                'id': 'dWW7qP423y8',
+                'ext': 'mp4',
+                'title': 'It\'s Bootleg AirPods Time.',
+                'upload_date': '20211021',
+                'channel_id': 'UC7Jwj9fkrf1adN4fMmTkpug',
+                'channel_url': 'http://www.youtube.com/channel/UC7Jwj9fkrf1adN4fMmTkpug',
+                'duration': 810,
+                'description': 'md5:7b567f898d8237b256f36c1a07d6d7bc',
+                'uploader': 'DankPods',
+                'uploader_id': 'UC7Jwj9fkrf1adN4fMmTkpug',
+                'uploader_url': 'http://www.youtube.com/channel/UC7Jwj9fkrf1adN4fMmTkpug'
+            }
+        }, {
             'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
             'only_matching': True
         }, {

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -370,6 +370,14 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 r'unable to download capture webpage \(it may not be archived\)'
             ]
         },
+        {   # Very old YouTube page, has - YouTube in title.
+            'url': 'http://web.archive.org/web/20070302011044/http://youtube.com/watch?v=-06-KB9XTzg',
+            'info_dict': {
+                'id': '-06-KB9XTzg',
+                'ext': 'flv',
+                'title': 'New Coin Hack!! 100% Safe!!'
+            }
+        },
         {
             'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
             'only_matching': True
@@ -394,11 +402,14 @@ class YoutubeWebArchiveIE(InfoExtractor):
         {
             'url': 'https://web.archive.org/web/20060527081937/http://www.youtube.com:80/watch.php?v=ELTFsLT73fA&amp;search=soccer',
             'only_matching': True
+        },
+        {
+            'url': 'https://web.archive.org/http://www.youtube.com:80/watch?v=-05VVye-ffg',
+            'only_matching': True
         }
     ]
     # TODO:
     # first page is 302 redirect (or bad capture), that is the only capture so fallback to video id for title
-    # examples using old title
     _YT_INITIAL_DATA_RE = r'(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s' % YoutubeIE._YT_INITIAL_DATA_RE
     _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s' % YoutubeIE._YT_INITIAL_PLAYER_RESPONSE_RE
     _YT_INITIAL_BOUNDARY_RE = r'(?:(?:var\s+meta|</script|\n)|%s)' % YoutubeIE._YT_INITIAL_BOUNDARY_RE
@@ -426,7 +437,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         if isinstance(res, list) and len(res) >= 2:
             # format response to make it easier to use
             return list(dict(zip(res[0], v)) for v in res[1:])
-        else:
+        elif not isinstance(res, list) or len(res) != 0:
             self.report_warning('Error while parsing CDX API response' + bug_reports_message())
 
     def _extract_yt_initial_variable(self, webpage, regex, video_id, name):

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -563,7 +563,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 {
                     'url': (self._WAYBACK_BASE_URL % (int_or_none(thumbnail_dict.get('timestamp')) or self._OLDEST_CAPTURE_DATE)) + thumbnail_dict.get('original'),
                     'filesize': int_or_none(thumbnail_dict.get('length')),
-                    'id': int_or_none(thumbnail_dict.get('length'))  # TODO. Also large filesize != best quality
+                    'preference': int_or_none(thumbnail_dict.get('length'))
                 } for thumbnail_dict in response)
             if not try_all:
                 break

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -532,12 +532,12 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
     def _extract_thumbnails(self, video_id):
         try_all = 'thumbnails' in self._configuration_arg('check_all')
-        thumbnail_base_urls = [(ext, server, 'http://{server}/vi{webp}/{video_id}'.format(
-            webp='_webp' if ext == 'webp' else '', video_id=video_id, server=server))
+        thumbnail_base_urls = ['http://{server}/vi{webp}/{video_id}'.format(
+            webp='_webp' if ext == 'webp' else '', video_id=video_id, server=server)
             for server in (self._YT_ALL_THUMB_SERVERS if try_all else self._YT_DEFAULT_THUMB_SERVERS) for ext in (('jpg', 'webp') if try_all else ('jpg',))]
 
         thumbnails = []
-        for ext, server, url in thumbnail_base_urls:
+        for url in thumbnail_base_urls:
             response = self._call_cdx_api(
                 video_id, url, filters=['mimetype:image/(?:webp|jpeg)'],
                 collapse=['urlkey'], query={'matchType': 'prefix'})

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -504,10 +504,9 @@ class YoutubeWebArchiveIE(InfoExtractor):
             or clean_html(get_element_by_id('eow-description', webpage))  # 9e6dd23
             or search_meta(['description', 'og:description', 'twitter:description']))
 
-        uploader = video_details.get('author'),
+        uploader = video_details.get('author')
 
         # Uploader ID and URL
-        uploader_id = uploader_url = None
         uploader_mobj = re.search(
             r'<link itemprop="url" href="(?P<uploader_url>https?://www\.youtube\.com/(?:user|channel)/(?P<uploader_id>[^"]+))">',
             webpage)

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -540,7 +540,9 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 format.update({'format_id': itag})
             else:
                 mime = try_get(video_file_url_qs, lambda x: x['mime'][0])
-                ext = mimetype2ext(mime) or urlhandle_detect_ext(urlh)
+                ext = (mimetype2ext(mime)
+                       or urlhandle_detect_ext(urlh)
+                       or mimetype2ext(urlh.headers.get('x-archive-guessed-content-type')))
                 format.update({'ext': ext})
             info['formats'] = [format]
             if not info.get('duration'):

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -513,7 +513,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
         # Uploader ID and URL
         uploader_mobj = re.search(
-            r'<link itemprop="url" href="(?P<uploader_url>https?://www\.youtube\.com/(?:user|channel)/(?P<uploader_id>[^"]+))">',
+            r'<link itemprop="url" href="(?P<uploader_url>https?://www\.youtube\.com/(?:user|channel)/(?P<uploader_id>[^"]+))">',  # @fd05024
             webpage)
         if uploader_mobj is not None:
             uploader_id, uploader_url = uploader_mobj.group('uploader_id'), uploader_mobj.group('uploader_url')

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -640,10 +640,10 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 (self._WAYBACK_BASE_URL + 'http://www.youtube.com/watch?v=%s') % (capture, video_id),
                 video_id=video_id, fatal=False, errnote='unable to download capture webpage (it may not be archived)',
                 note='Downloading capture webpage')
-            _info_dict = self._extract_metadata(video_id, webpage or '')
+            current_info = self._extract_metadata(video_id, webpage or '')
             # Try avoid getting deleted video metadata
-            if _info_dict.get('title'):
-                info = merge_dicts(info, _info_dict)
+            if current_info.get('title'):
+                info = merge_dicts(info, current_info)
                 if 'captures' not in self._configuration_arg('check_all'):
                     break
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -398,10 +398,10 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
     _YT_DEFAULT_THUMB_SERVERS = ['i.ytimg.com']  # thumbnails most likely archived on these servers
     _YT_ALL_THUMB_SERVERS = orderedSet(
-        _YT_DEFAULT_THUMB_SERVERS + ['img.youtube.com', *[f'{c}{n or ""}.ytimg.com' for c in ('i', 's') for n in range(0, 5)]])
+        _YT_DEFAULT_THUMB_SERVERS + ['img.youtube.com', *[f'{c}{n or ""}.ytimg.com' for c in ('i', 's') for n in (*range(0, 5), 9)]])
 
     _WAYBACK_BASE_URL = 'https://web.archive.org/web/%sif_/'
-    _EARLIEST_CAPTURE_DATE = 20050214000000
+    _OLDEST_CAPTURE_DATE = 20050214000000
     _NEWEST_CAPTURE_DATE = 205001010000000
 
     def _call_cdx_api(self, item_id, url, filters: list = None, collapse: list = None, query: dict = None, note='Downloading CDX API JSON'):
@@ -511,7 +511,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             # TODO fix sorting
             thumbnails.extend(
                 {
-                    'url': (self._WAYBACK_BASE_URL % (int_or_none(thumbnail_dict.get('timestamp')) or self._EARLIEST_CAPTURE_DATE)) + thumbnail_dict.get('original'),
+                    'url': (self._WAYBACK_BASE_URL % (int_or_none(thumbnail_dict.get('timestamp')) or self._OLDEST_CAPTURE_DATE)) + thumbnail_dict.get('original'),
                     'filesize': int_or_none(thumbnail_dict.get('length')),
                     'id': int_or_none(thumbnail_dict.get('length'))  # TODO. Also large filesize != best quality
                 } for thumbnail_dict in response)
@@ -543,7 +543,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             capture_dates.extend(modern_captures + all_captures)
 
         # Fallbacks
-        capture_dates.extend([self._EARLIEST_CAPTURE_DATE, self._NEWEST_CAPTURE_DATE])
+        capture_dates.extend([self._OLDEST_CAPTURE_DATE, self._NEWEST_CAPTURE_DATE])
         return orderedSet(capture_dates)
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -3,17 +3,15 @@ from __future__ import unicode_literals
 
 import re
 import json
-import itertools
 from .common import InfoExtractor
 from .youtube import YoutubeIE
 from ..compat import (
     compat_urllib_parse_unquote,
     compat_urllib_parse_unquote_plus,
-    compat_HTTPError, compat_urlparse
+    compat_HTTPError,
 )
 from ..utils import (
     clean_html,
-    determine_ext,
     dict_get,
     extract_attributes,
     ExtractorError,
@@ -22,15 +20,16 @@ from ..utils import (
     KNOWN_EXTENSIONS,
     merge_dicts,
     mimetype2ext,
+    orderedSet,
     parse_duration,
     parse_qs,
-    RegexNotFoundError,
     str_to_int,
     str_or_none,
+    traverse_obj,
     try_get,
     unified_strdate,
-    unified_timestamp, traverse_obj, float_or_none,
-    urljoin, orderedSet, get_domain, url_basename, base_url, urlhandle_detect_ext
+    unified_timestamp,
+    urlhandle_detect_ext
 )
 
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -496,13 +496,13 @@ class YoutubeWebArchiveIE(InfoExtractor):
             or search_meta('channelId')
             or self._search_regex(
                 r'data-channel-external-id=(["\'])(?P<id>(?:(?!\1).)+)\1',  # @b45a9e6
-                webpage, 'channel id', default=None, group='id')
-            )
+                webpage, 'channel id', default=None, group='id'))
         channel_url = f'http://www.youtube.com/channel/{channel_id}' if channel_id else None
+
         duration = int_or_none(
             video_details.get('lengthSeconds')
             or microformats.get('lengthSeconds')
-            or parse_duration(search_meta('duration'))) or None
+            or parse_duration(search_meta('duration')))
         description = (
             video_details.get('shortDescription')
             or YoutubeIE._get_text(microformats, 'description')

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -326,7 +326,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'id': 'jNQXAC9IVRw',
                 'ext': 'flv',
                 'title': 'Me at the zoo',
-                'upload_date': '20050423',  # TODO: uploader?
+                'upload_date': '20050423',
                 'channel_id': 'UC4QobU6STFB0P71PMvOGN5A',
                 'duration': 19,
                 'description': 'md5:10436b12e07ac43ff8df65287a56efb4',
@@ -574,7 +574,6 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 collapse=['urlkey'], query={'matchType': 'prefix'})
             if not response:
                 continue
-            # TODO fix sorting
             thumbnails.extend(
                 {
                     'url': (self._WAYBACK_BASE_URL % (int_or_none(thumbnail_dict.get('timestamp')) or self._OLDEST_CAPTURE_DATE)) + thumbnail_dict.get('original'),
@@ -584,7 +583,6 @@ class YoutubeWebArchiveIE(InfoExtractor):
             if not try_all:
                 break
 
-        # TODO: deal with duplicate files from different servers?
         self._remove_duplicate_formats(thumbnails)
         return thumbnails
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -279,7 +279,12 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'info_dict': {
                 'id': 'aYAGB11YrSs',
                 'ext': 'webm',
-                'title': 'Team Fortress 2 - Sandviches!'
+                'title': 'Team Fortress 2 - Sandviches!',
+                'description': 'md5:4984c0f9a07f349fc5d8e82ab7af4eaf',
+                'upload_date': '20110926',
+                'uploader': 'Zeurel',
+                'channel_id': 'UCukCyHaD-bK3in_pKpfH9Eg',
+                'duration': 32
             }
         },
         {
@@ -288,59 +293,87 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'info_dict': {
                 'id': '97t7Xj_iBv0',
                 'ext': 'mp4',
-                'title': 'How Flexible Machines Could Save The World'
+                'title': 'Why Machines That Bend Are Better',
+                'description': 'md5:00404df2c632d16a674ff8df1ecfbb6c',
+                'upload_date': '20190312',
+                'uploader': 'Veritasium',
+                'channel_id': 'UCHnyfMqiRRG1u-2MsSQLbXA',
+                'duration': 771
             }
         },
         {
-            # Video from 2012, webm format itag 45.
+            # Video from 2012, webm format itag 45. Newest capture is deleted video, with an invalid description.
+            # Should use the date in the link. Title ends with '- Youtube'.
             'url': 'https://web.archive.org/web/20120712231619/http://www.youtube.com/watch?v=AkhihxRKcrs&gl=US&hl=en',
             'info_dict': {
                 'id': 'AkhihxRKcrs',
                 'ext': 'webm',
-                'title': 'Limited Run: Mondo\'s Modern Classic 1 of 3 (SDCC 2012)'
+                'title': 'Limited Run: Mondo\'s Modern Classic 1 of 3 (SDCC 2012)',
+                'upload_date': '20120712',
+                'duration': 398,
+                'description': 'md5:ff4de6a7980cb65d951c2f6966a4f2f3'  # TODO: fix
+
             }
         },
         {
-            # Old flash-only video. Webpage title starts with "YouTube - ".
+            # FLV video. Video file URL does not provide itag information
             'url': 'https://web.archive.org/web/20081211103536/http://www.youtube.com/watch?v=jNQXAC9IVRw',
             'info_dict': {
                 'id': 'jNQXAC9IVRw',
-                'ext': 'unknown_video',
-                'title': 'Me at the zoo'
+                'ext': 'flv',
+                'title': 'Me at the zoo',
+                'upload_date': '20050423',  # TODO: uploader?
+                'channel_id': 'UC4QobU6STFB0P71PMvOGN5A',
+                'duration': 19,
+                'description': 'md5:56450c47046034c3a218d25cf2b52f4e'
             }
         },
         {
-            # Flash video with .flv extension (itag 34). Title has prefix "YouTube         -"
-            # Title has some weird unicode characters too.
             'url': 'https://web.archive.org/web/20110712231407/http://www.youtube.com/watch?v=lTx3G6h2xyA',
             'info_dict': {
                 'id': 'lTx3G6h2xyA',
                 'ext': 'flv',
-                'title': '‪Madeon - Pop Culture (live mashup)‬‏'
+                'title': 'Madeon - Pop Culture (live mashup)',
+                'upload_date': '20110711',
+                'uploader': 'Madeon',
+                'channel_id': 'UCqMDNf3Pn5L7pcNkuSEeO3w',
+                'duration': 204,
+                'description': 'md5:f7535343b6eda34a314eff8b85444680'
             }
         },
-        {   # Some versions of Youtube have have "YouTube" as page title in html (and later rewritten by js).
-            'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
+        {
+            # First capture is of dead video, second is the oldest from CDX response.
+            'url': 'https://web.archive.org/https://www.youtube.com/watch?v=1JYutPM8O6E',
             'info_dict': {
-                'id': 'kH-G_aIBlFw',
+                'id': '1JYutPM8O6E',
                 'ext': 'mp4',
-                'title': 'kH-G_aIBlFw'
-            },
-            'expected_warnings': [
-                'unable to extract title',
-            ]
+                'title': 'Fake Teen Doctor Strikes AGAIN! - Weekly Weird News',
+                'upload_date': '20160218',
+                'channel_id': 'UCdIaNUarhzLSXGoItz7BHVA',
+                'duration': 1236,
+                'description': 'md5:TODO' # TODO: fix description extraction
+            }
         },
         {
-            # First capture is a 302 redirect intermediary page.
-            'url': 'https://web.archive.org/web/20050214000000/http://www.youtube.com/watch?v=0altSZ96U4M',
+            # First capture of dead video, capture date in link links to dead capture.
+            'url': 'https://web.archive.org/web/20180803221945/https://www.youtube.com/watch?v=6FPhZJGvf4E',
             'info_dict': {
-                'id': '0altSZ96U4M',
+                'id': '6FPhZJGvf4E',
                 'ext': 'mp4',
-                'title': '0altSZ96U4M'
-            },
-            'expected_warnings': [
-                'unable to extract title',
-            ]
+                'title': 'WTF: Video Games Still Launch BROKEN?! - T.U.G.S.',
+                'upload_date': '20160219',
+                'channel_id': 'UCdIaNUarhzLSXGoItz7BHVA',
+                'duration': '798',
+                'description': 'md5:TODO'
+            }
+        },
+        {
+            'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
+            'only_matching': True
+        },
+        {
+            'url': 'https://web.archive.org/web/20050214000000_if/http://www.youtube.com/watch?v=0altSZ96U4M',
+            'only_matching': True
         },
         {
             # Video not archived, only capture is unavailable video page
@@ -356,11 +389,9 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'only_matching': True,
         }
     ]
-    # 2018 response context https://web.archive.org/web/20180803221945/https://www.youtube.com/watch?v=NGgpLa9zYpM&gl=US&hl=en
-    # https://web.archive.org/https://www.youtube.com/watch?v=zrc2gGhTJpk only capture has no title dead video. Working capture has params on URL, so have to use fallback.
-    # TODO: https://web.archive.org/https://www.youtube.com/watch?v=-giLdluEXqQ gives wrong description
-    # https://web.archive.org/web/20171205211234/https://www.youtube.com/watch?v=lHJTf93HL1s no working captures
-    # 6FPhZJGvf4E latest capture bad, oldest capture good
+    # TODO:
+    # first page is 302 redirect (or bad capture), that is the only capture so fallback to video id for title
+    # examples using old title
     _YT_INITIAL_DATA_RE = r'(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s' % YoutubeIE._YT_INITIAL_DATA_RE
     _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s' % YoutubeIE._YT_INITIAL_PLAYER_RESPONSE_RE
     _YT_INITIAL_BOUNDARY_RE = r'(?:(?:var\s+meta|</script|\n)|%s)' % YoutubeIE._YT_INITIAL_BOUNDARY_RE
@@ -531,9 +562,12 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 (self._WAYBACK_BASE_URL + 'http://www.youtube.com/watch?v=%s') % (capture, video_id),
                 video_id=video_id, fatal=False, errnote='unable to download video webpage (it may not be archived)',
                 note='Downloading capture webpage')
-            info = merge_dicts(info, self._extract_metadata(video_id, webpage or ''))
-            if info.get('title') and 'captures' not in self._configuration_arg('checkall'):
-                break
+            _info_dict = self._extract_metadata(video_id, webpage or '')
+            # Try avoid getting deleted video metadata
+            if _info_dict.get('title'):
+                info = merge_dicts(info, _info_dict)
+                if 'captures' not in self._configuration_arg('checkall'):
+                    break
 
         info['thumbnails'] = self._extract_thumbnails(video_id)
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -350,7 +350,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'upload_date': '20160218',
                 'channel_id': 'UCdIaNUarhzLSXGoItz7BHVA',
                 'duration': 1236,
-                'description': 'md5:TODO' # TODO: fix description extraction
+                'description': 'md5:TODO'  # TODO: fix description extraction
             }
         },
         {
@@ -439,8 +439,8 @@ class YoutubeWebArchiveIE(InfoExtractor):
         search_meta = ((lambda x: self._html_search_meta(x, webpage, default=None))
                        if webpage else (lambda x: None))
         player_response = self._extract_yt_initial_variable(
-                webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE,
-                video_id, 'initial player response') or {}
+            webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE,
+            video_id, 'initial player response') or {}
         initial_data = self._extract_yt_initial_variable(
             webpage, self._YT_INITIAL_DATA_RE,
             video_id, 'initial player response') or {}
@@ -481,7 +481,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             # https://github.com/ytdl-org/youtube-dl/blob/dc879c5a37dae588a5bb35d416635678356ad1b7/youtube_dl/extractor/youtube.py#L2202-L2205
             or self._search_regex(
                 [r'(?s)id="eow-date.*?>(.*?)</span>',
-                r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],
+                    r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],
                 webpage, 'upload date', default=None))
 
         info = {
@@ -504,7 +504,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         thumbnails = []
         for ext, server, url in thumbnail_base_urls:
             response = self._call_api(
-                video_id, url, filters=['mimetype:image\/(?:webp|jpeg)'],
+                video_id, url, filters=['mimetype:image/(?:webp|jpeg)'],
                 collapse=['urlkey'], query={'matchType': 'prefix'})
             if not response:
                 continue
@@ -542,7 +542,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             capture_dates.append(all_captures[0])
 
         if 'captures' in self._configuration_arg('checkall'):
-            capture_dates.extend(modern_captures+all_captures)
+            capture_dates.extend(modern_captures + all_captures)
 
         # Fallbacks
         capture_dates.extend([self._EARLIEST_CAPTURE_DATE, self._NEWEST_CAPTURE_DATE])
@@ -579,7 +579,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             # HTTP Error 404 is expected if the video is not saved.
             if isinstance(e.cause, compat_HTTPError) and e.cause.code == 404:
                 self.raise_no_formats(
-                    f'The requested video is not archived, indexed, or there is an issue with web.archive.org',
+                    'The requested video is not archived, indexed, or there is an issue with web.archive.org',
                     expected=True)
             else:
                 raise

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -268,7 +268,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
                 (?:https?(?::|%3[Aa])//)?
                 (?:
-                    (?:\w+\.)?youtube\.com/watch(?:\?|%3[fF])(?:[^\#]+(?:&|%26))?v(?:=|%3[dD])  # Youtube URL
+                    (?:\w+\.)?youtube\.com(?::(?:80|443))?/watch(?:\.php)?(?:\?|%3[fF])(?:[^\#]+(?:&|%26))?v(?:=|%3[dD])  # Youtube URL
                     |(?:wayback-fakeurl\.archive\.org/yt/)  # Or the internal fake url
                 )
                 (?P<id>[0-9A-Za-z_-]{11})(?:%26|\#|&|$)
@@ -381,15 +381,19 @@ class YoutubeWebArchiveIE(InfoExtractor):
         {
             # Video not archived, only capture is unavailable video page
             'url': 'https://web.archive.org/web/20210530071008/https://www.youtube.com/watch?v=lHJTf93HL1s&spfreload=10',
-            'only_matching': True,
+            'only_matching': True
         },
         {   # Encoded url
             'url': 'https://web.archive.org/web/20120712231619/http%3A//www.youtube.com/watch%3Fgl%3DUS%26v%3DAkhihxRKcrs%26hl%3Den',
-            'only_matching': True,
+            'only_matching': True
         },
         {
             'url': 'https://web.archive.org/web/20120712231619/http%3A//www.youtube.com/watch%3Fv%3DAkhihxRKcrs%26gl%3DUS%26hl%3Den',
-            'only_matching': True,
+            'only_matching': True
+        },
+        {
+            'url': 'https://web.archive.org/web/20060527081937/http://www.youtube.com:80/watch.php?v=ELTFsLT73fA&amp;search=soccer',
+            'only_matching': True
         }
     ]
     # TODO:

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -507,7 +507,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 continue
             webpage = self._download_webpage(
                 (self._WAYBACK_BASE_URL + 'http://www.youtube.com/watch?v=%s') % (capture_date, video_id),
-                video_id=video_id, fatal=False, errnote='unable to download video webpage (probably not archived)',
+                video_id=video_id, fatal=False, errnote='unable to download video webpage (it might not be archived)',
                 note=f'Downloading webpage capture {capture_date}')
             info = self._extract_metadata(video_id, webpage or '')
             info_dicts.append(info)
@@ -559,7 +559,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             # HTTP Error 404 is expected if the video is not saved.
             if isinstance(e.cause, compat_HTTPError) and e.cause.code == 404:
                 self.raise_no_formats(
-                    'HTTP Error %s. Most likely the video is not saved or there is an issue with web.archive.org' % e.cause.code,
+                    f'The requested video is not archived, indexed, or there is an issue with web.archive.org',
                     expected=True)
             else:
                 raise

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -493,7 +493,12 @@ class YoutubeWebArchiveIE(InfoExtractor):
         channel_id = str_or_none(
             video_details.get('channelId')
             or microformats.get('externalChannelId')
-            or search_meta('channelId'))
+            or search_meta('channelId')
+            or self._search_regex(
+                r'data-channel-external-id=(["\'])(?P<id>(?:(?!\1).)+)\1',  # @b45a9e6
+                webpage, 'channel id', default=None, group='id')
+            )
+        channel_url = f'http://www.youtube.com/channel/{channel_id}' if channel_id else None
         duration = int_or_none(
             video_details.get('lengthSeconds')
             or microformats.get('lengthSeconds')
@@ -501,7 +506,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         description = (
             video_details.get('shortDescription')
             or YoutubeIE._get_text(microformats, 'description')
-            or clean_html(get_element_by_id('eow-description', webpage))  # 9e6dd23
+            or clean_html(get_element_by_id('eow-description', webpage))  # @9e6dd23
             or search_meta(['description', 'og:description', 'twitter:description']))
 
         uploader = video_details.get('author')
@@ -513,7 +518,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         if uploader_mobj is not None:
             uploader_id, uploader_url = uploader_mobj.group('uploader_id'), uploader_mobj.group('uploader_url')
         else:
-            # a6211d2
+            # @a6211d2
             uploader_url = url_or_none(microformats.get('ownerProfileUrl'))
             uploader_id = self._search_regex(
                 r'(?:user|channel)/([^/]+)', uploader_url or '', 'uploader id', default=None)
@@ -523,7 +528,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             or search_meta(['uploadDate', 'datePublished'])
             or self._search_regex(
                 [r'(?s)id="eow-date.*?>(.*?)</span>',
-                 r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],  # 7998520
+                 r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],  # @7998520
                 webpage, 'upload date', default=None))
 
         info = {
@@ -532,6 +537,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'upload_date': upload_date,
             'uploader': uploader,
             'channel_id': channel_id,
+            'channel_url': channel_url,
             'duration': duration,
             'uploader_url': uploader_url,
             'uploader_id': uploader_id,

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -367,7 +367,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'description': 'md5:a1dbf12d9a3bd7cb4c5e33b27d77ffe7'
             },
             'expected_warnings': [
-                'unable to download capture webpage \(it may not be archived\)'
+                r'unable to download capture webpage \(it may not be archived\)'
             ]
         },
         {
@@ -440,14 +440,11 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
     def _extract_metadata(self, video_id, webpage):
 
-        search_meta = ((lambda x: self._html_search_meta(x, webpage, default=None))
-                       if webpage else (lambda x: None))
+        search_meta = ((lambda x: self._html_search_meta(x, webpage, default=None)) if webpage else (lambda x: None))
         player_response = self._extract_yt_initial_variable(
-            webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE,
-            video_id, 'initial player response') or {}
+            webpage, self._YT_INITIAL_PLAYER_RESPONSE_RE, video_id, 'initial player response') or {}
         initial_data = self._extract_yt_initial_variable(
-            webpage, self._YT_INITIAL_DATA_RE,
-            video_id, 'initial player response') or {}
+            webpage, self._YT_INITIAL_DATA_RE, video_id, 'initial player response') or {}
 
         initial_data_video = traverse_obj(
             initial_data, ('contents', 'twoColumnWatchNextResults', 'results', 'results', 'contents', ..., 'videoPrimaryInfoRenderer'),
@@ -483,10 +480,9 @@ class YoutubeWebArchiveIE(InfoExtractor):
         upload_date = unified_strdate(
             dict_get(microformats, ('uploadDate', 'publishDate'))
             or search_meta(['uploadDate', 'datePublished'])
-            # https://github.com/ytdl-org/youtube-dl/blob/dc879c5a37dae588a5bb35d416635678356ad1b7/youtube_dl/extractor/youtube.py#L2202-L2205
             or self._search_regex(
                 [r'(?s)id="eow-date.*?>(.*?)</span>',
-                    r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],
+                 r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],  # 7998520
                 webpage, 'upload date', default=None))
 
         info = {

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -531,7 +531,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                  r'(?:id="watch-uploader-info".*?>.*?|["\']simpleText["\']\s*:\s*["\'])(?:Published|Uploaded|Streamed live|Started) on (.+?)[<"\']'],  # @7998520
                 webpage, 'upload date', default=None))
 
-        info = {
+        return {
             'title': video_title,
             'description': description,
             'upload_date': upload_date,
@@ -542,7 +542,6 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'uploader_url': uploader_url,
             'uploader_id': uploader_id,
         }
-        return info
 
     def _extract_thumbnails(self, video_id):
         try_all = 'thumbnails' in self._configuration_arg('checkall')

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -486,6 +486,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 if count < len(thumbnail_base_urls) - 1:
                     self.report_warning(
                         f'Did not find any thumbnails. Trying {ext} format from {server}.')
+        # TODO: deduplicate by ignoring host too
         self._remove_duplicate_formats(thumbnails)
         return thumbnails
 

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -401,6 +401,22 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'uploader_url': 'http://www.youtube.com/channel/UC7Jwj9fkrf1adN4fMmTkpug'
             }
         }, {
+            # player response contains '};' See: https://github.com/ytdl-org/youtube-dl/issues/27093
+            'url': 'https://web.archive.org/web/20200827003909if_/http://www.youtube.com/watch?v=6Dh-RL__uN4',
+            'info_dict': {
+                'id': '6Dh-RL__uN4',
+                'ext': 'mp4',
+                'title': 'bitch lasagna',
+                'upload_date': '20181005',
+                'channel_id': 'UC-lHJZR3Gqxm24_Vd_AJ5Yw',
+                'channel_url': 'http://www.youtube.com/channel/UC-lHJZR3Gqxm24_Vd_AJ5Yw',
+                'duration': 135,
+                'description': 'md5:2dbe4051feeff2dab5f41f82bb6d11d0',
+                'uploader': 'PewDiePie',
+                'uploader_id': 'PewDiePie',
+                'uploader_url': 'http://www.youtube.com/user/PewDiePie'
+            }
+        }, {
             'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
             'only_matching': True
         }, {
@@ -424,8 +440,8 @@ class YoutubeWebArchiveIE(InfoExtractor):
             'only_matching': True
         }
     ]
-    _YT_INITIAL_DATA_RE = r'(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s' % YoutubeIE._YT_INITIAL_DATA_RE
-    _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s' % YoutubeIE._YT_INITIAL_PLAYER_RESPONSE_RE
+    _YT_INITIAL_DATA_RE = r'(?:(?:(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;)|%s)' % YoutubeIE._YT_INITIAL_DATA_RE
+    _YT_INITIAL_PLAYER_RESPONSE_RE = r'(?:(?:(?:window\s*\[\s*["\']ytInitialPlayerResponse["\']\s*\]|ytInitialPlayerResponse)\s*=[(\s]*({.+?})[)\s]*;)|%s)' % YoutubeIE._YT_INITIAL_PLAYER_RESPONSE_RE
     _YT_INITIAL_BOUNDARY_RE = r'(?:(?:var\s+meta|</script|\n)|%s)' % YoutubeIE._YT_INITIAL_BOUNDARY_RE
 
     _YT_DEFAULT_THUMB_SERVERS = ['i.ytimg.com']  # thumbnails most likely archived on these servers

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -488,20 +488,10 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 )
                 if 'nobreakonfind' not in self._configuration_arg('thumbnails'):
                     break  # TODO: how to we decide to break early, and how many archived eps do we check?
-        self._remove_duplicate_thumbs(thumbnails)
-        return thumbnails
 
-    @staticmethod
-    def _remove_duplicate_thumbs(formats):
-        # we need to deduplicate by checking only the file & parameters, not the whole url
-        format_urls = set()
-        unique_formats = []
-        for f in formats:
-            # TODO
-            if f['url'].split('/')[-1] not in format_urls:
-                format_urls.add(f['url'])
-                unique_formats.append(f)
-        formats[:] = unique_formats
+        # TODO: deal with duplicate files from different servers?
+        self._remove_duplicate_formats(thumbnails)
+        return thumbnails
 
     def _extract_webpage_title(self, webpage):
         page_title = self._html_search_regex(

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -448,7 +448,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
     def _extract_webpage_title(self, webpage):
         page_title = self._html_search_regex(
             r'<title>([^<]*)</title>', webpage, 'title', default='')
-        # YouTube video pages appear to always have either 'YouTube -' as suffix or '- YouTube' as prefix.
+        # YouTube video pages appear to always have either 'YouTube -' as prefix or '- YouTube' as suffix.
         return self._html_search_regex(
             r'(?:YouTube\s*-\s*(.*)$)|(?:(.*)\s*-\s*YouTube$)',
             page_title, 'title', default='')
@@ -557,7 +557,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         if 'captures' in self._configuration_arg('checkall'):
             capture_dates.extend(modern_captures + all_captures)
 
-        # Fallbacks
+        # Fallbacks if any of the above fail
         capture_dates.extend([self._OLDEST_CAPTURE_DATE, self._NEWEST_CAPTURE_DATE])
         return orderedSet(capture_dates)
 
@@ -601,10 +601,10 @@ class YoutubeWebArchiveIE(InfoExtractor):
         if urlh:
             url = compat_urllib_parse_unquote(urlh.url)
             video_file_url_qs = parse_qs(url)
-            # Attempt to recover any ext & format info from playback url
+            # Attempt to recover any ext & format info from playback url & response headers
             format = {'url': url, 'filesize': int_or_none(urlh.headers.get('x-archive-orig-content-length'))}
             itag = try_get(video_file_url_qs, lambda x: x['itag'][0])
-            if itag and itag in YoutubeIE._formats:  # Naughty access but it works
+            if itag and itag in YoutubeIE._formats:
                 format.update(YoutubeIE._formats[itag])
                 format.update({'format_id': itag})
             else:

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -410,6 +410,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'width': int_or_none(thumbnail.get('width')),
             })
         # TODO: generate thumbnail urls?
+        # TODO: fix thumbnails
         channel_id = str_or_none(
             video_details.get('channelId')
             or microformats.get('externalChannelId')

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -16,6 +16,7 @@ from ..utils import (
     dict_get,
     extract_attributes,
     ExtractorError,
+    get_element_by_id,
     HEADRequest,
     int_or_none,
     KNOWN_EXTENSIONS,
@@ -303,7 +304,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         },
         {
             # Video from 2012, webm format itag 45. Newest capture is deleted video, with an invalid description.
-            # Should use the date in the link. Title ends with '- Youtube'.
+            # Should use the date in the link. Title ends with '- Youtube'. Capture has description in eow-description
             'url': 'https://web.archive.org/web/20120712231619/http://www.youtube.com/watch?v=AkhihxRKcrs&gl=US&hl=en',
             'info_dict': {
                 'id': 'AkhihxRKcrs',
@@ -311,8 +312,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'title': 'Limited Run: Mondo\'s Modern Classic 1 of 3 (SDCC 2012)',
                 'upload_date': '20120712',
                 'duration': 398,
-                'description': 'md5:ff4de6a7980cb65d951c2f6966a4f2f3'  # TODO: fix
-
+                'description': 'md5:ff4de6a7980cb65d951c2f6966a4f2f3'
             }
         },
         {
@@ -325,7 +325,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'upload_date': '20050423',  # TODO: uploader?
                 'channel_id': 'UC4QobU6STFB0P71PMvOGN5A',
                 'duration': 19,
-                'description': 'md5:56450c47046034c3a218d25cf2b52f4e'
+                'description': 'md5:10436b12e07ac43ff8df65287a56efb4'
             }
         },
         {
@@ -351,7 +351,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'upload_date': '20160218',
                 'channel_id': 'UCdIaNUarhzLSXGoItz7BHVA',
                 'duration': 1236,
-                'description': 'md5:TODO'  # TODO: fix description extraction
+                'description': 'md5:21032bae736421e89c2edf36d1936947'
             }
         },
         {
@@ -363,9 +363,12 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 'title': 'WTF: Video Games Still Launch BROKEN?! - T.U.G.S.',
                 'upload_date': '20160219',
                 'channel_id': 'UCdIaNUarhzLSXGoItz7BHVA',
-                'duration': '798',
-                'description': 'md5:TODO'
-            }
+                'duration': 798,
+                'description': 'md5:a1dbf12d9a3bd7cb4c5e33b27d77ffe7'
+            },
+            'expected_warnings': [
+                'unable to download capture webpage \(it may not be archived\)'
+            ]
         },
         {
             'url': 'https://web.archive.org/web/http://www.youtube.com/watch?v=kH-G_aIBlFw',
@@ -474,6 +477,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
         description = (
             video_details.get('shortDescription')
             or YoutubeIE._get_text(microformats, 'description')
+            or clean_html(get_element_by_id('eow-description', webpage))  # 9e6dd23
             or search_meta(['description', 'og:description', 'twitter:description']))
 
         upload_date = unified_strdate(
@@ -572,7 +576,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 continue
             webpage = self._download_webpage(
                 (self._WAYBACK_BASE_URL + 'http://www.youtube.com/watch?v=%s') % (capture, video_id),
-                video_id=video_id, fatal=False, errnote='unable to download video webpage (it may not be archived)',
+                video_id=video_id, fatal=False, errnote='unable to download capture webpage (it may not be archived)',
                 note='Downloading capture webpage')
             _info_dict = self._extract_metadata(video_id, webpage or '')
             # Try avoid getting deleted video metadata

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -485,7 +485,6 @@ class YoutubeWebArchiveIE(InfoExtractor):
                 webpage, 'upload date', default=None))
 
         info = {
-            'id': video_id,
             'title': video_title,
             'description': description,
             'upload_date': upload_date,
@@ -568,7 +567,7 @@ class YoutubeWebArchiveIE(InfoExtractor):
 
         capture_dates = self._get_capture_dates(video_id, int_or_none(url_date))
         self.write_debug('Captures to try: ' + ', '.join(str(i) for i in capture_dates if i is not None))
-        info = {}
+        info = {'id': video_id}
         for capture in capture_dates:
             if not capture:
                 continue


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
    - **a couple of the regexps used in metadata extraction are from old youtube-dl commits**

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

#### IMPROVEMENTS
- Improved metadata extraction 
    - currently best for polymer UI YouTube captures
    - Title extraction should be fairly stable across almost all YouTube versions
    - Extract `filesize` and `extension` from non-standard archive.org headers
        - `unknown_video` extension should no longer occur
- Get archived thumbnails using CDX API
- Smarter webpage capture downloading 
  - query CDX for only 200 OK response captures
  - Tries multiple captures until it gets an infodict with title
  - order: try oldest polymer UI capture, user provided capture date, oldest capture from CDX, oldest capture web archive redirects to, newest capture web archive redirects to
- New extractor arg: `check_all=captures,thumbnails`
  - `thumbnails` queries CDX API many more times to thumbnails archived under other youtube image servers.
  - `captures` adds all other captures dates returned by CDX API to the capture-try list
 - supports `--ignore-no-formats-error` to allow metadata extraction even if video is not archived

#### ISSUES
- For querying captures of a video watch page, CDX API does not provide captures with extra params in the URL
    - e.g. `http://www.youtube.com/watch?v=AkhihxRKcrs&gl=US&hl=en`
    - probably not much of a problem, still have the fallbacks or date in url given
- yt-dlp has no idea how to sort the thumbnails
    - we really only have `filesize` to work with
- De-duplicating thumbnails does not work if they were archived from different ytimg servers.
- filesize not shown when downloading
     - archive.org doesn't provide `content-length` header for the video files

#### TODO
- [X] Fix description extraction for some older versions of YouTube, if possible
- [X] Fix up error handling to ensure everything is non-fatal
- [X] Find and add more tests for edge cases
- [X] Move video file URL request to be first, so we don't have to check for metadata if not needed?