### PR TITLE
[downloader/fragment] Fix bugs around resuming with Range

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -178,7 +178,7 @@ class FragmentFD(FileDownloader):
         dl = HttpQuietDownloader(
             self.ydl,
             {
-                'continuedl': True,
+                'continuedl': self.params.get('continuedl', True),
                 'quiet': self.params.get('quiet'),
                 'noprogress': True,
                 'ratelimit': self.params.get('ratelimit'),

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -16,6 +16,7 @@ from ..utils import (
     ContentTooShortError,
     encodeFilename,
     int_or_none,
+    parse_http_range,
     sanitized_Request,
     ThrottledDownload,
     write_xattr,
@@ -59,6 +60,9 @@ class HttpFD(FileDownloader):
         ctx.chunk_size = None
         throttle_start = None
 
+        # parse given Range 
+        req_start, req_end, _ = parse_http_range(headers.get('Range'))
+
         if self.params.get('continuedl', True):
             # Establish possible resume length
             if os.path.isfile(encodeFilename(ctx.tmpfilename)):
@@ -91,6 +95,9 @@ class HttpFD(FileDownloader):
                               if not is_test and chunk_size else chunk_size)
             if ctx.resume_len > 0:
                 range_start = ctx.resume_len
+                if req_start is not None:
+                    # offset the beginning of Range to be within request
+                    range_start += req_start
                 if ctx.is_resume:
                     self.report_resuming_byte(ctx.resume_len)
                 ctx.open_mode = 'ab'
@@ -99,9 +106,13 @@ class HttpFD(FileDownloader):
             else:
                 range_start = None
             ctx.is_resume = False
-            range_end = range_start + ctx.chunk_size - 1 if ctx.chunk_size else None
-            if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
-                range_end = ctx.data_len - 1
+            if req_end is not None:
+                # we're not allowed to download outside Range
+                range_end = req_end
+            else:
+                range_end = range_start + ctx.chunk_size - 1 if ctx.chunk_size else None
+                if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
+                    range_end = ctx.data_len - 1
             has_range = range_start is not None
             ctx.has_range = has_range
             request = sanitized_Request(url, request_data, headers)
@@ -124,23 +135,19 @@ class HttpFD(FileDownloader):
                 # https://github.com/ytdl-org/youtube-dl/issues/6057#issuecomment-126129799)
                 if has_range:
                     content_range = ctx.data.headers.get('Content-Range')
-                    if content_range:
-                        content_range_m = re.search(r'bytes (\d+)-(\d+)?(?:/(\d+))?', content_range)
+                    content_range_start, content_range_end, content_len = parse_http_range(content_range)
+                    if content_range_start is not None and range_start == content_range_start:
                         # Content-Range is present and matches requested Range, resume is possible
-                        if content_range_m:
-                            if range_start == int(content_range_m.group(1)):
-                                content_range_end = int_or_none(content_range_m.group(2))
-                                content_len = int_or_none(content_range_m.group(3))
-                                accept_content_len = (
-                                    # Non-chunked download
-                                    not ctx.chunk_size
-                                    # Chunked download and requested piece or
-                                    # its part is promised to be served
-                                    or content_range_end == range_end
-                                    or content_len < range_end)
-                                if accept_content_len:
-                                    ctx.data_len = content_len
-                                    return
+                        accept_content_len = (
+                            # Non-chunked download
+                            not ctx.chunk_size
+                            # Chunked download and requested piece or
+                            # its part is promised to be served
+                            or content_range_end == range_end
+                            or content_len < range_end)
+                        if accept_content_len:
+                            ctx.data_len = content_len
+                            return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file
                     # and performing entire redownload

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -5,7 +5,6 @@ import os
 import socket
 import time
 import random
-import re
 
 from .common import FileDownloader
 from ..compat import (
@@ -60,7 +59,7 @@ class HttpFD(FileDownloader):
         ctx.chunk_size = None
         throttle_start = None
 
-        # parse given Range 
+        # parse given Range
         req_start, req_end, _ = parse_http_range(headers.get('Range'))
 
         if self.params.get('continuedl', True):

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -105,13 +105,12 @@ class HttpFD(FileDownloader):
             else:
                 range_start = None
             ctx.is_resume = False
-            if req_end is not None:
+            range_end = range_start + ctx.chunk_size - 1 if ctx.chunk_size else None
+            if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
+                range_end = ctx.data_len - 1
+            if None not in (req_end, range_end):
                 # we're not allowed to download outside Range
-                range_end = req_end
-            else:
-                range_end = range_start + ctx.chunk_size - 1 if ctx.chunk_size else None
-                if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
-                    range_end = ctx.data_len - 1
+                range_end = min(req_end, range_end)
             has_range = range_start is not None
             ctx.has_range = has_range
             request = sanitized_Request(url, request_data, headers)

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -105,12 +105,13 @@ class HttpFD(FileDownloader):
             else:
                 range_start = None
             ctx.is_resume = False
-            range_end = range_start + ctx.chunk_size - 1 if ctx.chunk_size else None
-            if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
-                range_end = ctx.data_len - 1
-            if None not in (req_end, range_end):
+            if req_end is not None:
                 # we're not allowed to download outside Range
-                range_end = min(req_end, range_end)
+                range_end = req_end
+            else:
+                range_end = range_start + ctx.chunk_size - 1 if ctx.chunk_size else None
+                if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
+                    range_end = ctx.data_len - 1
             has_range = range_start is not None
             ctx.has_range = has_range
             request = sanitized_Request(url, request_data, headers)

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5252,6 +5252,16 @@ def join_nonempty(*values, delim='-', from_dict=None):
     return delim.join(map(str, filter(None, values)))
 
 
+def parse_http_range(range):
+    """ Parse value of "Range" or "Content-Range" HTTP header into tuple. """
+    if not range:
+        return None, None, None
+    crg = re.search(r'bytes[ =](\d+)-(\d+)?(?:/(\d+))?', range)
+    if not crg:
+        return None, None, None
+    return int(crg.group(1)), int(crg.group(2)), int_or_none(crg.group(3))
+
+
 class Config:
     own_args = None
     filename = None

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5259,7 +5259,7 @@ def parse_http_range(range):
     crg = re.search(r'bytes[ =](\d+)-(\d+)?(?:/(\d+))?', range)
     if not crg:
         return None, None, None
-    return int(crg.group(1)), int(crg.group(2)), int_or_none(crg.group(3))
+    return int(crg.group(1)), int_or_none(crg.group(2)), int_or_none(crg.group(3))
 
 
 class Config:


### PR DESCRIPTION
- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

See https://github.com/yt-dlp/yt-dlp/issues/2001#issuecomment-1052119472 and https://github.com/yt-dlp/yt-dlp/issues/2239#issuecomment-1052132403

Closes #2001
Closes #2239

![yt-dlp issue 2901 drawio](https://user-images.githubusercontent.com/10355528/155847839-deb0dc9e-76e2-4494-aba4-a6b7c2ebe773.png)

This changes behavior for `--no-continue` when native downloader involves, but the current behavior is wrong since the option states "Do not resume partially downloaded fragments."
