### PR TITLE
[globo] Adding new videoID regex #2730

### DIFF
--- a/yt_dlp/extractor/globo.py
+++ b/yt_dlp/extractor/globo.py
@@ -214,6 +214,14 @@ class GloboArticleIE(InfoExtractor):
     }, {
         'url': 'http://oglobo.globo.com/rio/a-amizade-entre-um-entregador-de-farmacia-um-piano-19946271',
         'only_matching': True,
+    }, {
+        'url': 'https://ge.globo.com/video/ta-na-area-como-foi-assistir-ao-jogo-do-palmeiras-que-a-globo-nao-passou-10287094.ghtml',
+        'info_dict': {
+            'id': 'ta-na-area-como-foi-assistir-ao-jogo-do-palmeiras-que-a-globo-nao-passou-10287094',
+            'title': 'Tá na Área: como foi assistir ao jogo do Palmeiras que a Globo não passou',
+            'description': 'md5:2d089d036c4c9675117d3a56f8c61739',
+        },
+        'playlist_count': 1,
     }]
 
     @classmethod

--- a/yt_dlp/extractor/globo.py
+++ b/yt_dlp/extractor/globo.py
@@ -186,6 +186,7 @@ class GloboArticleIE(InfoExtractor):
         r'\bvideosIDs\s*:\s*["\']?(\d{7,})',
         r'\bdata-id=["\'](\d{7,})',
         r'<div[^>]+\bid=["\'](\d{7,})',
+        r'<bs-player[^>]+\bvideoid=["\'](\d{8,})',
     ]
 
     _TESTS = [{
@@ -228,6 +229,6 @@ class GloboArticleIE(InfoExtractor):
         entries = [
             self.url_result('globo:%s' % video_id, GloboIE.ie_key())
             for video_id in orderedSet(video_ids)]
-        title = self._og_search_title(webpage, fatal=False)
+        title = self._og_search_title(webpage)
         description = self._html_search_meta('description', webpage)
         return self.playlist_result(entries, display_id, title, description)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Fixing #2730 

Added new video ID regex 
Removed fatal=False in _og_search_title to prevent double call.

### Prove of working

```
D:\ytdlp\yt-dlp>flake8 yt_dlp\extractor\globo.py

D:\ytdlp\yt-dlp>
D:\ytdlp\yt-dlp>python -m yt_dlp -v "https://ge.globo.com/video/ta-na-area-como-foi-assistir-ao-jogo-do-palmeiras-que-a-globo-nao-passou-10287094.ghtml"
[debug] Command-line config: ['-v', 'https://ge.globo.com/video/ta-na-area-como-foi-assistir-ao-jogo-do-palmeiras-que-a-globo-nao-passou-10287094.ghtml']
[debug] User config "C:\Users\User\AppData\Roaming\yt-dlp\config.txt": ['--ffmpeg-location', 'D:\\ytdlp\\ffmpeg\\bin']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8 (No ANSI), err utf-8 (No ANSI), pref cp1252
[debug] yt-dlp version 2022.01.21 [f20d607b0] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: c5332d7fb
[debug] Python version 3.8.10 (CPython 64bit) - Windows-7-6.1.7601-SP1
[debug] exe versions: ffmpeg N-105453-gcc5eb2e662-20220204 (setts), ffprobe N-105453-gcc5eb2e662-20220204
[debug] Optional libraries: sqlite
[debug] Proxy map: {}
[debug] [GloboArticle] Extracting URL: https://ge.globo.com/video/ta-na-area-como-foi-assistir-ao-jogo-do-palmeiras-que-a-globo-nao-passou-10287094.ghtml
[GloboArticle] ta-na-area-como-foi-assistir-ao-jogo-do-palmeiras-que-a-globo-nao-passou-10287094: Downloading webpage
[download] Downloading playlist: Tá na Área: como foi assistir ao jogo do Palmeiras que a Globo não passou
[GloboArticle] playlist Tá na Área: como foi assistir ao jogo do Palmeiras que a Globo não passou: Collected 1 videos; downloading 1 of them
[download] Downloading video 1 of 1
[debug] [Globo] Extracting URL: globo:10287094
[Globo] 10287094: Getting cookies
[Globo] 10287094: Downloading JSON metadata
[Globo] 10287094: Downloading security hash for 10287094
[Globo] 10287094: Getting locksession cookie
[Globo] 10287094: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 10287094: Downloading 1 format(s): hls-2736
[debug] Invoking downloader on "https://vod-as-03-35.video.globo.com/p2950/r90_1080/v0/c8/41/16/10287094_163cec99c0e033b73a02b1759e164e49098aae9f/10287094-w28s9eU-manifest.ism/10287094-w28s9eU-manifest-audio_por=128012-video_por=2453000.m3u8?hls_client_manifest_version=4"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 36
[download] Destination: Tá na Área - como foi assistir ao jogo do Palmeiras que a Globo não passou [10287094].mp4
[download] 100% of 67.89MiB in 00:06
[debug] ffprobe command line: "D:\ytdlp\ffmpeg\bin\ffprobe" -hide_banner -show_format -show_streams -print_format json "file:Tá na Área - como foi assistir ao jogo do Palmeiras que a Globo não passou [10287094].mp4"
[FixupM3u8] Fixing MPEG-TS in MP4 container of "Tá na Área - como foi assistir ao jogo do Palmeiras que a Globo não passou [10287094].mp4"
[debug] ffmpeg command line: "D:\ytdlp\ffmpeg\bin\ffmpeg" -y -loglevel "repeat+info" -i "file:Tá na Área - como foi assistir ao jogo do Palmeiras que a Globo não passou [10287094].mp4" -map 0 -dn -ignore_unknown -c copy -f mp4 "-bsf:a" aac_adtstoasc -movflags "+faststart" "file:Tá na Área - como foi assistir ao jogo do Palmeiras que a Globo não passou [10287094].temp.mp4"
[download] Finished downloading playlist: Tá na Área: como foi assistir ao jogo do Palmeiras que a Globo não passou

D:\ytdlp\yt-dlp>python test/test_download.py TestDownload.test_GloboArticle_all
C:\Users\User\AppData\Local\Programs\Python\Python38\lib\subprocess.py:946: ResourceWarning: subprocess 11804 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
[debug] [GloboArticle] Extracting URL: http://g1.globo.com/jornal-nacional/noticia/2014/09/novidade-na-fiscalizacao-de-bagagem-pela-receita-provoca-discussoes.html
[GloboArticle] novidade-na-fiscalizacao-de-bagagem-pela-receita-provoca-discussoes: Downloading webpage
[download] Downloading playlist: Novidade na fiscalização de bagagem pela Receita provoca discussões
[info] Writing playlist metadata as JSON to: test_GloboArticle_novidade-na-fiscalizacao-de-bagagem-pela-receita-provoca-discussoes.info.json
[GloboArticle] playlist Novidade na fiscalização de bagagem pela Receita provoca discussões: Collected 1 videos; downloading 1 of them
[download] Downloading video 1 of 1
[info] Writing updated playlist metadata as JSON to: test_GloboArticle_novidade-na-fiscalizacao-de-bagagem-pela-receita-provoca-discussoes.info.json
[download] Finished downloading playlist: Novidade na fiscalização de bagagem pela Receita provoca discussões
C:\Users\User\AppData\Local\Programs\Python\Python38\lib\subprocess.py:946: ResourceWarning: subprocess 11284 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
[debug] [GloboArticle] Extracting URL: http://g1.globo.com/pr/parana/noticia/2016/09/mpf-denuncia-lula-marisa-e-mais-seis-na-operacao-lava-jato.html
[GloboArticle] mpf-denuncia-lula-marisa-e-mais-seis-na-operacao-lava-jato: Downloading webpage
[download] Downloading playlist: Lula era o 'comandante máximo' do esquema da Lava Jato, diz MPF
[info] Writing playlist metadata as JSON to: test_GloboArticle_1_mpf-denuncia-lula-marisa-e-mais-seis-na-operacao-lava-jato.info.json
[GloboArticle] playlist Lula era o 'comandante máximo' do esquema da Lava Jato, diz MPF: Collected 6 videos; downloading 6 of them
[download] Downloading video 1 of 6
[download] Downloading video 2 of 6
[download] Downloading video 3 of 6
[download] Downloading video 4 of 6
[download] Downloading video 5 of 6
[download] Downloading video 6 of 6
[info] Writing updated playlist metadata as JSON to: test_GloboArticle_1_mpf-denuncia-lula-marisa-e-mais-seis-na-operacao-lava-jato.info.json
[download] Finished downloading playlist: Lula era o 'comandante máximo' do esquema da Lava Jato, diz MPF
.
----------------------------------------------------------------------
Ran 1 test in 0.538s

OK

```