### PR TITLE
[afreecatv] Add support for livestreams

### DIFF
--- a/supportedsites.md
+++ b/supportedsites.md
@@ -40,7 +40,6 @@
  - **aenetworks:collection**
  - **aenetworks:show**
  - **afreecatv**: afreecatv.com
- - **afreecatv:live**: afreecatv.com
  - **AirMozilla**
  - **AliExpressLive**
  - **AlJazeera**

--- a/supportedsites.md
+++ b/supportedsites.md
@@ -40,6 +40,7 @@
  - **aenetworks:collection**
  - **aenetworks:show**
  - **afreecatv**: afreecatv.com
+ - **afreecatv:live**: afreecatv.com
  - **AirMozilla**
  - **AliExpressLive**
  - **AlJazeera**

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -13,6 +13,7 @@ from ..utils import (
     qualities,
     traverse_obj,
     unified_strdate,
+    unified_timestamp,
     update_url_query,
     url_or_none,
     urlencode_postdata,
@@ -410,7 +411,8 @@ class AfreecaTVLiveIE(AfreecaTVIE):
             'title': '【 우루과이 오늘은 무슨일이? 】',
             'uploader': '박진우[JINU]',
             'uploader_id': 'pyh3646',
-            'upload_date': '20211223',
+            'timestamp': 1640661495,
+            'is_live': True,
         },
         'skip': 'Livestream has ended',
     }]
@@ -505,6 +507,7 @@ class AfreecaTVLiveIE(AfreecaTVIE):
             'title': channel_info.get('TITLE') or station_info.get('station_title'),
             'uploader': channel_info.get('BJNICK') or station_info.get('station_name'),
             'uploader_id': broadcaster_id,
-            'upload_date': unified_strdate(station_info.get('broad_start')),
+            'timestamp': unified_timestamp(station_info.get('broad_start')),
             'formats': formats,
+            'is_live': True,
         }

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -389,7 +389,7 @@ class AfreecaTVIE(InfoExtractor):
 class AfreecaTVLiveIE(AfreecaTVIE):
 
     IE_NAME = 'afreecatv:live'
-    _VALID_URL = r'https?://play\.afreeca(?:tv)?\.com(?::\d+)?/(?P<id>[^/]+)(?:/(?P<bno>\d+))?'
+    _VALID_URL = r'https?://play\.afreeca(?:tv)?\.com/(?P<id>[^/]+)(?:/(?P<bno>\d+))?'
     _TESTS = [{
         'url': 'https://play.afreecatv.com/pyh3646/237852185',
         'info_dict': {
@@ -402,6 +402,12 @@ class AfreecaTVLiveIE(AfreecaTVIE):
             'is_live': True,
         },
         'skip': 'Livestream has ended',
+    }, {
+        'url': 'http://play.afreeca.com/pyh3646/237852185',
+        'only_matching': True,
+    }, {
+        'url': 'http://play.afreeca.com/pyh3646',
+        'only_matching': True,
     }]
 
     _LIVE_API_URL = 'https://live.afreecatv.com/afreeca/player_live_api.php'

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -37,7 +37,10 @@ from .aenetworks import (
     HistoryPlayerIE,
     BiographyIE,
 )
-from .afreecatv import AfreecaTVIE
+from .afreecatv import (
+    AfreecaTVIE,
+    AfreecaTVLiveIE,
+)
 from .airmozilla import AirMozillaIE
 from .aljazeera import AlJazeeraIE
 from .alphaporno import AlphaPornoIE


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

AfreecaTV is a platform for both prerecorded and live video content. Until now, `yt-dlp` has only supported downloading VODs from AfreecaTV. This PR adds a new extractor for live video from AfreecaTV. The new extractor inherits from the existing AfreecaTV extractor in order to reuse its authentication logic.