### PR TITLE
[ondemandkorea] update jw_config regex

### DIFF
--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import re
+
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
@@ -71,8 +73,8 @@ class OnDemandKoreaIE(InfoExtractor):
 
         jw_config = self._parse_json(
             self._search_regex(
-                r'(?s)odkPlayer\.init.*?(?P<options>{[^;]+}).*?;',
-                webpage, 'jw config', group='options'),
+                r'playlist\s*=\s*\[(?P<options>.+)];?$',
+                webpage, 'jw config', flags=re.MULTILINE, group='options'),
             video_id, transform_source=js_to_json)
         info = self._parse_jwplayer_data(
             jw_config, video_id, require_title=False, m3u8_id='hls',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Currently, the ondemandkorea extractor is broken. The Javascript code containing the player configuration has changed on the website.

Before it was:
```javascript
odkPlayer.init({ 
  PLAYER_CONFIG_IS_HERE
});
```

Now it is:
```javascript
var playlist = [{ PLAYER_CONFIG_IS_HERE }]
```

This PR updates the regex, so the same data can be extracted as before.
