### PR TITLE
[skeb] add support for skeb.jp

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1315,6 +1315,7 @@ from .simplecast import (
 )
 from .sina import SinaIE
 from .sixplay import SixPlayIE
+from .skeb import SkebIE
 from .skyit import (
     SkyItPlayerIE,
     SkyItVideoIE,

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -59,6 +59,23 @@ class SkebIE(InfoExtractor):
             'vcodec': 'none',
             'abr': 128,
         },
+    }, {
+        'url': 'https://skeb.jp/@mollowmollow/works/6',
+        'info_dict': {
+            'id': '6',
+            'title': 'ヒロ。\n\n私のキャラク... by 諸々',
+            'descripion': 'md5:aa6cbf2ba320b50bce219632de195f07',
+            '_type': 'playlist',
+            'entries': [
+                {
+                'id': '486430',
+                'title': 'ヒロ。\n\n私のキャラク... by 諸々',
+                'descripion': 'md5:aa6cbf2ba320b50bce219632de195f07',
+            }, {
+                'id': '486431',
+                'title': 'ヒロ。\n\n私のキャラク... by 諸々',
+            }]
+        }
     }]
 
     def _real_extract(self, url):
@@ -118,13 +135,13 @@ class SkebIE(InfoExtractor):
         if not entries:
             raise ExtractorError('No video/audio attachment found in this commission.', expected=True)
         elif len(entries) == 1:
-            import json
-            entries[0]['a'] = 'dummyvalue'
-            print(json.dumps(entries[0]))
             return entries[0]
         else:
             parent.update({
-                '_type': 'multi_video',
+                '_type': 'playlist',
                 'entries': entries,
             })
+            import json
+            entries[0]['a'] = 'dummyvalue'
+            print(json.dumps(parent))
             return parent

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -17,7 +17,6 @@ class SkebIE(InfoExtractor):
             'id': video_id,
             'title': nuxt_data.get('title'),
             'descripion': nuxt_data.get('description'),
-            'reply': nuxt_data.get('thanks'),
             'uploader': traverse_obj(nuxt_data, ('creator', 'name')),
             'uploader_id': traverse_obj(nuxt_data, ('creator', 'screen_name')),
             'age_limit': 18 if nuxt_data.get('nsfw') else 0,

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -21,18 +21,43 @@ class SkebIE(InfoExtractor):
             'url': r're:https://skeb.+',
             'thumbnail': r're:https://skeb.+',
             'subtitles': {
-                'jpn': [
-                    {
-                        'url': r're:https://skeb.+',
-                        'ext': 'vtt'
-                    }
-                ]
+                'jpn': [{
+                    'url': r're:https://skeb.+',
+                    'ext': 'vtt'
+                }]
             },
             'width': 720,
             'height': 405,
             'duration': 313,
             'fps': 30,
             'ext': 'mp4',
+        },
+    }, {
+        'url': 'https://skeb.jp/@furukawa_nob/works/3',
+        'info_dict': {
+            'id': '489408',
+            'title': 'いつもお世話になってお... by 古川ノブ@音楽とVlo...',
+            'descripion': 'いつもお世話になっておりますきしをです。\n前回はステキなシチュボありがとう御座いました！\n\n今回は名指しで「おはようボイス」リクエストさせていただきます。\n\n・名指しNGでしたら、名指しなしでもOKです。\n・朝なかなか起きない相手を起こす。\n・仕事の日、遊びの日などシチュエーションはおまかせします。\n・尺は15秒〜30秒(オーバーでも大丈夫です)\n\n以上の内容でリクエストさせていただきます。\nご都合、ご内容問題御座いませんでしたら是非よろしくお願いいたします！',
+            'uploader': '古川ノブ@音楽とVlogのVtuber',
+            'uploader_id': 'furukawa_nob',
+            'age_limit': 0,
+            'tags': [
+                'よろしく', '大丈夫', 'お願い', 'でした',
+                '是非', 'O', 'バー', '遊び', 'おはよう',
+                'オーバ', 'ボイス',
+            ],
+            'url': r're:https://skeb.+',
+            'thumbnail': r're:https://skeb.+',
+            'subtitles': {
+                'jpn': [{
+                    'url': r're:https://skeb.+',
+                    'ext': 'vtt'
+                }]
+            },
+            'duration': 98,
+            'ext': 'mp3',
+            'vcodec': 'none',
+            'abr': 128,
         },
     }]
 
@@ -85,12 +110,17 @@ class SkebIE(InfoExtractor):
                 'duration': traverse_obj(item, ('information', 'duration')),
                 'fps': traverse_obj(item, ('information', 'frame_rate')),
                 'ext': preview_ext or given_ext,
-                'vcodec': 'none' if preview_ext == 'mp3' else None
+                'vcodec': 'none' if preview_ext == 'mp3' else None,
+                # you'll always get 128kbps MP3 for non-client viewers
+                'abr': 128 if preview_ext == 'mp3' else None,
             })
 
         if not entries:
-            raise ExtractorError('No video attachment found in this commission.', expected=True)
+            raise ExtractorError('No video/audio attachment found in this commission.', expected=True)
         elif len(entries) == 1:
+            import json
+            entries[0]['a'] = 'dummyvalue'
+            print(json.dumps(entries[0]))
             return entries[0]
         else:
             parent.update({

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -10,8 +10,7 @@ class SkebIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id)
-        nuxt_data = self._search_nuxt_data(webpage, video_id)
+        nuxt_data = self._search_nuxt_data(self._download_webpage(url, video_id), video_id)
 
         parent = {
             'id': video_id,

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -52,7 +52,6 @@ class SkebIE(InfoExtractor):
         if not entries:
             raise ExtractorError('No video attachment found in this commission.', expected=True)
         elif len(entries) == 1:
-            entries['id'] = parent['id']
             return entries[0]
         else:
             parent.update({

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -13,7 +13,7 @@ class SkebIE(InfoExtractor):
         'info_dict': {
             'id': '466853',
             'title': '内容はおまかせします！ by 姫ノ森りぃる@一周年',
-            'descripion': '内容はおまかせします！',
+            'descripion': 'md5:1ec50901efc3437cfbfe3790468d532d',
             'uploader': '姫ノ森りぃる@一周年',
             'uploader_id': 'riiru_wm',
             'age_limit': 0,
@@ -37,7 +37,7 @@ class SkebIE(InfoExtractor):
         'info_dict': {
             'id': '489408',
             'title': 'いつもお世話になってお... by 古川ノブ@音楽とVlo...',
-            'descripion': 'いつもお世話になっておりますきしをです。\n前回はステキなシチュボありがとう御座いました！\n\n今回は名指しで「おはようボイス」リクエストさせていただきます。\n\n・名指しNGでしたら、名指しなしでもOKです。\n・朝なかなか起きない相手を起こす。\n・仕事の日、遊びの日などシチュエーションはおまかせします。\n・尺は15秒〜30秒(オーバーでも大丈夫です)\n\n以上の内容でリクエストさせていただきます。\nご都合、ご内容問題御座いませんでしたら是非よろしくお願いいたします！',
+            'descripion': 'md5:5adc2e41d06d33b558bf7b1faeb7b9c2',
             'uploader': '古川ノブ@音楽とVlogのVtuber',
             'uploader_id': 'furukawa_nob',
             'age_limit': 0,

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -27,7 +27,7 @@ class SkebIE(InfoExtractor):
             vid_url = item.get('url')
             given_ext = traverse_obj(item, ('information', 'extension'))
             mimetype = ext2mimetype(given_ext)
-            if mimetype != 'image/gif' and mimetype.partition('/')[0] != 'video':
+            if mimetype != 'image/gif' and mimetype.partition('/')[0] != 'video' and not vid_url and not item.get('id'):
                 continue
             entries.append({
                 **parent,

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -66,8 +66,7 @@ class SkebIE(InfoExtractor):
             'title': 'ヒロ。\n\n私のキャラク... by 諸々',
             'descripion': 'md5:aa6cbf2ba320b50bce219632de195f07',
             '_type': 'playlist',
-            'entries': [
-                {
+            'entries': [{
                 'id': '486430',
                 'title': 'ヒロ。\n\n私のキャラク... by 諸々',
                 'descripion': 'md5:aa6cbf2ba320b50bce219632de195f07',
@@ -141,7 +140,4 @@ class SkebIE(InfoExtractor):
                 '_type': 'playlist',
                 'entries': entries,
             })
-            import json
-            entries[0]['a'] = 'dummyvalue'
-            print(json.dumps(parent))
             return parent

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import ExtractorError, determine_ext, ext2mimetype, traverse_obj
+from ..compat import compat_str
+
+
+class SkebIE(InfoExtractor):
+    _VALID_URL = r'https?://skeb\.jp/@[^/]+/works/(?P<id>\d+)'
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        nuxt_data = self._search_nuxt_data(webpage, video_id)
+
+        parent = {
+            'title': nuxt_data.get('title'),
+            'descripion': nuxt_data.get('description'),
+            'reply': nuxt_data.get('thanks'),
+            'uploader': traverse_obj(nuxt_data, ('creator', 'name')),
+            'uploader_id': traverse_obj(nuxt_data, ('creator', 'screen_name')),
+            'age_limit': 18 if nuxt_data.get('nsfw') else 0,
+            'tags': nuxt_data.get('tag_list'),
+        }
+
+        entries = []
+        for item in nuxt_data.get('previews') or []:
+            vid_url = item.get('url')
+            given_ext = traverse_obj(item, ('information', 'extension'))
+            mimetype = ext2mimetype(given_ext)
+            if mimetype != 'image/gif' and mimetype.partition('/')[0] != 'video':
+                continue
+            entries.append({
+                **parent,
+                'id': compat_str(item.get('id')),
+                'url': vid_url,
+                'thumbnail': item.get('poster_url'),
+                'subtitles': {
+                    'jpn': [{
+                        'url': item.get('vtt_url'),
+                        'ext': 'vtt',
+                    }]
+                } if item.get('vtt_url') else None,
+                'width': traverse_obj(item, ('information', 'width')),
+                'height': traverse_obj(item, ('information', 'height')),
+                'duration': traverse_obj(item, ('information', 'duration')),
+                'filesize': traverse_obj(item, ('information', 'byte_size')),
+                'fps': traverse_obj(item, ('information', 'frame_rate')),
+                'ext': determine_ext(vid_url) or given_ext,
+            })
+
+        if not entries:
+            raise ExtractorError('No video attachment found in this commission.', expected=True)
+        elif len(entries) == 1:
+            entries['id'] = parent['id']
+            return entries[0]
+        else:
+            parent.update({
+                '_type': 'multi_video',
+                'entries': entries,
+            })
+            return parent

--- a/yt_dlp/extractor/skeb.py
+++ b/yt_dlp/extractor/skeb.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from ..utils import ExtractorError, determine_ext, ext2mimetype, traverse_obj
-from ..compat import compat_str
 
 
 class SkebIE(InfoExtractor):
@@ -15,6 +14,7 @@ class SkebIE(InfoExtractor):
         nuxt_data = self._search_nuxt_data(webpage, video_id)
 
         parent = {
+            'id': video_id,
             'title': nuxt_data.get('title'),
             'descripion': nuxt_data.get('description'),
             'reply': nuxt_data.get('thanks'),
@@ -33,7 +33,7 @@ class SkebIE(InfoExtractor):
                 continue
             entries.append({
                 **parent,
-                'id': compat_str(item.get('id')),
+                'id': str(item['id']),
                 'url': vid_url,
                 'thumbnail': item.get('poster_url'),
                 'subtitles': {

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -38,6 +38,7 @@ import time
 import traceback
 import xml.etree.ElementTree
 import zlib
+import mimetypes
 
 from .compat import (
     compat_HTMLParseError,
@@ -4713,6 +4714,14 @@ def mimetype2ext(mt):
         return ext
 
     return subtype.replace('+', '.')
+
+
+def ext2mimetype(ext_or_url):
+    if not ext_or_url:
+        return None
+    if '.' not in ext_or_url:
+        ext_or_url = f'file.{ext_or_url}'
+    return mimetypes.guess_type(ext_or_url)[0]
 
 
 def parse_codecs(codecs_str):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR adds support for skeb.jp. Not geo-restricted maybe.

> skeb.jp is a middleman to commission artists for pictures, voice works, animations, etc. 

the above quote is from, and partially closes https://github.com/ytdl-org/youtube-dl/issues/30287