### PR TITLE
Fix rtvs extracor

### DIFF
--- a/yt_dlp/extractor/rtvs.py
+++ b/yt_dlp/extractor/rtvs.py
@@ -3,9 +3,16 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 
+from ..utils import (
+    int_or_none,
+    parse_duration,
+    traverse_obj,
+    unified_timestamp,
+)
+
 
 class RTVSIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?rtvs\.sk/(?:radio|televizia)/archiv/\d+/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?rtvs\.sk/(?:radio|televizia)/archiv/?.*/(?P<id>\d+)\??.*'
     _TESTS = [{
         # radio archive
         'url': 'http://www.rtvs.sk/radio/archiv/11224/414872',
@@ -13,35 +20,79 @@ class RTVSIE(InfoExtractor):
         'info_dict': {
             'id': '414872',
             'ext': 'mp3',
-            'title': 'Ostrov pokladov 1 časť.mp3'
-        },
-        'params': {
-            'skip_download': True,
+            'title': 'Ostrov pokladov 1 časť.mp3',
+            'duration': 2854,
+            'thumbnail': 'https://www.rtvs.sk/media/a501/image/file/2/0000/b1R8.rtvs.jpg',
+            'display_id': '135331',
         }
     }, {
         # tv archive
         'url': 'http://www.rtvs.sk/televizia/archiv/8249/63118',
-        'md5': '85e2c55cf988403b70cac24f5c086dc6',
         'info_dict': {
             'id': '63118',
             'ext': 'mp4',
             'title': 'Amaro Džives - Náš deň',
-            'description': 'Galavečer pri príležitosti Medzinárodného dňa Rómov.'
-        },
-        'params': {
-            'skip_download': True,
+            'description': 'Galavečer pri príležitosti Medzinárodného dňa Rómov.',
+            'thumbnail': 'https://www.rtvs.sk/media/a501/image/file/2/0031/L7Qm.amaro_dzives_png.jpg',
+            'timestamp': 1428555900,
+            'upload_date': '20150409',
+            'duration': 4986,
+        }
+    }, {
+        # tv archive
+        'url': 'https://www.rtvs.sk/televizia/archiv/18083?utm_source=web&utm_medium=rozcestnik&utm_campaign=Robin',
+        'info_dict': {
+            'id': '18083',
+            'ext': 'mp4',
+            'title': 'Robin',
+            'description': '\nRichard so svojím psíkom Robinom a deťmi prežívajú dobrodružné príbehy, ktoré pomáhajú malým divákom orientovať sa a nachádzať riešenia v rôznych zložitých životných situáciách.',
+            'timestamp': 1636652760,
+            'display_id': '307655',
+            'duration': 831,
+            'upload_date': '20211111',
+            'thumbnail': 'https://www.rtvs.sk/media/a501/image/file/2/0916/robin.jpg',
         }
     }]
+
+# TODO
+# live video https://www.rtvs.sk/televizia/live-3 , https://www.rtvs.sk/televizia/sport
+# live radio https://slovensko.rtvs.sk/player
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
         webpage = self._download_webpage(url, video_id)
+        iframe_id = self._search_regex(
+            r'<iframe[^>]+id\s*=\s*"player_[^_]+_([0-9]+)"', webpage,
+            'Iframe ID')
+        iframe_url = self._search_regex(
+            fr'<iframe[^>]+id\s*=\s*"player_[^_]+_{iframe_id}"[^>]+src\s*=\s*"([^"]+)"', webpage,
+            'Iframe URL')
 
-        playlist_url = self._search_regex(
-            r'playlist["\']?\s*:\s*(["\'])(?P<url>(?:(?!\1).)+)\1', webpage,
-            'playlist url', group='url')
-
+        webpage = self._download_webpage(iframe_url, video_id, 'Downloading iframe')
+        json_url = self._search_regex(
+            r'var\s+url\s*=\s*"([^"]+)"\s*\+\s*ruurl', webpage,
+            'Json URL')
+        full_json_url = f'https:{json_url}b=mozilla&p=win&v=97&f=0&d=1'
         data = self._download_json(
-            playlist_url, video_id, 'Downloading playlist')[0]
-        return self._parse_jwplayer_data(data, video_id=video_id)
+            full_json_url, video_id, 'Downloading json')
+
+        if data.get('clip'):
+            data['playlist'] = [data['clip']]
+
+        to_return = {
+            'id': video_id,
+            'display_id': iframe_id,
+            'title': traverse_obj(data, ('playlist', 0, 'title')),
+            'description': traverse_obj(data, ('playlist', 0, 'description')),
+            'duration': int_or_none(parse_duration(traverse_obj(data, ('playlist', 0, 'length')))),
+            'thumbnail': traverse_obj(data, ('playlist', 0, 'image')),
+            'timestamp': unified_timestamp(traverse_obj(data, ('playlist', 0, 'datetime_create'))),
+        }
+
+        if traverse_obj(data, ('playlist', 0, 'sources', 0, 'type')) == 'audio/mp3':
+            to_return['url'] = traverse_obj(data, ('playlist', 0, 'sources', 0, 'src'))
+        else:
+            to_return['formats'] = self._extract_m3u8_formats(traverse_obj(data, ('playlist', 0, 'sources', 0, 'src')), video_id)
+
+        return to_return


### PR DESCRIPTION
Fix valid url to match urls with only one id.
Extract video/audio URL from iframe

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixing RTVS extractor.
Fix valid url regex to match only 1 id in url.
Extract video/audio url from iframe.
Add test scenario 
#2758
