### PR TITLE
Fix format decimal suffix for exponents greater than 8

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1780,6 +1780,7 @@ Line 1
         self.assertEqual(format_bytes(1024**6), '1.00EiB')
         self.assertEqual(format_bytes(1024**7), '1.00ZiB')
         self.assertEqual(format_bytes(1024**8), '1.00YiB')
+        self.assertEqual(format_bytes(1024**9), '1024.00YiB')
 
     def test_hide_login_info(self):
         self.assertEqual(Config.hide_login_info(['-u', 'foo', '-p', 'bar']),

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2279,7 +2279,7 @@ def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     num, factor = float_or_none(num), float(factor)
     if num is None or num < 0:
         return None
-    exponent = 0 if num == 0 else int(math.log(num, factor))
+    exponent = 0 if num == 0 else min(int(math.log(num, factor)), 8)
     suffix = ['', *'kMGTPEZY'][exponent]
     if factor == 1024:
         suffix = {'k': 'Ki', '': ''}.get(suffix, f'{suffix}i')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2279,8 +2279,9 @@ def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     num, factor = float_or_none(num), float(factor)
     if num is None or num < 0:
         return None
-    exponent = 0 if num == 0 else min(int(math.log(num, factor)), 8)
-    suffix = ['', *'kMGTPEZY'][exponent]
+    POSSIBLE_SUFFIXES = 'kMGTPEZY'
+    exponent = 0 if num == 0 else min(int(math.log(num, factor)), len(POSSIBLE_SUFFIXES))
+    suffix = ['', *POSSIBLE_SUFFIXES][exponent]
     if factor == 1024:
         suffix = {'k': 'Ki', '': ''}.get(suffix, f'{suffix}i')
     converted = num / (factor ** exponent)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Before `format_decimal_suffix` would fail with an exponent greater than 8. Now it should be able handle larger numbers. While file sizes this large may be unrealistic, we can get size info from an external source themselves so it's good to handle this case.

**Before:**
```python
>>> from yt_dlp.utils import format_bytes
>>> format_bytes(1024**9)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\user\Documents\GitHub\yt-dlp\yt_dlp\utils.py", line 2291, in format_bytes
    return format_decimal_suffix(bytes, '%.2f%sB', factor=1024) or 'N/A'
  File "C:\Users\user\Documents\GitHub\yt-dlp\yt_dlp\utils.py", line 2283, in format_decimal_suffix
    suffix = ['', *'kMGTPEZY'][exponent]
IndexError: list index out of range
```

**After:**
```python
>>> from yt_dlp.utils import format_bytes
>>> format_bytes(1024**9)
'1024.00YiB'
```