### PR TITLE
Fixing globo #2524

### DIFF
--- a/yt_dlp/extractor/globo.py
+++ b/yt_dlp/extractor/globo.py
@@ -12,6 +12,7 @@ from ..compat import (
     compat_str,
 )
 from ..utils import (
+    HEADRequest,
     ExtractorError,
     float_or_none,
     orderedSet,
@@ -85,7 +86,9 @@ class GloboIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        self._download_webpage('https://globo-ab.globo.com/v2/selected-alternatives?experiments=player-isolated-experiment-02&skipImpressions=true', video_id, 'Getting cookies')
+        self._request_webpage(
+            HEADRequest('https://globo-ab.globo.com/v2/selected-alternatives?experiments=player-isolated-experiment-02&skipImpressions=true'),
+            video_id, 'Getting cookies')
 
         video = self._download_json(
             'http://api.globovideos.com/videos/%s/playlist' % video_id,
@@ -107,8 +110,7 @@ class GloboIE(InfoExtractor):
                 "tz": "-3.0:00"
             }).encode())
 
-        manifest = security['sources'][0]['url_template']
-        self._download_webpage(manifest, video_id, 'Getting locksession cookie')
+        self._request_webpage(HEADRequest(security['sources'][0]['url_template']), video_id, 'Getting locksession cookie')
 
         security_hash = security['sources'][0]['token']
         if not security_hash:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixing #2524

Added 2 calls to download pages to setup cookies. First call is needed to set GLBEXP and glb_uid cookies. Second call is needed to set locksession

Changed playback video version to 2. 
Fixed the JSON format for the new version.
Added a new test case.



