### PR TITLE
Clarify that `--audio-quality` is used when converting

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,10 +839,10 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                      to when -x is used. Currently supported
                                      formats are: best (default) or one of
                                      best|aac|flac|mp3|m4a|opus|vorbis|wav|alac
-    --audio-quality QUALITY          Specify ffmpeg audio quality, insert a
-                                     value between 0 (best) and 10 (worst) for
-                                     VBR or a specific bitrate like 128K
-                                     (default 5)
+    --audio-quality QUALITY          Specify ffmpeg audio quality to convert the
+                                     audio with. Insert a value between 0 (best)
+                                     and 10 (worst) for VBR or a specific
+                                     bitrate like 128K. (default 5)
     --remux-video FORMAT             Remux the video into another container if
                                      necessary (currently supported: mp4|mkv|flv
                                      |webm|mov|avi|mp3|mka|m4a|ogg|opus). If


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I thought that my change makes it clearer that `--audio-quality` is only used when converting the file, as stated here: https://discord.com/channels/807245652072857610/807247901981016094/954720168184008754.

If not, feel free to close this.
