### PR TITLE
[twitcasting] Don't return multi_video for archive with single hls manifest

### DIFF
--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -183,6 +183,13 @@ class TwitCastingIE(InfoExtractor):
             infodict = {
                 'formats': formats
             }
+        elif len(m3u8_urls) == 1:
+            infodict = {
+                'id': video_id,
+                # No problem here since there's only one manifest
+                'formats': self._extract_m3u8_formats(
+                    m3u8_urls[0], video_id, 'mp4', headers=self._M3U8_HEADERS),
+            }
         else:
             infodict = {
                 '_type': 'multi_video',

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -186,6 +186,7 @@ class TwitCastingIE(InfoExtractor):
         elif len(m3u8_urls) == 1:
             formats = self._extract_m3u8_formats(
                 m3u8_urls[0], video_id, 'mp4', headers=self._M3U8_HEADERS)
+            self._sort_formats(formats)
             infodict = {
                 # No problem here since there's only one manifest
                 'formats': formats,

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -184,11 +184,11 @@ class TwitCastingIE(InfoExtractor):
                 'formats': formats
             }
         elif len(m3u8_urls) == 1:
+            formats = self._extract_m3u8_formats(
+                m3u8_urls[0], video_id, 'mp4', headers=self._M3U8_HEADERS)
             infodict = {
-                'id': video_id,
                 # No problem here since there's only one manifest
-                'formats': self._extract_m3u8_formats(
-                    m3u8_urls[0], video_id, 'mp4', headers=self._M3U8_HEADERS),
+                'formats': formats,
             }
         else:
             infodict = {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Return as video when there's only one m3u8 manifest for the given archives.

It prevents previous file being overwritten by ConcatPP.