### PR TITLE
Fix Jamendo extractor by using _match_valid_url

### DIFF
--- a/yt_dlp/extractor/jamendo.py
+++ b/yt_dlp/extractor/jamendo.py
@@ -59,7 +59,7 @@ class JamendoIE(InfoExtractor):
             })[0]
 
     def _real_extract(self, url):
-        track_id, display_id = self._VALID_URL_RE.match(url).groups()
+        track_id, display_id = self._match_valid_url(url).groups()
         # webpage = self._download_webpage(
         #     'https://www.jamendo.com/track/' + track_id, track_id)
         # models = self._parse_json(self._html_search_regex(


### PR DESCRIPTION
Fixes #1857

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Extractors which don't define `_VALID_URL_RE` but only `_VALID_URL` shouldn't try to use it directly.
Instead they should use `_match_valid_url` which is a method defined in the common extractor class.