### PR TITLE
[peertube] Add support for media.fsfe.org

### DIFF
--- a/yt_dlp/extractor/peertube.py
+++ b/yt_dlp/extractor/peertube.py
@@ -87,6 +87,7 @@ class PeerTubeIE(InfoExtractor):
                             maindreieck-tv\.de|
                             mani\.tube|
                             manicphase\.me|
+                            media\.fsfe\.org|
                             media\.gzevd\.de|
                             media\.inno3\.cricket|
                             media\.kaitaia\.life|


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Add the [Free Software Foundation Europe](https://media.fsfe.org)'s Peertube instance to the list. It is using the new video URL format, so is currently not detected by youtube-dl (see ytdl-org/youtube-dl#29475). Basically the same PR as ytdl-org/youtube-dl#30536. As media.fsfe.org is in the official peertube instances list, I decided to put it there.
