### PR TITLE
[TVer/brightcove]added support for higher resolution thumbnail extraction

### DIFF
--- a/yt_dlp/extractor/brightcove.py
+++ b/yt_dlp/extractor/brightcove.py
@@ -577,27 +577,20 @@ class BrightcoveNewIE(AdobePassIE):
         if duration is not None and duration <= 0:
             is_live = True
 
-        common_res = ["160x90", "320x180", "480x270", "640x360", "768x432", "1024x576", "1280x720", "1366x768", "1920x1080"]
-        thumbnails = []
-        if '640x360' in json_data.get('poster'):
-            base_url = json_data.get('poster')
-            replace = '640x360'
-        else:
-            base_url = json_data.get('thumbnail')
-            replace = '160x90'
-        for res in common_res:
-            thumbnails.append({
-                'url': base_url.replace(replace, res),
-                'width': int(res.split('x')[0]),
-                'height': int(res.split('x')[1]),
-                'preference': len(thumbnails)
-            })
+        common_res = [(160, 90), (320, 180), (480, 720), (640, 360), (768, 432), (1024, 576), (1280, 720), (1366, 768), (1920, 1080)]
+        thumb_base_url = dict_get(json_data, ('poster', 'thumbnail')
+        thumbnails = [{
+            'url': re.sub(r'\d+x\d+', f'{w}x{h}', thumb_base_url), 
+            'width': w,
+            'height': h,
+        } for w, h in common_res] if thumb_base_url else None
             
         return {
             'id': video_id,
             'title': self._live_title(title) if is_live else title,
             'description': clean_html(json_data.get('description')),
             'thumbnail': json_data.get('thumbnail') or json_data.get('poster'),
+            'thumbnials': thumbnails,
             'duration': duration,
             'timestamp': parse_iso8601(json_data.get('published_at')),
             'uploader_id': json_data.get('account_id'),

--- a/yt_dlp/extractor/brightcove.py
+++ b/yt_dlp/extractor/brightcove.py
@@ -16,6 +16,7 @@ from ..compat import (
 )
 from ..utils import (
     clean_html,
+    dict_get,
     extract_attributes,
     ExtractorError,
     find_xpath_attr,
@@ -578,7 +579,7 @@ class BrightcoveNewIE(AdobePassIE):
             is_live = True
 
         common_res = [(160, 90), (320, 180), (480, 720), (640, 360), (768, 432), (1024, 576), (1280, 720), (1366, 768), (1920, 1080)]
-        thumb_base_url = dict_get(json_data, ('poster', 'thumbnail')
+        thumb_base_url = dict_get(json_data, ('poster', 'thumbnail'))
         thumbnails = [{
             'url': re.sub(r'\d+x\d+', f'{w}x{h}', thumb_base_url), 
             'width': w,

--- a/yt_dlp/extractor/brightcove.py
+++ b/yt_dlp/extractor/brightcove.py
@@ -577,6 +577,22 @@ class BrightcoveNewIE(AdobePassIE):
         if duration is not None and duration <= 0:
             is_live = True
 
+        common_res = ["160x90", "320x180", "480x270", "640x360", "768x432", "1024x576", "1280x720", "1366x768", "1920x1080"]
+        thumbnails = []
+        if '640x360' in json_data.get('poster'):
+            base_url = json_data.get('poster')
+            replace = '640x360'
+        else:
+            base_url = json_data.get('thumbnail')
+            replace = '160x90'
+        for res in common_res:
+            thumbnails.append({
+                'url': base_url.replace(replace, res),
+                'width': int(res.split('x')[0]),
+                'height': int(res.split('x')[1]),
+                'preference': len(thumbnails)
+            })
+            
         return {
             'id': video_id,
             'title': self._live_title(title) if is_live else title,

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -5,19 +5,19 @@ from .common import InfoExtractor
 
 
 class FujiTVFODPlus7IE(InfoExtractor):
-    _VALID_URL = r'https?://fod\.fujitv\.co\.jp/title/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
+    _VALID_URL = r'https?://i\.fod\.fujitv\.co\.jp/title/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
     _BASE_URL = 'http://i.fod.fujitv.co.jp/'
     _BITRATE_MAP = {
+        300: (320, 180),
         800: (640, 360),
         1200: (1280, 720),
         2000: (1280, 720),
-        4000: (1920, 1080),
     }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         formats = self._extract_m3u8_formats(
-            self._BASE_URL + 'abr/tv_android/%s.m3u8' % video_id, video_id, 'mp4')
+            self._BASE_URL + 'abr/pc_html5/%s.m3u8' % video_id, video_id, 'mp4')
         for f in formats:
             wh = self._BITRATE_MAP.get(f.get('tbr'))
             if wh:

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -5,7 +5,7 @@ from .common import InfoExtractor
 
 
 class FujiTVFODPlus7IE(InfoExtractor):
-    _VALID_URL = r'https?://i\.fod\.fujitv\.co\.jp/title/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
+    _VALID_URL = r'https?://i\.fod\.fujitv\.co\.jp/plus7/web/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
     _BASE_URL = 'http://i.fod.fujitv.co.jp/'
     _BITRATE_MAP = {
         300: (320, 180),

--- a/yt_dlp/extractor/fujitv.py
+++ b/yt_dlp/extractor/fujitv.py
@@ -5,19 +5,19 @@ from .common import InfoExtractor
 
 
 class FujiTVFODPlus7IE(InfoExtractor):
-    _VALID_URL = r'https?://i\.fod\.fujitv\.co\.jp/plus7/web/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
+    _VALID_URL = r'https?://fod\.fujitv\.co\.jp/title/[0-9a-z]{4}/(?P<id>[0-9a-z]+)'
     _BASE_URL = 'http://i.fod.fujitv.co.jp/'
     _BITRATE_MAP = {
-        300: (320, 180),
         800: (640, 360),
         1200: (1280, 720),
         2000: (1280, 720),
+        4000: (1920, 1080),
     }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         formats = self._extract_m3u8_formats(
-            self._BASE_URL + 'abr/pc_html5/%s.m3u8' % video_id, video_id, 'mp4')
+            self._BASE_URL + 'abr/tv_android/%s.m3u8' % video_id, video_id, 'mp4')
         for f in formats:
             wh = self._BITRATE_MAP.get(f.get('tbr'))
             if wh:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

added support for higher resolution thumbnail extraction for Tver (not sure for other sites that use this)
