### PR TITLE
[generic] improve KVS player video extraction

### DIFF
--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -3786,8 +3786,10 @@ class GenericIE(InfoExtractor):
                         'url': self._kvs_getrealurl(flashvars[key], flashvars['license_code']),
                         'format_id': format_id,
                         'ext': 'mp4',
-                        **parse_resolution(format_id)
+                        **(parse_resolution(format_id) or parse_resolution(flashvars[key]))
                     })
+                    if not formats[-1].get('height'):
+                        formats[-1]['quality'] = 1
 
                 self._sort_formats(formats)
 

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -3776,26 +3776,19 @@ class GenericIE(InfoExtractor):
                     protocol, _, _ = url.partition('/')
                     thumbnail = protocol + thumbnail
 
+                url_keys = list(filter(re.compile(r'video_url|video_alt_url\d+').fullmatch, flashvars.keys()))
                 formats = []
-                idx = 0
-                while True:
-                    key = 'video%s_url%s' % ('_alt' if idx > 0 else '', idx if idx > 1 else '')
-                    if key in flashvars and '/get_file/' in flashvars[key]:
-                        next_format = {
-                            'url': self._kvs_getrealurl(flashvars[key], flashvars['license_code']),
-                            'format_id': flashvars.get(key + '_text', key),
-                            'ext': 'mp4',
-                        }
-                        res = parse_resolution(next_format['format_id'])
-                        if 'height' in res:
-                            next_format['height'] = str_to_int(res['height'])
-                        if 'width' in res:
-                            next_format['width'] = str_to_int(res['width'])
+                for key in url_keys:
+                    if '/get_file/' not in flashvars[key]:
+                        continue
+                    format_id = flashvars.get(f'{key}_text', key)
+                    formats.append({
+                        'url': self._kvs_getrealurl(flashvars[key], flashvars['license_code']),
+                        'format_id': format_id,
+                        'ext': 'mp4',
+                        **parse_resolution(format_id)
+                    })
 
-                        formats.append(next_format)
-                        idx += 1
-                    else:
-                        break
                 self._sort_formats(formats)
 
                 return {

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -39,7 +39,6 @@ from ..utils import (
     xpath_attr,
     xpath_text,
     xpath_with_ns,
-    str_to_int,
 )
 from .commonprotocols import RtmpIE
 from .brightcove import (


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Current generic KVS player extractor does not work correctly on porntrex.com and issues were identified in #2281.
This is the follow up PR.
