### PR TITLE
[CamHub] Add extractor for CamHub.cc

### DIFF
--- a/yt_dlp/extractor/camhub.py
+++ b/yt_dlp/extractor/camhub.py
@@ -1,0 +1,30 @@
+# coding: utf-8
+from .common import InfoExtractor
+from ..utils import url_or_none
+
+
+# CamHub.cc uses KVS Player hosted inside an iframe.  GenericIE supports KVS Player, but can't
+# find the video content due to the iframe.  CamHubIE extracts the iframe src url, then hands it
+# off to GenericIE to do the rest.
+class CamHubIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?camhub\.cc/videos/(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'http://www.camhub.cc/videos/533581/syren-de-mer-onlyfans-05-07-2020have-a-happy-safe-holiday5f014e68a220979bdb8cd-source-27660a6a72c095ca/',
+        'md5': 'fbe89af4cfb59c8fd9f34a202bb03e32',
+        'info_dict': {
+            'id': '389508',
+            'ext': 'mp4',
+            'title': 'Syren De Mer  onlyfans_05-07-2020Have_a_happy_safe_holiday5f014e68a220979bdb8cd_source / Embed плеер',
+            'display_id': 'syren-de-mer-onlyfans-05-07-2020have-a-happy-safe-holiday5f014e68a220979bdb8cd-source',
+            'thumbnail': 'http://www.camhub.world/contents/videos_screenshots/389000/389508/preview.mp4.jpg',
+        }}]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        video_iframe_url = url_or_none(self._search_regex(
+            r'<div[^>]*?class=[\'"].*?embed-wrap.*?[\'"][^>]*>[^<]*<iframe[^>]*?src=[\'"]([^\'"?]*)',
+            webpage, 'video iframe url', fatal=True))
+
+        return self.url_result(video_iframe_url, 'Generic')

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -195,6 +195,7 @@ from .camdemy import (
     CamdemyIE,
     CamdemyFolderIE
 )
+from .camhub import CamHubIE
 from .cammodels import CamModelsIE
 from .camwithher import CamWithHerIE
 from .canalalpha import CanalAlphaIE


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [X] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

CamHub.cc uses KVS Player hosted inside an iframe.  GenericIE supports KVS Player, but can't find the video content due to the iframe and fails, so there has been no support for this site until now.  This new extractor, CamHubIE, simply extracts the iframe src url, then hands that url off to GenericIE to do the rest.

* Added new camhub.py extractor and test
* Added import in extractors.py
* Verified code with flake8 and ran test