### PR TITLE
Fix parsing YYYYMMDD dates in Nov/Dec

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -210,6 +210,7 @@ DATE_FORMATS = (
     '%Y/%m/%d %H:%M:%S',
     '%Y%m%d%H%M',
     '%Y%m%d%H%M%S',
+    '%Y%m%d',
     '%Y-%m-%d %H:%M',
     '%Y-%m-%d %H:%M:%S',
     '%Y-%m-%d %H:%M:%S.%f',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Surprisingly, the date format `%Y%m%d%H%M` will successfully match against one-digit month, day, hour, and minute strings, even though `%m` et al. are [documented as being zero-padded](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes). For most of the year, one of the digits in a two-digit month is zero, which prevents the month from being misinterpreted as month and date. However, for dates in November, 11 can parse as January 1st (similarly, 12 as January 2nd). In this case, the actual day will be interpreted as an hour and a minute.

This commit adds a format string of `%Y%m%d` to our supported date format strings. Because `unified_strdate` doesn't exit its parsing loop on the first successful match, the *bottom* of the list represents formats with higher priority, so we add this string directly below its problematic relatives.

Fixes #2076