### PR TITLE
Extend `--playlist-items` to support step

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -1046,6 +1046,7 @@ class TestYoutubeDL(unittest.TestCase):
 
         # Tests for --playlist-items Xn+Y
         # https://discord.com/channels/807245652072857610/926071133051187242
+        test_selection({'playlist_items': '0n'}, [])
         test_selection({'playlist_items': '0n+1'}, [1])
         test_selection({'playlist_items': '2n+1'}, [1, 3])
         test_selection({'playlist_items': '2n'}, [2, 4])
@@ -1055,6 +1056,7 @@ class TestYoutubeDL(unittest.TestCase):
         test_selection({'playlist_items': '5n+1'}, [1])
         test_selection({'playlist_items': '5n+5'}, [])
 
+        test_selection({'playlist_items': '0n-2'}, [])
         test_selection({'playlist_items': '2n-1'}, [1, 3])
         test_selection({'playlist_items': '3n-1'}, [2])
         test_selection({'playlist_items': '5n-5'}, [])

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -1044,22 +1044,29 @@ class TestYoutubeDL(unittest.TestCase):
         test_selection({'playlist_items': '2,4', 'playlistreverse': True}, [4, 2])
         test_selection({'playlist_items': '4,2'}, [4, 2])
 
-        # Tests for --playlist-items Xn+Y
+        # Tests for --playlist-items start:end:step
         # https://discord.com/channels/807245652072857610/926071133051187242
-        test_selection({'playlist_items': '0n'}, [])
-        test_selection({'playlist_items': '0n+1'}, [1])
-        test_selection({'playlist_items': '2n+1'}, [1, 3])
-        test_selection({'playlist_items': '2n'}, [2, 4])
-        test_selection({'playlist_items': '2n+0'}, [2, 4])
-        test_selection({'playlist_items': '3n+1'}, [1, 4])
-        test_selection({'playlist_items': '3n+5'}, [])
-        test_selection({'playlist_items': '5n+1'}, [1])
-        test_selection({'playlist_items': '5n+5'}, [])
+        test_selection({'playlist_items': '0:0:0'}, [])
+        test_selection({'playlist_items': '1::0'}, [1])
+        # test_selection({'playlist_items': '1:inf:0'}, [1])  # error
+        test_selection({'playlist_items': '1:inf:2'}, [1, 3])
+        test_selection({'playlist_items': '::2'}, [1, 3])
+        test_selection({'playlist_items': '0::2'}, [2, 4])
+        test_selection({'playlist_items': '1::3'}, [1, 4])
+        test_selection({'playlist_items': '1-:2'}, [1, 3])
+        test_selection({'playlist_items': '0-2:2'}, [2])
 
-        test_selection({'playlist_items': '0n-2'}, [])
-        test_selection({'playlist_items': '2n-1'}, [1, 3])
-        test_selection({'playlist_items': '3n-1'}, [2])
-        test_selection({'playlist_items': '5n-5'}, [])
+        # test_selection({'playlist_items': '-2:inf'}, [3, 4])
+        # test_selection({'playlist_items': '-2:inf:2'}, [3])
+
+        test_selection({'playlist_items': '5::3'}, [])
+        test_selection({'playlist_items': '1::5'}, [1])
+        test_selection({'playlist_items': '5::5'}, [])
+
+        # test_selection({'playlist_items': '-2::0'}, [3])
+        # test_selection({'playlist_items': '-1::2'}, [4])
+        # test_selection({'playlist_items': '-1::3'}, [4])
+        test_selection({'playlist_items': '-5::5'}, [])
 
     def test_urlopen_no_file_protocol(self):
         # see https://github.com/ytdl-org/youtube-dl/issues/8227

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -1055,6 +1055,10 @@ class TestYoutubeDL(unittest.TestCase):
         test_selection({'playlist_items': '5n+1'}, [1])
         test_selection({'playlist_items': '5n+5'}, [])
 
+        test_selection({'playlist_items': '2n-1'}, [1, 3])
+        test_selection({'playlist_items': '3n-1'}, [2])
+        test_selection({'playlist_items': '5n-5'}, [])
+
     def test_urlopen_no_file_protocol(self):
         # see https://github.com/ytdl-org/youtube-dl/issues/8227
         ydl = YDL()

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -1056,16 +1056,16 @@ class TestYoutubeDL(unittest.TestCase):
         test_selection({'playlist_items': '1-:2'}, [1, 3])
         test_selection({'playlist_items': '0-2:2'}, [2])
 
-        # test_selection({'playlist_items': '-2:inf'}, [3, 4])
-        # test_selection({'playlist_items': '-2:inf:2'}, [3])
+        test_selection({'playlist_items': '-2:inf'}, [3, 4])
+        test_selection({'playlist_items': '-2:inf:2'}, [3])
 
         test_selection({'playlist_items': '5::3'}, [])
         test_selection({'playlist_items': '1::5'}, [1])
         test_selection({'playlist_items': '5::5'}, [])
 
-        # test_selection({'playlist_items': '-2::0'}, [3])
-        # test_selection({'playlist_items': '-1::2'}, [4])
-        # test_selection({'playlist_items': '-1::3'}, [4])
+        test_selection({'playlist_items': '-2::0'}, [3])
+        test_selection({'playlist_items': '-1::2'}, [4])
+        test_selection({'playlist_items': '-1::3'}, [4])
         test_selection({'playlist_items': '-5::5'}, [])
 
     def test_urlopen_no_file_protocol(self):

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -1044,6 +1044,17 @@ class TestYoutubeDL(unittest.TestCase):
         test_selection({'playlist_items': '2,4', 'playlistreverse': True}, [4, 2])
         test_selection({'playlist_items': '4,2'}, [4, 2])
 
+        # Tests for --playlist-items Xn+Y
+        # https://discord.com/channels/807245652072857610/926071133051187242
+        test_selection({'playlist_items': '0n+1'}, [1])
+        test_selection({'playlist_items': '2n+1'}, [1, 3])
+        test_selection({'playlist_items': '2n'}, [2, 4])
+        test_selection({'playlist_items': '2n+0'}, [2, 4])
+        test_selection({'playlist_items': '3n+1'}, [1, 4])
+        test_selection({'playlist_items': '3n+5'}, [])
+        test_selection({'playlist_items': '5n+1'}, [1])
+        test_selection({'playlist_items': '5n+5'}, [])
+
     def test_urlopen_no_file_protocol(self):
         # see https://github.com/ytdl-org/youtube-dl/issues/8227
         ydl = YDL()

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1683,13 +1683,13 @@ class YoutubeDL(object):
                         continue
 
                     if real_step == 0:
-                        raise IndexError(f'Step must not be zero')
+                        raise IndexError('Step must not be zero')
                     iter_playlistitems.append(range(real_begin, real_end + 1, real_step))
                 elif not e or e == 'inf':
                     # range and infinite end, with or without start and step
                     if real_step == 0:
                         if e:
-                            raise IndexError(f'Step must not be zero')
+                            raise IndexError('Step must not be zero')
                         # special case: without end, treat this as single literal
                         iter_playlistitems.append((real_begin, ))
                         continue

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1668,11 +1668,11 @@ class YoutubeDL(object):
 
                         coef_s, ofs_s = mobj.group('coef', 'ofs')
                         coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)
-                        while ofs <= 0:
-                            ofs += coef
                         if coef == 0:
                             yield ofs
                         else:
+                            while ofs <= 0:
+                                ofs += coef
                             yield from itertools.count(ofs, coef)
                     elif '-' in string_segment:
                         start, end = string_segment.split('-')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1669,6 +1669,9 @@ class YoutubeDL(object):
                         coef_s, ofs_s = mobj.group('coef', 'ofs')
                         coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)
                         if coef == 0:
+                            if ofs < 0:
+                                # broken range
+                                continue
                             yield ofs
                         else:
                             while ofs <= 0:

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1664,9 +1664,7 @@ class YoutubeDL(object):
                     if 'n' in string_segment:
                         mobj = re.fullmatch(
                             r'(?P<coef>\d+)[mn](?P<ofs>[+-]\d+)?', playlistitems_str)
-                        if not mobj:
-                            mobj = re.fullmatch(
-                                r'(?P<ofs>[+-]?\d+)?\+(?P<coef>\d+)[mn]', playlistitems_str)
+                        assert mobj
 
                         coef_s, ofs_s = mobj.group('coef', 'ofs')
                         coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1670,9 +1670,12 @@ class YoutubeDL(object):
 
                         coef_s, ofs_s = mobj.group('coef', 'ofs')
                         coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)
-                        if ofs < 0:
+                        while ofs < 0:
                             ofs += coef
-                        yield from itertools.count(ofs, coef)
+                        if coef == 0:
+                            yield ofs
+                        else:
+                            yield from itertools.count(ofs, coef)
                     elif '-' in string_segment:
                         start, end = string_segment.split('-')
                         for item in range(int(start), int(end) + 1):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1661,28 +1661,27 @@ class YoutubeDL(object):
         if playlistitems_str is not None:
             def iter_playlistitems(format):
                 for string_segment in format.split(','):
-                    if '-' in string_segment:
+                    if 'n' in string_segment:
+                        mobj = re.fullmatch(
+                            r'(?P<coef>\d+)[mn](?P<ofs>[+-]\d+)?', playlistitems_str)
+                        if not mobj:
+                            mobj = re.fullmatch(
+                                r'(?P<ofs>[+-]?\d+)?\+(?P<coef>\d+)[mn]', playlistitems_str)
+
+                        coef_s, ofs_s = mobj.group('coef', 'ofs')
+                        coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)
+                        if ofs < 0:
+                            ofs += coef
+                        yield from itertools.count(ofs, coef)
+                    elif '-' in string_segment:
                         start, end = string_segment.split('-')
                         for item in range(int(start), int(end) + 1):
                             yield int(item)
                     else:
                         yield int(string_segment)
 
-            def every_item_range(mobj: re.Match):
-                coef_s, ofs_s = mobj.group('coef', 'ofs')
-                coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)
-                if ofs < 0:
-                    ofs += coef
-                yield from itertools.count(ofs, coef)
-                # cnt = ofs
-                # while True:
-                #     yield cnt
-                #     assert cnt < 700
-                #     cnt += coef
-
-            xny_match = re.fullmatch(r'(?P<coef>\d+)[mn](?P<ofs>[+-]\d+)?', playlistitems_str)
-            if xny_match:
-                playlistitems, infinite = LazyList(every_item_range(xny_match)), True
+            if 'n' in playlistitems_str:
+                playlistitems, infinite = LazyList(iter_playlistitems(playlistitems_str)), True
             else:
                 playlistitems = orderedSet(iter_playlistitems(playlistitems_str))
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1800,6 +1800,8 @@ class YoutubeDL(object):
             playlist_index, entry = entry_tuple
             if 'playlist-index' in self.params.get('compat_opts', []):
                 playlist_index = playlistitems[i - 1] if playlistitems else i + playliststart - 1
+            if playlist_index < 0 and 'playlist_count' in locals():
+                playlist_index += playlist_count + 1
             self.to_screen('[download] Downloading video %s of %s' % (i, n_entries))
             # This __x_forwarded_for_ip thing is a bit ugly but requires
             # minimal changes

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1787,7 +1787,7 @@ class YoutubeDL(object):
                 entry['__x_forwarded_for_ip'] = x_forwarded_for
             extra = {
                 'n_entries': n_entries,
-                '_last_playlist_index': max(playlistitems) if playlistitems and not infinite  else (playlistend or n_entries),
+                '_last_playlist_index': max(playlistitems) if playlistitems and not infinite else (playlistend or n_entries),
                 'playlist_count': ie_result.get('playlist_count'),
                 'playlist_index': playlist_index,
                 'playlist_autonumber': i,

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1668,7 +1668,7 @@ class YoutubeDL(object):
 
                         coef_s, ofs_s = mobj.group('coef', 'ofs')
                         coef, ofs = int(coef_s), int_or_none(ofs_s, default=0)
-                        while ofs < 0:
+                        while ofs <= 0:
                             ofs += coef
                         if coef == 0:
                             yield ofs


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This adds support for `--playlist-items Xn+Y` to take one from every X items from offset Y. Offset (Y) can be negative or zero, or even be omitted.