### PR TITLE
[Pladform] Fix redirection to external player

### DIFF
--- a/yt_dlp/extractor/pladform.py
+++ b/yt_dlp/extractor/pladform.py
@@ -63,12 +63,19 @@ class PladformIE(InfoExtractor):
             'http://out.pladform.ru/getVideo', video_id, query={
                 'pl': pl,
                 'videoid': video_id,
-            })
+            }, fatal=False)
 
         def fail(text):
             raise ExtractorError(
                 '%s returned error: %s' % (self.IE_NAME, text),
                 expected=True)
+
+        if not video:
+            targetUrl = self._request_webpage(url, None, note='Resolving final URL').geturl()
+            if (targetUrl != url):
+                return self.url_result(targetUrl)
+            else:
+                fail("Can't parse page")
 
         if video.tag == 'error':
             fail(video.text)

--- a/yt_dlp/extractor/pladform.py
+++ b/yt_dlp/extractor/pladform.py
@@ -28,6 +28,24 @@ class PladformIE(InfoExtractor):
                         (?P<id>\d+)
                     '''
     _TESTS = [{
+        'url': 'http://out.pladform.ru/player?pl=18079&type=html5&videoid=100231282',
+        'info_dict': {
+            'id': '6216d548e755edae6e8280667d774791',
+            'ext': 'mp4',
+            'timestamp': 1406117012,
+            'title': 'Гарик Мартиросян и Гарик Харламов - Кастинг на концерт ко Дню милиции',
+            'age_limit': 0,
+            'upload_date': '20140723',
+            'thumbnail': str,
+            'view_count': int,
+            'description': str,
+            'category': list,
+            'uploader_id': '12082',
+            'uploader': 'Comedy Club',
+            'duration': 367,
+        },
+        'expected_warnings': ['HTTP Error 404: Not Found']
+    }, {
         'url': 'https://out.pladform.ru/player?pl=64471&videoid=3777899&vk_puid15=0&vk_puid34=0',
         'md5': '53362fac3a27352da20fa2803cc5cd6f',
         'info_dict': {

--- a/yt_dlp/extractor/pladform.py
+++ b/yt_dlp/extractor/pladform.py
@@ -71,11 +71,10 @@ class PladformIE(InfoExtractor):
                 expected=True)
 
         if not video:
-            targetUrl = self._request_webpage(url, None, note='Resolving final URL').geturl()
-            if (targetUrl != url):
-                return self.url_result(targetUrl)
-            else:
-                fail("Can't parse page")
+            targetUrl = self._request_webpage(url, video_id, note='Resolving final URL').geturl()
+            if targetUrl == url:
+                raise ExtractorError('Can\'t parse page')
+            return self.url_result(targetUrl)
 
         if video.tag == 'error':
             fail(video.text)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Fix external player redirect URL extraction. Examples:
http://out.pladform.ru/player?pl=18079&type=html5&videoid=100246529 -> rutube
http://out.pladform.ru/player?pl=18079&type=html5&videoid=100231282 -> rutube
