### PR TITLE
fix PhantomJSwrapper get_param not exists bug in iq.com

### DIFF
--- a/yt_dlp/extractor/openload.py
+++ b/yt_dlp/extractor/openload.py
@@ -17,6 +17,7 @@ from ..utils import (
     get_exe_version,
     is_outdated_version,
     Popen,
+    USER_AGENTS,
 )
 
 
@@ -207,7 +208,7 @@ class PhantomJSwrapper(object):
 
         replaces = self.options
         replaces['url'] = url
-        user_agent = headers.get('User-Agent') or self.get_param('http_headers')['User-Agent']
+        user_agent = headers.get('User-Agent') or USER_AGENTS['Safari']
         replaces['ua'] = user_agent.replace('"', '\\"')
         replaces['jscode'] = jscode
 


### PR DESCRIPTION


## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When download from iq.com, it will cause `'PhantomJSwrapper' object has no attribute 'get_param'` error.

Example:
```
./yt-dlp "https://www.iq.com/play/poisoned-love-episode-2-1j6vpzb5i0o`
[iq.com] 1j6vpzb5i0o: Downloading webpage
ERROR: 'PhantomJSwrapper' object has no attribute 'get_param'
```

Solution:
Using default Safari user agent instead of calling get_param