### PR TITLE
[VrtNU] fix empty title in json test

### DIFF
--- a/yt_dlp/extractor/canvas.py
+++ b/yt_dlp/extractor/canvas.py
@@ -76,7 +76,7 @@ class CanvasIE(InfoExtractor):
                     'vrtPlayerToken': vrtPlayerToken,
                     'client': 'null',
                 }, expected_status=400)
-            if "title" not in data:
+            if 'title' not in data:
                 code = data.get('code')
                 if code == 'AUTHENTICATION_REQUIRED':
                     self.raise_login_required()

--- a/yt_dlp/extractor/canvas.py
+++ b/yt_dlp/extractor/canvas.py
@@ -76,7 +76,7 @@ class CanvasIE(InfoExtractor):
                     'vrtPlayerToken': vrtPlayerToken,
                     'client': 'null',
                 }, expected_status=400)
-            if not data.get('title'):
+            if "title" not in data:
                 code = data.get('code')
                 if code == 'AUTHENTICATION_REQUIRED':
                     self.raise_login_required()

--- a/yt_dlp/extractor/canvas.py
+++ b/yt_dlp/extractor/canvas.py
@@ -84,7 +84,7 @@ class CanvasIE(InfoExtractor):
                     self.raise_geo_restricted(countries=['BE'])
                 raise ExtractorError(data.get('message') or code, expected=True)
 
-        title = data['title']
+        title = data['title'] or f'{site_id} {video_id}'
         description = data.get('description')
 
         formats = []

--- a/yt_dlp/extractor/canvas.py
+++ b/yt_dlp/extractor/canvas.py
@@ -84,6 +84,7 @@ class CanvasIE(InfoExtractor):
                     self.raise_geo_restricted(countries=['BE'])
                 raise ExtractorError(data.get('message') or code, expected=True)
 
+        # Note: The title may be an empty string
         title = data['title'] or f'{site_id} {video_id}'
         description = data.get('description')
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### fixes download issue where internal JSON has empty title

fixes #2146

internal json has _empty_ `title` >> adapt test to test if key exists:
`{'duration': 3121060, 'skinType': 'vod', 'title': '', 'shortDescription': None, 'drm': 'vrt|2021-12-28T.....Z|.../...', 'drmExpired': '2021-12-28...', 'aspectRatio': '16:9', 'posterImageUrl': None, 'channelId': None, 'targetUrls': [{'type': 'mpeg_dash', 'url': 'https://remix-cf.lwc.vrtcdn.be/remix/0603b9c1-b117-4caf-a4c1-xxx/remix.ism/.mpd'}, {'type': 'hls_aes', 'url': 'https://remix-cf.lwc.vrtcdn.be/remix/0603b9c1-b117-4caf-a4c1-xxx/remix_aes.ism/.m3u8'}, {'type': 'hls', 'url': 'https://remix-cf.lwc.vrtcdn.be/remix/0603b9c1-b117-4caf-a4c1-xx/remix.ism/.m3u8'}], 'playlist': {'content': [{'eventType': 'ONBOARDING', 'duration': 3000, 'skippable': False}, {'eventType': 'STANDARD', 'duration': 3121060, 'skippable': True}]}}`