### PR TITLE
Call SponsorBlock directly from ModifyChaptersPP (fixes #2536)

### DIFF
--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -30,8 +30,8 @@ from .postprocessor import (
     FFmpegSubtitlesConvertorPP,
     FFmpegThumbnailsConvertorPP,
     FFmpegVideoRemuxerPP,
-    SponsorBlockPP,
 )
+from .postprocessor.sponsorblock import SponsorBlockHelper
 from .postprocessor.modify_chapters import DEFAULT_SPONSORBLOCK_CHAPTER_TITLE
 
 
@@ -1564,18 +1564,19 @@ def create_parser():
         '--sponsorblock-mark', metavar='CATS',
         dest='sponsorblock_mark', default=set(), action='callback', type='str',
         callback=_set_from_options_callback, callback_kwargs={
-            'allowed_values': SponsorBlockPP.CATEGORIES.keys(),
+            'allowed_values': SponsorBlockHelper.CATEGORIES.keys(),
             'aliases': {'default': ['all']}
         }, help=(
             'SponsorBlock categories to create chapters for, separated by commas. '
-            f'Available categories are all, default(=all), {", ".join(SponsorBlockPP.CATEGORIES.keys())}. '
+            f'Available categories are all, default(=all), {", ".join(SponsorBlockHelper.CATEGORIES.keys())}. '
             'You can prefix the category with a "-" to exempt it. See [1] for description of the categories. '
             'Eg: --sponsorblock-mark all,-preview [1] https://wiki.sponsor.ajay.app/w/Segment_Categories'))
     sponsorblock.add_option(
         '--sponsorblock-remove', metavar='CATS',
         dest='sponsorblock_remove', default=set(), action='callback', type='str',
         callback=_set_from_options_callback, callback_kwargs={
-            'allowed_values': set(SponsorBlockPP.CATEGORIES.keys()) - set(SponsorBlockPP.POI_CATEGORIES.keys()),
+            'allowed_values': (set(SponsorBlockHelper.CATEGORIES.keys())
+                               - set(SponsorBlockHelper.POI_CATEGORIES.keys())),
             # Note: From https://wiki.sponsor.ajay.app/w/Types:
             # The filler category is very aggressive.
             # It is strongly recommended to not use this in a client by default.
@@ -1585,7 +1586,7 @@ def create_parser():
             'If a category is present in both mark and remove, remove takes precedence. '
             'The syntax and available categories are the same as for --sponsorblock-mark '
             'except that "default" refers to "all,-filler" '
-            f'and {", ".join(SponsorBlockPP.POI_CATEGORIES.keys())} is not available'))
+            f'and {", ".join(SponsorBlockHelper.POI_CATEGORIES.keys())} is not available'))
     sponsorblock.add_option(
         '--sponsorblock-chapter-title', metavar='TEMPLATE',
         default=DEFAULT_SPONSORBLOCK_CHAPTER_TITLE, dest='sponsorblock_chapter_title',

--- a/yt_dlp/postprocessor/__init__.py
+++ b/yt_dlp/postprocessor/__init__.py
@@ -33,7 +33,6 @@ from .metadataparser import (
 from .modify_chapters import ModifyChaptersPP
 from .movefilesafterdownload import MoveFilesAfterDownloadPP
 from .sponskrub import SponSkrubPP
-from .sponsorblock import SponsorBlockPP
 from .xattrpp import XAttrMetadataPP
 
 _PLUGIN_CLASSES = load_plugins('postprocessor', 'PP', globals())


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

1. `SponsorBlockPP` is demoted from preprocessor to an ordinary class `SponsorBlockHelper`.
2. `SponsorBlockHelper` is now called directly from `ModifyChaptersPP` to fetch SponsorBlock segments just in time, rather than before all the filters (fixes #2536).
3. Added a single-entry cache for SponsorBlock segments to avoid making multiple requests when downloading multiple formats of the same video.
4. Apparently Highlight now requires `poi` `actionType`: https://wiki.sponsor.ajay.app/w/Types.
5. Ignore entire video segments: https://wiki.sponsor.ajay.app/w/Types.