### PR TITLE
GlomexEmbedIE._extract_urls: Avoid match objects to keep mem usage under control

### DIFF
--- a/yt_dlp/extractor/glomex.py
+++ b/yt_dlp/extractor/glomex.py
@@ -199,13 +199,12 @@ class GlomexEmbedIE(GlomexBaseIE):
         )''' % {'quot_re': r'["\']', 'url_re': VALID_SRC}
 
         for mtup in re.findall(EMBED_RE, webpage):
-            mdict = dict(zip(
-                (
-                    'url', '_',
-                    'html_tag', '_', 'integration_html', '_', 'id_html', '_', 'glomex_player',
-                    'script_tag', '_', '_', 'integration_js', '_', 'id_js',
-                ),
-                mtup))
+            # re.finditer causes a memory spike. See https://github.com/yt-dlp/yt-dlp/issues/2512
+            mdict = dict(zip((
+                'url', '_',
+                'html_tag', '_', 'integration_html', '_', 'id_html', '_', 'glomex_player',
+                'script_tag', '_', '_', 'integration_js', '_', 'id_js',
+            ), mtup))
             if mdict.get('url'):
                 url = unescapeHTML(mdict['url'])
                 if not cls.suitable(url):

--- a/yt_dlp/extractor/glomex.py
+++ b/yt_dlp/extractor/glomex.py
@@ -198,8 +198,14 @@ class GlomexEmbedIE(GlomexBaseIE):
             )+</script>
         )''' % {'quot_re': r'["\']', 'url_re': VALID_SRC}
 
-        for mobj in re.finditer(EMBED_RE, webpage):
-            mdict = mobj.groupdict()
+        for mtup in re.findall(EMBED_RE, webpage):
+            mdict = dict(zip(
+                (
+                    'url', '_',
+                    'html_tag', '_', 'integration_html', '_', 'id_html', '_', 'glomex_player',
+                    'script_tag', '_', '_', 'integration_js', '_', 'id_js',
+                ),
+                mtup))
             if mdict.get('url'):
                 url = unescapeHTML(mdict['url'])
                 if not cls.suitable(url):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Avoid match objects iteration in `GlomexEmbedIE._extract_urls` to keep memory usage under control.

Fix #2512