### PR TITLE
[downloader/mhtml] Fix fragments with absolute urls

### DIFF
--- a/yt_dlp/downloader/mhtml.py
+++ b/yt_dlp/downloader/mhtml.py
@@ -166,7 +166,11 @@ body > figure > img {
             if (i + 1) <= ctx['fragment_index']:
                 continue
 
-            fragment_url = urljoin(fragment_base_url, fragment['path'])
+            fragment_url = fragment.get('url')
+            if not fragment_url:
+                assert fragment_base_url
+                fragment_url = urljoin(fragment_base_url, fragment['path'])
+
             success, frag_content = self._download_fragment(ctx, fragment_url, info_dict)
             if not success:
                 continue

--- a/yt_dlp/downloader/mhtml.py
+++ b/yt_dlp/downloader/mhtml.py
@@ -168,6 +168,7 @@ body > figure > img {
 
             fragment_url = fragment.get('url')
             if not fragment_url:
+                assert fragment_base_url
                 fragment_url = urljoin(fragment_base_url, fragment['path'])
 
             success, frag_content = self._download_fragment(ctx, fragment_url, info_dict)

--- a/yt_dlp/downloader/mhtml.py
+++ b/yt_dlp/downloader/mhtml.py
@@ -168,7 +168,6 @@ body > figure > img {
 
             fragment_url = fragment.get('url')
             if not fragment_url:
-                assert fragment_base_url
                 fragment_url = urljoin(fragment_base_url, fragment['path'])
 
             success, frag_content = self._download_fragment(ctx, fragment_url, info_dict)

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -187,7 +187,7 @@ class FranceTVIE(InfoExtractor):
                 'protocol': 'mhtml',
                 'url': 'about:invalid',
                 'fragments': [{
-                    'path': sheet,
+                    'url': sheet,
                     # XXX: not entirely accurate; each spritesheet seems to be
                     # a 10×10 grid of thumbnails corresponding to approximately
                     # 2 seconds of the video; the last spritesheet may be shorter

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3207,7 +3207,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 'width': width,
                 'height': height,
                 'fragments': [{
-                    'path': url.replace('$M', str(j)),
+                    'url': url.replace('$M', str(j)),
                     'duration': min(fragment_duration, duration - (j * fragment_duration)),
                 } for j in range(math.ceil(fragment_count))],
             }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As per [extractor/common.py](https://github.com/yt-dlp/yt-dlp/blob/a825ffbffa0bea322e3ccb44c6f8e01d8d9572fb/yt_dlp/extractor/common.py#L174-L182), a fragment can either have a relative url (`path`) or absolute url (`url`). MhtmlFD currently does not take into account fragments that have an absolute url.

This also fixes the FranceTV extractor which incorrectly uses `path` for the absolute url in fragments.

The fix is copied from the implementation in [DashSegmentsFD](https://github.com/yt-dlp/yt-dlp/blob/a825ffbffa0bea322e3ccb44c6f8e01d8d9572fb/yt_dlp/downloader/dash.py#L71-L74).

