### PR TITLE
Recognise timed-text codecs in DASH manifests (stpp and wvtt)

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2716,8 +2716,6 @@ class InfoExtractor(object):
                     if content_type not in ('video', 'audio', 'text'):
                         if mime_type == 'image/jpeg':
                             content_type = mime_type
-                        # XXX: is this okay for mixed streams (video+audio, audio+subtitle)?
-                        # is it even possible to ever encounter them?
                         elif codecs['vcodec'] != 'none':
                             content_type = 'video'
                         elif codecs['acodec'] != 'none':
@@ -2768,8 +2766,8 @@ class InfoExtractor(object):
                             'format_note': 'DASH %s' % content_type,
                             'filesize': filesize,
                             'container': mimetype2ext(mime_type) + '_dash',
+                            **codecs
                         }
-                        f.update(codecs)
                     elif content_type == 'text':
                         f = {
                             'ext': mimetype2ext(mime_type),

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3196,7 +3196,7 @@ def parse_codecs(codecs_str):
         return {}
     split_codecs = list(filter(None, map(
         str.strip, codecs_str.strip().strip(',').split(','))))
-    vcodec, acodec, hdr = None, None, None
+    vcodec, acodec, tcodec, hdr = None, None, None, None
     for full_codec in split_codecs:
         parts = full_codec.split('.')
         codec = parts[0].replace('0', '')
@@ -3213,13 +3213,17 @@ def parse_codecs(codecs_str):
         elif codec in ('flac', 'mp4a', 'opus', 'vorbis', 'mp3', 'aac', 'ac-3', 'ec-3', 'eac3', 'dtsc', 'dtse', 'dtsh', 'dtsl'):
             if not acodec:
                 acodec = full_codec
+        elif codec in ('stpp', 'wvtt',):
+            if not tcodec:
+                tcodec = full_codec
         else:
             write_string('WARNING: Unknown codec %s\n' % full_codec, sys.stderr)
-    if vcodec or acodec:
+    if vcodec or acodec or tcodec:
         return {
             'vcodec': vcodec or 'none',
             'acodec': acodec or 'none',
             'dynamic_range': hdr,
+            **({'tcodec': tcodec} if tcodec is not None else {}),
         }
     elif len(split_codecs) == 2:
         return {


### PR DESCRIPTION
<details> <summary> Boilerplate (own code, improvement) </summary>
### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- Improvement
</details>

This is the [‘more long-term’ solution I alluded to before](https://github.com/yt-dlp/yt-dlp/issues/656#issuecomment-895087864). It makes the handling of subtitle vs non-subtitle streams in DASH manifests more uniform, and adds support for WebVTT-in-MP4 encapsulation (`wvtt` codec).