### PR TITLE
Correct path for docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ else:
         ('share/bash-completion/completions', ['completions/bash/yt-dlp']),
         ('share/zsh/site-functions', ['completions/zsh/_yt-dlp']),
         ('share/fish/vendor_completions.d', ['completions/fish/yt-dlp.fish']),
-        ('share/doc/yt_dlp', ['README.txt']),
+        ('share/doc/yt-dlp', ['README.txt']),
         ('share/man/man1', ['yt-dlp.1'])
     ]
     root = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
from https://sources.debian.org/patches/yt-dlp/2022.04.08-1/0001-Correct-path-for-docs.patch/
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code (although the patch is licensed under [GPL-2.0-or-later](https://metadata.ftp-master.debian.org/changelogs//main/y/yt-dlp/yt-dlp_2022.04.08-1_copyright) it is [not copyrightable](https://www.gnu.org/prep/maintain/maintain.html#Legally-Significant))

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

change yt_dlp to yt-dlp for the docs directory in setup.py for uniformity with other file paths