### PR TITLE
doc: fix example python usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1744,7 +1744,7 @@ From a Python program, you can embed yt-dlp in a more powerful fashion, like thi
 from yt_dlp import YoutubeDL
 
 ydl_opts = {'format': 'bestaudio'}
-with YoutubeDL(ydl_opts) as ydl:
+with yt_dlp.YoutubeDL(ydl_opts) as ydl:
     ydl.download(['https://www.youtube.com/watch?v=BaW_jenozKc'])
 ```
 


### PR DESCRIPTION
```
>>> with YoutubeDL(ydl_opts) as ydl:
...     ydl.download(['https://www.youtube.com/playlist?list=PLFW6onB8bLzhxdtSSsIp5mUy7uvSkvflS'])
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'YoutubeDL' is not defined
```

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix (documentation)
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The example provided for usage from a python script doesn't work (`NameError: name 'YoutubeDL' is not defined`). Correct usage is `with yt_dlp.YoutubeDL(ydl_opts) as ydl:`
