### PR TITLE
[youtube:tab] Fix duration extraction for shorts

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -625,6 +625,8 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(parse_duration('3h 11m 53s'), 11513)
         self.assertEqual(parse_duration('3 hours 11 minutes 53 seconds'), 11513)
         self.assertEqual(parse_duration('3 hours 11 mins 53 secs'), 11513)
+        self.assertEqual(parse_duration('3 hours, 11 minutes, 53 seconds'), 11513)
+        self.assertEqual(parse_duration('3 hours, 11 mins, 53 secs'), 11513)
         self.assertEqual(parse_duration('62m45s'), 3765)
         self.assertEqual(parse_duration('6m59s'), 419)
         self.assertEqual(parse_duration('49s'), 49)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -807,12 +807,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         description = self._get_text(renderer, 'descriptionSnippet')
         duration = parse_duration(self._get_text(
             renderer, 'lengthText', ('thumbnailOverlays', ..., 'thumbnailOverlayTimeStatusRenderer', 'text')))
-
         if duration is None:
             duration = parse_duration(self._search_regex(
-                r'ago\s*([A-Za-z0-9 ,]+?)\s*[\d,]+\s*views',
+                r'(?i)(ago)(?!.*\1)\s+(?P<duration>[a-z0-9 ,]+?)(?:\s+[\d,]+\s+views)?(?:\s+-\s+play\s+short)?$',
                 traverse_obj(renderer, ('title', 'accessibility', 'accessibilityData', 'label')),
-                video_id, default=None))
+                video_id, default=None, group='duration'))
 
         view_count = self._get_count(renderer, 'viewCountText')
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -810,7 +810,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         if duration is None:
             duration = parse_duration(self._search_regex(
-                r'ago\s*([A-Za-z0-9 ,]+?)\s*[\d,]+\sviews',
+                r'ago\s*([A-Za-z0-9 ,]+?)\s*[\d,]+\s*views',
                 traverse_obj(renderer, ('title', 'accessibility', 'accessibilityData', 'label')),
                 video_id, default=None))
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -810,7 +810,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         if duration is None:
             duration = parse_duration(self._search_regex(
                 r'(?i)(ago)(?!.*\1)\s+(?P<duration>[a-z0-9 ,]+?)(?:\s+[\d,]+\s+views)?(?:\s+-\s+play\s+short)?$',
-                traverse_obj(renderer, ('title', 'accessibility', 'accessibilityData', 'label')),
+                traverse_obj(renderer, ('title', 'accessibility', 'accessibilityData', 'label'), default='', expected_type=str),
                 video_id, default=None, group='duration'))
 
         view_count = self._get_count(renderer, 'viewCountText')

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -807,6 +807,13 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         description = self._get_text(renderer, 'descriptionSnippet')
         duration = parse_duration(self._get_text(
             renderer, 'lengthText', ('thumbnailOverlays', ..., 'thumbnailOverlayTimeStatusRenderer', 'text')))
+
+        if duration is None:
+            duration = parse_duration(self._search_regex(
+                r'ago\s*([A-Za-z0-9 ,]+?)\s*[\d,]+\sviews',
+                traverse_obj(renderer, ('title', 'accessibility', 'accessibilityData', 'label')),
+                video_id, default=None))
+
         view_count = self._get_count(renderer, 'viewCountText')
 
         uploader = self._get_text(renderer, 'ownerText', 'shortBylineText')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2638,23 +2638,23 @@ def parse_duration(s):
         m = re.match(
             r'''(?ix)(?:P?
                 (?:
-                    [0-9]+\s*y(?:ears?)?\s*
+                    [0-9]+\s*y(?:ears?)?,?\s*
                 )?
                 (?:
-                    [0-9]+\s*m(?:onths?)?\s*
+                    [0-9]+\s*m(?:onths?)?,?\s*
                 )?
                 (?:
-                    [0-9]+\s*w(?:eeks?)?\s*
+                    [0-9]+\s*w(?:eeks?)?,?\s*
                 )?
                 (?:
-                    (?P<days>[0-9]+)\s*d(?:ays?)?\s*
+                    (?P<days>[0-9]+)\s*d(?:ays?)?,?\s*
                 )?
                 T)?
                 (?:
-                    (?P<hours>[0-9]+)\s*h(?:ours?)?\s*
+                    (?P<hours>[0-9]+)\s*h(?:ours?)?,?\s*
                 )?
                 (?:
-                    (?P<mins>[0-9]+)\s*m(?:in(?:ute)?s?)?\s*
+                    (?P<mins>[0-9]+)\s*m(?:in(?:ute)?s?)?,?\s*
                 )?
                 (?:
                     (?P<secs>[0-9]+)(?P<ms>\.[0-9]+)?\s*s(?:ec(?:ond)?s?)?\s*


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

On some feeds (channels and search atm), YouTube has replaced the duration overlay (which is where we were getting duration from) with a shorts badge :roll_eyes: 

This PR adds a fallback to extract the duration from the accessibility data. 
I've had to modify `yt_dlp.utils.parse_duration` slightly to handle the duration format.

This data looks like this for reference:
```
WEIRD Sandwich Hack 😳 #shorts by Lionfield 13 hours ago 15 seconds 207,566 views - play Short
Italians get mad at VIRAL Tiktok videos by Lionfield 6 days ago 4 minutes, 39 seconds 168,049 views
this is it guys i quit by Yoe Mase Streamed 7 days ago 54 minutes 578 views
AN UNFILTERED STREAM OF CONTENT (Live Stream VOD) by Yoe Mase Streamed 11 months ago 2 hours, 24 minutes 678 views
# live
NASA Science Live: We Just Opened a 50-year-old Moon Sample by NASA
# in playlist
Why Self-Driving Cars DON'T Just CRASH by Techquickie 2 years ago 6 minutes, 15 seconds
```
(let me know if there are any edge cases I have missed!)


Related: https://github.com/TeamNewPipe/NewPipe/issues/8034 (thanks @TiA4f8R for alerting us)
