### PR TITLE
[YoutubeDL] ignore negative durations

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2321,7 +2321,7 @@ class YoutubeDL(object):
                 self.report_warning('Extractor failed to obtain "title". Creating a generic title instead')
                 info_dict['title'] = f'{info_dict["extractor"]} video #{info_dict["id"]}'
 
-        if info_dict.get('duration', 0) >= 0:
+        if 'duration' in info_dict and info_dict['duration'] >= 0:
             info_dict['duration_string'] = formatSeconds(info_dict['duration'])
 
         for ts_key, date_key in (
@@ -2505,7 +2505,7 @@ class YoutubeDL(object):
                 format['resolution'] = self.format_resolution(format, default=None)
             if format.get('dynamic_range') is None and format.get('vcodec') != 'none':
                 format['dynamic_range'] = 'SDR'
-            if (info_dict.get('duration', 0) >= 0 and format.get('tbr')
+            if ('duration' in info_dict and info_dict['duration'] >= 0 and format.get('tbr')
                     and not format.get('filesize') and not format.get('filesize_approx')):
                 format['filesize_approx'] = info_dict['duration'] * format['tbr'] * (1024 / 8)
 
@@ -2780,7 +2780,7 @@ class YoutubeDL(object):
         print_optional('thumbnail')
         print_optional('description')
         print_optional('filename')
-        if self.params.get('forceduration') and info_dict.get('duration', 0) >= 0:
+        if self.params.get('forceduration') and 'duration' in info_dict and info_dict['duration'] >= 0:
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2506,7 +2506,8 @@ class YoutubeDL(object):
             if format.get('dynamic_range') is None and format.get('vcodec') != 'none':
                 format['dynamic_range'] = 'SDR'
             if (info_dict.get('duration') and format.get('tbr')
-                    and not format.get('filesize') and not format.get('filesize_approx')):
+                    and not format.get('filesize') and not format.get('filesize_approx')
+                    and info_dict['duration'] >= 0):
                 format['filesize_approx'] = info_dict['duration'] * format['tbr'] * (1024 / 8)
 
             # Add HTTP headers, so that external programs can use them from the

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2321,7 +2321,7 @@ class YoutubeDL(object):
                 self.report_warning('Extractor failed to obtain "title". Creating a generic title instead')
                 info_dict['title'] = f'{info_dict["extractor"]} video #{info_dict["id"]}'
 
-        if info_dict.get('duration') is not None:
+        if info_dict.get('duration', 0) >= 0:
             info_dict['duration_string'] = formatSeconds(info_dict['duration'])
 
         for ts_key, date_key in (
@@ -2505,9 +2505,8 @@ class YoutubeDL(object):
                 format['resolution'] = self.format_resolution(format, default=None)
             if format.get('dynamic_range') is None and format.get('vcodec') != 'none':
                 format['dynamic_range'] = 'SDR'
-            if (info_dict.get('duration') and format.get('tbr')
-                    and not format.get('filesize') and not format.get('filesize_approx')
-                    and info_dict['duration'] >= 0):
+            if (info_dict.get('duration', 0) >= 0 and format.get('tbr')
+                    and not format.get('filesize') and not format.get('filesize_approx')):
                 format['filesize_approx'] = info_dict['duration'] * format['tbr'] * (1024 / 8)
 
             # Add HTTP headers, so that external programs can use them from the
@@ -2781,7 +2780,7 @@ class YoutubeDL(object):
         print_optional('thumbnail')
         print_optional('description')
         print_optional('filename')
-        if self.params.get('forceduration') and info_dict.get('duration') is not None:
+        if self.params.get('forceduration') and info_dict.get('duration', 0) >= 0:
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2243,7 +2243,7 @@ def unsmuggle_url(smug_url, default=None):
 def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     """ Formats numbers with decimal sufixes like K, M, etc """
     num, factor = float_or_none(num), float(factor)
-    if num is None:
+    if num is None or num < 0:
         return None
     exponent = 0 if num == 0 else int(math.log(num, factor))
     suffix = ['', *'kMGTPEZY'][exponent]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This patches a bug that extractor could return negative `duration`, which cause the following error.

It now ignores negative `duration` from the extractors. Duration with `0` is still permitted as everything seems to expect 0 or more.

Fix for extractor-side will be done soon.

### Step to reproduce:
1. Pass running live from Mirrativ.
2. Done.

```
$ yt-dlp 'https://mirrativ.com/live/M7m5QRJEHS9_gGxNbDAf8Q' -v
[debug] Command-line config: ['https://mirrativ.com/live/M7m5QRJEHS9_gGxNbDAf8Q', '-v']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, err utf-8, pref UTF-8
[debug] yt-dlp version 2022.02.04 [c1653e9ef]
[debug] Python version 3.9.10 (CPython 64bit) - Linux-5.13.0-28-generic-x86_64-with-glibc2.31
[debug] exe versions: ffmpeg n4.4.1-3-ge16ff82624-20211127 (setts), ffprobe n4.4.1-3-ge16ff82624-20211127, rtmpdump 2.4
[debug] Optional libraries: Crypto, mutagen, sqlite, websockets
[debug] Proxy map: {}
[debug] [mirrativ] Extracting URL: https://mirrativ.com/live/M7m5QRJEHS9_gGxNbDAf8Q
[mirrativ] M7m5QRJEHS9_gGxNbDAf8Q: Downloading webpage
[mirrativ] M7m5QRJEHS9_gGxNbDAf8Q: Downloading JSON metadata
[mirrativ] M7m5QRJEHS9_gGxNbDAf8Q: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
ERROR: math domain error
Traceback (most recent call last):
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 1381, in wrapper
    return func(self, *args, **kwargs)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 1465, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 1517, in process_ie_result
    ie_result = self.process_video_result(ie_result, download=download)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 2516, in process_video_result
    info_dict, _ = self.pre_process(info_dict)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 3329, in pre_process
    info = self.run_all_pps(key, info)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 3321, in run_all_pps
    self._forceprint(key, info)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 2704, in _forceprint
    info_copy['formats_table'] = self.render_formats_table(info_dict)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 3478, in render_formats_table
    table = [
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/YoutubeDL.py", line 3486, in <listcomp>
    format_field(f, 'filesize', ' \t%s', func=format_bytes) + format_field(f, 'filesize_approx', '~\t%s', func=format_bytes),
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/utils.py", line 4974, in format_field
    return template % (func(val) if func else val)
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/utils.py", line 2236, in format_bytes
    return format_decimal_suffix(bytes, '%.2f%sB', factor=1024) or 'N/A'
  File "/home/linuxbrew/.linuxbrew/Cellar/yt-dlp/2022.2.4/libexec/lib/python3.9/site-packages/yt_dlp/utils.py", line 2227, in format_decimal_suffix
    exponent = 0 if num == 0 else int(math.log(num, factor))
ValueError: math domain error
```