### PR TITLE
[ruv.is] new extractor (fixes #2122)

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1341,6 +1341,7 @@ from .rtve import (
 )
 from .rtvnh import RTVNHIE
 from .rtvs import RTVSIE
+from .rtvslo import RTVSLOIE
 from .ruhd import RUHDIE
 from .rule34video import Rule34VideoIE
 from .rumble import (

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1367,7 +1367,10 @@ from .megatvcom import (
 )
 from .rutv import RUTVIE
 from .ruutu import RuutuIE
-from .ruv import RuvIE
+from .ruv import (
+    RuvIE,
+    RuvSpilaIE
+)
 from .safari import (
     SafariIE,
     SafariApiIE,

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -100,7 +100,7 @@ class RTVSLOIE(InfoExtractor):
                         'width': f.get('width'),
                         'height': f.get('height'),
                         'ext': f.get('mediaType').lower(),
-                        'format_id': f'files_{strm}_{f.get("mediaType").lower()}_{f.get("bitrate")}'
+                        'format_id': f'files_{strm}_{f.get("mediaType", "").lower()}_{f.get("bitrate")}'
                     })
 
         if media.get('addaptiveMedia_sl', False):
@@ -122,8 +122,8 @@ class RTVSLOIE(InfoExtractor):
                         'filesize': f.get('filesize'),
                         'width': f.get('width'),
                         'height': f.get('height'),
-                        'ext': f.get('mediaType').lower(),
-                        'format_id': f'files-sl_{strm}_{f.get("mediaType").lower()}_{f.get("bitrate")}',
+                        'ext': f.get('mediaType', "").lower() or None,
+                        'format_id': f'files-sl_{strm}_{f.get("mediaType", "").lower()}_{f.get("bitrate")}',
                         'format_note': 'Sign language interpretation',
                         'preference': -10
                     })

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from ..utils import traverse_obj, parse_duration, unified_timestamp
+from ..utils import ExtractorError, traverse_obj, parse_duration, unified_timestamp
 
 
 class RTVSLOIE(InfoExtractor):
@@ -10,10 +10,53 @@ class RTVSLOIE(InfoExtractor):
     _TESTS = [
         {
             'url': 'https://www.rtvslo.si/rtv365/arhiv/174842550?s=tv',
-            'only_matching': True
+            'info_dict': {
+                'id': '174842550',
+                'ext': 'mp4',
+                'release_timestamp': 1643140032,
+                'upload_date': '20220125',
+                'series': 'Dnevnik',
+                'thumbnail': 'https://img.rtvcdn.si/_up/ava/ava_misc/show_logos/92/dnevnik_3_wide2.jpg',
+                'description': 'md5:76a18692757aeb8f0f51221106277dd2',
+                'timestamp': 1643137046,
+                'title': 'Dnevnik',
+                'series_id': '92',
+                'release_date': '20220125',
+                'duration': 1789,
+            },
         }, {
             'url': 'https://365.rtvslo.si/arhiv/utrip/174843754',
-            'only_matching': True
+            'info_dict': {
+                'id': '174843754',
+                'ext': 'mp4',
+                'series_id': '94',
+                'release_date': '20220129',
+                'timestamp': 1643484455,
+                'title': 'Utrip',
+                'duration': 813,
+                'thumbnail': 'https://img.rtvcdn.si/_up/ava/ava_misc/show_logos/94/utrip_1_wide2.jpg',
+                'description': 'md5:77f2892630c7b17bb7a5bb84319020c9',
+                'release_timestamp': 1643485825,
+                'upload_date': '20220129',
+                'series': 'Utrip',
+            },
+        }, {
+            'url': 'https://365.rtvslo.si/arhiv/il-giornale-della-sera/174844609',
+            'info_dict': {
+                'id': '174844609',
+                'ext': 'mp3',
+                'series_id': '106615841',
+                'title': 'Il giornale della sera',
+                'duration': 1328,
+                'series': 'Il giornale della sera',
+                'timestamp': 1643743800,
+                'release_timestamp': 1643745424,
+                'thumbnail': 'https://img.rtvcdn.si/_up/ava/ava_misc/show_logos/il-giornale-della-sera_wide2.jpg',
+                'upload_date': '20220201',
+                'bitrate': 128000,
+                'release_date': '20220201',
+            },
+
         }, {
             'url': 'https://4d.rtvslo.si/arhiv/dnevnik/174842550',
             'only_matching': True
@@ -73,6 +116,8 @@ class RTVSLOIE(InfoExtractor):
 
         if any('intermission.mp4' in x.get('url', '') for x in formats):
             self.raise_geo_restricted(countries=self._GEO_COUNTRIES, metadata_available=True)
+        if any('dummy_720p.mp4' in x.get('manifest_url', '') for x in formats) and meta.get('stub', '') == 'error':
+            raise ExtractorError(f'{self.IE_NAME} said: Clip not available')
 
         info = {
             'thumbnails': thumbs,

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -89,7 +89,7 @@ class RTVSLOIE(InfoExtractor):
         if media.get('addaptiveMedia', False):
             formats = self._extract_wowza_formats(
                 traverse_obj(media, ('addaptiveMedia', 'hls_sec'), expected_type=str),
-                v_id, skip_protocols=['f4m', 'rtmp'])
+                v_id, skip_protocols=['smil'])
         for strm in ('http', 'https'):
             for f in media.get('mediaFiles'):
                 if traverse_obj(f, ('streams', strm)):
@@ -105,7 +105,7 @@ class RTVSLOIE(InfoExtractor):
 
         if media.get('addaptiveMedia_sl', False):
             for f in self._extract_wowza_formats(
-                traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec')), v_id, skip_protocols=['f4m', 'rtmp']
+                traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec')), v_id, skip_protocols=['smil']
             ):
                 f.update({'format_note': 'Sign language interpretation', 'preference': -3})
                 formats.append(f)

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -68,7 +68,6 @@ class RTVSLOIE(InfoExtractor):
 
     def _real_extract(self, url):
         v_id = self._match_id(url)
-        date = unified_timestamp(meta.get('broadcastDate') or meta.get('broadcastDates')[0])
         meta = self._download_json(self._API_BASE.format('getRecordingDrm', v_id), v_id)['response']
 
         thumbs = [{'id': k, 'url': v} for (k, v) in meta.get('images').items()]
@@ -144,7 +143,7 @@ class RTVSLOIE(InfoExtractor):
             'id': v_id,
             'description': meta.get('description'),
             'formats': formats,
-            'timestamp': date,
+            'timestamp': unified_timestamp(traverse_obj(meta, 'broadcastDate', ('broadcastDates', 0))),
             'release_timestamp': unified_timestamp(meta.get('recordingDate')),
             'duration': meta.get('duration') or parse_duration(meta.get('length')),
             'webpage_url': ''.join(traverse_obj(meta, ('canonical', ('domain', 'path')))),

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -1,5 +1,8 @@
 from .common import InfoExtractor
-from ..utils import ExtractorError, traverse_obj, parse_duration, unified_timestamp
+from ..utils import (
+    ExtractorError, traverse_obj, parse_duration, unified_timestamp,
+    url_or_none
+)
 
 
 class RTVSLOIE(InfoExtractor):
@@ -108,7 +111,7 @@ class RTVSLOIE(InfoExtractor):
                 traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec')), v_id, skip_protocols=['smil']
             ):
                 f.update({
-                    'format_id': 'sign-'+f['format_id'],
+                    'format_id': 'sign-' + f['format_id'],
                     'format_note': 'Sign language interpretation', 'preference': -10,
                     'language': 'slv' if f.get('language', '') == 'eng' and f.get('acodec', '') else f.get('language')})
                 formats.append(f)

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -91,7 +91,7 @@ class RTVSLOIE(InfoExtractor):
                 traverse_obj(media, ('addaptiveMedia', 'hls_sec'), expected_type=url_or_none),
                 v_id, skip_protocols=['smil'])
         for strm in ('http', 'https'):
-            for f in media.get('mediaFiles'):
+            for f in media.get('mediaFiles', []):
                 if traverse_obj(f, ('streams', strm)):
                     formats.append({
                         'bitrate': f.get('bitrate'),
@@ -114,7 +114,7 @@ class RTVSLOIE(InfoExtractor):
                     'language': 'slv' if f.get('language', '') == 'eng' and f.get('acodec', '') else f.get('language')})
                 formats.append(f)
         for strm in ('http', 'https'):
-            for f in media.get('mediaFiles_sl'):
+            for f in media.get('mediaFiles_sl', []):
                 if traverse_obj(f, ('streams', strm)):
                     formats.append({
                         'bitrate': f.get('bitrate'),

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -107,7 +107,7 @@ class RTVSLOIE(InfoExtractor):
             for f in self._extract_wowza_formats(
                 traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec')), v_id, skip_protocols=['smil']
             ):
-                f.update({'format_note': 'Sign language interpretation', 'preference': -3})
+                f.update({'format_note': 'Sign language interpretation', 'preference': -10})
                 formats.append(f)
         for strm in ('http', 'https'):
             for f in media.get('mediaFiles_sl'):
@@ -121,7 +121,7 @@ class RTVSLOIE(InfoExtractor):
                         'ext': f.get('mediaType').lower(),
                         'format_id': f'files-sl_{strm}_{f.get("mediaType").lower()}_{f.get("bitrate")}',
                         'format_note': 'Sign language interpretation',
-                        'preference': -3
+                        'preference': -10
                     })
 
         self._sort_formats(formats)
@@ -129,9 +129,9 @@ class RTVSLOIE(InfoExtractor):
         if any('intermission.mp4' in x.get('url', '') for x in formats):
             self.raise_geo_restricted(countries=self._GEO_COUNTRIES, metadata_available=True)
         if any('dummy_720p.mp4' in x.get('manifest_url', '') for x in formats) and meta.get('stub', '') == 'error':
-            raise ExtractorError(f'{self.IE_NAME} said: Clip not available')
+            raise ExtractorError(f'{self.IE_NAME} said: Clip not available', expected=True)
 
-        info = {
+        return {
             'thumbnails': thumbs,
             'subtitles': subs,
             'title': meta.get('title'),
@@ -146,5 +146,3 @@ class RTVSLOIE(InfoExtractor):
             'series': meta.get('showName'),
             'series_id': meta.get('showId'),
         }
-
-        return info

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -1,0 +1,89 @@
+from .common import InfoExtractor
+from ..utils import traverse_obj, parse_duration, unified_timestamp
+
+
+class RTVSLOIE(InfoExtractor):
+    IE_NAME = 'rtvslo.si'
+    _VALID_URL = r'https?://(www\.)?rtvslo\.si\/rtv365\/arhiv\/(?P<id>[0-9]+)'
+    'https://(4d|365).rtvslo.si/arhiv/dnevnik/(?P<id>[0-9]+)'
+    _API_BASE = 'https://api.rtvslo.si/ava/{}/{}?client_id=82013fb3a531d5414f478747c1aca622'
+    _GEO_COUNTRIES = ['SI']
+    _TESTS = [{
+        'url': 'https://www.rtvslo.si/rtv365/arhiv/174842550?s=tv',
+        'only_matching': True
+    }]
+
+    def _real_extract(self, url):
+        v_id = self._match_id(url)
+        meta = self._download_json(self._API_BASE.format('getRecordingDrm', v_id), v_id).get('response')
+        date = unified_timestamp(meta.get('broadcastDate') or meta.get('broadcastDates')[0])
+
+        thumbs = [{'url': v, 'id': k} for (k, v) in meta.get('images').items()]
+        subs = {}
+        SUB_LANGS_MAP = {'Slovenski': 'sl', }
+
+        for s in meta.get('subtitles'):
+            if s.get('language') in SUB_LANGS_MAP.keys():
+                s['language'] = SUB_LANGS_MAP[s['language']]
+            if not subs.get(s.get('language'), False):
+                subs[s.get('language')] = []
+            subs[s.get('language')].append({'url': s.get('file'), 'format': s.get('format').lower()})
+
+        jwt = meta.get('jwt')
+
+        def _determine_extract_func(name):
+            if name in ('hls', 'hls_sec'):
+                return self._extract_m3u8_formats
+            elif name == 'mpeg-dash':
+                return self._extract_mpd_formats
+            elif name == 'jwplayer':
+                return self._extract_smil_formats
+            else:
+                return lambda x, y: {}
+
+        def _extract_media_file_formats(formats, media_source_key):
+            return [[_determine_extract_func(src)(url, v_id) or [{
+                'bitrate': f.get('bitrate'),
+                'url': url,
+                'filesize': f.get('filesize'),
+                'width': f.get('width'),
+                'height': f.get('height'),
+                'ext': f.get('mediaType').lower(),
+                'format_id': f'{media_source_key}_{f.get("mediaType").lower()}_{f.get("bitrate")}_{src}'
+            }] for src, url in f.get('streams', {}).items()] for f in formats]
+
+        media = self._download_json(self._API_BASE.format('getMedia', v_id) + f'&jwt={jwt}', v_id).get('response')
+
+        formats = []
+        [[formats.extend(g) for g in f] for f in _extract_media_file_formats(media.get('mediaFiles_sl', {}), 'files_sl')]
+        [[formats.extend(g) for g in f] for f in _extract_media_file_formats(media.get('mediaFiles', {}), 'files')]
+
+        def _extract_adaptive(data):
+            return [_determine_extract_func(name)(url, v_id) for name, url in data.items()]
+        [formats.extend(g) for g in _extract_adaptive(media.get('addaptiveMedia'))]
+        [formats.extend(g) for g in _extract_adaptive(media.get('addaptiveMedia_sl'))]
+        self._sort_formats(formats)
+
+        geoblocked = meta.get('geoblocked', 0) == 1
+        must_circumvent_geoblock = None  # TODO check whether playlist redirects to https://vodstr.rtvslo.si/encrypted11/intermission.mp4/playlist.m3u8
+        paywall = bool(meta.get('payTv')) or meta.get('source') == 'ZKP'
+        must_circumvent_paywall = None  # TODO check whether media data returns mediaFiles[0][stream] elements contain: http://progressive.rtvslo.si/encrypted06/preroll/payable.mp4
+        
+
+        info = {
+            'thumbnails': thumbs,
+            'subtitles': subs,
+            'title': meta.get('title'),
+            'id': v_id,
+            'description': meta.get('description'),
+            'formats': formats,
+            'timestamp': date,
+            'release_timestamp': unified_timestamp(meta.get('recordingDate')),
+            'duration': meta.get('duration') or parse_duration(meta.get('length')),
+            'webpage_url': ''.join(traverse_obj(meta, ('canonical', ('domain', 'path')))),
+            'tags': meta.get('genre'),
+            'series': meta.get('showName'),
+            'series_id': meta.get('showId'),
+        }
+
+        return info

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -68,7 +68,7 @@ class RTVSLOIE(InfoExtractor):
         meta = self._download_json(self._API_BASE.format('getRecordingDrm', v_id), v_id).get('response')
         date = unified_timestamp(meta.get('broadcastDate') or meta.get('broadcastDates')[0])
 
-        thumbs = [{'url': v, 'id': k} for (k, v) in meta.get('images').items()]
+        thumbs = [{'id': k, 'url': v} for (k, v) in meta.get('images').items()]
         SUB_LANGS_MAP = {'Slovenski': 'sl', }
 
         subs = {}
@@ -102,12 +102,13 @@ class RTVSLOIE(InfoExtractor):
                         'ext': f.get('mediaType').lower(),
                         'format_id': f'files_{strm}_{f.get("mediaType").lower()}_{f.get("bitrate")}'
                     })
+
         if media.get('addaptiveMedia_sl', False):
-            formats.extend([
+            for f in self._extract_wowza_formats(
+                traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec')), v_id, skip_protocols=['f4m', 'rtmp']
+            ):
                 f.update({'format_note': 'Sign language interpretation', 'preference': -3})
-                for f in self._extract_wowza_formats(
-                    traverse_obj(media, ('addaptiveMedia', 'hls_sec')),
-                    v_id, skip_protocols=['f4m', 'rtmp'])])
+                formats.append(f)
         for strm in ('http', 'https'):
             for f in media.get('mediaFiles_sl'):
                 if traverse_obj(f, ('streams', strm)):
@@ -118,7 +119,7 @@ class RTVSLOIE(InfoExtractor):
                         'width': f.get('width'),
                         'height': f.get('height'),
                         'ext': f.get('mediaType').lower(),
-                        'format_id': f'files_{strm}_{f.get("mediaType").lower()}_{f.get("bitrate")}',
+                        'format_id': f'files-sl_{strm}_{f.get("mediaType").lower()}_{f.get("bitrate")}',
                         'format_note': 'Sign language interpretation',
                         'preference': -3
                     })

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -72,7 +72,7 @@ class RTVSLOIE(InfoExtractor):
         SUB_LANGS_MAP = {'Slovenski': 'sl', }
 
         subs = {}
-        for s in traverse_obj(meta, 'subs', 'subtitles'):
+        for s in traverse_obj(meta, 'subs', 'subtitles', default={}):
             if s.get('language') in SUB_LANGS_MAP.keys():
                 s['language'] = SUB_LANGS_MAP[s['language']]
             if not subs.get(s.get('language'), False):

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -68,8 +68,8 @@ class RTVSLOIE(InfoExtractor):
 
     def _real_extract(self, url):
         v_id = self._match_id(url)
-        meta = self._download_json(self._API_BASE.format('getRecordingDrm', v_id), v_id).get('response')
         date = unified_timestamp(meta.get('broadcastDate') or meta.get('broadcastDates')[0])
+        meta = self._download_json(self._API_BASE.format('getRecordingDrm', v_id), v_id)['response']
 
         thumbs = [{'id': k, 'url': v} for (k, v) in meta.get('images').items()]
         SUB_LANGS_MAP = {'Slovenski': 'sl', }
@@ -86,7 +86,7 @@ class RTVSLOIE(InfoExtractor):
         if not jwt:
             raise ExtractorError('Site did not provide an authentication token, cannot proceed.')
 
-        media = self._download_json(self._API_BASE.format('getMedia', v_id) + f'&jwt={jwt}', v_id).get('response')
+        media = self._download_json(self._API_BASE.format('getMedia', v_id), v_id, query={'jwt': jwt})['response']
 
         formats = []
         if media.get('addaptiveMedia', False):

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -4,7 +4,7 @@ from ..utils import ExtractorError, traverse_obj, parse_duration, unified_timest
 
 class RTVSLOIE(InfoExtractor):
     IE_NAME = 'rtvslo.si'
-    _VALID_URL = r'https?://((365|4d)\.rtvslo.si/arhiv/[^/?#&;]+|(www\.)?rtvslo\.si/rtv365/arhiv)/(?P<id>([0-9]+))'
+    _VALID_URL = r'https?://(?:(?:365|4d)\.rtvslo.si/arhiv/[^/?#&;]+|(?:www\.)?rtvslo\.si/rtv365/arhiv)/(?P<id>(\d+))'
     _API_BASE = 'https://api.rtvslo.si/ava/{}/{}?client_id=82013fb3a531d5414f478747c1aca622'
     _GEO_COUNTRIES = ['SI']
     _TESTS = [

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -91,17 +91,15 @@ class RTVSLOIE(InfoExtractor):
                 traverse_obj(media, ('addaptiveMedia', 'hls_sec'), expected_type=url_or_none),
                 v_id, skip_protocols=['smil'])
         for strm in ('http', 'https'):
-            for f in media.get('mediaFiles', []):
-                if traverse_obj(f, ('streams', strm)):
-                    formats.append({
-                        'bitrate': f.get('bitrate'),
-                        'url': traverse_obj(f, ('streams', strm)),
-                        'filesize': f.get('filesize'),
-                        'width': f.get('width'),
-                        'height': f.get('height'),
-                        'ext': f.get('mediaType').lower(),
-                        'format_id': f'files_{strm}_{f.get("mediaType", "").lower()}_{f.get("bitrate")}'
-                    })
+            formats.extend({
+                'bitrate': f.get('bitrate'),
+                'url': traverse_obj(f, ('streams', strm)),
+                'filesize': f.get('filesize'),
+                'width': f.get('width'),
+                'height': f.get('height'),
+                'ext': f.get('mediaType', '').lower() or None,
+                'format_id': f'files_{strm}_{f.get("mediaType", "").lower()}_{f.get("bitrate")}',
+            } for f in media.get('mediaFiles', []) if traverse_obj(f, ('streams', strm)))
 
         if media.get('addaptiveMedia_sl', False):
             for f in self._extract_wowza_formats(
@@ -114,19 +112,17 @@ class RTVSLOIE(InfoExtractor):
                     'language': 'slv' if f.get('language', '') == 'eng' and f.get('acodec', '') else f.get('language')})
                 formats.append(f)
         for strm in ('http', 'https'):
-            for f in media.get('mediaFiles_sl', []):
-                if traverse_obj(f, ('streams', strm)):
-                    formats.append({
-                        'bitrate': f.get('bitrate'),
-                        'url': traverse_obj(f, ('streams', strm)),
-                        'filesize': f.get('filesize'),
-                        'width': f.get('width'),
-                        'height': f.get('height'),
-                        'ext': f.get('mediaType', "").lower() or None,
-                        'format_id': f'files-sl_{strm}_{f.get("mediaType", "").lower()}_{f.get("bitrate")}',
-                        'format_note': 'Sign language interpretation',
-                        'preference': -10
-                    })
+            formats.extend({
+                'bitrate': f.get('bitrate'),
+                'url': traverse_obj(f, ('streams', strm)),
+                'filesize': f.get('filesize'),
+                'width': f.get('width'),
+                'height': f.get('height'),
+                'ext': f.get('mediaType', '').lower() or None,
+                'format_id': f'files-sl_{strm}_{f.get("mediaType", "").lower()}_{f.get("bitrate")}',
+                'format_note': 'Sign language interpretation',
+                'preference': -10
+            } for f in media.get('mediaFiles_sl', []) if traverse_obj(f, ('streams', strm)))
 
         self._sort_formats(formats)
 

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -107,7 +107,10 @@ class RTVSLOIE(InfoExtractor):
             for f in self._extract_wowza_formats(
                 traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec')), v_id, skip_protocols=['smil']
             ):
-                f.update({'format_note': 'Sign language interpretation', 'preference': -10})
+                f.update({
+                    'format_id': 'sign-'+f['format_id'],
+                    'format_note': 'Sign language interpretation', 'preference': -10,
+                    'language': 'slv' if f.get('language', '') == 'eng' and f.get('acodec', '') else f.get('language')})
                 formats.append(f)
         for strm in ('http', 'https'):
             for f in media.get('mediaFiles_sl'):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This adds an extractor for the new `https://ruv.is/*/spila/...` VOD platform. There are no calls to `<dict>.get()` as the GraphQL API will always return an empty value if there is none present.
Creating this as draft because the `duration` returned by the API is not consistent with the duration shown in the player, I'll have to fix that.