### PR TITLE
[lrt] fix tests

### DIFF
--- a/yt_dlp/extractor/lrt.py
+++ b/yt_dlp/extractor/lrt.py
@@ -11,7 +11,7 @@ class LRTIE(InfoExtractor):
     _TESTS = [{
         # m3u8 download
         'url': 'https://www.lrt.lt/mediateka/irasas/2000127261/greita-ir-gardu-sicilijos-ikvepta-klasikiniu-makaronu-su-baklazanais-vakariene',
-        'md5': '85cb2bb530f31d91a9c65b479516ade4',
+        'md5': 'cb4b239351697e985ca3177dcc1ced8d',
         'info_dict': {
             'id': '2000127261',
             'ext': 'mp4',
@@ -20,6 +20,8 @@ class LRTIE(InfoExtractor):
             'duration': 3035,
             'timestamp': 1604079000,
             'upload_date': '20201030',
+            'tags': ['LRT TELEVIZIJA', 'Beatos virtuvė', 'Beata Nicholson', 'Makaronai', 'Baklažanai', 'Vakarienė', 'Receptas'],
+            'thumbnail': 'https://www.lrt.lt/img/2020/10/30/764041-126478-1287x836.jpg'
         },
     }, {
         # direct mp3 download


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Without this small change, the tests fail with:

```
$ python3 test/test_download.py TestDownload.test_LRT

F
======================================================================
FAIL: test_LRT (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_download.py", line 218, in test_template
    expect_info_dict(self, tc_res_dict, tc.get('info_dict', {}))
  File "/home/giedrius/dev/yt-dlp/test/helper.py", line 258, in expect_info_dict
    self.assertFalse(

AssertionError: {'tags', 'thumbnail'} is not false : Missing keys in test definition: tags, thumbnail
```

Plus, there is a md5 hash related error after this one.