### PR TITLE
Update Cookies.binarycookies location in cookies.py

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -454,7 +454,11 @@ def _extract_safari_cookies(profile, logger):
     cookies_path = os.path.expanduser('~/Library/Cookies/Cookies.binarycookies')
 
     if not os.path.isfile(cookies_path):
-        raise FileNotFoundError('could not find safari cookies database')
+        logger.info('Trying secondary cookie location')
+        cookies_path = os.path.expanduser('~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies')
+        
+        if not os.path.isfile(cookies_path):
+          raise FileNotFoundError('could not find safari cookies database')
 
     with open(cookies_path, 'rb') as f:
         cookies_data = f.read()

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -455,7 +455,7 @@ def _extract_safari_cookies(profile, logger):
 
     if not os.path.isfile(cookies_path):
         logger.info('Trying secondary cookie location')
-        cookies_path = os.path.expanduser('~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies') 
+        cookies_path = os.path.expanduser('~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies')
         if not os.path.isfile(cookies_path):
             raise FileNotFoundError('could not find safari cookies database')
 

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -454,7 +454,7 @@ def _extract_safari_cookies(profile, logger):
     cookies_path = os.path.expanduser('~/Library/Cookies/Cookies.binarycookies')
 
     if not os.path.isfile(cookies_path):
-        logger.info('Trying secondary cookie location')
+        logger.debug('Trying secondary cookie location')
         cookies_path = os.path.expanduser('~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies')
         if not os.path.isfile(cookies_path):
             raise FileNotFoundError('could not find safari cookies database')

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -455,10 +455,9 @@ def _extract_safari_cookies(profile, logger):
 
     if not os.path.isfile(cookies_path):
         logger.info('Trying secondary cookie location')
-        cookies_path = os.path.expanduser('~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies')
-        
+        cookies_path = os.path.expanduser('~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies') 
         if not os.path.isfile(cookies_path):
-          raise FileNotFoundError('could not find safari cookies database')
+            raise FileNotFoundError('could not find safari cookies database')
 
     with open(cookies_path, 'rb') as f:
         cookies_data = f.read()


### PR DESCRIPTION
If ~/Library/Cookies/Cookies.binarycookies doesn't exist use ~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies if it exist.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The Cookies.binarycookies file in macOS Monterey is in a different location. If the binarycookies file isn't found in the original location it'll check for the file in the new folder.  