### PR TITLE
[extractor/megatvcom] Add new extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1326,6 +1326,10 @@ from .glomex import (
     GlomexIE,
     GlomexEmbedIE,
 )
+from .megatvcom import (
+    MegaTVComIE,
+    MegaTVComEmbedIE,
+)
 from .rutv import RUTVIE
 from .ruutu import RuutuIE
 from .ruv import RuvIE

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -3486,7 +3486,7 @@ class GenericIE(InfoExtractor):
                 glomex_urls, video_id, video_title, ie=GlomexEmbedIE.ie_key())
 
         # Look for megatv.com embeds
-        megatvcom_urls = list(MegaTVComEmbedIE._extract_urls(webpage, url))
+        megatvcom_urls = list(MegaTVComEmbedIE._extract_urls(webpage))
         if megatvcom_urls:
             return self.playlist_from_matches(
                 megatvcom_urls, video_id, video_title, ie=MegaTVComEmbedIE.ie_key())

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -102,6 +102,7 @@ from .arte import ArteTVEmbedIE
 from .videopress import VideoPressIE
 from .rutube import RutubeIE
 from .glomex import GlomexEmbedIE
+from .megatvcom import MegaTVComEmbedIE
 from .limelight import LimelightBaseIE
 from .anvato import AnvatoIE
 from .washingtonpost import WashingtonPostIE
@@ -3483,6 +3484,12 @@ class GenericIE(InfoExtractor):
         if glomex_urls:
             return self.playlist_from_matches(
                 glomex_urls, video_id, video_title, ie=GlomexEmbedIE.ie_key())
+
+        # Look for megatv.com embeds
+        megatvcom_urls = list(MegaTVComEmbedIE._extract_urls(webpage, url))
+        if megatvcom_urls:
+            return self.playlist_from_matches(
+                megatvcom_urls, video_id, video_title, ie=MegaTVComEmbedIE.ie_key())
 
         # Look for WashingtonPost embeds
         wapo_urls = WashingtonPostIE._extract_urls(webpage)

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -1,0 +1,202 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+from urllib.parse import (
+    parse_qs,
+    urlparse,
+)
+
+from .common import InfoExtractor
+from ..compat import (
+    compat_str,
+)
+from ..utils import (
+    clean_html,
+    determine_ext,
+    ExtractorError,
+    extract_attributes,
+    get_element_by_class,
+    HEADRequest,
+    unescapeHTML,
+    unified_timestamp,
+)
+
+
+class MegaTVComBaseIE(InfoExtractor):
+    _PLAYER_DIV_ID = 'player_div_id'
+
+    def _extract_player_attrs(self, webpage):
+        PLAYER_DIV_RE = r'''(?x)
+        <div(?:
+            id=(?P<_q1>["'])(?P<%(pdi)s>%(pdi)s)(?P=_q1)|
+            [^>]*?
+        )+>
+        ''' % {'pdi': self._PLAYER_DIV_ID}
+        for mobj in re.finditer(PLAYER_DIV_RE, webpage):
+            if mobj.group(self._PLAYER_DIV_ID):
+                player_el = mobj.group(0)
+                break
+        else:
+            raise ExtractorError('no <div id="%s"> element found in webpage' %
+                                 self._PLAYER_DIV_ID)
+        return {
+            re.sub(r'^data-(?:kwik_)?', '', k): v
+            for k, v in extract_attributes(player_el).items()
+            if k not in ('id',)
+        }
+
+
+class MegaTVComIE(MegaTVComBaseIE):
+    IE_NAME = 'megatvcom'
+    IE_DESC = 'megatv.com videos'
+    _VALID_URL = r'https?://(?:www\.)?megatv\.com/(?:(?!\d{4})[^/]+/(?P<id>\d+)/[^/]+|\d{4}/\d{2}/\d{2}/.+)'
+
+    _TESTS = [{
+        'url': 'https://www.megatv.com/2021/10/23/egkainia-gia-ti-nea-skini-omega-tou-dimotikou-theatrou-peiraia/',
+        'md5': '2ebe96661cb81854889053cebb661068',
+        'info_dict': {
+            'id': '520979',
+            'ext': 'mp4',
+            'title': 'md5:70eef71a9cd2c1ecff7ee428354dded2',
+            'description': 'md5:0209fa8d318128569c0d256a5c404db1',
+            'timestamp': 1634975747,
+            'upload_date': '20211023',
+        },
+    }, {
+        'url': 'https://www.megatv.com/tvshows/527800/epeisodio-65-12/',
+        'md5': '8ab0c9d664cea11678670202b87bb2b1',
+        'info_dict': {
+            'id': '527800',
+            'ext': 'mp4',
+            'title': 'md5:fc322cb51f682eecfe2f54cd5ab3a157',
+            'description': 'md5:b2b7ed3690a78f2a0156eb790fdc00df',
+            'timestamp': 1636048859,
+            'upload_date': '20211104',
+        },
+    }]
+
+    def _match_article_id(self, webpage):
+        ART_RE = r'''(?x)
+        <article(?:
+            id=(?P<_q2>["'])Article_(?P<article>\d+)(?P=_q2)|
+            [^>]*?
+        )+>
+        '''
+        return compat_str(self._search_regex(ART_RE, webpage, 'article_id',
+                                             group='article'))
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        _is_article = video_id == 'None'
+        webpage = self._download_webpage(url,
+                                         'N/A' if _is_article else
+                                         video_id)
+        if _is_article:
+            video_id = self._match_article_id(webpage)
+        player_attrs = self._extract_player_attrs(webpage)
+        title = player_attrs.get('label') or self._og_search_title(webpage)
+        description = clean_html(get_element_by_class(
+            'article-wrapper' if _is_article else 'story_content',
+            webpage))
+        if not description:
+            description = self._og_search_description(webpage)
+        thumbnail = player_attrs.get('image') or \
+            self._og_search_thumbnail(webpage)
+        timestamp = unified_timestamp(self._html_search_meta(
+            'article:published_time', webpage))
+        try:
+            source = player_attrs['source']
+        except KeyError:
+            raise ExtractorError('no source found for %s' % video_id)
+        formats = self._extract_m3u8_formats(source, video_id, 'mp4') \
+            if determine_ext(source) == 'm3u8' else [source]
+        self._sort_formats(formats)
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'thumbnail': thumbnail,
+            'timestamp': timestamp,
+            'formats': formats,
+        }
+
+
+class MegaTVComEmbedIE(MegaTVComBaseIE):
+    IE_NAME = 'megatvcom:embed'
+    IE_DESC = 'megatv.com embedded videos'
+    _VALID_URL = r'https?://(?:www\.)?megatv\.com/embed/?\?p=\d+'
+
+    _TESTS = [{
+        'url': 'https://www.megatv.com/embed/?p=2020520979',
+        'md5': '2ebe96661cb81854889053cebb661068',
+        'info_dict': {
+            'id': '520979',
+            'ext': 'mp4',
+            'title': 'md5:70eef71a9cd2c1ecff7ee428354dded2',
+            'description': 'md5:0209fa8d318128569c0d256a5c404db1',
+            'timestamp': 1634975747,
+            'upload_date': '20211023',
+        },
+    }, {
+        'url': 'https://www.megatv.com/embed/?p=2020534081',
+        'md5': 'f9a15e315acbf01b128e8efa3f75aab3',
+        'info_dict': {
+            'id': '534081',
+            'ext': 'mp4',
+            'title': 'md5:062e9d5976ef854d8bdc1f5724d9b2d0',
+            'description': 'md5:36dbe4c3762d2ede9513eea8d07f6d52',
+            'timestamp': 1636376351,
+            'upload_date': '20211108',
+        },
+    }]
+
+    @classmethod
+    def _extract_urls(cls, webpage, origin_url=None):
+        # make the scheme in _VALID_URL optional
+        _URL_RE = r'(?:https?:)?//' + cls._VALID_URL.split('://', 1)[1]
+        EMBED_RE = r'''(?x)
+            <iframe[^>]+?src=(?P<_q1>%(quot_re)s)
+                (?P<url>%(url_re)s)(?P=_q1)
+        ''' % {'quot_re': r'["\']', 'url_re': _URL_RE}
+        for mobj in re.finditer(EMBED_RE, webpage):
+            url = unescapeHTML(mobj.group('url'))
+            if url.startswith('//'):
+                scheme = urlparse(origin_url).scheme if origin_url else 'https'
+                url = '%s:%s' % (scheme, url)
+            yield url
+
+    def _match_canonical_url(self, webpage):
+        LINK_RE = r'''(?x)
+        <link(?:
+            rel=(?P<_q1>%(quot_re)s)(?P<canonical>canonical)(?P=_q1)|
+            href=(?P<_q2>%(quot_re)s)(?P<href>(?:(?!(?P=_q2)).)+)(?P=_q2)|
+            [^>]*?
+        )+>
+        ''' % {'quot_re': r'["\']'}
+        for mobj in re.finditer(LINK_RE, webpage):
+            canonical, href = mobj.group('canonical', 'href')
+            if canonical and href:
+                return unescapeHTML(href)
+
+    def _real_extract(self, url):
+        webpage = self._download_webpage(url, 'N/A')
+        player_attrs = self._extract_player_attrs(webpage)
+        canonical_url = player_attrs.get('share_url') or \
+            self._match_canonical_url(webpage)
+        if not canonical_url:
+            raise ExtractorError('canonical URL not found')
+        video_id = parse_qs(urlparse(canonical_url).query)['p'][0]
+
+        # Resolve the canonical URL, following redirects, and defer to
+        # megatvcom, as the metadata extracted from the embeddable page some
+        # times are slightly different, for the same video
+        canonical_url = self._request_webpage(
+            HEADRequest(canonical_url), video_id,
+            note='Resolve canonical URL',
+            errnote='Could not resolve canonical URL').geturl()
+        return self.url_result(
+            canonical_url,
+            MegaTVComIE.ie_key(),
+            video_id
+        )

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -72,9 +72,10 @@ class MegaTVComIE(MegaTVComBaseIE):
                 r'<article[^>]*\sid=["\']Article_(\d+)["\']', webpage, 'article id')
         player_attrs = self._extract_player_attrs(webpage)
         title = player_attrs.get('label') or self._og_search_title(webpage)
-        description = clean_html(get_element_by_class(
+        description = get_element_by_class(
             'article-wrapper' if _is_article else 'story_content',
-            webpage))
+            webpage)
+        description = clean_html(re.sub(r'<script[^>]*>[^<]+</script>', '', description))
         if not description:
             description = self._og_search_description(webpage)
         thumbnail = player_attrs.get('image') or self._og_search_thumbnail(webpage)

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -109,8 +109,9 @@ class MegaTVComIE(MegaTVComBaseIE):
             source = player_attrs['source']
         except KeyError:
             raise ExtractorError('no source found for %s' % video_id)
-        formats = self._extract_m3u8_formats(source, video_id, 'mp4') \
-            if determine_ext(source) == 'm3u8' else [source]
+        formats, subs = self._extract_m3u8_formats_and_subtitles(
+            source, video_id, 'mp4') \
+            if determine_ext(source) == 'm3u8' else ([source], {})
         self._sort_formats(formats)
         return {
             'id': video_id,
@@ -119,6 +120,7 @@ class MegaTVComIE(MegaTVComBaseIE):
             'thumbnail': thumbnail,
             'timestamp': timestamp,
             'formats': formats,
+            'subtitles': subs,
         }
 
 

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -143,8 +143,7 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
     @classmethod
     def _extract_urls(cls, webpage):
         for mobj in cls._EMBED_RE.finditer(webpage):
-            url = unescapeHTML(mobj.group('url'))
-            yield url
+            yield unescapeHTML(mobj.group('url'))
 
     def _match_canonical_url(self, webpage):
         LINK_RE = r'''(?x)

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -8,9 +8,6 @@ from urllib.parse import (
 )
 
 from .common import InfoExtractor
-from ..compat import (
-    compat_str,
-)
 from ..utils import (
     clean_html,
     determine_ext,
@@ -83,12 +80,12 @@ class MegaTVComIE(MegaTVComBaseIE):
             [^>]*?
         )+>
         '''
-        return compat_str(self._search_regex(ART_RE, webpage, 'article_id',
-                                             group='article'))
+        return self._search_regex(ART_RE, webpage, 'article_id',
+                                  group='article')
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        _is_article = video_id == 'None'
+        _is_article = video_id is None
         webpage = self._download_webpage(url,
                                          'N/A' if _is_article else
                                          video_id)

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -2,10 +2,6 @@
 from __future__ import unicode_literals
 
 import re
-from urllib.parse import (
-    parse_qs,
-    urlparse,
-)
 
 from .common import InfoExtractor
 from ..utils import (

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -109,7 +109,7 @@ class MegaTVComIE(MegaTVComBaseIE):
 class MegaTVComEmbedIE(MegaTVComBaseIE):
     IE_NAME = 'megatvcom:embed'
     IE_DESC = 'megatv.com embedded videos'
-    _VALID_URL = r'https?://(?:www\.)?megatv\.com/embed/?\?p=(?P<id>\d+)'
+    _VALID_URL = r'(?:https?:)?//(?:www\.)?megatv\.com/embed/?\?p=(?P<id>\d+)'
 
     _TESTS = [{
         'url': 'https://www.megatv.com/embed/?p=2020520979',
@@ -141,12 +141,7 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
 
     @classmethod
     def _extract_urls(cls, webpage, origin_url=None):
-        # make the scheme in _VALID_URL optional
-        _URL_RE = r'(?:https?:)?//' + cls._VALID_URL.split('://', 1)[1]
-        EMBED_RE = r'''(?x)
-            <iframe[^>]+?src=(?P<_q1>["'])
-                (?P<url>%(url_re)s)(?P=_q1)
-        ''' % {'url_re': _URL_RE}
+        EMBED_RE = r'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>%s)(?P=_q1)''' % cls._VALID_URL
         for mobj in re.finditer(EMBED_RE, webpage):
             url = unescapeHTML(mobj.group('url'))
             if url.startswith('//'):

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -49,6 +49,8 @@ class MegaTVComIE(MegaTVComBaseIE):
             'description': 'md5:0209fa8d318128569c0d256a5c404db1',
             'timestamp': 1634975747,
             'upload_date': '20211023',
+            'display_id': 'egkainia-gia-ti-nea-skini-omega-tou-dimotikou-theatrou-peiraia',
+            'thumbnail': 'https://www.megatv.com/wp-content/uploads/2021/10/ΠΕΙΡΑΙΑΣ-1024x450.jpg',
         },
     }, {
         'url': 'https://www.megatv.com/tvshows/527800/epeisodio-65-12/',
@@ -60,6 +62,8 @@ class MegaTVComIE(MegaTVComBaseIE):
             'description': 'md5:b2b7ed3690a78f2a0156eb790fdc00df',
             'timestamp': 1636048859,
             'upload_date': '20211104',
+            'display_id': 'epeisodio-65-12',
+            'thumbnail': 'https://www.megatv.com/wp-content/uploads/2021/11/16-1-1.jpg',
         },
     }]
 
@@ -118,6 +122,8 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
             'description': 'md5:0209fa8d318128569c0d256a5c404db1',
             'timestamp': 1634975747,
             'upload_date': '20211023',
+            'display_id': 'egkainia-gia-ti-nea-skini-omega-tou-dimotikou-theatrou-peiraia',
+            'thumbnail': 'https://www.megatv.com/wp-content/uploads/2021/10/ΠΕΙΡΑΙΑΣ-1024x450.jpg',
         },
     }, {
         'url': 'https://www.megatv.com/embed/?p=2020534081',
@@ -129,6 +135,8 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
             'description': 'md5:36dbe4c3762d2ede9513eea8d07f6d52',
             'timestamp': 1636376351,
             'upload_date': '20211108',
+            'display_id': 'neo-rekor-stin-timi-tou-ilektrikou-reymatos-pano-apo-ta-200e-i-xondriki-timi-tou-ilektrikou',
+            'thumbnail': 'https://www.megatv.com/wp-content/uploads/2021/11/Capture-266.jpg',
         },
     }]
 

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -140,13 +140,10 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
     }]
 
     @classmethod
-    def _extract_urls(cls, webpage, origin_url=None):
+    def _extract_urls(cls, webpage):
         EMBED_RE = r'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>%s)(?P=_q1)''' % cls._VALID_URL
         for mobj in re.finditer(EMBED_RE, webpage):
             url = unescapeHTML(mobj.group('url'))
-            if url.startswith('//'):
-                scheme = urlparse(origin_url).scheme if origin_url else 'https'
-                url = '%s:%s' % (scheme, url)
             yield url
 
     def _match_canonical_url(self, webpage):

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -16,6 +16,7 @@ from ..utils import (
     get_element_by_class,
     get_element_html_by_id,
     HEADRequest,
+    parse_qs,
     unescapeHTML,
     unified_timestamp,
 )
@@ -90,7 +91,7 @@ class MegaTVComIE(MegaTVComBaseIE):
         if determine_ext(source) == 'm3u8':
             formats, subs = self._extract_m3u8_formats_and_subtitles(source, video_id, 'mp4')
         else:
-            formats, subs = [source], {}
+            formats, subs = [{'url': source}], {}
         if player_attrs.get('subs'):
             self._merge_subtitles({'und': [{'url': player_attrs['subs']}]}, target=subs)
         self._sort_formats(formats)
@@ -165,10 +166,9 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
         canonical_url = player_attrs.get('share_url') or self._match_canonical_url(webpage)
         if not canonical_url:
             raise ExtractorError('canonical URL not found')
-        video_id = parse_qs(urlparse(canonical_url).query)['p'][0]
+        video_id = parse_qs(canonical_url)['p'][0]
 
-        # Resolve the canonical URL, following redirects, and defer to
-        # megatvcom, as the metadata extracted from the embeddable page some
+        # Defer to megatvcom as the metadata extracted from the embeddable page some
         # times are slightly different, for the same video
         canonical_url = self._request_webpage(
             HEADRequest(canonical_url), video_id,

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -87,6 +87,8 @@ class MegaTVComIE(MegaTVComBaseIE):
             formats, subs = self._extract_m3u8_formats_and_subtitles(source, video_id, 'mp4')
         else:
             formats, subs = [source], {}
+        if player_attrs.get('subs'):
+            self._merge_subtitles({'und': [{'url': player_attrs['subs']}]}, target=subs)
         self._sort_formats(formats)
         return {
             'id': video_id,

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -14,6 +14,7 @@ from ..utils import (
     ExtractorError,
     extract_attributes,
     get_element_by_class,
+    get_element_html_by_id,
     HEADRequest,
     unescapeHTML,
     unified_timestamp,
@@ -24,9 +25,7 @@ class MegaTVComBaseIE(InfoExtractor):
     _PLAYER_DIV_ID = 'player_div_id'
 
     def _extract_player_attrs(self, webpage):
-        player_el = self._search_regex(
-            r'(<div[^>]*\sid=(?P<_q>["\'])%s(?P=_q)\s[^>]+>)' %
-            self._PLAYER_DIV_ID, webpage, 'player element')
+        player_el = get_element_html_by_id(self._PLAYER_DIV_ID, webpage)
         return {
             re.sub(r'^data-(?:kwik_)?', '', k): v
             for k, v in extract_attributes(player_el).items()

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -51,7 +51,7 @@ class MegaTVComIE(MegaTVComBaseIE):
 
     _TESTS = [{
         'url': 'https://www.megatv.com/2021/10/23/egkainia-gia-ti-nea-skini-omega-tou-dimotikou-theatrou-peiraia/',
-        'md5': '2ebe96661cb81854889053cebb661068',
+        'md5': '6546a1a37fff0dd51c9dce5f490b7d7d',
         'info_dict': {
             'id': '520979',
             'ext': 'mp4',
@@ -62,7 +62,7 @@ class MegaTVComIE(MegaTVComBaseIE):
         },
     }, {
         'url': 'https://www.megatv.com/tvshows/527800/epeisodio-65-12/',
-        'md5': '8ab0c9d664cea11678670202b87bb2b1',
+        'md5': 'cba2085d45c1abeb8e7e9b7e1d6c0072',
         'info_dict': {
             'id': '527800',
             'ext': 'mp4',
@@ -128,7 +128,7 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
 
     _TESTS = [{
         'url': 'https://www.megatv.com/embed/?p=2020520979',
-        'md5': '2ebe96661cb81854889053cebb661068',
+        'md5': '6546a1a37fff0dd51c9dce5f490b7d7d',
         'info_dict': {
             'id': '520979',
             'ext': 'mp4',
@@ -139,7 +139,7 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
         },
     }, {
         'url': 'https://www.megatv.com/embed/?p=2020534081',
-        'md5': 'f9a15e315acbf01b128e8efa3f75aab3',
+        'md5': '6ac8b3ce4dc6120c802f780a1e6b3812',
         'info_dict': {
             'id': '534081',
             'ext': 'mp4',

--- a/yt_dlp/extractor/megatvcom.py
+++ b/yt_dlp/extractor/megatvcom.py
@@ -110,6 +110,7 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
     IE_NAME = 'megatvcom:embed'
     IE_DESC = 'megatv.com embedded videos'
     _VALID_URL = r'(?:https?:)?//(?:www\.)?megatv\.com/embed/?\?p=(?P<id>\d+)'
+    _EMBED_RE = re.compile(rf'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>{_VALID_URL})(?P=_q1)''')
 
     _TESTS = [{
         'url': 'https://www.megatv.com/embed/?p=2020520979',
@@ -141,8 +142,7 @@ class MegaTVComEmbedIE(MegaTVComBaseIE):
 
     @classmethod
     def _extract_urls(cls, webpage):
-        EMBED_RE = r'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>%s)(?P=_q1)''' % cls._VALID_URL
-        for mobj in re.finditer(EMBED_RE, webpage):
+        for mobj in cls._EMBED_RE.finditer(webpage):
             url = unescapeHTML(mobj.group('url'))
             yield url
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This patch adds support for video extraction from megatv.com, a popular Greek content provider and (recently re-)established TV network.

* Add new IEs
  * MegaTVComBaseIE: Base IE class
  * MegaTVComIE: Extract from TV VOD pages and news articles, i.e. all sorts of pages showing videos on megatv.com
  * MegaTVComEmbedIE: Extract iframe-embeddable megatv.com videos
* When video_id is not matched in the URL, namely for news articles, extract it (article_id) from a particular element on the web page
* Derive metadata and sources directly from the web page, from data attributes of the player placeholder element and other commonly used elements
* Let MegaTVComEmbedIE defer to MegaTVComIE for extraction, as the metadata on the embeddable page are some times slightly different, for the same video

This patch was ported from ytdl-org/youtube-dl#30227 with the following changes/improvements:

* Parse HLS closed captions