### PR TITLE
[youtube:tab] Refactor and implement resolver

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1196,7 +1196,7 @@ class InfoExtractor:
         In case of failure return a default value or raise a WARNING or a
         RegexNotFoundError, depending on fatal, specifying the field name.
         """
-        if not isinstance(string, str):
+        if string is None:
             mobj = None
         elif isinstance(pattern, (str, compat_Pattern)):
             mobj = re.search(pattern, string, flags)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1196,7 +1196,7 @@ class InfoExtractor:
         In case of failure return a default value or raise a WARNING or a
         RegexNotFoundError, depending on fatal, specifying the field name.
         """
-        if string is None:
+        if not isinstance(string, str):
             mobj = None
         elif isinstance(pattern, (str, compat_Pattern)):
             mobj = re.search(pattern, string, flags)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3989,6 +3989,21 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
         return mapping
 
     def resolve_renderer(self, renderer, ctx=None):
+        """
+        Resolves a given renderer.
+        Can be in the format
+        {
+            "someInnerRenderer": <data>,
+            "someInnerRenderer2": <data>
+        }
+        contents/items are supported as well.
+
+        To allow continuation pages to be extracted, a context (ctx)
+        containing item_id, endpoint and client is required.
+
+        ctx can contain a "mapping" key containing mappings.
+        otherwise the default will be used.
+        """
         if not isinstance(renderer, dict):
             return
         if ctx is None:
@@ -4009,19 +4024,6 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
                 yield from result
             elif isinstance(result, dict):
                 yield result
-
-        """
-
-        {
-            'someRenderer':...
-            'someRenderer2':...
-        }
-        will resolve all renderers that match in the dict
-
-        if we hit a renderer with 'contents' -> sent to resolve_contents. which sends to iterate entries directly or indirectly (via renderer entries)
-        mapping should be stored in ctx.mapping, otherwise will use default.
-        'content' is picked up by this renderer
-        """
 
     @staticmethod
     def _extract_contents_list(renderer):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -627,9 +627,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         'CONTINUATION_REQUEST_TYPE_BROWSE': 'browse',
         'CONTINUATION_REQUEST_TYPE_SEARCH': 'search',
         'CONTINUATION_REQUEST_TYPE_WATCH_NEXT': 'next',
-      #  'CONTINUATION_REQUEST_TYPE_ACCOUNTS_LIST': '??',
-      #  'CONTINUATION_REQUEST_TYPE_COMMENTS_NOTIFICATION_MENU': '??',
-      #  'CONTINUATION_REQUEST_TYPE_COMMENT_REPLIES': '??',
+        # 'CONTINUATION_REQUEST_TYPE_ACCOUNTS_LIST': '??',
+        # 'CONTINUATION_REQUEST_TYPE_COMMENTS_NOTIFICATION_MENU': '??',
+        # 'CONTINUATION_REQUEST_TYPE_COMMENT_REPLIES': '??',
         'CONTINUATION_REQUEST_TYPE_REEL_WATCH_SEQUENCE': 'reel/reel_watch_sequence',
     }
 
@@ -694,7 +694,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         next_continuation_data = self._extract_next_continuation_data(renderer)
         if next_continuation_data is not None:
             return next_continuation_data
-        contents = traverse_obj(renderer, 'items', 'contents', expected_type=list, default = [renderer])
+        contents = traverse_obj(renderer, 'items', 'contents', expected_type=list, default=[renderer])
         continuation_eps = traverse_obj(
             contents, (..., 'continuationItemRenderer', ['continuationEndpoint', ('button', 'buttonRenderer', 'command')]), default=[], expected_type=dict)
 
@@ -4119,11 +4119,11 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
             ctx['endpoint'] = continuation_data[1] or ctx['endpoint']
             query = continuation_data[0]
             headers = self.generate_api_headers(
-                ytcfg=ctx.get('ytcfg'),  visitor_data=ctx.get('visitor_data'), default_client=ctx.get('client'),
+                ytcfg=ctx.get('ytcfg'), visitor_data=ctx.get('visitor_data'), default_client=ctx.get('client'),
                 account_syncid=ctx.get('account_syncid'))
 
             response = self._extract_response(
-                item_id=f'%s page %s' % (ctx['item_id'], page_num), ep=ctx['endpoint'],
+                item_id='%s page %s' % (ctx['item_id'], page_num), ep=ctx['endpoint'],
                 query=query, headers=headers, ytcfg=ctx.get('ytcfg'),
                 check_get_keys=check_get_keys, default_client=ctx['client'])
             continuation_list[:] = [None]
@@ -5657,7 +5657,8 @@ class YoutubeNotificationsIE(YoutubeTabBaseInfoExtractor):
         ytcfg = self._download_ytcfg('web', display_id) if not self.skip_webpage else {}
         self._report_playlist_authcheck(ytcfg)
 
-        response = self._extract_response(item_id=display_id, query={}, ytcfg=ytcfg,
+        response = self._extract_response(
+            item_id=display_id, query={}, ytcfg=ytcfg,
             ep='notification/get_notification_menu', check_get_keys='actions',
             headers=self.generate_api_headers(ytcfg=ytcfg))
 
@@ -5668,8 +5669,8 @@ class YoutubeNotificationsIE(YoutubeTabBaseInfoExtractor):
         ctx = self.make_resolver_context(
             display_id, 'notification/get_notification_menu', ytcfg, self._extract_visitor_data(response), mapping=mapping)
 
-        nsr = traverse_obj(response, ('actions', ...,
-        'openPopupAction', 'popup', 'multiPageMenuRenderer', 'sections', ..., 'multiPageMenuNotificationSectionRenderer'), get_all=False)
+        nsr = traverse_obj(
+            response, ('actions', ..., 'openPopupAction', 'popup', 'multiPageMenuRenderer', 'sections', ..., 'multiPageMenuNotificationSectionRenderer'), get_all=False)
         return self.playlist_result(self.resolve_renderer(nsr, ctx=ctx), display_id, display_id)
 
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4524,7 +4524,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
         renderer = traverse_obj(search, *content_keys)
 
         yield from self.resolve_renderer(renderer,
-                                         self.make_resolver_context(display_id, 'search', ytcfg, self._extract_visitor_data(search), default_client))
+                                         self.make_resolver_context(display_id, 'search', ytcfg=ytcfg, visitor_data=self._extract_visitor_data(search), client=default_client))
 
 
 class YoutubeTabIE(YoutubeTabBaseInfoExtractor):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3994,12 +3994,11 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
                 lambda x: x.lower().endswith(
                     ('playlistrenderer', 'channelrenderer', 'showrenderer', 'reelitemrenderer', 'radiorenderer')), # TODO: no support unviewable playlist extraction
             self._post_thread_entry: 'backstagePostThreadRenderer',
-            self.resolve_contents: [  # TODO: we could point these to resolve_renderer and let it detect contents and pass onto resolve_contents
-                'playlistVideoListRenderer', 'gridRenderer', 'itemSectionRenderer',
-                'expandedShelfContentsRenderer', 'sectionListRenderer', 'richGridRenderer'],
             self._hashtag_tile_entry: 'hashtagTileRenderer',
             self._music_reponsive_list_entry: 'musicResponsiveListItemRenderer',
-            self.resolve_renderer: ['content', 'richItemRenderer', 'richSectionRenderer', 'channelFeaturedContentRenderer', 'horizontalListRenderer']
+            self.resolve_renderer: [
+                'content', 'richItemRenderer', 'richSectionRenderer', 'channelFeaturedContentRenderer', 'horizontalListRenderer',
+                'playlistVideoListRenderer', 'gridRenderer', 'itemSectionRenderer', 'expandedShelfContentsRenderer', 'sectionListRenderer', 'richGridRenderer']
         })
 
     def resolve_renderer(self, renderer, ctx=None):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -627,9 +627,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         'CONTINUATION_REQUEST_TYPE_BROWSE': 'browse',
         'CONTINUATION_REQUEST_TYPE_SEARCH': 'search',
         'CONTINUATION_REQUEST_TYPE_WATCH_NEXT': 'next',
-        'CONTINUATION_REQUEST_TYPE_ACCOUNTS_LIST': '??',
-        'CONTINUATION_REQUEST_TYPE_COMMENTS_NOTIFICATION_MENU': '??',
-        'CONTINUATION_REQUEST_TYPE_COMMENT_REPLIES': '??',
+      #  'CONTINUATION_REQUEST_TYPE_ACCOUNTS_LIST': '??',
+      #  'CONTINUATION_REQUEST_TYPE_COMMENTS_NOTIFICATION_MENU': '??',
+      #  'CONTINUATION_REQUEST_TYPE_COMMENT_REPLIES': '??',
         'CONTINUATION_REQUEST_TYPE_REEL_WATCH_SEQUENCE': 'reel/reel_watch_sequence',
     }
 
@@ -3999,7 +3999,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
                 'expandedShelfContentsRenderer', 'sectionListRenderer', 'richGridRenderer'],
             self._hashtag_tile_entry: 'hashtagTileRenderer',
             self._music_reponsive_list_entry: 'musicResponsiveListItemRenderer',
-            self.resolve_renderer: ['content', 'richItemRenderer', 'richSectionRenderer', 'channelFeaturedContentRenderer']
+            self.resolve_renderer: ['content', 'richItemRenderer', 'richSectionRenderer', 'channelFeaturedContentRenderer', 'horizontalListRenderer']
         })
 
     def resolve_renderer(self, renderer, ctx=None):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4074,8 +4074,6 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
         ctx = ctx.copy()
         continuation_list = [None]
         mapping = {}
-        if not mapping:
-            mapping = self._get_basic_renderer_mapping()
 
         # required for continuation
         if all(ctx.get(key) for key in ('item_id', 'endpoint', 'client')):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3991,7 +3991,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
                 'expandedShelfContentsRenderer', 'sectionListRenderer', 'richGridRenderer'],
             self._hashtag_tile_entry: ['hashtagTileRenderer'],
             self._music_reponsive_list_entry: ['musicResponsiveListItemRenderer'],
-            self.resolve_renderer: ['content', 'richItemRenderer', 'richSectionRenderer']
+            self.resolve_renderer: ['content', 'richItemRenderer', 'richSectionRenderer', 'channelFeaturedContentRenderer']
 
         }
         mapping = {}

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3917,19 +3917,6 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
         # Shelf may not contain shelf URL, fallback to extraction from content
         yield from self.resolve_renderer(shelf_renderer, ctx=ctx)
 
-    # TODO should be able to merge this into new extraction
-    def _playlist_entries(self, video_list_renderer):
-        for content in video_list_renderer['contents']:
-            if not isinstance(content, dict):
-                continue
-            renderer = content.get('playlistVideoRenderer') or content.get('playlistPanelVideoRenderer')
-            if not isinstance(renderer, dict):
-                continue
-            video_id = renderer.get('videoId')
-            if not video_id:
-                continue
-            yield self._extract_video(renderer)
-
     def _video_entry(self, video_renderer, ctx=None):
         video_id = video_renderer.get('videoId')
         if video_id:
@@ -4260,7 +4247,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
     def _extract_mix_playlist(self, playlist, playlist_id, data, ytcfg):
         first_id = last_id = response = None
         for page_num in itertools.count(1):
-            videos = list(self._playlist_entries(playlist))
+            videos = list(self.resolve_renderer(playlist))
             if not videos:
                 return
             start = next((i for i, v in enumerate(videos) if v['id'] == last_id), -1) + 1

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -886,7 +886,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def is_music_url(url):
         return re.match(r'https?://music\.youtube\.com/', url) is not None
 
-    def _extract_video(self, renderer, **kwargs):
+    def _extract_video(self, renderer):
         video_id = renderer.get('videoId')
         title = self._get_text(renderer, 'title')
         description = self._get_text(renderer, 'descriptionSnippet')
@@ -3962,8 +3962,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
 
     def _get_basic_renderer_mapping(self):
         """
-        All resolvers must have signature
-        renderer, ctx=None
+        All resolvers must be able to take (renderer, ctx)
         """
         return self.reverse_dict({
             self._video_entry: r're:[A-Za-z]*[Vv]ideoRenderer$',

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3913,6 +3913,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
         if shelf_url:
             title = self._get_text(shelf_renderer, 'title')
             yield self.url_result(shelf_url, video_title=title)
+            return
         # Shelf may not contain shelf URL, fallback to extraction from content
         yield from self.resolve_renderer(shelf_renderer, ctx=ctx)
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -5204,6 +5204,19 @@ class YoutubeTabIE(YoutubeTabBaseInfoExtractor):
             'uploader_url': 'https://www.youtube.com/channel/UCKcqXmCcyqnhgpA5P0oHH_Q',
         },
         'playlist_mincount': 2
+    }, {
+        'note': 'channel with nested continuations within shelf renderers',
+        'url': 'https://www.youtube.com/channel/UC_vVy4OI86F0amXqFN_zTMg',
+        'info_dict': {
+            'id': 'UC_vVy4OI86F0amXqFN_zTMg',
+            'title': 'UC_vVy4OI86F0amXqFN_zTMg - Home',
+            'tags': [],
+        },
+        'playlist_mincount': 500,
+        # yt seems to choke on its own continuations when given the /featured tab directly
+        'expected_warnings': [
+            'the playlist redirect gave error',
+        ],
     }]
 
     @classmethod

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3991,7 +3991,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
                 'expandedShelfContentsRenderer', 'sectionListRenderer', 'richGridRenderer'],
             self._hashtag_tile_entry: ['hashtagTileRenderer'],
             self._music_reponsive_list_entry: ['musicResponsiveListItemRenderer'],
-            self.resolve_renderer: ['content', 'richItemRenderer']
+            self.resolve_renderer: ['content', 'richItemRenderer', 'richSectionRenderer']
 
         }
         mapping = {}

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4099,6 +4099,8 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
             }))
         ctx['mapping'] = {**mapping, **(ctx.get('mapping') or {})}
 
+        # TODO: allow the check_get_keys check to be similar to that of resolve_renderer key comparison.
+        # Then we should be safe with doing check_get_keys = mapping.keys()
         check_get_keys = ('continuationContents', 'onResponseReceivedActions', 'onResponseReceivedEndpoints', 'onResponseReceivedCommands', 'actions')
 
         yield from self._resolve_entries(entries, ctx=ctx)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [X] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This implements a general recursive resolver that replaces the existing set of random and messy functions.

This allows us to easily add and maintain support for new layouts/renderers/pages.

**TODO: better docs, will add more to here later**

---- 

The main entry function is `resolve_renderer(renderer, ctx)`

If ctx with item_id, endpoint and client is provided then it will follow continuations. Otherwise it'll ignore them.

--- 

continuation_context = the renderer with initial list of items/contents and all the continuation pages that "attach" to that list. 

**Continuations**
Refactored to contain continuation endpoint. If there is no continuation endpoint extracted, the previous endpoint used in the continuation context is to be assumed.

**Mapping**
Contains mappings for json keys to respective resolving function.
Can be either an exact string match or regex match (prefixed with `re:`).

Every resolver function must take (renderer, ctx).

**Context (ctx)**

- item_id: required for continuation extraction
- endpoint: endpoint the renderer was extracted from. required for continuation extraction
- client: client the renderer is from. required for continuation extraction.
- mapping: mapping for resolver. if not provided will use default mapping.
- contents_keys: if a renderer contains one of these keys, it may be the start of a continuation context. e.g. `contents`
- ytcfg, visitor_data, account_syncid

Note the mapping may be copied & updated throughout resolving process e.g. to add continuation mappings.

--- 
TODO:
- [ ] docs
- [ ] any better way to store the context?
- [ ] implement same key check as resolve_renderer for check_get_keys
- [ ] radioRenderer fix
- [ ] try merge in comment extraction (might be for another PR?)
- [ ] Useful debug messages: adding continuation to continuation list that already has a continuation, 
- [ ] Add some easy way for excluding renderers