### PR TITLE
[crunchyroll] Login support

### DIFF
--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -44,6 +44,7 @@ from ..aes import (
 
 class CrunchyrollBaseIE(InfoExtractor):
     _LOGIN_URL = 'https://www.crunchyroll.com/welcome/login'
+    _API_BASE = 'https://api.crunchyroll.com'
     _NETRC_MACHINE = 'crunchyroll'
 
     def _call_rpc_api(self, method, video_id, note=None, data=None):
@@ -64,7 +65,7 @@ class CrunchyrollBaseIE(InfoExtractor):
             return
 
         upsell_response = self._download_json(
-            'https://api.crunchyroll.com/get_upsell_data.0.json', None, 'Getting session id',
+            f'{self._API_BASE}/get_upsell_data.0.json', None, 'Getting session id',
             query={
                 'sess_id': 1,
                 'device_id': 'whatvalueshouldbeforweb',
@@ -77,7 +78,7 @@ class CrunchyrollBaseIE(InfoExtractor):
         session_id = upsell_response['data']['session_id']
 
         login_response = self._download_json(
-            f'{api_url}/login.1.json', None, 'Logging in',
+            f'{self._API_BASE}/login.1.json', None, 'Logging in',
             data=compat_urllib_parse_urlencode({
                 'account': username,
                 'password': password,

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -63,20 +63,13 @@ class CrunchyrollBaseIE(InfoExtractor):
         if self._get_cookies(self._LOGIN_URL).get('etp_rt'):
             return
 
-        # login_page = self._download_webpage(
-        #     self._LOGIN_URL, None, 'Downloading login page')
-        # window_etp = self._parse_json(
-        #     self._search_regex(r'<script>\s*window\.etp\s*=\s*({.+?})\s*</script>', login_page, 'etp data'),
-        #     'etp_data')
-        api_url = 'https://api.crunchyroll.com'  # api_url = window_etp['config']['crapiApiUrl']
-
         upsell_response = self._download_json(
-            f'{api_url}/get_upsell_data.0.json', None, 'Getting session id',
+            'https://api.crunchyroll.com/get_upsell_data.0.json', None, 'Getting session id',
             query={
                 'sess_id': 1,
-                'device_id': 'whatvalueshouldbeforweb',  # window_etp['config']['deviceId'],
-                'device_type': 'com.crunchyroll.static',  # window_etp['config']['deviceType'],
-                'access_token': 'giKq5eY27ny3cqz',  # window_etp['config']['accessToken'],
+                'device_id': 'whatvalueshouldbeforweb',
+                'device_type': 'com.crunchyroll.static',
+                'access_token': 'giKq5eY27ny3cqz',
                 'referer': self._LOGIN_URL
             })
         if upsell_response['code'] != 'ok':

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -35,7 +35,6 @@ from ..utils import (
     sanitized_Request,
     traverse_obj,
     try_get,
-    urlencode_postdata,
     xpath_text,
 )
 from ..aes import (
@@ -44,8 +43,7 @@ from ..aes import (
 
 
 class CrunchyrollBaseIE(InfoExtractor):
-    _LOGIN_URL = 'https://www.crunchyroll.com/login'
-    _LOGIN_FORM = 'login_form'
+    _LOGIN_URL = 'https://www.crunchyroll.com/welcome/login'
     _NETRC_MACHINE = 'crunchyroll'
 
     def _call_rpc_api(self, method, video_id, note=None, data=None):
@@ -62,50 +60,40 @@ class CrunchyrollBaseIE(InfoExtractor):
         username, password = self._get_login_info()
         if username is None:
             return
-
-        login_page = self._download_webpage(
-            self._LOGIN_URL, None, 'Downloading login page')
-
-        def is_logged(webpage):
-            return 'href="/logout"' in webpage
-
-        # Already logged in
-        if is_logged(login_page):
+        if self._get_cookies(self._LOGIN_URL).get('etp_rt'):
             return
 
-        login_form_str = self._search_regex(
-            r'(?P<form><form[^>]+?id=(["\'])%s\2[^>]*>)' % self._LOGIN_FORM,
-            login_page, 'login form', group='form')
+        # login_page = self._download_webpage(
+        #     self._LOGIN_URL, None, 'Downloading login page')
+        # window_etp = self._parse_json(
+        #     self._search_regex(r'<script>\s*window\.etp\s*=\s*({.+?})\s*</script>', login_page, 'etp data'),
+        #     'etp_data')
+        api_url = 'https://api.crunchyroll.com'  # api_url = window_etp['config']['crapiApiUrl']
 
-        post_url = extract_attributes(login_form_str).get('action')
-        if not post_url:
-            post_url = self._LOGIN_URL
-        elif not post_url.startswith('http'):
-            post_url = compat_urlparse.urljoin(self._LOGIN_URL, post_url)
+        upsell_response = self._download_json(
+            f'{api_url}/get_upsell_data.0.json', None, 'Getting session id',
+            query={
+                'sess_id': 1,
+                'device_id': 'whatvalueshouldbeforweb',  # window_etp['config']['deviceId'],
+                'device_type': 'com.crunchyroll.static',  # window_etp['config']['deviceType'],
+                'access_token': 'giKq5eY27ny3cqz',  # window_etp['config']['accessToken'],
+                'referer': self._LOGIN_URL
+            })
+        if upsell_response['code'] != 'ok':
+            raise ExtractorError('Could not get session id')
+        session_id = upsell_response['data']['session_id']
 
-        login_form = self._form_hidden_inputs(self._LOGIN_FORM, login_page)
-
-        login_form.update({
-            'login_form[name]': username,
-            'login_form[password]': password,
-        })
-
-        response = self._download_webpage(
-            post_url, None, 'Logging in', 'Wrong login info',
-            data=urlencode_postdata(login_form),
-            headers={'Content-Type': 'application/x-www-form-urlencoded'})
-
-        # Successful login
-        if is_logged(response):
-            return
-
-        error = self._html_search_regex(
-            '(?s)<ul[^>]+class=["\']messages["\'][^>]*>(.+?)</ul>',
-            response, 'error message', default=None)
-        if error:
-            raise ExtractorError('Unable to login: %s' % error, expected=True)
-
-        raise ExtractorError('Unable to log in')
+        login_response = self._download_json(
+            f'{api_url}/login.1.json', None, 'Logging in',
+            data=compat_urllib_parse_urlencode({
+                'account': username,
+                'password': password,
+                'session_id': session_id
+            }).encode('ascii'))
+        if login_response['code'] != 'ok':
+            raise ExtractorError('Login failed. Bad username or password?', expected=True)
+        if not self._get_cookies(self._LOGIN_URL).get('etp_rt'):
+            raise ExtractorError('Login succeeded but did not set etp_rt cookie')
 
     def _real_initialize(self):
         self._login()


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Closes #1424 

Hardcodes some data that could be retrieved from self._LOGIN_URL if cloudflare wasn't so trigger-happy.

The data does appear to be constant, but I've left the retrieval method in comments so that if they do change, breakages can be easily fixed by anyone who can use a web browser's "view source" feature and knows a little python.

If anyone knows a way to reliably get around this and download the page, that would of course be preferable.

I have not tested this with the non-beta site, as I'm in the US and thus forced to the beta site, but it *should* work, and since it wasn't working before, it is, at worst, a no-op for those users.