### PR TITLE
Extend file access retries to check rename and remove as well

### DIFF
--- a/yt_dlp/downloader/common.py
+++ b/yt_dlp/downloader/common.py
@@ -210,28 +210,36 @@ class FileDownloader(object):
     def ytdl_filename(self, filename):
         return filename + '.ytdl'
 
-    def sanitize_open(self, filename, open_mode):
-        file_access_retries = self.params.get('file_access_retries', 10)
-        retry = 0
-        while True:
-            try:
-                return sanitize_open(filename, open_mode)
-            except (IOError, OSError) as err:
-                retry = retry + 1
-                if retry > file_access_retries or err.errno not in (errno.EACCES,):
-                    raise
-                self.to_screen(
-                    '[download] Got file access error. Retrying (attempt %d of %s) ...'
-                    % (retry, self.format_retries(file_access_retries)))
-                time.sleep(0.01)
+    def wrap_file_access(func):
+        def inner(self, *argv, **kwargs):
+            file_access_retries = self.params.get('file_access_retries', 10)
+            retry = 0
+            while True:
+                try:
+                    return func(self, *argv, **kwargs)
+                except (IOError, OSError) as err:
+                    retry = retry + 1
+                    if retry > file_access_retries or err.errno not in (errno.EACCES, errno.EINVAL):
+                        raise
+                    self.to_screen(
+                        '[download] Got file access error. Retrying (attempt %d of %s) ...'
+                        % (retry, self.format_retries(file_access_retries)))
+                    time.sleep(0.01)
+        return inner
 
+    @wrap_file_access
+    def sanitize_open(self, filename, open_mode):
+        return sanitize_open(filename, open_mode)
+
+    @wrap_file_access
+    def try_remove(self, filename):
+        os.remove(filename)
+
+    @wrap_file_access
     def try_rename(self, old_filename, new_filename):
         if old_filename == new_filename:
             return
-        try:
-            os.replace(old_filename, new_filename)
-        except (IOError, OSError) as err:
-            self.report_error(f'unable to rename file: {err}')
+        os.replace(old_filename, new_filename)
 
     def try_utime(self, filename, last_modified_hdr):
         """Try to set the last-modified time of the given file."""

--- a/yt_dlp/downloader/common.py
+++ b/yt_dlp/downloader/common.py
@@ -220,6 +220,8 @@ class FileDownloader(object):
                 except (IOError, OSError) as err:
                     retry = retry + 1
                     if retry > file_access_retries or err.errno not in (errno.EACCES, errno.EINVAL):
+                        if func.__name__ == 'try_rename':
+                            return self.report_error(f'unable to rename file: {err}')
                         raise
                     self.to_screen(
                         '[download] Got file access error. Retrying (attempt %d of %s) ...'

--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -159,9 +159,9 @@ class ExternalFD(FragmentFD):
             dest.write(decrypt_fragment(fragment, src.read()))
             src.close()
             if not self.params.get('keep_fragments', False):
-                os.remove(encodeFilename(fragment_filename))
+                self.try_remove(encodeFilename(fragment_filename))
         dest.close()
-        os.remove(encodeFilename('%s.frag.urls' % tmpfilename))
+        self.try_remove(encodeFilename('%s.frag.urls' % tmpfilename))
         return 0
 
 

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -159,7 +159,7 @@ class FragmentFD(FileDownloader):
             if self.__do_ytdl_file(ctx):
                 self._write_ytdl_file(ctx)
             if not self.params.get('keep_fragments', False):
-                os.remove(encodeFilename(ctx['fragment_filename_sanitized']))
+                self.try_remove(encodeFilename(ctx['fragment_filename_sanitized']))
             del ctx['fragment_filename_sanitized']
 
     def _prepare_frag_download(self, ctx):
@@ -305,7 +305,7 @@ class FragmentFD(FileDownloader):
         if self.__do_ytdl_file(ctx):
             ytdl_filename = encodeFilename(self.ytdl_filename(ctx['filename']))
             if os.path.isfile(ytdl_filename):
-                os.remove(ytdl_filename)
+                self.try_remove(ytdl_filename)
         elapsed = time.time() - ctx['started']
 
         if ctx['tmpfilename'] == '-':

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -727,7 +727,7 @@ def create_parser():
         help='Number of retries (default is %default), or "infinite"')
     downloader.add_option(
         '--file-access-retries',
-        dest='file_access_retries', metavar='RETRIES', default=10,
+        dest='file_access_retries', metavar='RETRIES', default=3,
         help='Number of times to retry on file access error (default is %default), or "infinite"')
     downloader.add_option(
         '--fragment-retries',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I'm still getting some file access errors on my laptop, so I extended the logic to cover a few more places. I added `try_remove`, matching `try_rename` to avoid bare `os.remove` calls. To avoid code duplication I turned the retry logic into a decorator that wraps `sanitize_open`, `try_remove` and `try_rename`.

Notes:
- `try_rename` had a custom error message. I couldn't add it to the decorator and I think it would have conflicted with the error handling so it now raises the built in error if it fails.
- I added `error.EINVAL` (error 22) to the list of errors to retry, as I also saw this error on my laptop (I'm pretty sure it's the same problem as the parameter looks fine and it doesn't fail every time).