### PR TITLE
[reddit] Support videos derived from GIFs

### DIFF
--- a/yt_dlp/extractor/reddit.py
+++ b/yt_dlp/extractor/reddit.py
@@ -22,7 +22,7 @@ class RedditIE(InfoExtractor):
             'title': 'That small heart attack.',
             'display_id': '6rrwyj',
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',
-            'thumbnails': 'count:4',
+            'thumbnails': 'count:5',
             'timestamp': 1501941939,
             'upload_date': '20170805',
             'uploader': 'Antw87',
@@ -44,7 +44,7 @@ class RedditIE(InfoExtractor):
             'title': 'I\'m never driving again',
             'display_id': 'ks2fjy',
             'thumbnail': r're:^https?://.*\.(?:jpg|gif)',
-            'thumbnails': 'count:4',
+            'thumbnails': 'count:5',
             'timestamp': 1609983156,
             'upload_date': '20210107',
             'uploader': 'IvanKaramazov28',
@@ -125,6 +125,11 @@ class RedditIE(InfoExtractor):
                 'height': int_or_none(src.get('height')),
             })
 
+        add_thumbnail({
+            'url': data.get('thumbnail'),
+            'width': data.get('thumbnail_width'),
+            'height': data.get('thumbnail_height')
+        })
         for image in try_get(data, lambda x: x['preview']['images']) or []:
             if not isinstance(image, dict):
                 continue

--- a/yt_dlp/extractor/reddit.py
+++ b/yt_dlp/extractor/reddit.py
@@ -20,6 +20,7 @@ class RedditIE(InfoExtractor):
             'id': 'zv89llsvexdz',
             'ext': 'mp4',
             'title': 'That small heart attack.',
+            'display_id': '6rrwyj',
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',
             'thumbnails': 'count:4',
             'timestamp': 1501941939,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

It seems that Reddit automatically converts uploaded GIFs to mp4. This PR extracts the converted videos (and adds an appropriate test case). It also gets the JPEG thumbnail, displayed on Reddit itself, which was not previously extracted.

Thank you!