### PR TITLE
[CBC Gem] Support 1080p shows

### DIFF
--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -339,10 +339,10 @@ class CBCGemIE(InfoExtractor):
                 yield {
                     **base_format,
                     'format_id': join_nonempty('sec', height),
-                    'url': re.sub(r'(QualityLevels\()\d+(\))', fr'\1{bitrate}\2', base_url)
+                    'url': re.sub(r'(QualityLevels\()\d+(\))', fr'\1{bitrate}\2', base_url),
                     'width': int_or_none(video_quality.attrib.get('MaxWidth')),
                     'tbr': bitrate / 1000.0,
-                    'height': height
+                    'height': height,
                 }
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import copy
 import re
 import json
 import base64
@@ -12,11 +11,13 @@ from ..compat import (
     compat_str,
 )
 from ..utils import (
+    int_or_none,
+    join_nonempty,
     js_to_json,
-    smuggle_url,
-    try_get,
     orderedSet,
+    smuggle_url,
     strip_or_none,
+    try_get,
     ExtractorError,
 )
 
@@ -316,7 +317,7 @@ class CBCGemIE(InfoExtractor):
 
     def _find_secret_formats(self, formats, video_id):
         """ Find a valid video url and convert it to the secret variant """
-        base_format = next((f for f in formats if f.get('height')), None)
+        base_format = next((f for f in formats if f.get('vcodec') != 'none'), None)
         if not base_format:
             return
 
@@ -339,7 +340,7 @@ class CBCGemIE(InfoExtractor):
                 yield {
                     **base_format,
                     'format_id': join_nonempty('sec', height),
-                    'url': re.sub(r'(QualityLevels\()\d+(\))', fr'\1{bitrate}\2', base_url),
+                    'url': re.sub(r'(QualityLevels\()\d+(\))', fr'\<1>{bitrate}\2', base_url),
                     'width': int_or_none(video_quality.attrib.get('MaxWidth')),
                     'tbr': bitrate / 1000.0,
                     'height': height,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This adds a new check to pull out "secret" video formats such at 6Mb 1080p. The original video formats begin with `hls-` while the new ones begin with `sec-`. Here is sample output with the changes (requires a free CBC account and geolocation within Canada):

```
~ % yt-dlp "https://gem.cbc.ca/media/murdoch-mysteries/s01e01" --username '***' --password '***' -F
[gem.cbc.ca] murdoch-mysteries/s01e01: Downloading JSON metadata
[gem.cbc.ca] murdoch-mysteries/s01e01: Downloading JSON metadata
[gem.cbc.ca] murdoch-mysteries/s01e01: Downloading m3u8 information
[gem.cbc.ca] murdoch-mysteries/s01e01: Downloading secret XML
[info] Available formats for murdoch-mysteries/s01e01:
ID                              EXT RESOLUTION │   FILESIZE   TBR PROTO  │ VCODEC        VBR ACODEC     MORE INFO
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
hls-audio-English__Descriptive_ m4a            │                  m3u8_n │ audio only        mp4a.40.2  [eng] English (Descriptive)
hls-audio-English               m4a            │                  m3u8_n │ audio only        mp4a.40.2  [eng] English
sec-234-0                       mp4 416x234    │ ~ 32.34MiB   99k m3u8_n │ avc1.4d401f   99k video only
sec-234-1                       mp4 416x234    │ ~ 64.70MiB  199k m3u8_n │ avc1.4d401f  199k video only
sec-234-2                       mp4 416x234    │ ~129.39MiB  399k m3u8_n │ avc1.4d401f  399k video only
hls-621                         mp4 416x234    │ ~200.99MiB  621k m3u8_n │ avc1.42c00d  621k video only
sec-360-0                       mp4 640x360    │ ~194.09MiB  599k m3u8_n │ avc1.4d401f  599k video only
hls-825                         mp4 640x360    │ ~267.11MiB  825k m3u8_n │ avc1.42c01e  825k video only
sec-360-1                       mp4 640x360    │ ~320.33MiB  990k m3u8_n │ avc1.4d401f  990k video only
hls-1224                        mp4 640x360    │ ~396.13MiB 1224k m3u8_n │ avc1.42c01e 1224k video only
sec-540                         mp4 960x540    │ ~571.11MiB 1765k m3u8_n │ avc1.4d401f 1765k video only
hls-2016                        mp4 960x540    │ ~652.43MiB 2016k m3u8_n │ avc1.4d401f 2016k video only
sec-720-0                       mp4 1280x720   │ ~796.94MiB 2463k m3u8_n │ avc1.4d401f 2463k video only
hls-2730                        mp4 1280x720   │ ~883.22MiB 2730k m3u8_n │ avc1.4d401f 2730k video only
sec-720-1                       mp4 1280x720   │ ~  1.07GiB 3380k m3u8_n │ avc1.4d401f 3380k video only
hls-3667                        mp4 1280x720   │ ~  1.16GiB 3667k m3u8_n │ avc1.4d401f 3667k video only
sec-1080                        mp4 1920x1080  │ ~  1.88GiB 5939k m3u8_n │ avc1.4d401f 5939k video only
```

Feel free to make or suggest any changes - I just want to make my findings available to others