### PR TITLE
[YoutubeDL] Display video titles in formats list output (fixes issue #2035)

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3355,8 +3355,14 @@ class YoutubeDL(object):
                 if f.get('preference') is None or f['preference'] >= -1000]
             header_line = ['format code', 'extension', 'resolution', 'note']
 
+        video_descriptor = info_dict['id']
+        if info_dict['title'] is not None:
+            if 'filename' in self.params.get('compat_opts', []):
+                video_descriptor = info_dict['title'] + '-' + video_descriptor
+            else:
+                video_descriptor = info_dict['title'] + ' [' + video_descriptor + ']'
         self.to_screen(
-            '[info] Available formats for %s:' % info_dict['id'])
+            '[info] Available formats for %s:' % video_descriptor)
         self.to_stdout(render_table(
             header_line, table,
             extra_gap=(0 if new_format else 1),

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3356,7 +3356,7 @@ class YoutubeDL(object):
             header_line = ['format code', 'extension', 'resolution', 'note']
 
         video_descriptor = info_dict['id']
-        if info_dict['title'] is not None:
+        if self.params.get('show_title') and info_dict['title'] is not None:
             if 'filename' in self.params.get('compat_opts', []):
                 video_descriptor = info_dict['title'] + '-' + video_descriptor
             else:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -774,6 +774,7 @@ def _real_main(argv=None):
         'geo_bypass': opts.geo_bypass,
         'geo_bypass_country': opts.geo_bypass_country,
         'geo_bypass_ip_block': opts.geo_bypass_ip_block,
+        'show_title': opts.show_title,
         '_warnings': warnings,
         '_deprecation_warnings': deprecation_warnings,
         'compat_opts': compat_opts,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -281,6 +281,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='no_color', default=False,
         help='Do not emit color codes in output')
     general.add_option(
+        '--show-title',
+        action='store_true', dest='show_title', default=False,
+        help='Show video title in output')
+    general.add_option(
         '--compat-options',
         metavar='OPTS', dest='compat_opts', default=set(), type='str',
         action='callback', callback=_set_from_options_callback,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ x] Improvement
- [ ] New extractor
- [ ] New feature

---

Optionally display all video titles in the formats list output, using the standard dash or bracket notation - issue #2035.

Usage as:
$ yt-dlp --show-title -vF https://www.youtube.com/watch?v=9_dgIfz876A

Cheers and thank you!

Parmjit V.