### PR TITLE
[mildom] Fixes and improvements (should close #2519 )

### DIFF
--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -172,6 +172,51 @@ class MildomVodIE(MildomBaseIE):
     IE_NAME = 'mildom:vod'
     IE_DESC = 'Download a VOD in Mildom'
     _VALID_URL = r'https?://(?:(?:www|m)\.)mildom\.com/playback/(?P<user_id>\d+)/(?P<id>(?P=user_id)-[a-zA-Z0-9]+-?[0-9]*)'
+    _TESTS = [{
+        'url': 'https://www.mildom.com/playback/10882672/10882672-1597662269',
+        'info_dict': {
+            'id': '10882672-1597662269',
+            'ext': 'mp4',
+            'title': '始めてのミルダム配信じゃぃ！',
+            'thumbnail': r're:^https?://.*\.(png|jpg)$',
+            'upload_date': '20200817',
+            'duration': 4138.37,
+            'description': 'ゲームをしたくて！',
+            'timestamp': 1597662269.0,
+            'uploader_id': '10882672',
+            'uploader': 'kson組長(けいそん)',
+        },
+    },
+        {
+        'url': 'https://www.mildom.com/playback/10882672/10882672-1597758589870-477',
+        'info_dict': {
+            'id': '10882672-1597758589870-477',
+            'ext': 'mp4',
+            'title': '【kson】感染メイズ！麻酔銃で無双する',
+            'thumbnail': r're:^https?://.*\.(png|jpg)$',
+            'timestamp': 1597759093.0,
+            'uploader': 'kson組長(けいそん)',
+            'duration': 4302.58,
+            'uploader_id': '10882672',
+            'description': 'このステージ絶対乗り越えたい',
+            'upload_date': '20200818',
+        },
+    },
+        {
+        'url': 'https://www.mildom.com/playback/10882672/10882672-buha9td2lrn97fk2jme0',
+        'info_dict': {
+            'id': '10882672-buha9td2lrn97fk2jme0',
+            'ext': 'mp4',
+            'title': '【kson組長】CART RACER!!!',
+            'thumbnail': r're:^https?://.*\.(png|jpg)$',
+            'uploader_id': '10882672',
+            'uploader': 'kson組長(けいそん)',
+            'upload_date': '20201104',
+            'timestamp': 1604494797.0,
+            'duration': 4657.25,
+            'description': 'WTF',
+        },
+    }]
 
     def _real_extract(self, url):
         m = self._match_valid_url(url)
@@ -250,6 +295,14 @@ class MildomUserVodIE(MildomBaseIE):
             'title': 'Uploads from ねこばたけ',
         },
         'playlist_mincount': 351,
+    },
+        {
+        'url': 'https://www.mildom.com/profile/10882672',
+        'info_dict': {
+            'id': '10882672',
+            'title': 'Uploads from kson組長(けいそん)',
+        },
+        'playlist_mincount': 191,
     }]
 
     def _entries(self, user_id):

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -15,6 +15,7 @@ from ..utils import (
 )
 from ..compat import (
     compat_str,
+    compat_numeric_types
 )
 
 
@@ -158,7 +159,7 @@ class MildomIE(MildomBaseIE):
 class MildomVodIE(MildomBaseIE):
     IE_NAME = 'mildom:vod'
     IE_DESC = 'Download a VOD in Mildom'
-    _VALID_URL = r'https?://(?:(?:www|m)\.)mildom\.com/playback/(?P<user_id>\d+)/(?P<id>(?P=user_id)-[a-zA-Z0-9]+)'
+    _VALID_URL = r'https?://(?:(?:www|m)\.)mildom\.com/playback/(?P<user_id>\d+)/(?P<id>(?P=user_id)-[a-zA-Z0-9\-]+)'
 
     def _real_extract(self, url):
         m = self._match_valid_url(url)
@@ -208,11 +209,24 @@ class MildomVodIE(MildomBaseIE):
             })
 
         self._sort_formats(formats)
+        
+        timestamp = try_get(autoplay['publish_time'], compat_numeric_types)
+
+        duration = try_get(autoplay['video_length'], compat_numeric_types)
+
+        thumbnails=[]
+        thumbnail_url=try_get(autoplay['upload_pic'], compat_str)
+        thumbnails.append({
+                'url': thumbnail_url,
+            })
 
         return {
             'id': video_id,
             'title': title,
             'description': description,
+            'timestamp': timestamp//1000,
+            'duration': duration//1000,
+            'thumbnails': thumbnails,
             'uploader': uploader,
             'uploader_id': user_id,
             'formats': formats,

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -284,4 +284,3 @@ class MildomUserVodIE(MildomBaseIE):
 
         return self.playlist_result(
             self._entries(user_id), user_id, 'Uploads from %s' % profile['loginname'])
-    

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -231,9 +231,7 @@ class MildomVodIE(MildomBaseIE):
                 lambda x: x['video_pic'],
             ), compat_str)
 
-        thumbnails.append({
-                'url': thumbnail_url,
-            })
+        thumbnails.append({'url': thumbnail_url})
 
         return {
             'id': video_id,
@@ -286,3 +284,4 @@ class MildomUserVodIE(MildomBaseIE):
 
         return self.playlist_result(
             self._entries(user_id), user_id, 'Uploads from %s' % profile['loginname'])
+    

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -151,7 +151,7 @@ class MildomIE(MildomBaseIE):
 
         self._sort_formats(formats)
 
-        timestamp = try_get(enterstudio['live_start_ms'], compat_numeric_types)
+        timestamp = float_or_none(enterstudio.get('live_start_ms'), scale=1000)
 
         return {
             'id': result_video_id,

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -239,7 +239,7 @@ class MildomVodIE(MildomBaseIE):
             'description': description,
             'timestamp': timestamp // 1000,
             'duration': duration // 1000,
-            'thumbnails': thumbnails,
+            'thumbnail': dict_get(autoplay, ('upload_pic', 'video_pic')),
             'uploader': uploader,
             'uploader_id': user_id,
             'formats': formats,

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -29,8 +29,8 @@ class MildomBaseIE(InfoExtractor):
         if content['code'] == 0:
             return content['body']
         else:
-            self.raise_no_formats('Video not found or premium content. Mildom error code %i, "%s"' 
-                                  % (content['code'] , content['message']), expected=True)
+            self.raise_no_formats('Video not found or premium content. Mildom error code %i, "%s"'
+                                  % (content['code'], content['message']), expected=True)
 
     def _common_queries(self, query={}, init=False):
         dc = self._fetch_dispatcher_config()
@@ -108,7 +108,7 @@ class MildomIE(MildomBaseIE):
 
         enterstudio = self._call_api(
             'https://cloudac.mildom.com/nonolive/gappserv/live/enterstudio', video_id,
-            note='Downloading live metadata', query={'user_id': video_id , '__platform': "web"})
+            note='Downloading live metadata', query={'user_id': video_id, '__platform': "web"})
         result_video_id = enterstudio.get('log_id', video_id)
 
         title = try_get(
@@ -150,14 +150,14 @@ class MildomIE(MildomBaseIE):
             fmt.setdefault('http_headers', {})['Referer'] = 'https://www.mildom.com/'
 
         self._sort_formats(formats)
-        
+
         timestamp = try_get(enterstudio['live_start_ms'], compat_numeric_types)
 
         return {
             'id': result_video_id,
             'title': title,
             'description': description,
-            'timestamp': timestamp//1000,
+            'timestamp': timestamp // 1000,
             'uploader': uploader,
             'uploader_id': video_id,
             'formats': formats,
@@ -218,29 +218,29 @@ class MildomVodIE(MildomBaseIE):
             })
 
         self._sort_formats(formats)
-        
+
         timestamp = try_get(autoplay['publish_time'], compat_numeric_types)
 
         duration = try_get(autoplay['video_length'], compat_numeric_types)
 
-        thumbnails=[]
+        thumbnails = []
 
         thumbnail_url = try_get(
             autoplay, (
                 lambda x: x['upload_pic'],
                 lambda x: x['video_pic'],
             ), compat_str)
-        
+
         thumbnails.append({
-                    'url': thumbnail_url,
-                })
+                'url': thumbnail_url,
+            })
 
         return {
             'id': video_id,
             'title': title,
             'description': description,
-            'timestamp': timestamp//1000,
-            'duration': duration//1000,
+            'timestamp': timestamp // 1000,
+            'duration': duration // 1000,
             'thumbnails': thumbnails,
             'uploader': uploader,
             'uploader_id': user_id,
@@ -282,7 +282,7 @@ class MildomUserVodIE(MildomBaseIE):
 
         profile = self._call_api(
             'https://cloudac.mildom.com/nonolive/gappserv/user/profileV2', user_id,
-            query={'user_id': user_id , '__platform': "web"}, note='Downloading user profile')['user_info']
+            query={'user_id': user_id, '__platform': "web"}, note='Downloading user profile')['user_info']
 
         return self.playlist_result(
             self._entries(user_id), user_id, 'Uploads from %s' % profile['loginname'])

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -108,7 +108,7 @@ class MildomIE(MildomBaseIE):
 
         enterstudio = self._call_api(
             'https://cloudac.mildom.com/nonolive/gappserv/live/enterstudio', video_id,
-            note='Downloading live metadata', query={'user_id': video_id, '__platform': "web"})
+            note='Downloading live metadata', query={'user_id': video_id, '__platform': 'web'})
         result_video_id = enterstudio.get('log_id', video_id)
 
         title = try_get(

--- a/yt_dlp/extractor/mildom.py
+++ b/yt_dlp/extractor/mildom.py
@@ -185,8 +185,7 @@ class MildomVodIE(MildomBaseIE):
             'uploader_id': '10882672',
             'uploader': 'kson組長(けいそん)',
         },
-    },
-        {
+    }, {
         'url': 'https://www.mildom.com/playback/10882672/10882672-1597758589870-477',
         'info_dict': {
             'id': '10882672-1597758589870-477',
@@ -200,8 +199,7 @@ class MildomVodIE(MildomBaseIE):
             'description': 'このステージ絶対乗り越えたい',
             'upload_date': '20200818',
         },
-    },
-        {
+    }, {
         'url': 'https://www.mildom.com/playback/10882672/10882672-buha9td2lrn97fk2jme0',
         'info_dict': {
             'id': '10882672-buha9td2lrn97fk2jme0',
@@ -290,8 +288,7 @@ class MildomUserVodIE(MildomBaseIE):
             'title': 'Uploads from ねこばたけ',
         },
         'playlist_mincount': 351,
-    },
-        {
+    }, {
         'url': 'https://www.mildom.com/profile/10882672',
         'info_dict': {
             'id': '10882672',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This should deal with issue #2519 , including the improvements I proposed. I have tested the changes in a couple of channels containing the problematic video IDs, plus a few livestreams, and everything seems to work as intended. Regarding the video IDs getting truncated in the download log, I must have misremembered it because I could not reproduce anything like that. The download archive seems to work normally.

* Fixed _VALID_URL regex (now it looks explicitly for an optional third digit block in the video ID)
* Added '__plataform=web' to cloudac queries. Now referers and access token cookies are probably no longer needed, but I do not dare remove the code yet. _Just in case_.
* Added extra metadata: timestamp, duration and thumbnails for VODs, and timestamp (technically stream start time) for live streams.
* Added graceful(-ish) failure if a video or channel is not found or if access is restricted, using raise_no_formats. It now returns a brief error message and the error code found in the json, and hides the exception details unless -v is used.
