### PR TITLE
[veoh] Accept "videos" URLs; prefer HQ format; get additional metadata

### DIFF
--- a/yt_dlp/extractor/veoh.py
+++ b/yt_dlp/extractor/veoh.py
@@ -9,7 +9,7 @@ from ..utils import (
 
 
 class VeohIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?veoh\.com/(?:watch|embed|iphone/#_Watch)/(?P<id>(?:v|e|yapi-)[\da-zA-Z]+)'
+    _VALID_URL = r'https?://(?:www\.)?veoh\.com/(?:watch|videos|embed|iphone/#_Watch)/(?P<id>(?:v|e|yapi-)[\da-zA-Z]+)'
 
     _TESTS = [{
         'url': 'http://www.veoh.com/watch/v56314296nk7Zdmz3',

--- a/yt_dlp/extractor/veoh.py
+++ b/yt_dlp/extractor/veoh.py
@@ -13,7 +13,7 @@ class VeohIE(InfoExtractor):
 
     _TESTS = [{
         'url': 'http://www.veoh.com/watch/v56314296nk7Zdmz3',
-        'md5': '9e7ecc0fd8bbee7a69fe38953aeebd30',
+        'md5': '620e68e6a3cff80086df3348426c9ca3',
         'info_dict': {
             'id': 'v56314296nk7Zdmz3',
             'ext': 'mp4',
@@ -61,7 +61,7 @@ class VeohIE(InfoExtractor):
         title = video['title']
 
         thumbnail_url = None
-        q = qualities(['HQ', 'Regular'])
+        q = qualities(['Regular', 'HQ'])
         formats = []
         for f_id, f_url in video.get('src', {}).items():
             if not f_url:

--- a/yt_dlp/extractor/veoh.py
+++ b/yt_dlp/extractor/veoh.py
@@ -53,19 +53,6 @@ class VeohIE(InfoExtractor):
         'only_matching': True,
     }]
 
-    def _extract_video(self, source):
-        return {
-            'id': source.get('videoId'),
-            'title': source.get('title'),
-            'description': source.get('description'),
-            'thumbnail': source.get('highResImage') or source.get('medResImage'),
-            'uploader': source.get('username'),
-            'duration': int_or_none(source.get('length')),
-            'view_count': int_or_none(source.get('views')),
-            'age_limit': 18 if source.get('isMature') == 'true' or source.get('isSexy') == 'true' else 0,
-            'formats': self._extract_formats(source),
-        }
-
     def _real_extract(self, url):
         video_id = self._match_id(url)
         video = self._download_json(

--- a/yt_dlp/extractor/veoh.py
+++ b/yt_dlp/extractor/veoh.py
@@ -19,8 +19,16 @@ class VeohIE(InfoExtractor):
             'id': 'v56314296nk7Zdmz3',
             'ext': 'mp4',
             'title': 'Straight Backs Are Stronger',
+            'description': 'At LUMOback, we believe straight backs are stronger. The LUMOback Posture & Movement Sensor: It gently vibrates when you slouch, inspiring improved posture and mobility. Use the app to track your data and improve your posture over time.',
+            'thumbnail': 're:https://fcache\\.veoh\\.com/file/f/th56314296\\.jpg(\\?.*)?',
             'uploader': 'LUMOback',
-            'description': 'At LUMOback, we believe straight backs are stronger.  The LUMOback Posture & Movement Sensor:  It gently vibrates when you slouch, inspiring improved posture and mobility.  Use the app to track your data and improve your posture over time. ',
+            'duration': 46,
+            'view_count': int,
+            'average_rating': int,
+            'comment_count': int,
+            'age_limit': 0,
+            'categories': ['technology_and_gaming'],
+            'tags': ['posture', 'posture', 'sensor', 'back', 'pain', 'wearable', 'tech', 'lumo'],
         },
     }, {
         'url': 'http://www.veoh.com/embed/v56314296nk7Zdmz3',
@@ -52,6 +60,24 @@ class VeohIE(InfoExtractor):
     }, {
         'url': 'http://www.veoh.com/watch/e152215AJxZktGS',
         'only_matching': True,
+    }, {
+        'url': 'https://www.veoh.com/videos/v16374379WA437rMH',
+        'md5': 'cceb73f3909063d64f4b93d4defca1b3',
+        'info_dict': {
+            'id': 'v16374379WA437rMH',
+            'ext': 'mp4',
+            'title': 'Phantasmagoria 2, pt. 1-3',
+            'description': 'Phantasmagoria: a Puzzle of Flesh',
+            'thumbnail': 're:https://fcache\\.veoh\\.com/file/f/th16374379\\.jpg(\\?.*)?',
+            'uploader': 'davidspackage',
+            'duration': 968,
+            'view_count': int,
+            'average_rating': int,
+            'comment_count': int,
+            'age_limit': 18,
+            'categories': ['technology_and_gaming', 'gaming'],
+            'tags': ['puzzle', 'of', 'flesh'],
+        }
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/veoh.py
+++ b/yt_dlp/extractor/veoh.py
@@ -19,7 +19,7 @@ class VeohIE(InfoExtractor):
             'id': 'v56314296nk7Zdmz3',
             'ext': 'mp4',
             'title': 'Straight Backs Are Stronger',
-            'description': 'At LUMOback, we believe straight backs are stronger. The LUMOback Posture & Movement Sensor: It gently vibrates when you slouch, inspiring improved posture and mobility. Use the app to track your data and improve your posture over time.',
+            'description': 'md5:203f976279939a6dc664d4001e13f5f4',
             'thumbnail': 're:https://fcache\\.veoh\\.com/file/f/th56314296\\.jpg(\\?.*)?',
             'uploader': 'LUMOback',
             'duration': 46,
@@ -82,10 +82,10 @@ class VeohIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        json = self._download_json(
+        metadata = self._download_json(
             'https://www.veoh.com/watch/getVideo/' + video_id,
             video_id)
-        video = json['video']
+        video = metadata['video']
         title = video['title']
 
         thumbnail_url = None
@@ -104,7 +104,7 @@ class VeohIE(InfoExtractor):
                 })
         self._sort_formats(formats)
 
-        categories = json.get('categoryPath')
+        categories = metadata.get('categoryPath')
         if not categories:
             category = try_get(video, lambda x: x['category'].strip().removeprefix('category_'))
             categories = [category] if category else None


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is an update of [youtube-dl PR 22661](https://github.com/ytdl-org/youtube-dl/pull/22661). It makes the following changes to the veoh extractor:

- Accept `videos` URLs.
- Prefer high quality (current master incorrectly marks "Regular" rather than "HQ" as "best").
- Extract metadata for `age_limit`, `categories`, and `tags`.

It also updates the test cases and removes the defunct `_extract_video` method.

Thank you!