### PR TITLE
Updated fujitv.py on extracting 1080P stream from tv_android m3u8

### DIFF
--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -18,7 +18,7 @@ class FujiTVFODPlus7IE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         formats = self._extract_m3u8_formats(
-            self._BASE_URL + 'abr/android_tv/%s.m3u8' % video_id, video_id, 'mp4')
+            self._BASE_URL + 'abr/tv_android/%s.m3u8' % video_id, video_id, 'mp4')
         for f in formats:
             wh = self._BITRATE_MAP.get(f.get('tbr'))
             if wh:

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -27,6 +27,89 @@ class FujiTVFODPlus7IE(InfoExtractor):
                     'height': wh[1],
                 })
         self._sort_formats(formats)
+        print(formats)
+
+        _TESTS = [{
+            'url': 'https://fod.fujitv.co.jp/title/5d40/5d40810075',
+            'info_dict': {
+                'id': '5d40810075',
+                'ext': 'mp4',
+                'formats': [
+                    {
+                        'format_id': '800',
+                        'format_index': None,
+                        'url': 'https://fod-plus7.hls.wseod.stream.ne.jp/www08/fod-plus7/_definst_/mp4:video/56789/5d40/5d40810075me111e991.mp4/chunklist.m3u8',
+                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_us7.hls.wseod.stream.ne.jp/www08/fod-plus7/_definst_/mp4:video/56789/5d40/5d40810075me111e991.mp4/chunklist.m3u8', 'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
+                        'tbr': 800.0,
+                        'ext': 'mp4',
+                        'fps': None,
+                        'protocol': 'm3u8_native',
+                        'preference': None,
+                        'quality': None,
+                        'width': 640,
+                        'height': 360,
+                        'video_ext': 'mp4',
+                        'audio_ext': 'none',
+                        'vbr': 800.0,
+                        'abr': 0.0,
+                    },
+                    {
+                        'format_id': '4000',
+                        'format_index': None,
+                        'url': 'https://fod-plus7-high.hls.wseod.stream.ne.jp/www08/fod-plus7-high/_definst_/mp4:video/56789/5d40/5d40810075me112e991.mp4/chunklist.m3u8',
+                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
+                        'tbr': 1200.0,
+                        'ext': 'mp4',
+                        'fps': None,
+                        'protocol': 'm3u8_native',
+                        'preference': None,
+                        'quality': None,
+                        'width': 1280,
+                        'height': 720,
+                        'video_ext': 'mp4',
+                        'audio_ext': 'none',
+                        'vbr': 1200.0,
+                        'abr': 0.0
+                    },
+                    {
+                        'format_id': '2000',
+                        'format_index': None,
+                        'url': 'https://fod-plus7-high.hls.wseod.stream.ne.jp/www08/fod-plus7-high/_definst_/mp4:video/56789/5d40/5d40810075me113e991.mp4/chunklist.m3u8',
+                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
+                        'tbr': 2000.0,
+                        'ext': 'mp4',
+                        'fps': None,
+                        'protocol': 'm3u8_native',
+                        'preference': None,
+                        'quality': None,
+                        'width': 1280,
+                        'height': 720,
+                        'video_ext': 'mp4',
+                        'audio_ext': 'none',
+                        'vbr': 4000.0,
+                        'abr': 0.0
+                    },
+                    {
+                        'format_id': '4000',
+                        'format_index': None,
+                        'url': 'https://fod-plus7-high.hls.wseod.stream.ne.jp/www08/fod-plus7-high/_definst_/mp4:video/56789/5d40/5d40810075me115e991.mp4/chunklist.m3u8',
+                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
+                        'tbr': 4000.0,
+                        'ext': 'mp4',
+                        'fps': None,
+                        'protocol': 'm3u8_native',
+                        'preference': None,
+                        'quality': None,
+                        'width': 1920,
+                        'height': 1080,
+                        'video_ext': 'mp4',
+                        'audio_ext': 'none',
+                        'vbr': 4000.0,
+                        'abr': 0.0
+                    }],
+                'thumbnail': self._BASE_URL + 'pc/image/wbtn/wbtn_%s.jpg' % video_id,
+            }
+        }]
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -5,7 +5,7 @@ from .common import InfoExtractor
 
 
 class FujiTVFODPlus7IE(InfoExtractor):
-    _VALID_URL = r'https?://i\.fod\.fujitv\.co\.jp/plus7/web/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
+    _VALID_URL = r'https?://fod\.fujitv\.co\.jp/title/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
     _BASE_URL = 'http://i.fod.fujitv.co.jp/'
     _BITRATE_MAP = {
         300: (320, 180),

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -12,12 +12,13 @@ class FujiTVFODPlus7IE(InfoExtractor):
         800: (640, 360),
         1200: (1280, 720),
         2000: (1280, 720),
+        4000: (1920, 1080),
     }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         formats = self._extract_m3u8_formats(
-            self._BASE_URL + 'abr/pc_html5/%s.m3u8' % video_id, video_id, 'mp4')
+            self._BASE_URL + 'abr/android_tv/%s.m3u8' % video_id, video_id, 'mp4')
         for f in formats:
             wh = self._BITRATE_MAP.get(f.get('tbr'))
             if wh:

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -15,6 +15,18 @@ class FujiTVFODPlus7IE(InfoExtractor):
         4000: (1920, 1080),
     }
 
+    _TESTS = [{
+        'url': 'https://fod.fujitv.co.jp/title/5d40/5d40810075',
+        'info_dict': {
+            'id': '5d40810075',
+            'title': '5d40810075',
+            'ext': 'mp4',
+            'format_id': '4000',
+            'thumbnail': 'http://i.fod.fujitv.co.jp/pc/image/wbtn/wbtn_5d40810075.jpg'
+        },
+        'skip': 'Expires after a week'
+    }]
+
     def _real_extract(self, url):
         video_id = self._match_id(url)
         formats = self._extract_m3u8_formats(
@@ -27,89 +39,6 @@ class FujiTVFODPlus7IE(InfoExtractor):
                     'height': wh[1],
                 })
         self._sort_formats(formats)
-        print(formats)
-
-        _TESTS = [{
-            'url': 'https://fod.fujitv.co.jp/title/5d40/5d40810075',
-            'info_dict': {
-                'id': '5d40810075',
-                'ext': 'mp4',
-                'formats': [
-                    {
-                        'format_id': '800',
-                        'format_index': None,
-                        'url': 'https://fod-plus7.hls.wseod.stream.ne.jp/www08/fod-plus7/_definst_/mp4:video/56789/5d40/5d40810075me111e991.mp4/chunklist.m3u8',
-                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_us7.hls.wseod.stream.ne.jp/www08/fod-plus7/_definst_/mp4:video/56789/5d40/5d40810075me111e991.mp4/chunklist.m3u8', 'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
-                        'tbr': 800.0,
-                        'ext': 'mp4',
-                        'fps': None,
-                        'protocol': 'm3u8_native',
-                        'preference': None,
-                        'quality': None,
-                        'width': 640,
-                        'height': 360,
-                        'video_ext': 'mp4',
-                        'audio_ext': 'none',
-                        'vbr': 800.0,
-                        'abr': 0.0,
-                    },
-                    {
-                        'format_id': '4000',
-                        'format_index': None,
-                        'url': 'https://fod-plus7-high.hls.wseod.stream.ne.jp/www08/fod-plus7-high/_definst_/mp4:video/56789/5d40/5d40810075me112e991.mp4/chunklist.m3u8',
-                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
-                        'tbr': 1200.0,
-                        'ext': 'mp4',
-                        'fps': None,
-                        'protocol': 'm3u8_native',
-                        'preference': None,
-                        'quality': None,
-                        'width': 1280,
-                        'height': 720,
-                        'video_ext': 'mp4',
-                        'audio_ext': 'none',
-                        'vbr': 1200.0,
-                        'abr': 0.0
-                    },
-                    {
-                        'format_id': '2000',
-                        'format_index': None,
-                        'url': 'https://fod-plus7-high.hls.wseod.stream.ne.jp/www08/fod-plus7-high/_definst_/mp4:video/56789/5d40/5d40810075me113e991.mp4/chunklist.m3u8',
-                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
-                        'tbr': 2000.0,
-                        'ext': 'mp4',
-                        'fps': None,
-                        'protocol': 'm3u8_native',
-                        'preference': None,
-                        'quality': None,
-                        'width': 1280,
-                        'height': 720,
-                        'video_ext': 'mp4',
-                        'audio_ext': 'none',
-                        'vbr': 4000.0,
-                        'abr': 0.0
-                    },
-                    {
-                        'format_id': '4000',
-                        'format_index': None,
-                        'url': 'https://fod-plus7-high.hls.wseod.stream.ne.jp/www08/fod-plus7-high/_definst_/mp4:video/56789/5d40/5d40810075me115e991.mp4/chunklist.m3u8',
-                        'manifest_url': 'http://i.fod.fujitv.co.jp/abr/tv_android/5d40810075.m3u8',
-                        'tbr': 4000.0,
-                        'ext': 'mp4',
-                        'fps': None,
-                        'protocol': 'm3u8_native',
-                        'preference': None,
-                        'quality': None,
-                        'width': 1920,
-                        'height': 1080,
-                        'video_ext': 'mp4',
-                        'audio_ext': 'none',
-                        'vbr': 4000.0,
-                        'abr': 0.0
-                    }],
-                'thumbnail': self._BASE_URL + 'pc/image/wbtn/wbtn_%s.jpg' % video_id,
-            }
-        }]
 
         return {
             'id': video_id,


### PR DESCRIPTION
getting high resolution from android tv stream

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

fixes for fuji FOD and updated that it can extract 1080 stream from that
