### PR TITLE
[twitcasting] Throw proper error for login-only streams

### DIFF
--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -97,6 +97,10 @@ class TwitCastingIE(InfoExtractor):
             'Downloading live info', fatal=False)
 
         is_live = 'data-status="online"' in webpage
+
+        if not traverse_obj(stream_server_data, 'llfmp4') and is_live:
+            raise ExtractorError('You must be logged in to watch.', expected=True)
+
         formats = []
         if is_live and not m3u8_url:
             m3u8_url = 'https://twitcasting.tv/%s/metastream.m3u8' % uploader_id

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -14,6 +14,7 @@ from ..utils import (
     parse_duration,
     qualities,
     str_to_int,
+    traverse_obj,
     try_get,
     unified_timestamp,
     urlencode_postdata,
@@ -101,7 +102,8 @@ class TwitCastingIE(InfoExtractor):
             m3u8_url = 'https://twitcasting.tv/%s/metastream.m3u8' % uploader_id
         if is_live and has_websockets and stream_server_data:
             qq = qualities(['base', 'mobilesource', 'main'])
-            for mode, ws_url in stream_server_data['llfmp4']['streams'].items():
+            streams = traverse_obj(stream_server_data, ('llfmp4', 'streams')) or {}
+            for mode, ws_url in streams.items():
                 formats.append({
                     'url': ws_url,
                     'format_id': 'ws-%s' % mode,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Closes #2289. Looks like the situation happens when the streamer requires login to watch streams.
(The lint error is happened outside of this PR)