### PR TITLE
Manifest subtitles V

### DIFF
--- a/yt_dlp/extractor/go.py
+++ b/yt_dlp/extractor/go.py
@@ -217,6 +217,7 @@ class GoIE(AdobePassIE):
         title = video_data['title']
 
         formats = []
+        subtitles = {}
         for asset in video_data.get('assets', {}).get('asset', []):
             asset_url = asset.get('value')
             if not asset_url:
@@ -256,8 +257,10 @@ class GoIE(AdobePassIE):
                     error_message = ', '.join([error['message'] for error in errors])
                     raise ExtractorError('%s said: %s' % (self.IE_NAME, error_message), expected=True)
                 asset_url += '?' + entitlement['uplynkData']['sessionKey']
-                formats.extend(self._extract_m3u8_formats(
-                    asset_url, video_id, 'mp4', m3u8_id=format_id or 'hls', fatal=False))
+                fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                    asset_url, video_id, 'mp4', m3u8_id=format_id or 'hls', fatal=False)
+                formats.extend(fmts)
+                self._merge_subtitles(subs, target=subtitles)
             else:
                 f = {
                     'format_id': format_id,
@@ -281,7 +284,6 @@ class GoIE(AdobePassIE):
                 formats.append(f)
         self._sort_formats(formats)
 
-        subtitles = {}
         for cc in video_data.get('closedcaption', {}).get('src', []):
             cc_url = cc.get('value')
             if not cc_url:

--- a/yt_dlp/extractor/viu.py
+++ b/yt_dlp/extractor/viu.py
@@ -88,10 +88,9 @@ class ViuIE(ViuBaseIE):
             #     r'(/hlsc_)[a-z]+(\d+\.m3u8)',
             #     r'\1whe\2', video_data['href'])
             m3u8_url = video_data['href']
-        formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4')
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4')
         self._sort_formats(formats)
 
-        subtitles = {}
         for key, value in video_data.items():
             mobj = re.match(r'^subtitle_(?P<lang>[^_]+)_(?P<ext>(vtt|srt))', key)
             if not mobj:


### PR DESCRIPTION
<details> <summary> Boilerplate (own code, improvement/feature/fix) </summary>

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- Improvement
- New feature
- Bug fix

</details>

Previously in this series: #247, #515, #948, #2686.

The Go case was caught, again, on issue tracker: <https://github.com/yt-dlp/yt-dlp/issues/2764#issuecomment-1038542729>, <https://github.com/yt-dlp/yt-dlp/issues/2818#issuecomment-1046365267>. This PR is *not* expected to resolve the overall tickets, though.

The fix for viu is speculative, as the reporter in the upstream ticket (ytdl-org/youtube-dl#30779) used the direct stream URL instead of the player frontend URL. It is not certain if this will work, as I have no means to test it.

As a side note, the viu extractor contains a somewhat curious FIXME comment, which I did not address here, but I think is worth paying some attention to:

https://github.com/yt-dlp/yt-dlp/blob/4628a3aa751ac0b2161b216662f0e959eb9bd206/yt_dlp/extractor/viu.py#L79-L82
