### PR TITLE
[extractor/tvopengr] Add new extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1648,6 +1648,10 @@ from .tvnow import (
     TVNowAnnualIE,
     TVNowShowIE,
 )
+from .tvopengr import (
+    TVOpenGrWatchIE,
+    TVOpenGrEmbedIE,
+)
 from .tvp import (
     TVPEmbedIE,
     TVPIE,

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -135,6 +135,7 @@ from .arcpublishing import ArcPublishingIE
 from .medialaan import MedialaanIE
 from .simplecast import SimplecastIE
 from .wimtv import WimTVIE
+from .tvopengr import TVOpenGrEmbedIE
 from .tvp import TVPEmbedIE
 from .blogger import BloggerIE
 from .mainstreaming import MainStreamingIE
@@ -3608,6 +3609,11 @@ class GenericIE(InfoExtractor):
         if rumble_urls:
             return self.playlist_from_matches(
                 rumble_urls, video_id, video_title, ie=RumbleEmbedIE.ie_key())
+
+        # Look for (tvopen|ethnos).gr embeds
+        tvopengr_urls = list(TVOpenGrEmbedIE._extract_urls(webpage, url))
+        if tvopengr_urls:
+            return self.playlist_from_matches(tvopengr_urls, video_id, video_title, ie=TVOpenGrEmbedIE.ie_key())
 
         tvp_urls = TVPEmbedIE._extract_urls(webpage)
         if tvp_urls:

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -2178,6 +2178,22 @@ class GenericIE(InfoExtractor):
             },
         },
         {
+            # tvopengr:embed
+            'url': 'https://www.ethnos.gr/World/article/190604/hparosiaxekinoynoisynomiliessthgeneyhmethskiatoypolemoypanoapothnoykrania',
+            'md5': 'eb0c3995d0a6f18f6538c8e057865d7d',
+            'info_dict': {
+                'id': '101119',
+                'ext': 'mp4',
+                'display_id': 'oikarpoitondiapragmateyseonhparosias',
+                'title': 'md5:b979f4d640c568617d6547035528a149',
+                'description': 'md5:e54fc1977c7159b01cc11cd7d9d85550',
+                'timestamp': 1641772800,
+                'upload_date': '20220110',
+                'thumbnail': 'https://opentv-static.siliconweb.com/imgHandler/1920/70bc39fa-895b-4918-a364-c39d2135fc6d.jpg',
+
+            }
+        },
+        {
             # blogger embed
             'url': 'https://blog.tomeuvizoso.net/2019/01/a-panfrost-milestone.html',
             'md5': 'f1bc19b6ea1b0fd1d81e84ca9ec467ac',

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -3611,7 +3611,7 @@ class GenericIE(InfoExtractor):
                 rumble_urls, video_id, video_title, ie=RumbleEmbedIE.ie_key())
 
         # Look for (tvopen|ethnos).gr embeds
-        tvopengr_urls = list(TVOpenGrEmbedIE._extract_urls(webpage, url))
+        tvopengr_urls = list(TVOpenGrEmbedIE._extract_urls(webpage))
         if tvopengr_urls:
             return self.playlist_from_matches(tvopengr_urls, video_id, video_title, ie=TVOpenGrEmbedIE.ie_key())
 

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -133,7 +133,7 @@ class TVOpenGrEmbedIE(TVOpenGrBaseIE):
     }]
 
     @classmethod
-    def _extract_urls(cls, webpage, origin_url=None):
+    def _extract_urls(cls, webpage):
         EMBED_RE = r'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>%s)(?P=_q1)''' % cls._VALID_URL
         for mobj in re.finditer(EMBED_RE, webpage):
             yield unescapeHTML(mobj.group('url'))

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -1,0 +1,147 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+import urllib.parse
+
+from .common import InfoExtractor
+from ..utils import (
+    determine_ext,
+    get_elements_text_and_html_by_attribute,
+    unescapeHTML,
+)
+
+
+class TVOpenGrBaseIE(InfoExtractor):
+    def _return_canonical_url(self, url, video_id):
+        webpage = self._download_webpage(url, video_id)
+        canonical_url = self._og_search_url(webpage)
+        title = self._og_search_title(webpage)
+        self.to_screen(f'{video_id}: Redirect to canonical URL')
+        return self.url_result(canonical_url, ie=TVOpenGrWatchIE.ie_key(), video_id=video_id, video_title=title)
+
+
+class TVOpenGrWatchIE(TVOpenGrBaseIE):
+    IE_NAME = 'tvopengr:watch'
+    IE_DESC = 'tvopen.gr (and ethnos.gr) videos'
+    _VALID_URL = r'(?P<scheme>https?)://(?P<netloc>(?:www\.)?(?:tvopen|ethnos)\.gr)/watch/(?P<id>\d+)/(?P<slug>[^/]+)'
+    _API_ENDPOINT = '//www.tvopen.gr/templates/data/player'
+
+    _TESTS = [{
+        'url': 'https://www.ethnos.gr/watch/101009/nikoskaprabelosdenexoymekanenanasthenhsemethmethmetallaxhomikron',
+        'md5': '8728570e3a72e0f8d9475ba94859fdc1',
+        'info_dict': {
+            'id': '101009',
+            'title': 'md5:51f68773dcb6c70498cd326f45fefdf0',
+            'display_id': 'nikoskaprabelosdenexoymekanenanasthenhsemethmethmetallaxhomikron',
+            'description': 'md5:78fff49f18fb3effe41b070e5c7685d6',
+            'thumbnail': 'https://opentv-static.siliconweb.com/imgHandler/1920/d573ba71-ec5f-43c6-b4cb-d181f327d3a8.jpg',
+            'ext': 'mp4',
+            'upload_date': '20220109',
+            'timestamp': 1641686400,
+        },
+    }, {
+        'url': 'https://www.tvopen.gr/watch/100979/se28099agapaomenalla7cepeisodio267cmhthrargiapashskakias',
+        'md5': '38f98a1be0c577db4ea2d1b1c0770c48',
+        'info_dict': {
+            'id': '100979',
+            'title': 'md5:e021f3001e16088ee40fa79b20df305b',
+            'display_id': 'se28099agapaomenalla7cepeisodio267cmhthrargiapashskakias',
+            'description': 'md5:ba17db53954134eb8d625d199e2919fb',
+            'thumbnail': 'https://opentv-static.siliconweb.com/imgHandler/1920/9bb71cf1-21da-43a9-9d65-367950fde4e3.jpg',
+            'ext': 'mp4',
+            'upload_date': '20220108',
+            'timestamp': 1641600000,
+        },
+    }]
+
+    def _download_api_data(self, cid, scheme='https'):
+        url = f'{scheme}:{self._API_ENDPOINT}'
+        query = {'cid': cid}
+        return self._download_json(
+            url, query,
+            'Downloading JSON',
+            'Unable to download JSON',
+            query=query)
+
+    def _extract_formats_and_subs(self, options, video_id):
+        formats, subs = [], {}
+        for format_id, format_url in options.items():
+            if format_id not in ('stream', 'httpstream', 'mpegdash'):
+                continue
+            ext = determine_ext(format_url)
+            if ext == 'm3u8':
+                formats_, subs_ = self._extract_m3u8_formats_and_subtitles(
+                    format_url, video_id, 'mp4', m3u8_id=format_id,
+                    fatal=False)
+            elif ext == 'mpd':
+                formats_, subs_ = self._extract_mpd_formats_and_subtitles(
+                    format_url, video_id, 'mp4', fatal=False)
+            else:
+                formats.append({
+                    'url': format_url,
+                    'format_id': format_id,
+                })
+                continue
+            formats.extend(formats_)
+            subs.update(subs_)
+        self._sort_formats(formats)
+        return formats, subs
+
+    def _real_extract(self, url):
+        scheme, netloc, video_id, display_id = self._match_valid_url(url).group('scheme', 'netloc', 'id', 'slug')
+        if netloc.find('tvopen.gr') == -1:
+            return self._return_canonical_url(url, video_id)
+        webpage = self._download_webpage(url, video_id)
+        info = self._search_json_ld(webpage, video_id, expected_type='VideoObject')
+        info['formats'], info['subtitles'] = self._extract_formats_and_subs(
+            self._download_api_data(video_id, scheme=scheme), video_id)
+        max_width = max([format.get('width') or 0 for format in info['formats']])
+        if max_width:
+            for thumbnail in info['thumbnails']:
+                thumbnail['url'] = re.sub(r'(/imgHandler/)\d+', rf'\g<1>{max_width}', thumbnail['url'])
+        description, _html = next(get_elements_text_and_html_by_attribute('class', 'description', webpage))
+        if description and _html.startswith('<span '):
+            info['description'] = description
+        info['id'] = video_id
+        info['display_id'] = display_id
+        return info
+
+
+class TVOpenGrEmbedIE(TVOpenGrBaseIE):
+    IE_NAME = 'tvopengr:embed'
+    IE_DESC = 'tvopen.gr embedded videos'
+    _VALID_URL = r'https?://(?:www\.|cdn\.|)(?:tvopen|ethnos).gr/embed/(?P<id>\d+)'
+
+    _TESTS = [{
+        'url': 'https://cdn.ethnos.gr/embed/100963',
+        'md5': '2da147881f45571d81662d94d086628b',
+        'info_dict': {
+            'id': '100963',
+            'display_id': 'koronoiosapotoysdieythyntestonsxoleionselftestgiaosoysdenbrhkan',
+            'title': 'md5:2c71876fadf0cda6043da0da5fca2936',
+            'description': 'md5:17482b4432e5ed30eccd93b05d6ea509',
+            'thumbnail': 'https://opentv-static.siliconweb.com/imgHandler/1920/5804e07f-799a-4247-a696-33842c94ca37.jpg',
+            'ext': 'mp4',
+            'upload_date': '20220108',
+            'timestamp': 1641600000,
+        },
+    }]
+
+    @classmethod
+    def _extract_urls(cls, webpage, origin_url=None):
+        # make the scheme in _VALID_URL optional
+        _URL_RE = r'(?:https?:)?//' + cls._VALID_URL.split('://', 1)[1]
+        EMBED_RE = r'''(?x)
+            <iframe[^>]+?src=(?P<_q1>["'])(?P<url>%(url_re)s)(?P=_q1)
+        ''' % {'url_re': _URL_RE}
+        for mobj in re.finditer(EMBED_RE, webpage):
+            url = unescapeHTML(mobj.group('url'))
+            if url.startswith('//'):
+                scheme = urllib.parse.urlparse(origin_url).scheme if origin_url else 'https'
+                url = f'{scheme}:{url}'
+            yield url
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        return self._return_canonical_url(url, video_id)

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -116,6 +116,7 @@ class TVOpenGrEmbedIE(TVOpenGrBaseIE):
     IE_NAME = 'tvopengr:embed'
     IE_DESC = 'tvopen.gr embedded videos'
     _VALID_URL = r'(?:https?:)?//(?:www\.|cdn\.|)(?:tvopen|ethnos).gr/embed/(?P<id>\d+)'
+    _EMBED_RE = re.compile(rf'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>{_VALID_URL})(?P=_q1)''')
 
     _TESTS = [{
         'url': 'https://cdn.ethnos.gr/embed/100963',
@@ -134,8 +135,7 @@ class TVOpenGrEmbedIE(TVOpenGrBaseIE):
 
     @classmethod
     def _extract_urls(cls, webpage):
-        EMBED_RE = r'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>%s)(?P=_q1)''' % cls._VALID_URL
-        for mobj in re.finditer(EMBED_RE, webpage):
+        for mobj in cls._EMBED_RE.finditer(webpage):
             yield unescapeHTML(mobj.group('url'))
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -7,6 +7,7 @@ from .common import InfoExtractor
 from ..utils import (
     determine_ext,
     get_elements_text_and_html_by_attribute,
+    merge_dicts,
     unescapeHTML,
 )
 
@@ -77,6 +78,21 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
         self._sort_formats(formats)
         return formats, subs
 
+    @staticmethod
+    def _scale_thumbnails_to_max_width(formats, thumbnails, url_width_re):
+        _keys = ('width', 'height')
+        max_dimensions = max(
+            [tuple(format.get(k) or 0 for k in _keys) for format in formats],
+            default=(0, 0))
+        if not max_dimensions[0]:
+            return thumbnails
+        return [
+            merge_dicts(
+                {'url': re.sub(url_width_re, str(max_dimensions[0]), thumbnail['url'])},
+                dict(zip(_keys, max_dimensions)), thumbnail)
+            for thumbnail in thumbnails
+        ]
+
     def _real_extract(self, url):
         netloc, video_id, display_id = self._match_valid_url(url).group('netloc', 'id', 'slug')
         if netloc.find('tvopen.gr') == -1:
@@ -86,13 +102,8 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
         info['formats'], info['subtitles'] = self._extract_formats_and_subs(
             self._download_json(self._API_ENDPOINT, video_id, query={'cid': video_id}),
             video_id)
-        max_dimensions = max(
-            [tuple(format.get(k) or 0 for k in ('width', 'height')) for format in info['formats']],
-            default=(0, 0))
-        if max_dimensions[0]:
-            for thumbnail in info['thumbnails']:
-                thumbnail['url'] = re.sub(r'(/imgHandler/)\d+', rf'\g<1>{max_dimensions[0]}', thumbnail['url'])
-                thumbnail['width'], thumbnail['height'] = max_dimensions
+        info['thumbnails'] = self._scale_thumbnails_to_max_width(
+            info['formats'], info['thumbnails'], r'(?<=/imgHandler/)\d+')
         description, _html = next(get_elements_text_and_html_by_attribute('class', 'description', webpage))
         if description and _html.startswith('<span '):
             info['description'] = description

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -88,7 +88,7 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
             video_id)
         max_dimensions = max(
             [tuple(format.get(k) or 0 for k in ('width', 'height')) for format in info['formats']],
-            default=None)
+            default=(0, 0))
         if max_dimensions[0]:
             for thumbnail in info['thumbnails']:
                 thumbnail['url'] = re.sub(r'(/imgHandler/)\d+', rf'\g<1>{max_dimensions[0]}', thumbnail['url'])

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -123,9 +123,7 @@ class TVOpenGrEmbedIE(TVOpenGrBaseIE):
 
     @classmethod
     def _extract_urls(cls, webpage, origin_url=None):
-        EMBED_RE = r'''(?x)
-            <iframe[^>]+?src=(?P<_q1>["'])(?P<url>%(url_re)s)(?P=_q1)
-        ''' % {'url_re': cls._VALID_URL}
+        EMBED_RE = r'''<iframe[^>]+?src=(?P<_q1>["'])(?P<url>%s)(?P=_q1)''' % cls._VALID_URL
         for mobj in re.finditer(EMBED_RE, webpage):
             yield unescapeHTML(mobj.group('url'))
 

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -23,7 +23,7 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
     IE_NAME = 'tvopengr:watch'
     IE_DESC = 'tvopen.gr (and ethnos.gr) videos'
     _VALID_URL = r'https?://(?P<netloc>(?:www\.)?(?:tvopen|ethnos)\.gr)/watch/(?P<id>\d+)/(?P<slug>[^/]+)'
-    _API_ENDPOINT = '//www.tvopen.gr/templates/data/player'
+    _API_ENDPOINT = 'https://www.tvopen.gr/templates/data/player'
 
     _TESTS = [{
         'url': 'https://www.ethnos.gr/watch/101009/nikoskaprabelosdenexoymekanenanasthenhsemethmethmetallaxhomikron',
@@ -84,8 +84,7 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
         webpage = self._download_webpage(url, video_id)
         info = self._search_json_ld(webpage, video_id, expected_type='VideoObject')
         info['formats'], info['subtitles'] = self._extract_formats_and_subs(
-            self._download_json(
-                f'{self.http_scheme()}:{self._API_ENDPOINT}', video_id, query={'cid': video_id}),
+            self._download_json(self._API_ENDPOINT, video_id, query={'cid': video_id}),
             video_id)
         max_dimensions = max(
             [tuple(format.get(k) or 0 for k in ('width', 'height')) for format in info['formats']],

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -53,9 +53,9 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
         },
     }]
 
-    def _extract_formats_and_subs(self, options, video_id):
+    def _extract_formats_and_subs(self, response, video_id):
         formats, subs = [], {}
-        for format_id, format_url in options.items():
+        for format_id, format_url in response.items():
             if format_id not in ('stream', 'httpstream', 'mpegdash'):
                 continue
             ext = determine_ext(format_url)

--- a/yt_dlp/extractor/tvopengr.py
+++ b/yt_dlp/extractor/tvopengr.py
@@ -96,10 +96,13 @@ class TVOpenGrWatchIE(TVOpenGrBaseIE):
         info = self._search_json_ld(webpage, video_id, expected_type='VideoObject')
         info['formats'], info['subtitles'] = self._extract_formats_and_subs(
             self._download_api_data(video_id, scheme=scheme), video_id)
-        max_width = max([format.get('width') or 0 for format in info['formats']])
-        if max_width:
+        max_dimensions = max(
+            [tuple(format.get(k) or 0 for k in ('width', 'height')) for format in info['formats']],
+            default=None)
+        if max_dimensions[0]:
             for thumbnail in info['thumbnails']:
-                thumbnail['url'] = re.sub(r'(/imgHandler/)\d+', rf'\g<1>{max_width}', thumbnail['url'])
+                thumbnail['url'] = re.sub(r'(/imgHandler/)\d+', rf'\g<1>{max_dimensions[0]}', thumbnail['url'])
+                thumbnail['width'], thumbnail['height'] = max_dimensions
         description, _html = next(get_elements_text_and_html_by_attribute('class', 'description', webpage))
         if description and _html.startswith('<span '):
             info['description'] = description


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This patch adds support for video extraction from tvopen.gr and affiliated ethnos.gr, a popular Greek TV content provider and news outlet.

* Add new IEs
  * TVOpenGrBaseIE: Base IE class
  * TVOpenGrWatchIE: Extract videos from TV VOD pages on tvopen.gr and ethnos.gr
  * TVOpenGrEmbedIE: Extract iframe-embeddable tvopen.gr or ethnos.gr videos
* For embeddable and `tvopengr:watch` videos not on tvopen.gr, redirect to the equivalent page at tvopen.gr/watch/... which includes better metadata
  * `VideoObject` JSON-LD
  * full (rather than truncated) description (extracted from a `span[@class='description']` element content)
* TVOpenGrWatchIE queries an API endpoint to get the respective stream/source URLs and then detect formats/subtitles
* The thumbnail endpoint dynamically scales image per specified width, therefore modify the thumbnail URL to use the maximum width among extracted formats