### PR TITLE
[mixcloud] add restriction detection

### DIFF
--- a/yt_dlp/extractor/mixcloud.py
+++ b/yt_dlp/extractor/mixcloud.py
@@ -129,7 +129,7 @@ class MixcloudIE(MixcloudBaseIE):
     }
     restrictedReason
     id''', track_id, username, slug)
-           
+
         if not cloudcast:
             raise ExtractorError('Track not found', expected=True)
 
@@ -141,7 +141,7 @@ class MixcloudIE(MixcloudBaseIE):
                 # https://help.mixcloud.com/hc/en-us/articles/360010592220-Why-can-I-only-replay-a-show-three-times-
                 raise ExtractorError('You have reached your play limit for this track', expected=True)
             else:
-                raise ExtractorError('Track is restricted', expected=True)            
+                raise ExtractorError('Track is restricted', expected=True)
 
         title = cloudcast['name']
 

--- a/yt_dlp/extractor/mixcloud.py
+++ b/yt_dlp/extractor/mixcloud.py
@@ -133,15 +133,13 @@ class MixcloudIE(MixcloudBaseIE):
         if not cloudcast:
             raise ExtractorError('Track not found', expected=True)
 
-        if cloudcast['restrictedReason']:
-            reason = cloudcast['restrictedReason']
-            if reason == "tracklist":
-                raise ExtractorError('Track unavailable in your country due to licensing restrictions', expected=True)
-            elif reason == "repeat_play":
-                # https://help.mixcloud.com/hc/en-us/articles/360010592220-Why-can-I-only-replay-a-show-three-times-
-                raise ExtractorError('You have reached your play limit for this track', expected=True)
-            else:
-                raise ExtractorError('Track is restricted', expected=True)
+        reason = cloudcast.get('restrictedReason')
+        if reason == 'tracklist':
+            raise ExtractorError('Track unavailable in your country due to licensing restrictions', expected=True)
+        elif reason == 'repeat_play':
+            raise ExtractorError('You have reached your play limit for this track', expected=True)
+        elif reason:
+            raise ExtractorError('Track is restricted', expected=True)
 
         title = cloudcast['name']
 

--- a/yt_dlp/extractor/mixcloud.py
+++ b/yt_dlp/extractor/mixcloud.py
@@ -12,6 +12,7 @@ from ..compat import (
     compat_zip
 )
 from ..utils import (
+    ExtractorError,
     int_or_none,
     parse_iso8601,
     strip_or_none,
@@ -125,7 +126,22 @@ class MixcloudIE(MixcloudBaseIE):
       tag {
         name
       }
-    }''', track_id, username, slug)
+    }
+    restrictedReason
+    id''', track_id, username, slug)
+           
+        if not cloudcast:
+            raise ExtractorError('Track not found', expected=True)
+
+        if cloudcast['restrictedReason']:
+            reason = cloudcast['restrictedReason']
+            if reason == "tracklist":
+                raise ExtractorError('Track unavailable in your country due to licensing restrictions', expected=True)
+            elif reason == "repeat_play":
+                # https://help.mixcloud.com/hc/en-us/articles/360010592220-Why-can-I-only-replay-a-show-three-times-
+                raise ExtractorError('You have reached your play limit for this track', expected=True)
+            else:
+                raise ExtractorError('Track is restricted', expected=True)            
 
         title = cloudcast['name']
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some tracks on mixcloud can be restricted from being played. This patch adds proper detection of this, as well as throwing an error when a track is not found.

example track with licensing restriction: `https://www.mixcloud.com/mistabibs/mista-bibs-modelling-network-best-of-akon/`
