### PR TITLE
[improvement] download status and speed estimation for concurrent fragmented downloads

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -192,7 +192,6 @@ class FragmentFD(FileDownloader):
             'url': frag_url,
             'http_headers': headers or info_dict.get('http_headers'),
             'request_data': request_data,
-            'ctx_id': ctx.get('ctx_id'),
         }
         success, _ = ctx['dl'].download(fragment_filename, fragment_info_dict)
         if not success:
@@ -300,7 +299,7 @@ class FragmentFD(FileDownloader):
 
         resume_len = ctx['complete_frags_downloaded_bytes']
         total_frags = ctx['total_frags']
-        ctx_id = ctx.get('ctx_id')
+
         # This dict stores the download progress, it's updated by the progress
         # hook
         state = {
@@ -396,7 +395,6 @@ class FragmentFD(FileDownloader):
             'filename': ctx['filename'],
             'status': 'finished',
             'elapsed': elapsed,
-            'ctx_id': ctx.get('ctx_id'),
             'max_progress': ctx.get('max_progress'),
             'progress_idx': ctx.get('progress_idx'),
         }, info_dict)

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -315,7 +315,6 @@ class HttpFD(FileDownloader):
                     'eta': eta,
                     'speed': speed,
                     'elapsed': now - ctx.start_time,
-                    'ctx_id': info_dict.get('ctx_id'),
                 }, info_dict)
 
                 if data_len is not None and byte_counter == data_len:
@@ -361,7 +360,6 @@ class HttpFD(FileDownloader):
                 'filename': ctx.filename,
                 'status': 'finished',
                 'elapsed': time.time() - ctx.start_time,
-                'ctx_id': info_dict.get('ctx_id'),
             }, info_dict)
 
             return True


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fragmented downloads can be speed up by using more threads. This makes the progress bar appear jittery as it is updated by each thread. This PR rewrites the logic, which summarizes the progress of each fragment and allows updates on the eta and speed calculation in separate intervals.

* `_start_frag_download()` is locked while executed by a thread, thus avoiding inconsistent updates of nonlocal variables (ctx, status)
* the progress is only updated in fixed intervals of 0.9 seconds
* the calculation of speed and eta is done between the current time and about 3 seconds before, this is more accurate than the average over the whole download time - when you resume a download the last fragments can be read from temporary files which increases the speed but does not reflect the download speed from the server
*  the console title output of `HttpQuietDownloader` is suppressed as ist messes with the output of `FragmentedFD`
* when Ctrl+C is pressed on concurrent downloads (N>1) emit a warning and shut down the ThreadPoolExecutor gracefully, waiting for pending fragments to finish

### additional issue
yt-dlp doesn't detect, if a fragmented file was already fully downloaded. All fragments are downloaded again and appended to the existing file. This can be detected, when 

`ctx['fragment_index'] == 0 and resume_len > 0`

One of the commits deals with it by warning and setting the file mode to `wb`. As it is not part of the actual problem it can be put into a separate PR.