### PR TITLE
[ParamountPlus] fix to download all episodes from series

### DIFF
--- a/yt_dlp/extractor/paramountplus.py
+++ b/yt_dlp/extractor/paramountplus.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import itertools
 
 from .common import InfoExtractor
 from .cbs import CBSBaseIE
@@ -128,11 +129,14 @@ class ParamountPlusSeriesIE(InfoExtractor):
             'id': 'spongebob-squarepants',
         }
     }]
-    _API_URL = 'https://www.paramountplus.com/shows/{}/xhr/episodes/page/0/size/100000/xs/0/season/0/'
+    _API_URL = 'https://www.paramountplus.com/shows/{}/xhr/episodes/page/{}/size/50/xs/0/season/0/'
 
     def _entries(self, show_name):
-        show_json = self._download_json(self._API_URL.format(show_name), video_id=show_name)
-        if show_json.get('success'):
+        for page in itertools.count():
+            show_json = self._download_json(
+                f'https://www.paramountplus.com/shows/{show_name}/xhr/episodes/page/{page}/size/50/xs/0/season/0', show_name)
+            if not show_json.get('success'):
+                return
             for episode in show_json['result']['data']:
                 yield self.url_result(
                     'https://www.paramountplus.com%s' % episode['url'],

--- a/yt_dlp/extractor/paramountplus.py
+++ b/yt_dlp/extractor/paramountplus.py
@@ -129,7 +129,6 @@ class ParamountPlusSeriesIE(InfoExtractor):
             'id': 'spongebob-squarepants',
         }
     }]
-    _API_URL = 'https://www.paramountplus.com/shows/{}/xhr/episodes/page/{}/size/50/xs/0/season/0/'
 
     def _entries(self, show_name):
         for page in itertools.count():


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

ParamountPlus extractor was only downloading the first 50 episodes of TV series.  This fixes the extractor to download all episodes.

Tests `TestDownload.test_ParamountPlusSeries_1` and `TestDownload.test_ParamountPlusSeries_2` were failing, now passing.

This issue is mentioned in #1466, but does not completely solve what's reported there.