### PR TITLE
[npr]: get stream url from json-ld

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1503,7 +1503,7 @@ class InfoExtractor:
             author = e.get('author')
             embed_url = url_or_none(e.get('embedUrl'))
             info.update({
-                'url': url_or_none(e.get('contentUrl')),
+                'url': traverse_obj(e, 'contentUrl', 'embedUrl', expected_type=url_or_none),
                 'title': unescapeHTML(e.get('name')),
                 'description': unescapeHTML(e.get('description')),
                 'thumbnails': [{'url': url_or_none(url)}
@@ -1521,8 +1521,6 @@ class InfoExtractor:
                 'height': int_or_none(e.get('height')),
                 'view_count': int_or_none(e.get('interactionCount')),
             })
-            if embed_url:
-                info.update({'formats': [{'url': embed_url}]})
             extract_interaction_statistic(e)
             extract_chapter_information(e)
 

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1570,7 +1570,7 @@ class InfoExtractor:
                     })
                     if traverse_obj(e, ('video', 0, '@type')) == 'VideoObject':
                         extract_video_object(e['video'][0])
-                    if traverse_obj(e, ('subjectOf', 0, '@type')) == 'VideoObject':
+                    elif traverse_obj(e, ('subjectOf', 0, '@type')) == 'VideoObject':
                         extract_video_object(e['subjectOf'][0])
                 elif item_type == 'VideoObject':
                     extract_video_object(e)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1501,7 +1501,6 @@ class InfoExtractor:
         def extract_video_object(e):
             assert e['@type'] == 'VideoObject'
             author = e.get('author')
-            embed_url = url_or_none(e.get('embedUrl'))
             info.update({
                 'url': traverse_obj(e, 'contentUrl', 'embedUrl', expected_type=url_or_none),
                 'title': unescapeHTML(e.get('name')),

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1503,6 +1503,7 @@ class InfoExtractor:
             author = e.get('author')
             info.update({
                 'url': url_or_none(e.get('contentUrl')),
+                'embedUrl': url_or_none(e.get('embedUrl')),
                 'title': unescapeHTML(e.get('name')),
                 'description': unescapeHTML(e.get('description')),
                 'thumbnails': [{'url': url_or_none(url)}
@@ -1569,6 +1570,8 @@ class InfoExtractor:
                     })
                     if traverse_obj(e, ('video', 0, '@type')) == 'VideoObject':
                         extract_video_object(e['video'][0])
+                    if traverse_obj(e, ('subjectOf', 0, '@type')) == 'VideoObject':
+                        extract_video_object(e['subjectOf'][0])
                 elif item_type == 'VideoObject':
                     extract_video_object(e)
                     if expected_type is None:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1501,9 +1501,9 @@ class InfoExtractor:
         def extract_video_object(e):
             assert e['@type'] == 'VideoObject'
             author = e.get('author')
+            embed_url = url_or_none(e.get('embedUrl'))
             info.update({
                 'url': url_or_none(e.get('contentUrl')),
-                'embedUrl': url_or_none(e.get('embedUrl')),
                 'title': unescapeHTML(e.get('name')),
                 'description': unescapeHTML(e.get('description')),
                 'thumbnails': [{'url': url_or_none(url)}
@@ -1521,6 +1521,8 @@ class InfoExtractor:
                 'height': int_or_none(e.get('height')),
                 'view_count': int_or_none(e.get('interactionCount')),
             })
+            if embed_url:
+                info.update({'formats': [{'url': embed_url}]})
             extract_interaction_statistic(e)
             extract_chapter_information(e)
 

--- a/yt_dlp/extractor/npr.py
+++ b/yt_dlp/extractor/npr.py
@@ -51,6 +51,15 @@ class NprIE(InfoExtractor):
         # multimedia, no formats, stream
         'url': 'https://www.npr.org/2020/02/14/805476846/laura-stevenson-tiny-desk-concert',
         'only_matching': True,
+    }, {
+        'url': 'https://www.npr.org/2022/03/15/1084896560/bonobo-tiny-desk-home-concert',
+        'info_dict': {
+            'id': '1086468851',
+            'ext': 'mp4',
+            'title': 'Bonobo: Tiny Desk (Home) Concert',
+            'duration': 1061,
+            'thumbnail': r're:^https?://media.npr.org/assets/img/.*\.jpg$',
+        },
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/npr.py
+++ b/yt_dlp/extractor/npr.py
@@ -67,11 +67,8 @@ class NprIE(InfoExtractor):
 
         # Fetch the JSON-LD from the npr page.
         json_ld = self._search_json_ld(
-            self._download_webpage(url, playlist_id),
-            playlist_id,
-            'NewsArticle',
-            fatal=False
-        )
+            self._download_webpage(url, playlist_id), playlist_id,
+            'NewsArticle', fatal=False)
 
         KNOWN_FORMATS = ('threegp', 'm3u8', 'smil', 'mp4', 'mp3')
         quality = qualities(KNOWN_FORMATS)

--- a/yt_dlp/extractor/npr.py
+++ b/yt_dlp/extractor/npr.py
@@ -116,10 +116,10 @@ class NprIE(InfoExtractor):
                     stream_url, stream_id, 'mp4', 'm3u8_native',
                     m3u8_id='hls', fatal=False))
 
-            if len(formats) == 0 and json_ld.get('embedUrl', None) is not None:
-                # Add the embedUrl as a stream.
+            if (len(formats) == 0 and len(json_ld.get('formats', [])) > 0
+                    and json_ld.get('formats')[0].get('url', None)):
                 formats.extend(self._extract_m3u8_formats(
-                    json_ld.get('embedUrl'), 'hlsUrl', 'mp4', 'm3u8_native',
+                    json_ld.get('formats')[0].get('url'), media_id, 'mp4', 'm3u8_native',
                     m3u8_id='hls', fatal=False))
 
             self._sort_formats(formats)

--- a/yt_dlp/extractor/npr.py
+++ b/yt_dlp/extractor/npr.py
@@ -67,8 +67,7 @@ class NprIE(InfoExtractor):
 
         # Fetch the JSON-LD from the npr page.
         json_ld = self._search_json_ld(
-            self._download_webpage(url, playlist_id), playlist_id,
-            'NewsArticle', fatal=False)
+            self._download_webpage(url, playlist_id), playlist_id, 'NewsArticle', fatal=False)
 
         KNOWN_FORMATS = ('threegp', 'm3u8', 'smil', 'mp4', 'mp3')
         quality = qualities(KNOWN_FORMATS)
@@ -116,11 +115,8 @@ class NprIE(InfoExtractor):
                     stream_url, stream_id, 'mp4', 'm3u8_native',
                     m3u8_id='hls', fatal=False))
 
-            if (len(formats) == 0 and len(json_ld.get('formats', [])) > 0
-                    and json_ld.get('formats')[0].get('url', None)):
-                formats.extend(self._extract_m3u8_formats(
-                    json_ld.get('formats')[0].get('url'), media_id, 'mp4', 'm3u8_native',
-                    m3u8_id='hls', fatal=False))
+            if not formats and json_ld.get('url'):
+                formats.extend(self._extract_m3u8_formats(json_ld['url'], media_id, 'mp4', m3u8_id='hls', fatal=False))
 
             self._sort_formats(formats)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Extract JSON-LD from the NRP webpage if it's available. If the
"format" and "stream" fields in the multimedia dictionary are 
empty in the result returned by the NPR API, use the 
embedURL from the JSON-LD, if it exists, as a stream url.

Update `InfoExtractor._json_ld.traverse_json_ld` to look for a
VideoObject in "subjectOf" if the `item_type` is "NewsArticle".

Update `InfoExtractor._json_ld.extract_video_object` to extract
"embedUrl" from the VideoObject.

Addresses the issue downloading the [Bonobo Tiny Desk Concert][bonobo] (#1934)

[bonobo]: https://www.npr.org/2022/03/15/1084896560/bonobo-tiny-desk-home-concert