### PR TITLE
[ok.ru] add mobile fallback

### DIFF
--- a/yt_dlp/extractor/odnoklassniki.py
+++ b/yt_dlp/extractor/odnoklassniki.py
@@ -294,7 +294,6 @@ class OdnoklassnikiIE(InfoExtractor):
             note='Downloading mobile webpage')
 
         error = self._search_regex(
-            # popular] video</a><div class="empty">[reason in russian]</div>
             r'видео</a>\s*<div\s+class="empty">(.+?)</div>',
             webpage, 'error', default=None)
         if error:

--- a/yt_dlp/extractor/odnoklassniki.py
+++ b/yt_dlp/extractor/odnoklassniki.py
@@ -12,6 +12,7 @@ from ..compat import (
 )
 from ..utils import (
     ExtractorError,
+    float_or_none,
     unified_strdate,
     int_or_none,
     qualities,
@@ -97,6 +98,14 @@ class OdnoklassnikiIE(InfoExtractor):
         },
         'skip': 'Video has not been found',
     }, {
+        'note': 'Only available in mobile webpage',
+        'url': 'https://m.ok.ru/video/2361249957145',
+        'info_dict': {
+            'id': '2361249957145',
+            'title': 'Быковское крещение',
+            'duration': 3038.181,
+        },
+    }, {
         'url': 'http://ok.ru/web-api/video/moviePlayer/20079905452',
         'only_matching': True,
     }, {
@@ -131,13 +140,24 @@ class OdnoklassnikiIE(InfoExtractor):
             return mobj.group('url')
 
     def _real_extract(self, url):
+        try:
+            return self._extract_desktop(url)
+        except ExtractorError as e:
+            try:
+                return self._extract_mobile(url)
+            except ExtractorError:
+                # error message of desktop webpage is in English
+                raise e
+
+    def _extract_desktop(self, url):
         start_time = int_or_none(compat_parse_qs(
             compat_urllib_parse_urlparse(url).query).get('fromTime', [None])[0])
 
         video_id = self._match_id(url)
 
         webpage = self._download_webpage(
-            'http://ok.ru/video/%s' % video_id, video_id)
+            'http://ok.ru/video/%s' % video_id, video_id,
+            note='Downloading desktop webpage')
 
         error = self._search_regex(
             r'[^>]+class="vp_video_stub_txt"[^>]*>([^<]+)<',
@@ -265,3 +285,33 @@ class OdnoklassnikiIE(InfoExtractor):
 
         info['formats'] = formats
         return info
+
+    def _extract_mobile(self, url):
+        video_id = self._match_id(url)
+
+        webpage = self._download_webpage(
+            'http://m.ok.ru/video/%s' % video_id, video_id,
+            note='Downloading mobile webpage')
+
+        error = self._search_regex(
+            # popular] video</a><div class="empty">[reason in russian]</div>
+            r'видео</a>\s*<div\s+class="empty">(.+?)</div>',
+            webpage, 'error', default=None)
+        if error:
+            raise ExtractorError(error, expected=True)
+
+        json_data = self._search_regex(
+            r'data-video="(.+?)"', webpage, 'json data')
+        json_data = self._parse_json(unescapeHTML(json_data), video_id) or {}
+
+        return {
+            'id': video_id,
+            'title': json_data.get('videoName'),
+            'duration': float_or_none(json_data.get('videoDuration'), scale=1000),
+            'thumbnail': json_data.get('videoPosterSrc'),
+            'formats': [{
+                'format_id': 'mobile',
+                'url': json_data.get('videoSrc'),
+                'ext': 'mp4',
+            }]
+        }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some videos in Odnoklassniki only available in mobile website.
This adds fallback for the extractor to extract from mobile webpage, in case of PC webpage says not found.

Test case attached.

(note: not related to issue 1971)