### PR TITLE
Man page: Clarify behavior of `--check-formats`

### DIFF
--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -632,11 +632,7 @@ def create_parser():
     video_format.add_option(
         '--check-formats',
         action='store_const', const='selected', dest='check_formats', default=None,
-        help=(
-            'Check that the selected formats are actually downloadable.'
-            'When used with a "best" format (e.g., --format bestvideo+bestaudio),'
-            'yt-dlp will download the next best format if the best format'
-            'is unavailable.'))
+        help='Make sure formats are selected only from those that are actually downloadable')
     video_format.add_option(
         '--check-all-formats',
         action='store_true', dest='check_formats',

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -632,7 +632,11 @@ def create_parser():
     video_format.add_option(
         '--check-formats',
         action='store_const', const='selected', dest='check_formats', default=None,
-        help='Check that the selected formats are actually downloadable')
+        help=(
+            'Check that the selected formats are actually downloadable.'
+            'When used with a "best" format (e.g., --format bestvideo+bestaudio),'
+            'yt-dlp will download the next best format if the best format'
+            'is unavailable.'))
     video_format.add_option(
         '--check-all-formats',
         action='store_true', dest='check_formats',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement — documentation
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

It looks like `--check-formats` attempts to download the next best format if the server 503s on the best one. This PR clarifies this behavior in the manpage.

Related: [#3308](https://github.com/yt-dlp/yt-dlp/issues/3308#issuecomment-1088277324)