### PR TITLE
[suggestion] show total frags when downloading YouTube live video with --live-from-start

### DIFF
--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -73,7 +73,7 @@ class DashSegmentsFD(FragmentFD):
 
             yield {
                 'frag_index': frag_index,
-                'fragment_count_tmp': fragment.get('fragment_count_tmp'),
+                'fragment_count': fragment.get('fragment_count'),
                 'index': i,
                 'url': fragment_url,
             }

--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -73,6 +73,7 @@ class DashSegmentsFD(FragmentFD):
 
             yield {
                 'frag_index': frag_index,
+                'fragment_count_tmp': fragment.get('fragment_count_tmp'),
                 'index': i,
                 'url': fragment_url,
             }

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -255,6 +255,9 @@ class FragmentFD(FileDownloader):
             if s['status'] not in ('downloading', 'finished'):
                 return
 
+            if not total_frags and ctx.get('fragment_count_tmp'):
+                state['fragment_count'] = ctx['fragment_count_tmp']
+
             if ctx_id is not None and s.get('ctx_id') != ctx_id:
                 return
 
@@ -463,6 +466,7 @@ class FragmentFD(FileDownloader):
             fatal, count = is_fatal(fragment.get('index') or (frag_index - 1)), 0
             while count <= fragment_retries:
                 try:
+                    ctx['fragment_count_tmp'] = fragment.get('fragment_count_tmp')
                     if self._download_fragment(ctx, fragment['url'], info_dict, headers):
                         break
                     return

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -255,8 +255,8 @@ class FragmentFD(FileDownloader):
             if s['status'] not in ('downloading', 'finished'):
                 return
 
-            if not total_frags and ctx.get('fragment_count_tmp'):
-                state['fragment_count'] = ctx['fragment_count_tmp']
+            if not total_frags and ctx.get('fragment_count'):
+                state['fragment_count'] = ctx['fragment_count']
 
             if ctx_id is not None and s.get('ctx_id') != ctx_id:
                 return
@@ -466,7 +466,7 @@ class FragmentFD(FileDownloader):
             fatal, count = is_fatal(fragment.get('index') or (frag_index - 1)), 0
             while count <= fragment_retries:
                 try:
-                    ctx['fragment_count_tmp'] = fragment.get('fragment_count_tmp')
+                    ctx['fragment_count'] = fragment.get('fragment_count')
                     if self._download_fragment(ctx, fragment['url'], info_dict, headers):
                         break
                     return

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2350,6 +2350,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     last_segment_url = urljoin(fragment_base_url, 'sq/%d' % idx)
                     yield {
                         'url': last_segment_url,
+                        'fragment_count_tmp': last_seq,
                     }
                 if known_idx == last_seq:
                     no_fragment_score += 5

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2350,7 +2350,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     last_segment_url = urljoin(fragment_base_url, 'sq/%d' % idx)
                     yield {
                         'url': last_segment_url,
-                        'fragment_count_tmp': last_seq,
+                        'fragment_count': last_seq,
                     }
                 if known_idx == last_seq:
                     no_fragment_score += 5


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

See this PR as a demo/suggestion as the implementation is quirky. E.g. it does not work with concurrent fragment download.

When downloading a YouTube live video with `--live-from-start` and `--downloader native` I would like to see how many fragments are available, so I get a feeling, when the download is catching up with the current time. Total fragments will be updated as new fragments are available.

I don't think it is necessary to compute percentage or ETA since live videos have no determined end.
```
[download] 106.00MiB at 63.29KiB/s (04:56) (frag 787/788)
[download] 61.52MiB at 15.99KiB/s (04:53) (frag 787/788)
```