### PR TITLE
[VideocampusSachsen] Fix extractor

### DIFF
--- a/yt_dlp/extractor/videocampus_sachsen.py
+++ b/yt_dlp/extractor/videocampus_sachsen.py
@@ -40,7 +40,7 @@ class VideocampusSachsenIE(InfoExtractor):
         video_id, tmp_id, display_id = self._match_valid_url(url).group('id', 'tmp_id', 'display_id')
         webpage = self._download_webpage(url, video_id or tmp_id, fatal=False) or ''
 
-        if not tmp_id:
+        if not video_id:
             video_id = self._html_search_regex(
                 r'src="https?://videocampus\.sachsen\.de/media/embed\?key=([0-9a-f]+)&',
                 webpage, 'video_id')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

<!-- Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.
-->

Regex extraction of a `/m/`-URL only provides a `tmp_id`. Currently, no `video_id` needed for the final medium URL is being produced, causing the download to fail.