### PR TITLE
[utils] Improve parsing for nested HTML elements

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -47,7 +47,7 @@ from yt_dlp.utils import (
     get_elements_html_by_class,
     get_elements_html_by_attribute,
     get_elements_text_and_html_by_attribute,
-    get_first_element_text_and_html_by_tag,
+    get_element_text_and_html_by_tag,
     InAdvancePagedList,
     int_or_none,
     intlist_to_bytes,
@@ -1662,7 +1662,7 @@ Line 1
         self.assertEqual(get_elements_text_and_html_by_attribute('class', 'foo', html), [])
         self.assertEqual(get_elements_text_and_html_by_attribute('class', 'no-such-foo', html), [])
 
-    GET_FIRST_ELEMENT_BY_TAG_TEST_STRING = '''
+    GET_ELEMENT_BY_TAG_TEST_STRING = '''
     random text lorem ipsum</p>
     <div>
         this should be returned
@@ -1674,21 +1674,21 @@ Line 1
     </div>
     but this text should not be returned
     '''
-    GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_HTML = GET_FIRST_ELEMENT_BY_TAG_TEST_STRING.strip()[32:276]
-    GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_TEXT = GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_HTML[5:-6]
-    GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_HTML = GET_FIRST_ELEMENT_BY_TAG_TEST_STRING.strip()[78:119]
-    GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_TEXT = GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_HTML[6:-7]
+    GET_ELEMENT_BY_TAG_RES_OUTERDIV_HTML = GET_ELEMENT_BY_TAG_TEST_STRING.strip()[32:276]
+    GET_ELEMENT_BY_TAG_RES_OUTERDIV_TEXT = GET_ELEMENT_BY_TAG_RES_OUTERDIV_HTML[5:-6]
+    GET_ELEMENT_BY_TAG_RES_INNERSPAN_HTML = GET_ELEMENT_BY_TAG_TEST_STRING.strip()[78:119]
+    GET_ELEMENT_BY_TAG_RES_INNERSPAN_TEXT = GET_ELEMENT_BY_TAG_RES_INNERSPAN_HTML[6:-7]
 
-    def test_get_first_element_text_and_html_by_tag(self):
-        html = self.GET_FIRST_ELEMENT_BY_TAG_TEST_STRING
+    def test_get_element_text_and_html_by_tag(self):
+        html = self.GET_ELEMENT_BY_TAG_TEST_STRING
 
         self.assertEqual(
-            get_first_element_text_and_html_by_tag('div', html),
-            (self.GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_TEXT, self.GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_HTML))
+            get_element_text_and_html_by_tag('div', html),
+            (self.GET_ELEMENT_BY_TAG_RES_OUTERDIV_TEXT, self.GET_ELEMENT_BY_TAG_RES_OUTERDIV_HTML))
         self.assertEqual(
-            get_first_element_text_and_html_by_tag('span', html),
-            (self.GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_TEXT, self.GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_HTML))
-        self.assertRaises(compat_HTMLParseError, get_first_element_text_and_html_by_tag, 'article', html)
+            get_element_text_and_html_by_tag('span', html),
+            (self.GET_ELEMENT_BY_TAG_RES_INNERSPAN_TEXT, self.GET_ELEMENT_BY_TAG_RES_INNERSPAN_HTML))
+        self.assertRaises(compat_HTMLParseError, get_element_text_and_html_by_tag, 'article', html)
 
     def test_iri_to_uri(self):
         self.assertEqual(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -42,6 +42,12 @@ from yt_dlp.utils import (
     get_element_by_attribute,
     get_elements_by_class,
     get_elements_by_attribute,
+    get_element_html_by_class,
+    get_element_html_by_attribute,
+    get_elements_html_by_class,
+    get_elements_html_by_attribute,
+    get_elements_text_and_html_by_attribute,
+    get_first_element_text_and_html_by_tag,
     InAdvancePagedList,
     int_or_none,
     intlist_to_bytes,
@@ -116,6 +122,7 @@ from yt_dlp.compat import (
     compat_chr,
     compat_etree_fromstring,
     compat_getenv,
+    compat_HTMLParseError,
     compat_os_name,
     compat_setenv,
 )
@@ -1573,45 +1580,115 @@ Line 1
         self.assertEqual(urshift(3, 1), 1)
         self.assertEqual(urshift(-3, 1), 2147483646)
 
+    GET_ELEMENT_BY_CLASS_TEST_STRING = '''
+        <span class="foo bar">nice</span>
+    '''
+
     def test_get_element_by_class(self):
-        html = '''
-            <span class="foo bar">nice</span>
-        '''
+        html = self.GET_ELEMENT_BY_CLASS_TEST_STRING
 
         self.assertEqual(get_element_by_class('foo', html), 'nice')
         self.assertEqual(get_element_by_class('no-such-class', html), None)
 
+    def test_get_element_html_by_class(self):
+        html = self.GET_ELEMENT_BY_CLASS_TEST_STRING
+
+        self.assertEqual(get_element_html_by_class('foo', html), html.strip())
+        self.assertEqual(get_element_by_class('no-such-class', html), None)
+
+    GET_ELEMENT_BY_ATTRIBUTE_TEST_STRING = '''
+        <div itemprop="author" itemscope>foo</div>
+    '''
+
     def test_get_element_by_attribute(self):
-        html = '''
-            <span class="foo bar">nice</span>
-        '''
+        html = self.GET_ELEMENT_BY_CLASS_TEST_STRING
 
         self.assertEqual(get_element_by_attribute('class', 'foo bar', html), 'nice')
         self.assertEqual(get_element_by_attribute('class', 'foo', html), None)
         self.assertEqual(get_element_by_attribute('class', 'no-such-foo', html), None)
 
-        html = '''
-            <div itemprop="author" itemscope>foo</div>
-        '''
+        html = self.GET_ELEMENT_BY_ATTRIBUTE_TEST_STRING
 
         self.assertEqual(get_element_by_attribute('itemprop', 'author', html), 'foo')
 
+    def test_get_element_html_by_attribute(self):
+        html = self.GET_ELEMENT_BY_CLASS_TEST_STRING
+
+        self.assertEqual(get_element_html_by_attribute('class', 'foo bar', html), html.strip())
+        self.assertEqual(get_element_html_by_attribute('class', 'foo', html), None)
+        self.assertEqual(get_element_html_by_attribute('class', 'no-such-foo', html), None)
+
+        html = self.GET_ELEMENT_BY_ATTRIBUTE_TEST_STRING
+
+        self.assertEqual(get_element_html_by_attribute('itemprop', 'author', html), html.strip())
+
+    GET_ELEMENTS_BY_CLASS_TEST_STRING = '''
+        <span class="foo bar">nice</span><span class="foo bar">also nice</span>
+    '''
+    GET_ELEMENTS_BY_CLASS_RES = ['<span class="foo bar">nice</span>', '<span class="foo bar">also nice</span>']
+
     def test_get_elements_by_class(self):
-        html = '''
-            <span class="foo bar">nice</span><span class="foo bar">also nice</span>
-        '''
+        html = self.GET_ELEMENTS_BY_CLASS_TEST_STRING
 
         self.assertEqual(get_elements_by_class('foo', html), ['nice', 'also nice'])
         self.assertEqual(get_elements_by_class('no-such-class', html), [])
 
+    def test_get_elements_html_by_class(self):
+        html = self.GET_ELEMENTS_BY_CLASS_TEST_STRING
+
+        self.assertEqual(get_elements_html_by_class('foo', html), self.GET_ELEMENTS_BY_CLASS_RES)
+        self.assertEqual(get_elements_html_by_class('no-such-class', html), [])
+
     def test_get_elements_by_attribute(self):
-        html = '''
-            <span class="foo bar">nice</span><span class="foo bar">also nice</span>
-        '''
+        html = self.GET_ELEMENTS_BY_CLASS_TEST_STRING
 
         self.assertEqual(get_elements_by_attribute('class', 'foo bar', html), ['nice', 'also nice'])
         self.assertEqual(get_elements_by_attribute('class', 'foo', html), [])
         self.assertEqual(get_elements_by_attribute('class', 'no-such-foo', html), [])
+
+    def test_get_elements_html_by_attribute(self):
+        html = self.GET_ELEMENTS_BY_CLASS_TEST_STRING
+
+        self.assertEqual(get_elements_html_by_attribute('class', 'foo bar', html), self.GET_ELEMENTS_BY_CLASS_RES)
+        self.assertEqual(get_elements_html_by_attribute('class', 'foo', html), [])
+        self.assertEqual(get_elements_html_by_attribute('class', 'no-such-foo', html), [])
+
+    def test_get_elements_text_and_html_by_attribute(self):
+        html = self.GET_ELEMENTS_BY_CLASS_TEST_STRING
+
+        self.assertEqual(
+            get_elements_text_and_html_by_attribute('class', 'foo bar', html),
+            list(zip(['nice', 'also nice'], self.GET_ELEMENTS_BY_CLASS_RES)))
+        self.assertEqual(get_elements_text_and_html_by_attribute('class', 'foo', html), [])
+        self.assertEqual(get_elements_text_and_html_by_attribute('class', 'no-such-foo', html), [])
+
+    GET_FIRST_ELEMENT_BY_TAG_TEST_STRING = '''
+    random text lorem ipsum</p>
+    <div>
+        this should be returned
+        <span>this should also be returned</span>
+        <div>
+            this should also be returned
+        </div>
+        closing tag above should not trick, so this should also be returned
+    </div>
+    but this text should not be returned
+    '''
+    GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_HTML = GET_FIRST_ELEMENT_BY_TAG_TEST_STRING.strip()[32:276]
+    GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_TEXT = GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_HTML[5:-6]
+    GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_HTML = GET_FIRST_ELEMENT_BY_TAG_TEST_STRING.strip()[78:119]
+    GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_TEXT = GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_HTML[6:-7]
+
+    def test_get_first_element_text_and_html_by_tag(self):
+        html = self.GET_FIRST_ELEMENT_BY_TAG_TEST_STRING
+
+        self.assertEqual(
+            get_first_element_text_and_html_by_tag('div', html),
+            (self.GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_TEXT, self.GET_FIRST_ELEMENT_BY_TAG_RES_OUTERDIV_HTML))
+        self.assertEqual(
+            get_first_element_text_and_html_by_tag('span', html),
+            (self.GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_TEXT, self.GET_FIRST_ELEMENT_BY_TAG_RES_INNERSPAN_HTML))
+        self.assertRaises(compat_HTMLParseError, get_first_element_text_and_html_by_tag, 'article', html)
 
     def test_iri_to_uri(self):
         self.assertEqual(

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -441,11 +441,11 @@ def get_elements_by_attribute(attribute, value, html, escape_value=True, return_
     retlist = []
     for m in re.finditer(r'''(?xs)
         <(?P<tag>[a-zA-Z0-9:._-]+)
-         (?:\s+[a-zA-Z0-9:._-]+(?:=[a-zA-Z0-9:._-]*|="[^"]*"|='[^']*'|))*?
-         \s+%s=['"]?%s['"]?
-         (?:\s+[a-zA-Z0-9:._-]+(?:=[a-zA-Z0-9:._-]*|="[^"]*"|='[^']*'|))*?
+         (?:\s+[a-zA-Z0-9_:.-]+(?:=\S*?|\s*=\s*(?:"[^"]*"|'[^']*')|))*?
+         \s+%(attribute)s(?:=%(value)s|\s*=\s*(?P<_q>['"]?)%(value)s(?P=_q))
+         (?:\s+[a-zA-Z0-9_:.-]+(?:=\S*?|\s*=\s*(?:"[^"]*"|'[^']*')|))*?
         \s*>
-    ''' % (re.escape(attribute), value), html):
+    ''' % {'attribute': re.escape(attribute), 'value': value}, html):
         whole, content = get_first_element_by_tag(m.group('tag'), html[m.start():])
 
         if return_content:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -513,12 +513,18 @@ class HTMLBreakOnClosingTagParser(compat_HTMLParser):
     def __exit__(self, *_):
         self.close()
 
+    def close(self):
+        # handle_endtag does not return upon raising HTMLBreakOnClosingTagException,
+        # so data remains buffered; we no longer have any interest in it, thus
+        # override this method to discard it
+        pass
+
     def handle_starttag(self, tag, _):
         self.tagstack.append(tag)
 
     def handle_endtag(self, tag):
         if not self.tagstack:
-            return
+            raise compat_HTMLParseError('no tags in the stack')
         while self.tagstack:
             inner_tag = self.tagstack.pop()
             if inner_tag == tag:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -444,7 +444,7 @@ def get_elements_by_attribute(attribute, value, html, escape_value=True, return_
          (?:\s+[a-zA-Z0-9:._-]+(?:=[a-zA-Z0-9:._-]*|="[^"]*"|='[^']*'|))*?
          \s+%s=['"]?%s['"]?
          (?:\s+[a-zA-Z0-9:._-]+(?:=[a-zA-Z0-9:._-]*|="[^"]*"|='[^']*'|))*?
-        [^>]*>
+        \s*>
     ''' % (re.escape(attribute), value), html):
         whole, content = get_first_element_by_tag(m.group('tag'), html[m.start():])
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This patch improves the usability of `get_elements_by_attribute` and all its' calling variants for parsing nested HTML elements and allowing it to also return the matched element rather than only its' content.

* Introduce `get_first_element_by_tag`, which matches the first element with the given tag and returns a tuple with the whole element and its' content
  * This works with `HTMLBreakOnClosingTagParser`, which parses nested elements to a stack of tags and stops when it reaches the closing
    tag for the first opening tag it encountered
* Modify `get_elements_by_attribute` to only match the opening tag and defer to the former function for finding the closing tag, so as to properly parse nested elements for the same tag; this is otherwise impossible with python (stdlib) RE
* Also introduce kwarg return_content, which allows this function and all its' calling functions to either return the tag content (by default) or the matched element and its' content
