### PR TITLE
[niconico:tag] add support for searching tags

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -663,6 +663,8 @@ class NiconicoPlaylistIE(InfoExtractor):
 
 
 class NicovideoSearchBaseIE(InfoExtractor):
+    _SEARCH_TYPE = 'search'
+
     def _entries(self, url, item_id, query=None, note='Downloading page %(page)s'):
         query = query or {}
         pages = [query['page']] if 'page' in query else itertools.count(1)
@@ -677,7 +679,7 @@ class NicovideoSearchBaseIE(InfoExtractor):
 
     def _search_results(self, query):
         return self._entries(
-            self._proto_relative_url(f'//www.nicovideo.jp/search/{query}'), query)
+            self._proto_relative_url(f'//www.nicovideo.jp/{self._SEARCH_TYPE}/{query}'), query)
 
 
 class NicovideoSearchIE(NicovideoSearchBaseIE, SearchInfoExtractor):
@@ -755,6 +757,25 @@ class NicovideoSearchDateIE(NicovideoSearchBaseIE, SearchInfoExtractor):
             query['page'] = str(page_num)
 
         yield from super()._entries(url, item_id, query=query, note=note)
+
+
+class NicovideoTagURLIE(NicovideoSearchBaseIE):
+    IE_NAME = 'niconico:tag'
+    IE_DESC = 'NicoNico video tag URLs'
+    _SEARCH_TYPE = 'tag'
+    _VALID_URL = r'https?://(?:www\.)?nicovideo\.jp/tag/(?P<id>[^?#&]+)?'
+    _TESTS = [{
+        'url': 'https://www.nicovideo.jp/tag/%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%82%BF%E3%83%AA%E3%83%BC%E6%B7%AB%E5%A4%A2',
+        'info_dict': {
+            'id': 'ドキュメンタリー淫夢',
+            'title': 'ドキュメンタリー淫夢'
+        },
+        'playlist_mincount': 400,
+    }]
+
+    def _real_extract(self, url):
+        query = self._match_id(url)
+        return self.playlist_result(self._entries(url, query), query, query)
 
 
 class NiconicoUserIE(InfoExtractor):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This adds support for searching by tags in NicoNico, not covered by #672

Example URL: https://www.nicovideo.jp/tag/%E3%83%93%E3%83%AA%E3%83%BC%E3%83%BB%E3%83%98%E3%83%AA%E3%83%B3%E3%83%88%E3%83%B3