### PR TITLE
[bbc] Fix extraction of news articles

### DIFF
--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -1171,11 +1171,9 @@ class BBCIE(BBCCoUkIE):
                 return self.playlist_result(
                     entries, playlist_id, playlist_title, playlist_description)
 
-        initial_data = self._parse_json(self._search_regex(
+        initial_data = self._parse_json(self._parse_json(self._search_regex(
             r'window\.__INITIAL_DATA__\s*=\s*("{.+?}");', webpage,
-            'preload state', default='{}'), playlist_id, fatal=False)
-        if isinstance(initial_data, str):
-            initial_data = self._parse_json(initial_data, playlist_id, fatal=False)
+            'preload state', default='"{}"'), playlist_id, fatal=False), playlist_id, fatal=False)
         if initial_data:
             def parse_media(media):
                 if not media:

--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -1172,8 +1172,10 @@ class BBCIE(BBCCoUkIE):
                     entries, playlist_id, playlist_title, playlist_description)
 
         initial_data = self._parse_json(self._search_regex(
-            r'window\.__INITIAL_DATA__\s*=\s*({.+?});', webpage,
+            r'window\.__INITIAL_DATA__\s*=\s*("{.+?}");', webpage,
             'preload state', default='{}'), playlist_id, fatal=False)
+        if isinstance(initial_data, str):
+            initial_data = self._parse_json(initial_data, playlist_id, fatal=False)
         if initial_data:
             def parse_media(media):
                 if not media:
@@ -1214,7 +1216,7 @@ class BBCIE(BBCCoUkIE):
                 if name == 'media-experience':
                     parse_media(try_get(resp, lambda x: x['data']['initialItem']['mediaItem'], dict))
                 elif name == 'article':
-                    for block in (try_get(resp, lambda x: x['data']['blocks'], list) or []):
+                    for block in (try_get(resp, lambda x: x['data']['content']['model']['blocks'], list) or []):
                         if block.get('type') != 'media':
                             continue
                         parse_media(block.get('model'))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Fixes "Unable to extract playlist data" error on BBC news articles (https://github.com/yt-dlp/yt-dlp/issues/1374)
`window.__INITIAL_DATA__` is now a JSON string which needs to be parsed twice. Blocks for articles are now nested in two more layers.