### PR TITLE
Disable thumbnail conversion for mkv

### DIFF
--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -79,14 +79,15 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         original_thumbnail = thumbnail_filename = info['thumbnails'][idx]['filepath']
 
-        # Convert unsupported thumbnail formats to PNG (see #25687, #25717)
-        # Original behavior was to convert to JPG, but since JPG is a lossy
-        # format, there will be some additional data loss.
-        # PNG, on the other hand, is lossless.
         thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:]
-        if thumbnail_ext not in ('jpg', 'jpeg', 'png'):
-            thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'png')
-            thumbnail_ext = 'png'
+        if info['ext'] not in ['mkv', 'mka']:
+            # Convert unsupported thumbnail formats to PNG (see #25687, #25717)
+            # Original behavior was to convert to JPG, but since JPG is a lossy
+            # format, there will be some additional data loss.
+            # PNG, on the other hand, is lossless.
+            if thumbnail_ext not in ('jpg', 'jpeg', 'png'):
+                thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'png')
+                thumbnail_ext = 'png'
 
         mtime = os.stat(encodeFilename(filename)).st_mtime
 
@@ -102,7 +103,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         elif info['ext'] in ['mkv', 'mka']:
             options = list(self.stream_copy_opts())
 
-            mimetype = 'image/%s' % ('png' if thumbnail_ext == 'png' else 'jpeg')
+            mimetype = 'image/%s' % ('jpeg' if thumbnail_ext == 'jpg' else thumbnail_ext)
             old_stream, new_stream = self.get_stream_number(
                 filename, ('tags', 'mimetype'), mimetype)
             if old_stream is not None:

--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -80,14 +80,11 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         original_thumbnail = thumbnail_filename = info['thumbnails'][idx]['filepath']
 
         thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:]
-        if info['ext'] not in ['mkv', 'mka']:
-            # Convert unsupported thumbnail formats to PNG (see #25687, #25717)
-            # Original behavior was to convert to JPG, but since JPG is a lossy
-            # format, there will be some additional data loss.
-            # PNG, on the other hand, is lossless.
-            if thumbnail_ext not in ('jpg', 'jpeg', 'png'):
-                thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'png')
-                thumbnail_ext = 'png'
+        # Convert unsupported thumbnail formats (see #25687, #25717)
+        # PNG is preferred since JPEG is lossy
+        if info['ext'] not in ('mkv', 'mka') and thumbnail_ext not in ('jpg', 'jpeg', 'png'):
+            thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'png')
+            thumbnail_ext = 'png'
 
         mtime = os.stat(encodeFilename(filename)).st_mtime
 
@@ -103,7 +100,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         elif info['ext'] in ['mkv', 'mka']:
             options = list(self.stream_copy_opts())
 
-            mimetype = 'image/%s' % ('jpeg' if thumbnail_ext == 'jpg' else thumbnail_ext)
+            mimetype = 'image/%s' % ('jpeg' if thumbnail_ext in ('jpg', 'jpeg') else thumbnail_ext)
             old_stream, new_stream = self.get_stream_number(
                 filename, ('tags', 'mimetype'), mimetype)
             if old_stream is not None:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Skips converting thumbnail when embedding thumbnails for mkv only. closes #3209