### PR TITLE
add "uploader" metadata to manyvids.com extractor

### DIFF
--- a/yt_dlp/extractor/manyvids.py
+++ b/yt_dlp/extractor/manyvids.py
@@ -50,6 +50,10 @@ class ManyVidsIE(InfoExtractor):
              r'<h2[^>]+class=["\']h2 m-0["\'][^>]*>([^<]+)'),
             webpage, 'title', default=None) or self._html_search_meta(
             'twitter:title', webpage, 'title', fatal=True)
+        
+            r'<span[^>]+class=(["\'])title\1[^>]*>(?P<title>[^<]+)',
+
+        uploader = self._html_search_regex(r'<meta[^>]+name="author"[^>]*>([^<]+)', webpage, 'uploader')
 
         if any(p in webpage for p in ('preview_videos', '_preview.mp4')):
             title += ' (Preview)'
@@ -89,4 +93,5 @@ class ManyVidsIE(InfoExtractor):
             'view_count': view_count,
             'like_count': like_count,
             'formats': formats,
+            'uploader': uploader,
         }

--- a/yt_dlp/extractor/manyvids.py
+++ b/yt_dlp/extractor/manyvids.py
@@ -50,8 +50,6 @@ class ManyVidsIE(InfoExtractor):
              r'<h2[^>]+class=["\']h2 m-0["\'][^>]*>([^<]+)'),
             webpage, 'title', default=None) or self._html_search_meta(
             'twitter:title', webpage, 'title', fatal=True)
-        
-            r'<span[^>]+class=(["\'])title\1[^>]*>(?P<title>[^<]+)',
 
         uploader = self._html_search_regex(r'<meta[^>]+name="author"[^>]*>([^<]+)', webpage, 'uploader')
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
added the `uploader` metadata field to the manyvids.com extractor. I was also considering adding the `uploader_id` and `creator` fields, but they are not cleanly available on the webpage, only in non-unique `<a/>` elements that hold the url of the profile like so: `<a href="/Profile/123456/My-Username/">`