### PR TITLE
[crunchyroll:beta] Add self-contained support for crunchyroll beta for logged in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,6 +1670,11 @@ The following extractors use this feature:
 * `language`: Languages to extract. Eg: `crunchyroll:language=jaJp`
 * `hardsub`: Which hard-sub versions to extract. Eg: `crunchyroll:hardsub=None,enUS`
 
+#### crunchyroll:beta
+* `format`: Which stream type(s) to extract. Default is `adaptive_hls` Eg: `crunchyrollbeta:format=vo_adaptive_hls`
+    * Potentially useful values include `adaptive_hls`, `adaptive_dash`, `vo_adaptive_hls`, `vo_adaptive_dash`, `download_hls`, `trailer_hls`, `trailer_dash`
+* `hardsub`: Preference order for which hardsub versions to extract. Default is `None` (no hardsubs). Eg: `crunchyrollbeta:hardsub=en-US,None`
+
 #### vikichannel
 * `video_types`: Types of videos to download - one or more of `episodes`, `movies`, `clips`, `trailers`
 

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -24,6 +24,7 @@ from ..utils import (
     bytes_to_intlist,
     extract_attributes,
     float_or_none,
+    format_field,
     intlist_to_bytes,
     int_or_none,
     join_nonempty,

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -838,7 +838,7 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
             'season_id': episode_response.get('season_id'),
             'season_number': episode_response.get('season_number'),
             'episode': episode_response.get('title'),
-            'episode_number': episode_response.get('episode_number'),
+            'episode_number': episode_response.get('sequence_number'),
             'subtitles': subtitles,
             'formats': formats
         }

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -828,7 +828,7 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
                     if f.get('acodec') != 'none':
                         f['language'] = stream_response.get('audio_locale')
                     f['quality'] = hardsub_preference(hardsub_lang.lower())
-                    formats.extend(adaptive_formats)
+                formats.extend(adaptive_formats)
         self._sort_formats(formats)
 
         return {

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -809,7 +809,7 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
                     format_id = join_nonempty(
                         stream_type,
                         format_field(stream_response, 'audio_locale', 'audio-%s'),
-                        format_field(stream_response, 'hardsub_locale', 'hardsub-%s'))
+                        format_field(stream, 'hardsub_locale', 'hardsub-%s'))
                     if not stream.get('url'):
                         continue
                     if stream_type.split('_')[-1] == 'hls':

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -778,6 +778,8 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
             f'{api_domain}/cms/v2{bucket}/episodes/{internal_id}', display_id,
             note='Retrieving episode metadata',
             query=params)
+        if episode_response.get('is_premium_only') and not episode_response.get('playback'):
+            raise ExtractorError('This video is for premium members only.', expected=True)
         stream_response = self._download_json(
             episode_response['playback'], display_id,
             note='Retrieving stream info')

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -828,7 +828,7 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
 
         return {
             'id': internal_id,
-            'title': episode_response.get('season_title') + ' Episode ' + episode_response.get('episode') + ' – ' + episode_response.get('title'),
+            'title': '%s Episode %s – %s' % (episode_response.get('season_title'), episode_response.get('episode'), episode_response.get('title')),
             'description': episode_response.get('description').replace(r'\r\n', '\n'),
             'duration': float_or_none(episode_response.get('duration_ms'), 1000),
             'thumbnails': thumbnails,

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -753,7 +753,7 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
         api_domain = traverse_obj(app_config, ('cxApiParams', 'apiDomain'))
         basic_token = str(base64.b64encode(('%s:' % client_id).encode('ascii')), 'ascii')
         auth_response = self._download_json(
-            api_domain + '/auth/v1/token', display_id,
+            f'{api_domain}/auth/v1/token', display_id,
             note='Authenticating with cookie',
             headers={
                 'Authorization': 'Basic ' + basic_token
@@ -805,8 +805,8 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
                 for stream in streams.values():
                     format_id = join_nonempty(
                         stream_type,
-                        'audio-%s' % stream_response.get('audio_locale'),
-                        stream.get('hardsub_locale') and 'hardsub-%s' % stream.get('hardsub_locale'))
+                        format_field(stream_response, 'audio_locale', 'audio-%s'),
+                        format_field(stream_response, 'hardsub_locale', 'hardsub-%s'))
                     if stream_type.split('_')[-1] == 'hls':
                         adaptive_formats = self._extract_m3u8_formats(
                             stream.get('url'), display_id, 'mp4', m3u8_id=format_id,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The existing crunchyroll beta support simply parses the page enough to find the non-beta url, then hands off to the non-beta extractor. This no longer functions for premium content for US users, since the non-beta site forcibly redirects to the beta site. See #1911.

This implements direct support for crunchyroll beta through the API, but only when a login cookie is present. Otherwise, it hands off to the non-beta extractor as usual (this is in line with what happens with an actual browser as well).

Notes:
- This is literally the first python code I have ever written. It's probably pretty horrible. I've tested that it works, but the way encoding issues are handled in python isn't familiar to me... I pretty much just tried random things until it started behaving as I wanted in that regard, so there might be problems hidden away there.
- Probably could do with some better code formatting.
- I don't know that my format generation behaves well in sufficiently many circumstances, though it behaves similarly to the non-beta crunchyroll extractor in my testing. It's mostly monkey-see-monkey-do from other extractors, rather than well-thought-out code.
- It's rather unfortunate that there's nowhere to put crunchyroll's `sequence_number` metadata in yt-dlp. This would be awfully handy to have for reasonable filename generation, as some series on the site have non-integral episode numbers. See https://beta.crunchyroll.com/series/GEXH3W8G1/the-faraway-paladin for an example.
- No series extractor at the moment, but the authorization structure is no different, so it's just a matter of interpreting the api's json output for `api_domain + '/cms/v2' + bucket + '/series/' + series_id` with the same query string.
- There are quite a few different stream types I'm not looking at here. It's possible that a different group than `adaptive_hls` is the way to go.