### PR TITLE
[utils] Fix get_elements_text_and_html_by_attribute regex

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1659,10 +1659,10 @@ Line 1
         html = self.GET_ELEMENTS_BY_CLASS_TEST_STRING
 
         self.assertEqual(
-            get_elements_text_and_html_by_attribute('class', 'foo bar', html),
+            list(get_elements_text_and_html_by_attribute('class', 'foo bar', html)),
             list(zip(['nice', 'also nice'], self.GET_ELEMENTS_BY_CLASS_RES)))
-        self.assertEqual(get_elements_text_and_html_by_attribute('class', 'foo', html), [])
-        self.assertEqual(get_elements_text_and_html_by_attribute('class', 'no-such-foo', html), [])
+        self.assertEqual(list(get_elements_text_and_html_by_attribute('class', 'foo', html)), [])
+        self.assertEqual(list(get_elements_text_and_html_by_attribute('class', 'no-such-foo', html)), [])
 
     GET_ELEMENT_BY_TAG_TEST_STRING = '''
     random text lorem ipsum</p>

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -473,7 +473,7 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, escape_value
     attribute in the passed HTML document
     """
 
-    value_quote_optional = '' if re.match(r'''[\s"'`=<>]''', value) else r'?'
+    value_quote_optional = '' if re.match(r'''[\s"'`=<>]''', value) else '?'
 
     value = re.escape(value) if escape_value else value
 
@@ -488,7 +488,8 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, escape_value
 
         yield (
             unescapeHTML(re.sub(r'^(?P<q>["\'])(?P<content>.*)(?P=q)$', r'\g<content>', content, flags=re.DOTALL)),
-            whole)
+            whole
+        )
 
 
 class HTMLBreakOnClosingTagParser(compat_HTMLParser):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -477,12 +477,11 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, escape_value
 
     value = re.escape(value) if escape_value else value
 
-    match_pattern = re.compile(
-        r'''<(?P<tag>[a-zA-Z0-9:._-]+)(?:\s+[a-zA-Z0-9_:.-]+(?:=[^\s"'`=<>]+|=(?:"[^"]*"|'[^']*')|))*?\s+%(attribute)s=(?P<_q>['"]%(vqo)s)%(value)s(?P=_q)''' %
+    partial_element_re = \
+        r'''<(?P<tag>[a-zA-Z0-9:._-]+)(?:\s+[a-zA-Z0-9_:.-]+(?:=[^\s"'`=<>]+|=(?:"[^"]*"|'[^']*')|))*?\s+%(attribute)s=(?P<_q>['"]%(vqo)s)%(value)s(?P=_q)''' % \
         {'attribute': re.escape(attribute), 'value': value, 'vqo': value_quote_optional}
-    )
 
-    for m in match_pattern.finditer(html):
+    for m in re.finditer(partial_element_re, html):
         content, whole = get_element_text_and_html_by_tag(m.group('tag'), html[m.start():])
 
         yield unescapeHTML(re.sub(r'^(?P<q>["\'])(?P<content>.*)(?P=q)$', r'\g<content>', content, flags=re.DOTALL)), \

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -486,8 +486,9 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, escape_value
     for m in re.finditer(partial_element_re, html):
         content, whole = get_element_text_and_html_by_tag(m.group('tag'), html[m.start():])
 
-        yield unescapeHTML(re.sub(r'^(?P<q>["\'])(?P<content>.*)(?P=q)$', r'\g<content>', content, flags=re.DOTALL)), \
-            whole
+        yield (
+            unescapeHTML(re.sub(r'^(?P<q>["\'])(?P<content>.*)(?P=q)$', r'\g<content>', content, flags=re.DOTALL)),
+            whole)
 
 
 class HTMLBreakOnClosingTagParser(compat_HTMLParser):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -473,24 +473,20 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, escape_value
     attribute in the passed HTML document
     """
 
+    value_quote_optional = '' if re.match(r'''[\s"'`=<>]''', value) else r'?'
+
     value = re.escape(value) if escape_value else value
 
-    retlist = []
-    for m in re.finditer(r'''(?xs)
-        <(?P<tag>[a-zA-Z0-9:._-]+)
-         (?:\s+[a-zA-Z0-9_:.-]+(?:=\S*?|\s*=\s*(?:"[^"]*"|'[^']*')|))*?
-         \s+%(attribute)s(?:=%(value)s|\s*=\s*(?P<_q>['"]?)%(value)s(?P=_q))
-         (?:\s+[a-zA-Z0-9_:.-]+(?:=\S*?|\s*=\s*(?:"[^"]*"|'[^']*')|))*?
-        \s*>
-    ''' % {'attribute': re.escape(attribute), 'value': value}, html):
+    match_pattern = re.compile(
+        r'''<(?P<tag>[a-zA-Z0-9:._-]+)(?:\s+[a-zA-Z0-9_:.-]+(?:=[^\s"'`=<>]+|=(?:"[^"]*"|'[^']*')|))*?\s+%(attribute)s=(?P<_q>['"]%(vqo)s)%(value)s(?P=_q)''' %
+        {'attribute': re.escape(attribute), 'value': value, 'vqo': value_quote_optional}
+    )
+
+    for m in match_pattern.finditer(html):
         content, whole = get_element_text_and_html_by_tag(m.group('tag'), html[m.start():])
 
-        retlist.append((
-            unescapeHTML(re.sub(r'(?s)^(?P<q>["\'])(?P<content>.*)(?P=q)$', r'\g<content>', content)),
-            whole,
-        ))
-
-    return retlist
+        yield unescapeHTML(re.sub(r'^(?P<q>["\'])(?P<content>.*)(?P=q)$', r'\g<content>', content, flags=re.DOTALL)), \
+            whole
 
 
 class HTMLBreakOnClosingTagParser(compat_HTMLParser):

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -477,9 +477,11 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, escape_value
 
     value = re.escape(value) if escape_value else value
 
-    partial_element_re = \
-        r'''<(?P<tag>[a-zA-Z0-9:._-]+)(?:\s+[a-zA-Z0-9_:.-]+(?:=[^\s"'`=<>]+|=(?:"[^"]*"|'[^']*')|))*?\s+%(attribute)s=(?P<_q>['"]%(vqo)s)%(value)s(?P=_q)''' % \
-        {'attribute': re.escape(attribute), 'value': value, 'vqo': value_quote_optional}
+    partial_element_re = r'''(?x)
+        <(?P<tag>[a-zA-Z0-9:._-]+)
+         (?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?
+         \s%(attribute)s\s*=\s*(?P<_q>['"]%(vqo)s)(?-x:%(value)s)(?P=_q)
+        ''' % {'attribute': re.escape(attribute), 'value': value, 'vqo': value_quote_optional}
 
     for m in re.finditer(partial_element_re, html):
         content, whole = get_element_text_and_html_by_tag(m.group('tag'), html[m.start():])


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

* Simplify regex to avoid catastrophic backtracking, noticed after #2129
  * Loosely match anything between the tag and the AV-pair of interest (authored by @pukkandan)
  * Only match up to the AV-pair of interest, rather than the end of the end of the opening tag
  * Strictly match an unquoted value
  * Likewise determine if quotes are optional around the matched value
  * Avoid `re.DOTALL` as `.` is not used
* Yield directly in `re.finditer`, rather than append to and return a list
  * Noop as both calling functions perform list comprehension
  * But adapt direct calls in `test_utils.test_get_elements_text_and_html_by_attribute`