### PR TITLE
[RUTV] Fix format sorting

### DIFF
--- a/yt_dlp/extractor/rutv.py
+++ b/yt_dlp/extractor/rutv.py
@@ -181,7 +181,6 @@ class RUTVIE(InfoExtractor):
                         'rtmp_live': True,
                         'ext': 'flv',
                         'vbr': str_to_int(quality),
-                        'quality': preference,
                     }
                 elif transport == 'm3u8':
                     formats.extend(self._extract_m3u8_formats(
@@ -192,13 +191,15 @@ class RUTVIE(InfoExtractor):
                         'url': url
                     }
                 fmt.update({
-                    'width': width,
-                    'height': height,
+                    'width': width * int_or_none(quality, default=height) / height,
+                    'height': int_or_none(quality, default=height),
                     'format_id': '%s-%s' % (transport, quality),
+                    'quality': quality,
+                    'preference': preference,
                 })
                 formats.append(fmt)
 
-        self._sort_formats(formats)
+        self._sort_formats(formats, ('quality', 'preference'))
 
         return {
             'id': video_id,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes format sorting for RUTV. Closes #3084 

Example: (This is `-S ext:m3u8` equivalent but notice the order of HTTP formats)
```
[debug] Default format spec: bestvideo*+bestaudio/best
[info] Available formats for 2338386:
ID        EXT RESOLUTION │   FILESIZE   TBR PROTO  │ VCODEC    VBR ACODEC  ABR │ DEBUG
─────────────────────────────────────────────────────────────────────────────────────────────────
http-234  mp4 unknown    │                  https  │ unknown       unknown     │
http-360  mp4 unknown    │                  https  │ unknown       unknown     │
http-540  mp4 unknown    │                  https  │ unknown       unknown     │
http-720  mp4 unknown    │                  https  │ unknown       unknown     │
http-1080 mp4 unknown    │                  https  │ unknown       unknown     │
hls-400   mp4 unknown    │ ~152.00MiB  400k m3u8_n │ unknown  400k unknown  0k │
hls-800   mp4 unknown    │ ~304.00MiB  800k m3u8_n │ unknown  800k unknown  0k │
hls-1200  mp4 unknown    │ ~456.01MiB 1200k m3u8_n │ unknown 1200k unknown  0k │
hls-1800  mp4 unknown    │ ~684.01MiB 1800k m3u8_n │ unknown 1800k unknown  0k │
hls-4050  mp4 unknown    │ ~  1.50GiB 4050k m3u8_n │ unknown 4050k unknown  0k │ bestvideo*, best
```