### PR TITLE
[downloader/http] Make retrying more lenient

### DIFF
--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -11,6 +11,7 @@ from .common import FileDownloader
 from ..compat import (
     compat_str,
     compat_urllib_error,
+    compat_http_client
 )
 from ..utils import (
     ContentTooShortError,
@@ -251,7 +252,7 @@ class HttpFD(FileDownloader):
                     # Download and write
                     data_block = ctx.data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
 
-                except (TimeoutError, ConnectionResetError, ssl.SSLError) as err:
+                except (TimeoutError, ConnectionResetError, ssl.SSLError, compat_http_client.HTTPException) as err:
                     retry(err)
 
                 byte_counter += len(data_block)

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals
 
-import errno
 import os
-import socket
 import ssl
 import time
 import random
@@ -198,13 +196,12 @@ class HttpFD(FileDownloader):
                     raise
                 raise RetryDownload(err)
             except compat_urllib_error.URLError as err:
-                # TODO: What errors should we exclude?
-                if not any(isinstance(err.reason, et) for et in (ssl.CertificateError, )):
-                    raise RetryDownload(err)
-                raise
+                if isinstance(err.reason, ssl.CertificateError):
+                    raise
+                raise RetryDownload(err)
 
             # TODO: when do these occur now?
-            except (TimeoutError, ConnectionResetError) as err:
+            except (TimeoutError, ConnectionError) as err:
                 raise RetryDownload(err)
 
         def download():
@@ -252,7 +249,7 @@ class HttpFD(FileDownloader):
                     # Download and write
                     data_block = ctx.data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
 
-                except (TimeoutError, ConnectionResetError, ssl.SSLError, compat_http_client.HTTPException) as err:
+                except (TimeoutError, ConnectionError, ssl.SSLError, compat_http_client.HTTPException) as err:
                     retry(err)
 
                 byte_counter += len(data_block)

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -201,8 +201,8 @@ class HttpFD(FileDownloader):
                 if isinstance(err.reason, ssl.CertificateError):
                     raise
                 raise RetryDownload(err)
-            # In urllib.request.AbstractHTTPHandler, the response is partially read on request,
-            # in which during any of these errors will not be wrapped by URLError
+            # In urllib.request.AbstractHTTPHandler, the response is partially read on request.
+            # Any errors that occur during this will not be wrapped by URLError
             except RESPONSE_READ_EXCEPTIONS as err:
                 raise RetryDownload(err)
 

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -23,7 +23,7 @@ from ..utils import (
     XAttrUnavailableError,
 )
 
-HTTP_RES_READ_EXCEPTIONS = (TimeoutError, ConnectionError, ssl.SSLError, compat_http_client.HTTPException)
+RESPONSE_READ_EXCEPTIONS = (TimeoutError, ConnectionError, ssl.SSLError, compat_http_client.HTTPException)
 
 
 class HttpFD(FileDownloader):
@@ -203,7 +203,7 @@ class HttpFD(FileDownloader):
                 raise RetryDownload(err)
             # In urllib.request.AbstractHTTPHandler, the response is partially read on request,
             # in which during any of these errors will not be wrapped by URLError
-            except HTTP_RES_READ_EXCEPTIONS as err:
+            except RESPONSE_READ_EXCEPTIONS as err:
                 raise RetryDownload(err)
 
         def download():
@@ -250,7 +250,7 @@ class HttpFD(FileDownloader):
                 try:
                     # Download and write
                     data_block = ctx.data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
-                except HTTP_RES_READ_EXCEPTIONS as err:
+                except RESPONSE_READ_EXCEPTIONS as err:
                     retry(err)
 
                 byte_counter += len(data_block)

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -199,7 +199,7 @@ class HttpFD(FileDownloader):
                 raise RetryDownload(err)
             except compat_urllib_error.URLError as err:
                 # TODO: What errors should we exclude?
-                if any(isinstance(err.reason, et) for et in (ssl.CertificateError, )):
+                if not any(isinstance(err.reason, et) for et in (ssl.CertificateError, )):
                     raise RetryDownload(err)
                 raise
 

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -201,8 +201,8 @@ class HttpFD(FileDownloader):
                 if isinstance(err.reason, ssl.CertificateError):
                     raise
                 raise RetryDownload(err)
-            # The response is partially read on request, in which during any of these errors will not be wrapped by URLError
-            # See: https://github.com/python/cpython/blob/7c776521418676c074a483266339d31c950f516e/Lib/urllib/request.py#L1346-L1355
+            # In urllib.request.AbstractHTTPHandler, the response is partially read on request,
+            # in which during any of these errors will not be wrapped by URLError
             except HTTP_RES_READ_EXCEPTIONS as err:
                 raise RetryDownload(err)
 

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -129,9 +129,7 @@ class HttpFD(FileDownloader):
                 try:
                     ctx.data = self.ydl.urlopen(request)
                 except (compat_urllib_error.URLError, ) as err:
-                    # reason may not be available, e.g. for urllib2.HTTPError on python 2.6
-                    reason = getattr(err, 'reason', None)
-                    if isinstance(reason, socket.timeout):
+                    if isinstance(err.reason, TimeoutError):
                         raise RetryDownload(err)
                     raise err
                 # When trying to resume, Content-Range HTTP header of response has to be checked
@@ -203,13 +201,8 @@ class HttpFD(FileDownloader):
                     # Unexpected HTTP error
                     raise
                 raise RetryDownload(err)
-            except socket.timeout as err:
+            except (TimeoutError, ConnectionResetError) as err:
                 raise RetryDownload(err)
-            except socket.error as err:
-                if err.errno in (errno.ECONNRESET, errno.ETIMEDOUT):
-                    # Connection reset is no problem, just retry
-                    raise RetryDownload(err)
-                raise
 
         def download():
             nonlocal throttle_start

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import errno
 import os
 import socket
+import ssl
 import time
 import random
 
@@ -254,16 +255,9 @@ class HttpFD(FileDownloader):
                 try:
                     # Download and write
                     data_block = ctx.data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
-                # socket.timeout is a subclass of socket.error but may not have
-                # errno set
-                except socket.timeout as e:
+
+                except (TimeoutError, ConnectionResetError, ssl.SSLError) as e:
                     retry(e)
-                except socket.error as e:
-                    # SSLError on python 2 (inherits socket.error) may have
-                    # no errno set but this error message
-                    if e.errno in (errno.ECONNRESET, errno.ETIMEDOUT) or getattr(e, 'message', None) == 'The read operation timed out':
-                        retry(e)
-                    raise
 
                 byte_counter += len(data_block)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Makes the http downloader much more lenient on what it retries on, to survive any sort of brief network interruption etc. (given enough retries for such). 

We are thinking it is better to retry on more even though some may be unrecoverable, vs retrying on few, known and likely to be recoverable errors but missing many other cases.

Resolves https://github.com/yt-dlp/yt-dlp/issues/3056, https://github.com/yt-dlp/yt-dlp/issues/2071, https://github.com/yt-dlp/yt-dlp/issues/3034, https://github.com/yt-dlp/yt-dlp/issues/2969 and prob many upstream

Might also help sorting exceptions in #2861 simpler.
