### PR TITLE
Fix format_bytes output for bytes

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -778,8 +778,8 @@ class TestYoutubeDL(unittest.TestCase):
         test('%(title5)#U', 'a\u0301e\u0301i\u0301 𝐀')
         test('%(title5)+U', 'áéí A')
         test('%(title5)+#U', 'a\u0301e\u0301i\u0301 A')
-        test('%(height)D', '1K')
-        test('%(height)5.2D', ' 1.08K')
+        test('%(height)D', '1kB')
+        test('%(height)5.2D', ' 1.08kB')
         test('%(title4)#S', 'foo_bar_test')
         test('%(title4).10S', ('foo \'bar\' ', 'foo \'bar\'' + ('#' if compat_os_name == 'nt' else ' ')))
         if compat_os_name == 'nt':

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -111,6 +111,7 @@ from yt_dlp.utils import (
     parse_codecs,
     iri_to_uri,
     LazyList,
+    format_bytes
 )
 from yt_dlp.compat import (
     compat_chr,
@@ -1687,6 +1688,38 @@ Line 1
         test(ll, 10, 10, range(11))
         ll = reversed(ll)
         test(ll, -15, 14, range(15))
+
+
+class TestFormatBytes(unittest.TestCase):
+    def test_0(self):
+        self.assertEqual(format_bytes(0), '0.00B')
+
+    def test_byte(self):
+        self.assertEqual(format_bytes(1000), '1000.00B')
+
+    def test_kibibyte(self):
+        self.assertEqual(format_bytes(1024), '1.00KiB')
+
+    def test_mebibyte(self):
+        self.assertEqual(format_bytes(1024**2), '1.00MiB')
+
+    def test_gibibyte(self):
+        self.assertEqual(format_bytes(1024**3), '1.00GiB')
+
+    def test_tebibyte(self):
+        self.assertEqual(format_bytes(1024**4), '1.00TiB')
+
+    def test_pebibyte(self):
+        self.assertEqual(format_bytes(1024**5), '1.00PiB')
+
+    def test_exbibyte(self):
+        self.assertEqual(format_bytes(1024**6), '1.00EiB')
+
+    def test_zebibyte(self):
+        self.assertEqual(format_bytes(1024**7), '1.00ZiB')
+
+    def test_yobibyte(self):
+        self.assertEqual(format_bytes(1024**8), '1.00YiB')
 
 
 if __name__ == '__main__':

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2110,15 +2110,12 @@ def unsmuggle_url(smug_url, default=None):
     return url, data
 
 # See: https://en.wikipedia.org/wiki/Byte#Multiple-byte_units
-BYTE_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
-BYTE_UNITS_METRIC = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+BYTE_UNITS = ('B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB')
+BYTE_UNITS_METRIC = ('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB')
 
 def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     """ Formats numbers with decimal sufixes like K, M, etc """
-    units = BYTE_UNITS_METRIC
-
-    if factor == 1024:
-        units = BYTE_UNITS
+    units = BYTE_UNITS if factor == 1024 else BYTE_UNITS_METRIC
 
     num, factor = float_or_none(num), float(factor)
     if num is None:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2109,9 +2109,11 @@ def unsmuggle_url(smug_url, default=None):
     data = json.loads(jsond)
     return url, data
 
+
 # See: https://en.wikipedia.org/wiki/Byte#Multiple-byte_units
 BYTE_UNITS = ('B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB')
 BYTE_UNITS_METRIC = ('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB')
+
 
 def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     """ Formats numbers with decimal sufixes like K, M, etc """

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2109,20 +2109,28 @@ def unsmuggle_url(smug_url, default=None):
     data = json.loads(jsond)
     return url, data
 
+# See: https://en.wikipedia.org/wiki/Byte#Multiple-byte_units
+BYTE_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+BYTE_UNITS_METRIC = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
 def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     """ Formats numbers with decimal sufixes like K, M, etc """
+    units = BYTE_UNITS_METRIC
+
+    if factor == 1024:
+        units = BYTE_UNITS
+
     num, factor = float_or_none(num), float(factor)
     if num is None:
         return None
     exponent = 0 if num == 0 else int(math.log(num, factor))
-    suffix = ['', *'KMGTPEZY'][exponent]
+    suffix = units[exponent]
     converted = num / (factor ** exponent)
     return fmt % (converted, suffix)
 
 
 def format_bytes(bytes):
-    return format_decimal_suffix(bytes, '%.2f%siB', factor=1024) or 'N/A'
+    return format_decimal_suffix(bytes, '%.2f%s', factor=1024) or 'N/A'
 
 
 def lookup_unit_table(unit_table, s):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

A small fix for the bug introduced in version [2021.12.25](https://github.com/yt-dlp/yt-dlp/releases/tag/2021.12.25) for the `format_bytes` function:

```python
>>> from yt_dlp import utils
>>> utils.format_bytes(0)
'0.00iB'
>>> utils.format_bytes(500)
'500.00iB'
```

This pull request fixes the unit for bytes:

```python
>>> from yt_dlp import utils
>>> utils.format_bytes(0)
'0.00B'
>>> utils.format_bytes(500)
'500.00B'
```

I used units as defined on Wikipedia's Byte page [Multiple-byte units](https://en.wikipedia.org/wiki/Byte#Multiple-byte_units).
