### PR TITLE
[downloader/fragment] Improve `--live-from-start` for YouTube livestreams

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -405,7 +405,8 @@ class FragmentFD(FileDownloader):
                     except concurrent.futures.TimeoutError:
                         continue
         else:
-            def bindoj_result(future): return future.result()
+            def bindoj_result(future):
+                return future.result()
 
         spins = []
         for idx, (ctx, fragments, info_dict) in enumerate(args):
@@ -451,7 +452,8 @@ class FragmentFD(FileDownloader):
 
         def download_fragment(fragment, ctx):
             if not interrupt_trigger[0]:
-                return False, frag_index
+                return False, fragment['frag_index']
+
             frag_index = ctx['fragment_index'] = fragment['frag_index']
             ctx['last_error'] = None
             headers = info_dict.get('http_headers', {}).copy()

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -419,8 +419,11 @@ class FragmentFD(FileDownloader):
                 interrupt_trigger[0] = False
             finally:
                 tpe.shutdown(wait=True)
-        if not interrupt_trigger[0]:
-            raise KeyboardInterrupt()
+        # we expect the user wants to stop and DO WANT the preceding postprocessors to run;
+        # so returning a intermediate result here instead of KeyboardInterrupt
+
+        # if not interrupt_trigger[0]:
+        #     raise KeyboardInterrupt()
         return result
 
     def download_and_append_fragments(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes bogus behavior of `--live-from-start` for YouTube, includes:
- Intermediate `Frag` files remains without being concatten
- Ctrl+C problem on Windows
- Merger doesn't run after downloading

I'm running a long-run tests now, but ready for preliminary review 

Memo for myself:
Long-lasting live: https://www.youtube.com/watch?v=fEvM-OUbaKs
Shorter live: find one here: https://nijisanji.net/ https://schedule.hololive.tv/

Known problems:
- Network socket leak (workaround: `ulimit -n 65536`)