### PR TITLE
[Twitch] Add VOD ID and VOD offset in seconds to info

### DIFF
--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -944,6 +944,23 @@ class TwitchClipsIE(TwitchBaseIE):
             'vod_offset_seconds': 7694,
         },
     }, {
+        'url': 'https://clips.twitch.tv/SpineyCleverPidgeonSwiftRage',
+        'md5': '1daf87320506728073b80adcd34f5341',
+        'info_dict': {
+            'id': '455099327',
+            'display_id': 'SpineyCleverPidgeonSwiftRage',
+            'ext': 'mp4',
+            'title': 'Duck yoinks the mic',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'timestamp': 1557660810,
+            'upload_date': '20190512',
+            'creator': 'DashDucks',
+            'uploader': 'Michael_I_Guess',
+            'uploader_id': '57406191',
+            'vod_id': None,
+            'vod_offset_seconds': None,
+        },
+    }, {
         # multiple formats
         'url': 'https://clips.twitch.tv/rflegendary/UninterestedBeeDAESuppy',
         'only_matching': True,

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -940,6 +940,8 @@ class TwitchClipsIE(TwitchBaseIE):
             'creator': 'EA',
             'uploader': 'stereotype_',
             'uploader_id': '43566419',
+            'vod_id': '72078016',
+            'vod_offset_seconds': 7694,
         },
     }, {
         # multiple formats

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -1004,6 +1004,10 @@ class TwitchClipsIE(TwitchBaseIE):
       sourceURL
     }
     viewCount
+    video {
+      id
+    }
+    videoOffsetSeconds
   }
 }''' % video_id}, 'Downloading clip GraphQL', fatal=False)
 
@@ -1054,4 +1058,6 @@ class TwitchClipsIE(TwitchBaseIE):
             'creator': try_get(clip, lambda x: x['broadcaster']['displayName'], compat_str),
             'uploader': try_get(clip, lambda x: x['curator']['displayName'], compat_str),
             'uploader_id': try_get(clip, lambda x: x['curator']['id'], compat_str),
+            'vod_id': try_get(clip, lambda x: x['video']['id'], compat_str),
+            'vod_offset_seconds': clip.get("videoOffsetSeconds"),
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Include the ID of the [VOD](https://help.twitch.tv/s/article/video-on-demand?language=en_US) where a Twitch clip was clipped from and how many seconds into the VOD the clip was from.

For example, in the [Twitch clip](https://clips.twitch.tv/FaintLightGullWholeWheat) linked in the tests for `TwitchClipsIE`:

![image](https://user-images.githubusercontent.com/6130147/146543205-18783fc1-1ef5-4b35-bfd5-b3831eac4054.png)

The `View Full Video` button links to `https://twitch.tv/videos/72078016?tt_content=full_vod_button&tt_medium=clips_web&t=2h8m14s`, a Twitch VOD with ID `72078016` at timestamp `2h8m14s`.

In this case, the `vod_id` is `72078016` and `vod_offset_seconds` is `7694` (`2h8m14s` converted to seconds).

Conversely, if a Twitch clip's associated Twitch VOD is no longer available (e.g. it has been removed by the broadcaster, it has expired, etc.), the VOD ID and offset will be `None`.

This addition would be helpful for archivists who would like to also preserve which Twitch VOD a Twitch clip is from. 