### PR TITLE
Assorted cleanups II

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -115,7 +115,6 @@ from yt_dlp.utils import (
     unified_timestamp,
     unsmuggle_url,
     update_url_query,
-    uppercase_escape,
     url_basename,
     url_or_none,
     urlencode_postdata,
@@ -826,10 +825,6 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(strip_or_none(None), None)
         self.assertEqual(strip_or_none(42), None)
         self.assertEqual(strip_or_none([]), None)
-
-    def test_uppercase_escape(self):
-        self.assertEqual(uppercase_escape('aä'), 'aä')
-        self.assertEqual(uppercase_escape('\\U0001d550'), '𝕐')
 
     def test_lowercase_escape(self):
         self.assertEqual(lowercase_escape('aä'), 'aä')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -918,10 +918,8 @@ class YoutubeDL:
             self.to_stderr(f'{self._format_err("WARNING:", self.Styles.WARNING)} {message}', only_once)
 
     def deprecation_warning(self, message):
-        if self.params.get('logger') is not None:
-            self.params['logger'].warning(f'DeprecationWarning: {message}')
-        else:
-            self.to_stderr(f'{self._format_err("DeprecationWarning:", self.Styles.ERROR)} {message}', True)
+        import warnings
+        warnings.warn(DeprecationWarning(message), stacklevel=2)
 
     def report_error(self, message, *args, **kwargs):
         '''

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -124,7 +124,6 @@ from .utils import (
     platform_name,
     preferredencoding,
     prepend_extension,
-    register_socks_protocols,
     remove_terminal_sequences,
     render_table,
     replace_extension,
@@ -670,7 +669,6 @@ class YoutubeDL:
                 when=when)
 
         self._setup_opener()
-        register_socks_protocols()
 
         def preload_download_archive(fn):
             """Preload the archive, if any is specified"""

--- a/yt_dlp/__main__.py
+++ b/yt_dlp/__main__.py
@@ -2,6 +2,7 @@
 # Execute with
 # $ python -m yt_dlp
 
+import os
 import sys
 
 if __package__ is None and not hasattr(sys, 'frozen'):
@@ -13,4 +14,5 @@ if __package__ is None and not hasattr(sys, 'frozen'):
 import yt_dlp
 
 if __name__ == '__main__':
+    os.environ['YTDLP_IN_CLI'] = '1'
     yt_dlp.main()

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1729,7 +1729,7 @@ class InfoExtractor:
                     return False
                 self.ydl.deprecation_warning(
                     f'Using arbitrary fields ({field}) for format sorting is deprecated '
-                    'and may be removed in a future version')
+                    'and may be removed in a future version', to_user=True)
                 self.settings[field] = {}
             propObj = self.settings[field]
             if key not in propObj:
@@ -1815,8 +1815,8 @@ class InfoExtractor:
                     alias, field = field, self._get_field_setting(field, 'field')
                     if self._get_field_setting(alias, 'deprecated'):
                         self.ydl.deprecation_warning(
-                            f'Format sorting alias {alias} is deprecated '
-                            f'and may be removed in a future version. Please use {field} instead')
+                            f'Format sorting alias {alias} is deprecated and may be removed in a future version. '
+                            f'Please use {field} instead', to_user=True)
                 reverse = match.group('reverse') is not None
                 closest = match.group('separator') == '~'
                 limit_text = match.group('limit')

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2823,7 +2823,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         max_depth = int_or_none(get_single_config_arg('max_comment_depth'))
         if max_depth:
             self._downloader.deprecation_warning(
-                '[youtube] max_comment_depth extractor argument is deprecated. Set max replies in the max-comments extractor argument instead.')
+                '[youtube] max_comment_depth extractor argument is deprecated. '
+                'Set max replies in the max-comments extractor argument instead.', to_user=True)
         if max_depth == 1 and parent:
             return
 

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1699,7 +1699,9 @@ def create_parser():
 
 
 def _hide_login_info(opts):
-    write_string(
-        'DeprecationWarning: "yt_dlp.options._hide_login_info" is deprecated and may be removed in a future version. '
-        'Use "yt_dlp.utils.Config.hide_login_info" instead\n')
+    import warnings
+    warnings.warn(DeprecationWarning(
+        '"yt_dlp.options._hide_login_info" is deprecated and may be removed in a future version. '
+        'Use "yt_dlp.utils.Config.hide_login_info" instead\n'
+    ))
     return Config.hide_login_info(opts)

--- a/yt_dlp/postprocessor/common.py
+++ b/yt_dlp/postprocessor/common.py
@@ -76,7 +76,9 @@ class PostProcessor(metaclass=PostProcessorMetaClass):
         if self._downloader:
             return self._downloader.report_warning(text, *args, **kwargs)
 
-    def deprecation_warning(self, text):
+    def deprecation_warning(self, text, **kwargs):
+        if self._downloader:
+            return self._downloader.deprecation_warning(text, stacklevel=3, **kwargs)
         import warnings
         warnings.warn(DeprecationWarning(text), stacklevel=2)
 

--- a/yt_dlp/postprocessor/common.py
+++ b/yt_dlp/postprocessor/common.py
@@ -11,7 +11,6 @@ from ..utils import (
     encodeFilename,
     network_exceptions,
     sanitized_Request,
-    write_string,
 )
 
 
@@ -78,9 +77,8 @@ class PostProcessor(metaclass=PostProcessorMetaClass):
             return self._downloader.report_warning(text, *args, **kwargs)
 
     def deprecation_warning(self, text):
-        if self._downloader:
-            return self._downloader.deprecation_warning(text)
-        write_string(f'DeprecationWarning: {text}')
+        import warnings
+        warnings.warn(DeprecationWarning(text), stacklevel=2)
 
     def report_error(self, text, *args, **kwargs):
         self.deprecation_warning('"yt_dlp.postprocessor.PostProcessor.report_error" is deprecated. '

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -158,10 +158,12 @@ class FFmpegPostProcessor(PostProcessor):
 
         if self.basename == 'avconv':
             self.deprecation_warning(
-                'Support for avconv is deprecated and may be removed in a future version. Use ffmpeg instead')
+                'Support for avconv is deprecated and may be removed in a future version. '
+                'Use ffmpeg instead', to_user=True)
         if self.probe_basename == 'avprobe':
             self.deprecation_warning(
-                'Support for avprobe is deprecated and may be removed in a future version. Use ffprobe instead')
+                'Support for avprobe is deprecated and may be removed in a future version. '
+                'Use ffprobe instead', to_user=True)
 
     @property
     def available(self):

--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -8,7 +8,7 @@ import traceback
 from zipimport import zipimporter
 
 from .compat import compat_realpath
-from .utils import Popen, encode_compat_str, write_string
+from .utils import Popen, encode_compat_str
 from .version import __version__
 
 
@@ -215,12 +215,14 @@ def run_update(ydl):
 
 # Deprecated
 def update_self(to_screen, verbose, opener):
+    import warnings
 
     printfn = to_screen
 
-    write_string(
-        'DeprecationWarning: "yt_dlp.update.update_self" is deprecated and may be removed in a future version. '
-        'Use "yt_dlp.update.run_update(ydl)" instead\n')
+    warnings.warn(DeprecationWarning(
+        '"yt_dlp.update.update_self" is deprecated and may be removed in a future version. '
+        'Use "yt_dlp.update.run_update(ydl)" instead\n'
+    ))
 
     class FakeYDL():
         _opener = opener

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -77,19 +77,6 @@ except ImportError:
     has_certifi = False
 
 
-def register_socks_protocols():
-    # "Register" SOCKS protocols
-    # In Python < 2.6.5, urlsplit() suffers from bug https://bugs.python.org/issue7904
-    # URLs with protocols not in urlparse.uses_netloc are not handled correctly
-    for scheme in ('socks', 'socks4', 'socks4a', 'socks5'):
-        if scheme not in compat_urlparse.uses_netloc:
-            compat_urlparse.uses_netloc.append(scheme)
-
-
-# This is not clearly defined otherwise
-compiled_regex_type = type(re.compile(''))
-
-
 def random_user_agent():
     _USER_AGENT_TPL = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36'
     _CHROME_VERSIONS = (
@@ -2724,14 +2711,6 @@ class InAdvancePagedList(PagedList):
             yield from page_results
 
 
-def uppercase_escape(s):
-    unicode_escape = codecs.getdecoder('unicode_escape')
-    return re.sub(
-        r'\\U[0-9a-fA-F]{8}',
-        lambda m: unicode_escape(m.group(0))[0],
-        s)
-
-
 def lowercase_escape(s):
     unicode_escape = codecs.getdecoder('unicode_escape')
     return re.sub(
@@ -4560,113 +4539,6 @@ def urshift(val, n):
     return val >> n if val >= 0 else (val + 0x100000000) >> n
 
 
-# Based on png2str() written by @gdkchan and improved by @yokrysty
-# Originally posted at https://github.com/ytdl-org/youtube-dl/issues/9706
-def decode_png(png_data):
-    # Reference: https://www.w3.org/TR/PNG/
-    header = png_data[8:]
-
-    if png_data[:8] != b'\x89PNG\x0d\x0a\x1a\x0a' or header[4:8] != b'IHDR':
-        raise OSError('Not a valid PNG file.')
-
-    int_map = {1: '>B', 2: '>H', 4: '>I'}
-    unpack_integer = lambda x: compat_struct_unpack(int_map[len(x)], x)[0]
-
-    chunks = []
-
-    while header:
-        length = unpack_integer(header[:4])
-        header = header[4:]
-
-        chunk_type = header[:4]
-        header = header[4:]
-
-        chunk_data = header[:length]
-        header = header[length:]
-
-        header = header[4:]  # Skip CRC
-
-        chunks.append({
-            'type': chunk_type,
-            'length': length,
-            'data': chunk_data
-        })
-
-    ihdr = chunks[0]['data']
-
-    width = unpack_integer(ihdr[:4])
-    height = unpack_integer(ihdr[4:8])
-
-    idat = b''
-
-    for chunk in chunks:
-        if chunk['type'] == b'IDAT':
-            idat += chunk['data']
-
-    if not idat:
-        raise OSError('Unable to read PNG data.')
-
-    decompressed_data = bytearray(zlib.decompress(idat))
-
-    stride = width * 3
-    pixels = []
-
-    def _get_pixel(idx):
-        x = idx % stride
-        y = idx // stride
-        return pixels[y][x]
-
-    for y in range(height):
-        basePos = y * (1 + stride)
-        filter_type = decompressed_data[basePos]
-
-        current_row = []
-
-        pixels.append(current_row)
-
-        for x in range(stride):
-            color = decompressed_data[1 + basePos + x]
-            basex = y * stride + x
-            left = 0
-            up = 0
-
-            if x > 2:
-                left = _get_pixel(basex - 3)
-            if y > 0:
-                up = _get_pixel(basex - stride)
-
-            if filter_type == 1:  # Sub
-                color = (color + left) & 0xff
-            elif filter_type == 2:  # Up
-                color = (color + up) & 0xff
-            elif filter_type == 3:  # Average
-                color = (color + ((left + up) >> 1)) & 0xff
-            elif filter_type == 4:  # Paeth
-                a = left
-                b = up
-                c = 0
-
-                if x > 2 and y > 0:
-                    c = _get_pixel(basex - stride - 3)
-
-                p = a + b - c
-
-                pa = abs(p - a)
-                pb = abs(p - b)
-                pc = abs(p - c)
-
-                if pa <= pb and pa <= pc:
-                    color = (color + a) & 0xff
-                elif pb <= pc:
-                    color = (color + b) & 0xff
-                else:
-                    color = (color + c) & 0xff
-
-            current_row.append(color)
-
-    return width, height, pixels
-
-
 def write_xattr(path, key, value):
     # This mess below finds the best xattr tool for the job
     try:
@@ -4870,13 +4742,6 @@ def clean_podcast_url(url):
                 st\.fm # https://podsights.com/docs/
             )/e
         )/''', '', url)
-
-
-_HEX_TABLE = '0123456789abcdef'
-
-
-def random_uuidv4():
-    return re.sub(r'[xy]', lambda x: _HEX_TABLE[random.randint(0, 15)], 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx')
 
 
 def make_dir(path, to_screen=None):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4886,8 +4886,11 @@ def traverse_obj(
 
 
 def traverse_dict(dictn, keys, casesense=True):
-    write_string('DeprecationWarning: yt_dlp.utils.traverse_dict is deprecated '
-                 'and may be removed in a future version. Use yt_dlp.utils.traverse_obj instead')
+    import warnings
+    warnings.warn(DeprecationWarning(
+        'yt_dlp.utils.traverse_dict is deprecated '
+        'and may be removed in a future version. Use yt_dlp.utils.traverse_obj instead'
+    ))
     return traverse_obj(dictn, keys, casesense=casesense, is_user_input=True, traverse_string=True)
 
 


### PR DESCRIPTION
<details> <summary> Boilerplate (own code, improvement) </summary>

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- Improvement

</details>

(Spritual follow-up to #372.)

Most of these commits remove dead code and compatibility hacks meant for no longer supported Python versions. The SWF interpreter is removed again; it was pretty silly to keep it around in the first place.

The patches are pretty much unrelated to each other, so feel free to cherry-pick them individually as they are pushed on this branch.

Some further cleanups to consider:

- ~~`_windows_write_string` in utils seems to be a workaround for <https://bugs.python.org/issue1602>, which is apparently fixed in 3.6.  We should be able to get rid of it too. (I’m not sure what `write_string` itself adds over plain `sys.stderr.write` either.)~~
- ~~`locked_file` may be re-written as a `@contextlib.contextmanager`~~
- `uppercase_escape` and `lowercase_escape`: those functions seem as bad an idea as `addslashes` and `stripslashes` in PHP. The former doesn’t appear to be used anywhere at all other than in tests; the latter has a number of appearances in extractors, most of which seem pretty redundant, e.g.

   https://github.com/yt-dlp/yt-dlp/blob/11aa91a12f95821500fa064402a3e2c046b072fb/yt_dlp/extractor/chaturbate.py#L47-L51

   where the JSON parser is supposed to take case of `\uXXXX` escapes already.
- Split `utils` into thematically-linked modules. Right now it contains functions for as disparate subtitle conversion, HTML parsing, dictionary traversal, bug workarounds, command line handling… It’s become an unmanageable mess.
- Likewise, move out ‘common’ extractor methods from `InfoExtractor`, which has also become something of a god object anti-pattern. (Say, move manifest parsing into its own modules, one per manifest format.)