### PR TITLE
[general options] add --force-extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,13 @@ You can also fork the project on github and run your fork's [build workflow](.gi
     --extractor-descriptions         Output descriptions of all supported
                                      extractors and exit
     --force-generic-extractor        Force extraction to use the generic
-                                     extractor
+                                     extractor (deprecated in factor of --force-
+                                     extractor generic)
+    --force-extractor None           Force extraction to use only the given
+                                     extractors. This can save significant time
+                                     at program startup if only one particular
+                                     extractor is going to be used for a given
+                                     invocation.
     --default-search PREFIX          Use this prefix for unqualified URLs. For
                                      example "gvsearch2:" downloads two videos
                                      from google videos for the search term

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -684,6 +684,7 @@ def parse_options(argv=None):
         'windowsfilenames': opts.windowsfilenames,
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,
+        'force_extractor': opts.force_extractor,
         'ratelimit': opts.ratelimit,
         'throttledratelimit': opts.throttledratelimit,
         'overwrites': opts.overwrites,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -269,8 +269,12 @@ def create_parser():
         help='Output descriptions of all supported extractors and exit')
     general.add_option(
         '--force-generic-extractor',
-        action='store_true', dest='force_generic_extractor', default=False,
-        help='Force extraction to use the generic extractor')
+        action='store_true', dest='force_generic_extractor', default=None,
+        help='Force extraction to use the generic extractor (deprecated in factor of --force-extractor generic)')
+    general.add_option(
+        '--force-extractor',
+        default=[], action='append', dest='force_extractor',
+        help='Force extraction to use only the given extractors. This can save significant time at program startup if only one particular extractor is going to be used for a given invocation.')
     general.add_option(
         '--default-search',
         dest='default_search', metavar='PREFIX',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This commit adds support for a new command-line flag, --force-extractor,
that takes as an argument the name of an extractor. This extractor is
pased to extract_info as the ie_key, which causes the given extractor to
be used directly without having to run `__init__` on all supported
extractors.

This is important because each extractor typically needs to compile a
regex, and all of that regex compilation adds up. In a profiler, this
extractor initialization occupies 80% of startup time on my test
machine (the rest is module import and checking ffmpeg versions).

Passing --force-extractor therefore gives the user a faster startup when
a given invocation is known to always need a particular, named
extractor.