### PR TITLE
tv.line.me Cover art-thumbnail fix

### DIFF
--- a/yt_dlp/extractor/line.py
+++ b/yt_dlp/extractor/line.py
@@ -7,6 +7,7 @@ from ..compat import compat_str
 from ..utils import (
     int_or_none,
     js_to_json,
+    try_get,
     str_or_none,
 )
 
@@ -79,6 +80,10 @@ class LineTVIE(InfoExtractor):
             formats[0]['vcodec'] = 'none'
 
         title = self._og_search_title(webpage)
+        
+        # Cover art or thumbnail extraction
+        thumbnail = try_get(video_info, lambda x: x['meta']['cover']['source'])
+        thumbnail = thumbnail.split('?')[0] # Full Size Thumbnail
 
         # like_count requires an additional API request https://tv.line.me/api/likeit/getCount
 
@@ -88,8 +93,7 @@ class LineTVIE(InfoExtractor):
             'formats': formats,
             'extra_param_to_segment_url': extra_query[1:],
             'duration': duration,
-            'thumbnails': [{'url': thumbnail['source']}
-                           for thumbnail in video_info.get('thumbnails', {}).get('list', [])],
+            'thumbnail': thumbnail,
             'view_count': video_info.get('meta', {}).get('count'),
         }
 


### PR DESCRIPTION
Pull correct full size cover art or thumbnail image in

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pulls in the correct full size cover art for tv.line.me. I don't really have the knowledge needed to make use of Flake8