### PR TITLE
[docs] Fix list formatting in manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * youtube-dl tries to remove some superfluous punctuations from filenames. While this can sometimes be helpfull, it is often undesirable. So yt-dlp tries to keep the fields in the filenames as close to their original values as possible. You can use `--compat-options filename-sanitization` to revert to youtube-dl's behavior
 
 For ease of use, a few more compat options are available:
+
 * `--compat-options all`: Use all compat options
 * `--compat-options youtube-dl`: Same as `--compat-options all,-multistreams`
 * `--compat-options youtube-dlc`: Same as `--compat-options all,-no-live-chat,-no-youtube-channel-redirect`


### PR DESCRIPTION
Apparently pandoc requires empty line before an itemized list.

Before:
```
       For  ease  of  use,  a  few more compat options are available: * --com‐
       pat-options all: Use all compat options * --compat-options  youtube-dl:
       Same   as   --compat-options   all,-multistreams   *   --compat-options
       youtube-dlc:            Same            as             --compat-options
       all,-no-live-chat,-no-youtube-channel-redirect
```

After:
```
       For ease of use, a few more compat options are available:

       • --compat-options all: Use all compat options

       • --compat-options  youtube-dl:  Same  as  --compat-options all,-multi‐
         streams

       • --compat-options    youtube-dlc:     Same     as     --compat-options
         all,-no-live-chat,-no-youtube-channel-redirect
```