### PR TITLE
[downloader/http] Reject broken range before request

### DIFF
--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -157,7 +157,7 @@ class HttpFD(FileDownloader):
                             or content_range_end == range_end
                             or content_len < range_end)
                         if accept_content_len:
-                            ctx.data_len = content_len
+                            ctx.data_len = min(content_len, req_end or content_len) - (req_start or 0)
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -118,6 +118,7 @@ class HttpFD(FileDownloader):
             else:
                 range_end = None
 
+            print(f'start={range_start} end={range_end}')
             if range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -18,6 +18,7 @@ from ..utils import (
     parse_http_range,
     sanitized_Request,
     ThrottledDownload,
+    try_get,
     write_xattr,
     XAttrMetadataError,
     XAttrUnavailableError,
@@ -157,7 +158,10 @@ class HttpFD(FileDownloader):
                             or content_range_end == range_end
                             or content_len < range_end)
                         if accept_content_len:
-                            ctx.data_len = min(content_len, req_end or content_len) - (req_start or 0)
+                            ctx.data_len = try_get(None, [
+                                lambda x: req_end - req_start,
+                                lambda x: content_range_end - content_range_start + ctx.resume_len])
+                            # print(ctx.data_len, req_end - req_start, content_range_end - content_range_start + ctx.resume_len)
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -18,7 +18,6 @@ from ..utils import (
     parse_http_range,
     sanitized_Request,
     ThrottledDownload,
-    try_get,
     write_xattr,
     XAttrMetadataError,
     XAttrUnavailableError,
@@ -158,7 +157,7 @@ class HttpFD(FileDownloader):
                             or content_range_end == range_end
                             or content_len < range_end)
                         if accept_content_len:
-                            ctx.data_len = min(content_len, try_get(None, lambda x: req_end - req_start + ctx.resume_len) or float('inf'))
+                            ctx.data_len = min(content_len, req_end or content_len) - (req_start or 0)
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -102,6 +102,8 @@ class HttpFD(FileDownloader):
                 ctx.open_mode = 'ab'
             elif ctx.chunk_size > 0:
                 range_start = 0
+            elif req_start is not None:
+                range_start = req_start
             else:
                 range_start = None
             ctx.is_resume = False
@@ -115,6 +117,11 @@ class HttpFD(FileDownloader):
                 range_end = req_end
             else:
                 range_end = None
+
+            if range_start > range_end:
+                ctx.resume_len = 0
+                ctx.open_mode = 'wb'
+                raise RetryDownload(AssertionError(f'Conflicting range. (start={range_start} > end={range_end})'))
 
             if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
                 range_end = ctx.data_len - 1

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -18,6 +18,7 @@ from ..utils import (
     parse_http_range,
     sanitized_Request,
     ThrottledDownload,
+    try_get,
     write_xattr,
     XAttrMetadataError,
     XAttrUnavailableError,
@@ -157,7 +158,7 @@ class HttpFD(FileDownloader):
                             or content_range_end == range_end
                             or content_len < range_end)
                         if accept_content_len:
-                            ctx.data_len = min(content_len, req_end or content_len) - (req_start or 0)
+                            ctx.data_len = min(content_len, try_get(None, lambda x: req_end - req_start + ctx.resume_len) or float('inf'))
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -122,10 +122,6 @@ class HttpFD(FileDownloader):
             if has_range and range_end is not None and range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'
-
-                if ctx.tmpfilename != '-' and ctx.stream:
-                    # TODO: do we need truncating file here?
-                    pass
                 raise RetryDownload(AssertionError(f'Conflicting range. (start={range_start} > end={range_end})'))
 
             if range_end and ctx.data_len is not None and range_end >= ctx.data_len:

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -118,16 +118,15 @@ class HttpFD(FileDownloader):
             else:
                 range_end = None
 
-            # print(f'start={range_start} end={range_end}')
-            if range_start is not None and range_end is not None and range_start > range_end:
+            ctx.has_range = has_range = range_start is not None
+            # NOTE: `range_end is not None` may be omotted but no confidence
+            if has_range and range_end is not None and range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'
                 raise RetryDownload(AssertionError(f'Conflicting range. (start={range_start} > end={range_end})'))
 
             if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
                 range_end = ctx.data_len - 1
-            has_range = range_start is not None
-            ctx.has_range = has_range
             request = sanitized_Request(url, request_data, headers)
             if has_range:
                 set_range(request, range_start, range_end)

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -119,7 +119,6 @@ class HttpFD(FileDownloader):
                 range_end = None
 
             ctx.has_range = has_range = range_start is not None
-            # NOTE: `range_end is not None` may be omotted but no confidence
             if has_range and range_end is not None and range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -18,7 +18,6 @@ from ..utils import (
     parse_http_range,
     sanitized_Request,
     ThrottledDownload,
-    try_get,
     write_xattr,
     XAttrMetadataError,
     XAttrUnavailableError,
@@ -158,12 +157,7 @@ class HttpFD(FileDownloader):
                             or content_range_end == range_end
                             or content_len < range_end)
                         if accept_content_len:
-                            if ctx.chunk_size:
-                                ctx.data_len = content_len
-                            else:
-                                ctx.data_len = try_get(None, [
-                                    lambda x: req_end - req_start,
-                                    lambda x: content_range_end - content_range_start + ctx.resume_len]) or content_len
+                            ctx.data_len = min(content_len, req_end or content_len) - (req_start or 0)
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -122,7 +122,7 @@ class HttpFD(FileDownloader):
             if has_range and range_end is not None and range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'
-                raise RetryDownload(AssertionError(f'Conflicting range. (start={range_start} > end={range_end})'))
+                raise RetryDownload(Exception(f'Conflicting range. (start={range_start} > end={range_end})'))
 
             if range_end and ctx.data_len is not None and range_end >= ctx.data_len:
                 range_end = ctx.data_len - 1

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -100,10 +100,10 @@ class HttpFD(FileDownloader):
                 if ctx.is_resume:
                     self.report_resuming_byte(ctx.resume_len)
                 ctx.open_mode = 'ab'
-            elif ctx.chunk_size > 0:
-                range_start = 0
             elif req_start is not None:
                 range_start = req_start
+            elif ctx.chunk_size > 0:
+                range_start = 0
             else:
                 range_start = None
             ctx.is_resume = False

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -158,10 +158,12 @@ class HttpFD(FileDownloader):
                             or content_range_end == range_end
                             or content_len < range_end)
                         if accept_content_len:
-                            ctx.data_len = try_get(None, [
-                                lambda x: req_end - req_start,
-                                lambda x: content_range_end - content_range_start + ctx.resume_len]) or content_len
-                            # print(ctx.data_len, req_end - req_start, content_range_end - content_range_start + ctx.resume_len)
+                            if ctx.chunk_size:
+                                ctx.data_len = content_len
+                            else:
+                                ctx.data_len = try_get(None, [
+                                    lambda x: req_end - req_start,
+                                    lambda x: content_range_end - content_range_start + ctx.resume_len]) or content_len
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is
                     # trying to send the whole file, resume is not possible, so wiping the local file

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -122,6 +122,10 @@ class HttpFD(FileDownloader):
             if has_range and range_end is not None and range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'
+
+                if ctx.tmpfilename != '-' and ctx.stream:
+                    # TODO: do we need truncating file here?
+                    pass
                 raise RetryDownload(AssertionError(f'Conflicting range. (start={range_start} > end={range_end})'))
 
             if range_end and ctx.data_len is not None and range_end >= ctx.data_len:

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -118,8 +118,8 @@ class HttpFD(FileDownloader):
             else:
                 range_end = None
 
-            print(f'start={range_start} end={range_end}')
-            if range_start > range_end:
+            # print(f'start={range_start} end={range_end}')
+            if range_start is not None and range_end is not None and range_start > range_end:
                 ctx.resume_len = 0
                 ctx.open_mode = 'wb'
                 raise RetryDownload(AssertionError(f'Conflicting range. (start={range_start} > end={range_end})'))

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -160,7 +160,7 @@ class HttpFD(FileDownloader):
                         if accept_content_len:
                             ctx.data_len = try_get(None, [
                                 lambda x: req_end - req_start,
-                                lambda x: content_range_end - content_range_start + ctx.resume_len])
+                                lambda x: content_range_end - content_range_start + ctx.resume_len]) or content_len
                             # print(ctx.data_len, req_end - req_start, content_range_end - content_range_start + ctx.resume_len)
                             return
                     # Content-Range is either not present or invalid. Assuming remote webserver is


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Funimation seems to respond with 206 even if the start is before end, while it's supposed to respond 406. It addresses that problem.

I'm not confident with the code, but at least we can download video without corrupting anything.