### PR TITLE
[Generic] Linux -- Fixed issue with cookies from browser with unsupported desktop session

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -664,6 +664,8 @@ def _get_linux_desktop_environment(env):
             return _LinuxDesktopEnvironment.KDE
         elif 'xfce' in desktop_session:
             return _LinuxDesktopEnvironment.XFCE
+        else:
+            return _LinuxDesktopEnvironment.OTHER
     else:
         if 'GNOME_DESKTOP_SESSION_ID' in env:
             return _LinuxDesktopEnvironment.GNOME


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

There was a somewhat recent issue with Linux where everything using cookies from browser would fail due to an AttributeError when trying to find the keyring. It was addressed in release 2022.01.21 (for the life of me I can't find the original issue). 

The new release fixes that issue, but sort of just moved it up the chain. When attempting to use cookies from browser with the latest release I get this: 

```
 File "/usr/lib/python3.10/site-packages/yt_dlp/cookies.py", line 333, in __init__
    password = _get_linux_keyring_password(browser_keyring_name, keyring, logger)

  File "/usr/lib/python3.10/site-packages/yt_dlp/cookies.py", line 793, in _get_linux_keyring_password
    keyring = _LinuxKeyring[keyring] if keyring else _choose_linux_keyring(logger)

  File "/usr/lib/python3.10/site-packages/yt_dlp/cookies.py", line 682, in _choose_linux_keyring
    logger.debug('detected desktop environment: {}'.format(desktop_environment.name))
AttributeError: 'NoneType' object has no attribute 'name'
```

I just grabbed the last little bit of the log error. This PR addresses this issue by returning `_LinuxDesktopEnvironment.OTHER` if the `DESKTOP_SESSION` variable isn't KDE, XFCE, or Gnome.
