### PR TITLE
[arte] Move to v2 API

### DIFF
--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -175,7 +175,7 @@ class ArteTVIE(ArteTVBaseIE):
                 self.report_warning(f'Skipping stream with unknown protocol {stream["protocol"]}')
 
             # TODO: chapters from stream['segments']?
-            # The JS also apparently looks for chapters in config['data']['attributes']['chapters'],
+            # The JS also looks for chapters in config['data']['attributes']['chapters'],
             # but I am yet to find a video having those
 
         self._sort_formats(formats)
@@ -205,7 +205,13 @@ class ArteTVEmbedIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?arte\.tv/player/v\d+/index\.php\?.*?\bjson_url=.+'
     _TESTS = [{
         'url': 'https://www.arte.tv/player/v5/index.php?json_url=https%3A%2F%2Fapi.arte.tv%2Fapi%2Fplayer%2Fv2%2Fconfig%2Fde%2F100605-013-A&lang=de&autoplay=true&mute=0100605-013-A',
-        'only_matching': True,
+        'info_dict': {
+            'id': '100605-013-A',
+            'ext': 'mp4',
+            'title': 'United we Stream November Lockdown Edition #13',
+            'description': 'md5:be40b667f45189632b78c1425c7c2ce1',
+            'upload_date': '20201116',
+        },
     }, {
         'url': 'https://www.arte.tv/player/v3/index.php?json_url=https://api.arte.tv/api/player/v2/config/de/100605-013-A',
         'only_matching': True,
@@ -229,7 +235,12 @@ class ArteTVPlaylistIE(ArteTVBaseIE):
     _VALID_URL = r'https?://(?:www\.)?arte\.tv/(?P<lang>%s)/videos/(?P<id>RC-\d{6})' % ArteTVBaseIE._ARTE_LANGUAGES
     _TESTS = [{
         'url': 'https://www.arte.tv/en/videos/RC-016954/earn-a-living/',
-        'only_matching': True,
+        'info_dict': {
+            'id': 'RC-016954',
+            'title': 'Earn a Living',
+            'description': 'md5:d322c55011514b3a7241f7fb80d494c2',
+        },
+        'playlist_mincount': 6,
     }, {
         'url': 'https://www.arte.tv/pl/videos/RC-014123/arte-reportage/',
         'playlist_mincount': 100,

--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -30,17 +30,7 @@ class ArteTVIE(ArteTVBaseIE):
                     ''' % {'langs': ArteTVBaseIE._ARTE_LANGUAGES}
     _TESTS = [{
         'url': 'https://www.arte.tv/en/videos/088501-000-A/mexico-stealing-petrol-to-survive/',
-        'info_dict': {
-            'id': '088501-000-A',
-            'title': 'Mexico: Stealing Petrol to Survive',
-            'alt_title': 'ARTE Reportage',
-            'description': 'md5:35ec9baaa8ad0b2456447c7972ba3ca0',
-            'duration': 1428,
-            'thumbnail': 'https://api-cdn.arte.tv/api/mami/v1/program/en/088501-000-A/940x530?ts=1626083168',
-            'upload_date': '20190628',
-            'timestamp': 1561759200,
-            'ext': 'mp4',
-        },
+        'only_matching': True,
     }, {
         'url': 'https://www.arte.tv/pl/videos/100103-000-A/usa-dyskryminacja-na-porodowce/',
         'info_dict': {
@@ -50,10 +40,11 @@ class ArteTVIE(ArteTVBaseIE):
             'alt_title': 'ARTE Reportage',
             'upload_date': '20201103',
             'duration': 554,
-            'thumbnail': 'https://api-cdn.arte.tv/api/mami/v1/program/pl/100103-000-A/940x530?ts=1625425425',
+            'thumbnail': r're:https://api-cdn\.arte\.tv/.+940x530',
             'timestamp': 1604417980,
             'ext': 'mp4',
         },
+        'params': {'skip_download': 'm3u8'}
     }, {
         'url': 'https://api.arte.tv/api/player/v2/config/de/100605-013-A',
         'only_matching': True,
@@ -64,7 +55,7 @@ class ArteTVIE(ArteTVBaseIE):
 
     _GEO_BYPASS = True
 
-    _LANG_MAP = {       # the RHS are not ISO codes, but French abbreviations
+    _LANG_MAP = {  # ISO639 -> French abbreviations
         'fr': 'F',
         'de': 'A',
         'en': 'E[ANG]',
@@ -181,8 +172,8 @@ class ArteTVIE(ArteTVBaseIE):
         return {
             'id': metadata['providerId'],
             'webpage_url': traverse_obj(metadata, ('link', 'url')),
-            'title': metadata.get('title'),
-            'alt_title': metadata.get('subtitle'),
+            'title': metadata.get('subtitle'),
+            'alt_title': metadata.get('title'),
             'description': metadata.get('description'),
             'duration': traverse_obj(metadata, ('duration', 'seconds')),
             'language': metadata.get('language'),
@@ -208,6 +199,7 @@ class ArteTVEmbedIE(InfoExtractor):
             'description': 'md5:be40b667f45189632b78c1425c7c2ce1',
             'upload_date': '20201116',
         },
+        'skip': 'No video available'
     }, {
         'url': 'https://www.arte.tv/player/v3/index.php?json_url=https://api.arte.tv/api/player/v2/config/de/100605-013-A',
         'only_matching': True,
@@ -231,12 +223,7 @@ class ArteTVPlaylistIE(ArteTVBaseIE):
     _VALID_URL = r'https?://(?:www\.)?arte\.tv/(?P<lang>%s)/videos/(?P<id>RC-\d{6})' % ArteTVBaseIE._ARTE_LANGUAGES
     _TESTS = [{
         'url': 'https://www.arte.tv/en/videos/RC-016954/earn-a-living/',
-        'info_dict': {
-            'id': 'RC-016954',
-            'title': 'Earn a Living',
-            'description': 'md5:d322c55011514b3a7241f7fb80d494c2',
-        },
-        'playlist_mincount': 6,
+        'only_matching': True,
     }, {
         'url': 'https://www.arte.tv/pl/videos/RC-014123/arte-reportage/',
         'playlist_mincount': 100,
@@ -284,7 +271,7 @@ class ArteTVCategoryIE(ArteTVBaseIE):
     def suitable(cls, url):
         return (
             not any(ie.suitable(url) for ie in (ArteTVIE, ArteTVPlaylistIE, ))
-            and super(ArteTVCategoryIE, cls).suitable(url))
+            and super().suitable(url))
 
     def _real_extract(self, url):
         lang, playlist_id = self._match_valid_url(url).groups()

--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -1,18 +1,14 @@
 import re
 
 from .common import InfoExtractor
-from ..compat import (
-    compat_str,
-)
 from ..utils import (
-    GeoRestrictedError,
     ExtractorError,
+    GeoRestrictedError,
     int_or_none,
     parse_iso8601,
     parse_qs,
     strip_or_none,
     traverse_obj,
-    try_get,
     url_or_none,
 )
 
@@ -93,7 +89,7 @@ class ArteTVIE(ArteTVBaseIE):
     ''')
 
     # all obtained by exhaustive testing
-    _GEO_COUNTRIES = {
+    _COUNTRIES_MAP = {
         'DE_FR': {
             'BL', 'DE', 'FR', 'GF', 'GP', 'MF', 'MQ', 'NC',
             'PF', 'PM', 'RE', 'WF', 'YT',
@@ -125,7 +121,7 @@ class ArteTVIE(ArteTVBaseIE):
         geoblocking = traverse_obj(config, ('data', 'attributes', 'restriction', 'geoblocking')) or {}
         if geoblocking.get('restrictedArea'):
             raise GeoRestrictedError(f'Video restricted to {geoblocking["code"]!r}',
-                                     countries=self._GEO_COUNTRIES.get(geoblocking['code'], ('DE', 'FR')))
+                                     countries=self._COUNTRIES_MAP.get(geoblocking['code'], ('DE', 'FR')))
 
         if not traverse_obj(config, ('data', 'attributes', 'rights')):
             # Eg: https://www.arte.tv/de/videos/097407-215-A/28-minuten


### PR DESCRIPTION
<details> <summary> Boilerplate (own code, improvement) </summary>

- I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- Improvement

---

</details>

~~The v1 API code was removed for simplicity, even though it still mostly works.~~ ~~Not anymore.~~ ~~Not not anymore.~~ Not not not anymore, the v1 API is now completely down (404).

I have left a number of ‘XXX’ comments in, please take a look before merging.

The testcases for this extractor are stale. I have not updated them, other than throwing away `upload_date`, which the updated code no longer extracts.

Fixes or subsumes:
- #3086 
- #3428
- #3502
- ytdl-org/youtube-dl#29640
- ytdl-org/youtube-dl#29653
- ytdl-org/youtube-dl#29870
- ytdl-org/youtube-dl#30816
- ytdl-org/youtube-dl#30878

To settle before merging:
- [x] Whether to keep v1 API extraction ~~(it looks like Arte has pulled the plug on the v1 API, so no, it seems)~~ (probably not worth the trouble if even Arte themselves neglect it; plus, text subtitles in v2 API > burned-in subtitles in v1 API)
- [x] Update testcases (I think good enough for now; videos may expire in the future, though)
- [x] Language preference inferred from version label
- [x] All the XXX comments
  - [x] Non-HLS protocols
  - [x] `null`s for videos that are no longer available
  - [x] Whether `rights` is a good `upload_date` replacement (I say good enough)
  - [x] `id` vs `providerId` (decided to use `providerId` after all)
  - [x] extract chapters from `stream['segments']` (deferred this one)
- [x] Is `stream['versions']` always a one-element list? (answer seems to be yes; even the host’s own player seems to assume so)
- [x] Handling of <https://api.arte.tv/api/player/v2/config/fr/LIVE>
- [x] Whether to also extract unlisted non-streaming mp4 URLs (my answer: no, #3521 should take care of this)