### PR TITLE
[twitter] Include x-csrf-token header if ct0 cookie is set

### DIFF
--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -90,6 +90,9 @@ class TwitterBaseIE(InfoExtractor):
         headers = {
             'Authorization': 'Bearer AAAAAAAAAAAAAAAAAAAAAPYXBAAAAAAACLXUNDekMxqa8h%2F40K4moUkGsoc%3DTYfbDKbT3jJPCEVnMYqilB28NHfOPqkca3qaAxGfsyKCs0wRbw',
         }
+        token = self._get_cookies(self._API_BASE + path).get('ct0')
+        if token:
+            headers['x-csrf-token'] = token.value
         if not self._GUEST_TOKEN:
             self._GUEST_TOKEN = self._download_json(
                 self._API_BASE + 'guest/activate.json', video_id,

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -90,7 +90,7 @@ class TwitterBaseIE(InfoExtractor):
         headers = {
             'Authorization': 'Bearer AAAAAAAAAAAAAAAAAAAAAPYXBAAAAAAACLXUNDekMxqa8h%2F40K4moUkGsoc%3DTYfbDKbT3jJPCEVnMYqilB28NHfOPqkca3qaAxGfsyKCs0wRbw',
         }
-        token = self._get_cookies(self._API_BASE + path).get('ct0')
+        token = self._get_cookies(self._API_BASE).get('ct0')
         if token:
             headers['x-csrf-token'] = token.value
         if not self._GUEST_TOKEN:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

To resolve issue #2762.
This patch adds a `x-csrf-token` header to the API requests when the `ct0` cookie is set, resolving the HTTP Error 403 when twitter URLs are supplied with a cookie file (`--cookies` / `--cookies-from-browser`).