### PR TITLE
[NBCSports] fix regexes to properly extract platform URLs

### DIFF
--- a/yt_dlp/extractor/nbc.py
+++ b/yt_dlp/extractor/nbc.py
@@ -197,9 +197,12 @@ class NBCSportsVPlayerIE(InfoExtractor):
             'timestamp': 1426270238,
             'upload_date': '20150313',
             'uploader': 'NBCU-SPORTS',
+            'duration': 72.818,
+            'chapters': [],
+            'thumbnail': r're:^https?://.*\.jpg$'
         }
     }, {
-        'url': 'https://vplayer.nbcsports.com/p/BxmELC/nbcsports_embed/select/media/_hqLjQ95yx8Z',
+        'url': 'https://vplayer.nbcsports.com/p/BxmELC/nbcsports_embed/select/media/PEgOtlNcC_y2',
         'only_matching': True,
     }, {
         'url': 'https://www.nbcsports.com/vplayer/p/BxmELC/nbcsports/select/PHJSaFWbrTY9?form=html&autoPlay=true',
@@ -208,16 +211,15 @@ class NBCSportsVPlayerIE(InfoExtractor):
 
     @staticmethod
     def _extract_url(webpage):
-        iframe_m = re.search(
-            r'<(?:iframe[^>]+|div[^>]+data-(?:mpx-)?)src="(?P<url>%s[^"]+)"' % NBCSportsVPlayerIE._VALID_URL_BASE, webpage)
-        if iframe_m:
-            return iframe_m.group('url')
+        video_urls = re.search(
+            r'(var videoSrc = |div[^>]+data-(?:mpx-)?src=)"(?P<url>%s[^\"]+)' % NBCSportsVPlayerIE._VALID_URL_BASE, webpage)
+        if video_urls:
+            return video_urls.group('url')
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        theplatform_url = self._og_search_video_url(webpage).replace(
-            'vplayer.nbcsports.com', 'player.theplatform.com')
+        theplatform_url = self._html_search_regex(r'tp:releaseUrl="(.+?)"', webpage, 'url')
         return self.url_result(theplatform_url, 'ThePlatform')
 
 

--- a/yt_dlp/extractor/nbc.py
+++ b/yt_dlp/extractor/nbc.py
@@ -212,7 +212,7 @@ class NBCSportsVPlayerIE(InfoExtractor):
     @staticmethod
     def _extract_url(webpage):
         video_urls = re.search(
-            r'(var videoSrc = |div[^>]+data-(?:mpx-)?src=)"(?P<url>%s[^\"]+)' % NBCSportsVPlayerIE._VALID_URL_BASE, webpage)
+            r'(?:iframe[^>]+|var video|div[^>]+data-(?:mpx-)?)[sS]rc\s?=\s?"(?P<url>%s[^\"]+)' % NBCSportsVPlayerIE._VALID_URL_BASE, webpage)
         if video_urls:
             return video_urls.group('url')
 
@@ -237,6 +237,9 @@ class NBCSportsIE(InfoExtractor):
             'uploader': 'NBCU-SPORTS',
             'upload_date': '20150330',
             'timestamp': 1427726529,
+            'chapters': [],
+            'thumbnail': 'https://hdliveextra-a.akamaihd.net/HD/image_sports/NBCU_Sports_Group_-_nbcsports/253/303/izzodps.jpg',
+            'duration': 528.395,
         }
     }, {
         # data-mpx-src


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Update the regexes in the `NBCSportsVPlayer` and `NBCSports` extractors to get proper URLS for ThePlatform. Closes #2059.