### PR TITLE
[ruv.is] add extractor

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1377,7 +1377,10 @@ from .megatvcom import (
 )
 from .rutv import RUTVIE
 from .ruutu import RuutuIE
-from .ruv import RuvIE
+from .ruv import (
+    RuvIE,
+    RuvSpilaIE
+)
 from .safari import (
     SafariIE,
     SafariApiIE,

--- a/yt_dlp/extractor/ruv.py
+++ b/yt_dlp/extractor/ruv.py
@@ -168,10 +168,11 @@ class RuvSpilaIE(InfoExtractor):
         for trk in episode.get('subtitles', []):
             subs[trk.get('name')] = {'url': trk.get('value')}
 
-        if '.m3u8' in episode['file']:
-            formats = self._extract_m3u8_formats(episode['file'], display_id)
+        media_url = episode['file']
+        if '.m3u8' in media_url:
+            formats = self._extract_m3u8_formats(media_url, display_id)
         else:
-            formats = [{'url': episode['file']}]
+            formats = [{'url': media_url}]
 
         clips = [
             {'start_time': parse_duration(c.get('time')), 'title': c.get('text')}

--- a/yt_dlp/extractor/ruv.py
+++ b/yt_dlp/extractor/ruv.py
@@ -117,6 +117,7 @@ class RuvSpilaIE(InfoExtractor):
             'upload_date': '20220201',
             'thumbnail': 'https://d38kdhuogyllre.cloudfront.net/fit-in/1960x/filters:quality(65)/hd_posters/94boog-iti3jg.jpg',
             'description': 'Íþróttafréttir.',
+            'age_limit': 0,
         },
     }, {
         'url': 'https://www.ruv.is/utvarp/spila/i-ljosi-sogunnar/23795/7hqkre',
@@ -129,6 +130,7 @@ class RuvSpilaIE(InfoExtractor):
             'upload_date': '20220204',
             'timestamp': 1643965500,
             'title': 'Nellie Bly II',
+            'age_limit': 0,
         },
     }, {
         'url': 'https://www.ruv.is/ungruv/spila/ungruv/28046/8beuph',
@@ -177,7 +179,8 @@ class RuvSpilaIE(InfoExtractor):
             'id': display_id,
             'title': traverse_obj(program, ('episodes', 0, 'title'), 'title'),
             'description': traverse_obj(
-                program, ('episodes', 0, 'description'), 'description', 'short_description'),
+                program, ('episodes', 0, 'description'), 'description', 'short_description',
+                expected_type=lambda x: x or None),
             'thumbnail': episode.get('image', '').replace('$$IMAGESIZE$$', '1960') or None,
             'timestamp': unified_timestamp(episode.get('firstrun')),
             'formats': formats,

--- a/yt_dlp/extractor/ruv.py
+++ b/yt_dlp/extractor/ruv.py
@@ -160,8 +160,9 @@ class RuvSpilaIE(InfoExtractor):
         episode = program['episodes'][0]
 
         subs = {}
-        [subs.setdefault(trk['name'], []).append({'url': trk['value'], 'ext': 'vtt'})
-         for trk in episode.get('subtitles') if trk.get('name') and trk.get('value')]
+        for trk in episode.get('subtitles'):
+            if trk.get('name') and trk.get('value'):
+                subs.setdefault(trk['name'], []).append({'url': trk['value'], 'ext': 'vtt'})
 
         media_url = episode['file']
         if determine_ext(media_url) == 'm3u8':

--- a/yt_dlp/extractor/ruv.py
+++ b/yt_dlp/extractor/ruv.py
@@ -159,11 +159,9 @@ class RuvSpilaIE(InfoExtractor):
             }''' % (series_id, display_id)})['data']['Program']
         episode = program['episodes'][0]
 
-        subs = {
-            trk['name']: trk['value']
-            for trk in episode.get('subtitles') or []
-            if trk.get('name') and trk.get('value')
-        }
+        subs = {}
+        [subs.setdefault(trk['name'], []).append({'url': trk['value'], 'ext': 'vtt'})
+         for trk in episode.get('subtitles') if trk.get('name') and trk.get('value')]
 
         media_url = episode['file']
         if determine_ext(media_url) == 'm3u8':
@@ -181,6 +179,7 @@ class RuvSpilaIE(InfoExtractor):
             'description': traverse_obj(
                 program, ('episodes', 0, 'description'), 'description', 'short_description',
                 expected_type=lambda x: x or None),
+            'subtitles': subs,
             'thumbnail': episode.get('image', '').replace('$$IMAGESIZE$$', '1960') or None,
             'timestamp': unified_timestamp(episode.get('firstrun')),
             'formats': formats,

--- a/yt_dlp/extractor/ruv.py
+++ b/yt_dlp/extractor/ruv.py
@@ -116,7 +116,6 @@ class RuvSpilaIE(InfoExtractor):
             'timestamp': 1643743500,
             'upload_date': '20220201',
             'thumbnail': 'https://d38kdhuogyllre.cloudfront.net/fit-in/1960x/filters:quality(65)/hd_posters/94boog-iti3jg.jpg',
-            'duration': 300,
             'description': 'Íþróttafréttir.',
         },
     }, {
@@ -130,7 +129,6 @@ class RuvSpilaIE(InfoExtractor):
             'upload_date': '20220204',
             'timestamp': 1643965500,
             'title': 'Nellie Bly II',
-            'duration': 2400,
         },
     }, {
         'url': 'https://www.ruv.is/ungruv/spila/ungruv/28046/8beuph',
@@ -186,6 +184,5 @@ class RuvSpilaIE(InfoExtractor):
             'timestamp': timestamp,
             'formats': formats,
             'age_limit': episode.get('rating'),
-            'duration': episode.get('duration'),
             'chapters': clips
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This adds an extractor for the new `https://ruv.is/*/spila/...` VOD platform. 
Creating this as draft because the duration returned by the API is not consistent with the duration shown in the player, I'll have to fix that.

Fixes #2122.