### PR TITLE
Update video codecs priority in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1435,7 +1435,7 @@ The available fields are:
  - `quality`: The quality of the format
  - `source`: The preference of the source
  - `proto`: Protocol used for download (`https`/`ftps` > `http`/`ftp` > `m3u8_native`/`m3u8` > `http_dash_segments`> `websocket_frag` > `mms`/`rtsp` > `f4f`/`f4m`)
- - `vcodec`: Video Codec (`av01` > `vp9.2` > `vp9` > `h265` > `h264` > `vp8` > `h263` > `theora` > other)
+ - `vcodec`: Video Codec (`vp9.2` > `vp9` > `av01` > `h265` > `h264` > `vp8` > `h263` > `theora` > other)
  - `acodec`: Audio Codec (`flac`/`alac` > `wav`/`aiff` > `opus` > `vorbis` > `aac` > `mp4a` > `mp3` > `eac3` > `ac3` > `dts` > other)
  - `codec`: Equivalent to `vcodec,acodec`
  - `vext`: Video Extension (`mp4` > `webm` > `flv` > other). If `--prefer-free-formats` is used, `webm` is preferred.


### PR DESCRIPTION
As of today, yt-dlp prioritizes VP9 over AV1.

I'm not 100% sure the sorting I'm giving here is the correct one. It would be great if someone could confirm it's correct.