### PR TITLE
[fragment] Add exponential backoff support

### DIFF
--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -692,6 +692,7 @@ def parse_options(argv=None):
         'fragment_retries': opts.fragment_retries,
         'extractor_retries': opts.extractor_retries,
         'skip_unavailable_fragments': opts.skip_unavailable_fragments,
+        'exponential_backoff': opts.exponential_backoff,
         'keep_fragments': opts.keep_fragments,
         'concurrent_fragment_downloads': opts.concurrent_fragment_downloads,
         'buffersize': opts.buffersize,

--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -24,6 +24,7 @@ from ..utils import (
     check_executable,
     Popen,
     remove_end,
+    sleep_exponential,
 )
 
 
@@ -124,6 +125,7 @@ class ExternalFD(FragmentFD):
 
         fragment_retries = self.params.get('fragment_retries', 0)
         skip_unavailable_fragments = self.params.get('skip_unavailable_fragments', True)
+        exponential_backoff = self.params.get('exponential_backoff', 0.0)
 
         count = 0
         while count <= fragment_retries:
@@ -139,6 +141,7 @@ class ExternalFD(FragmentFD):
                 self.to_screen(
                     '[%s] Got error. Retrying fragments (attempt %d of %s)...'
                     % (self.get_basename(), count, self.format_retries(fragment_retries)))
+                sleep_exponential(exponential_backoff, count)
         if count > fragment_retries:
             if not skip_unavailable_fragments:
                 self.report_error('Giving up after %s fragment retries' % fragment_retries)

--- a/yt_dlp/downloader/ism.py
+++ b/yt_dlp/downloader/ism.py
@@ -9,6 +9,7 @@ from ..compat import (
     compat_Struct,
     compat_urllib_error,
 )
+from ..utils import sleep_exponential
 
 
 u8 = compat_Struct('>B')
@@ -252,6 +253,7 @@ class IsmFD(FragmentFD):
             'ism_track_written': False,
         })
 
+        exponential_backoff = self.params.get('exponential_backoff', 0.0)
         fragment_retries = self.params.get('fragment_retries', 0)
         skip_unavailable_fragments = self.params.get('skip_unavailable_fragments', True)
 
@@ -277,6 +279,7 @@ class IsmFD(FragmentFD):
                     count += 1
                     if count <= fragment_retries:
                         self.report_retry_fragment(err, frag_index, count, fragment_retries)
+                        sleep_exponential(exponential_backoff, count)
             if count > fragment_retries:
                 if skip_unavailable_fragments:
                     self.report_skip_fragment(frag_index)

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -734,6 +734,14 @@ def create_parser():
         dest='fragment_retries', metavar='RETRIES', default=10,
         help='Number of retries for a fragment (default is %default), or "infinite" (DASH, hlsnative and ISM)')
     downloader.add_option(
+        '--exponential-backoff',
+        default=0.0, metavar='SECS', type=float,
+        help=(
+            'Start value for exponential backoff when doing retries, in seconds. '
+            'Currently only supported for fragment retries, and capped at 60 seconds. '
+            'The backoff is then calculated by `exponential backoff secs * 1.5 ** number of attempts`. '
+            '(default is %default)'))
+    downloader.add_option(
         '--skip-unavailable-fragments', '--no-abort-on-unavailable-fragment',
         action='store_true', dest='skip_unavailable_fragments', default=True,
         help='Skip unavailable fragments for DASH, hlsnative and ISM (default) (Alias: --no-abort-on-unavailable-fragment)')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5490,3 +5490,8 @@ has_websockets = bool(compat_websockets)
 def merge_headers(*dicts):
     """Merge dicts of http headers case insensitively, prioritizing the latter ones"""
     return {k.title(): v for k, v in itertools.chain.from_iterable(map(dict.items, dicts))}
+
+
+def sleep_exponential(initial_delay_secs, attempt_nr, max_delay_secs=60):
+    if initial_delay_secs:
+        time.sleep(min(initial_delay_secs * 1.5 ** attempt_nr, max_delay_secs))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When downloading a HLS video I noted that many fragments were missing. Looking at the log, these fragments were given transient 429s in order to suggest to the client that it should back off and try again after a few seconds. However, the current retries happen as fast as we can go, which means those fragments just end up skipped.

This patch adds support for exponential backoff when doing fragment retries, which increases the chance that the fragment will eventually be provided in such cases. This is disabled by default, and can be enabled with --fragment-retry-backoff.

Example delays in seconds are as follows with the default 10 retries:

    >>> for i in range(10): print("{:.2f}".format(0.25 * 1.5 ** i))
    0.25
    0.38
    0.56
    0.84
    1.27
    1.90
    2.85
    4.27
    6.41
    9.61
