### PR TITLE
[downloader/ffmpeg] Specify headers for each http input stream

### DIFF
--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -382,13 +382,15 @@ class FFmpegFD(ExternalFD):
         # if end_time:
         #     args += ['-t', compat_str(end_time - start_time)]
 
-        if info_dict.get('http_headers') is not None and re.match(r'^https?://', urls[0]):
-            # Trailing \r\n after each HTTP header is important to prevent warning from ffmpeg/avconv:
-            # [http @ 00000000003d2fa0] No trailing CRLF found in HTTP header.
-            headers = handle_youtubedl_headers(info_dict['http_headers'])
-            args += [
+        http_headers = None
+        if info_dict.get('http_headers'):
+            youtubedl_headers = handle_youtubedl_headers(info_dict['http_headers'])
+            http_headers = [
+                # Trailing \r\n after each HTTP header is important to prevent warning from ffmpeg/avconv:
+                # [http @ 00000000003d2fa0] No trailing CRLF found in HTTP header.
                 '-headers',
-                ''.join(f'{key}: {val}\r\n' for key, val in headers.items())]
+                ''.join(f'{key}: {val}\r\n' for key, val in youtubedl_headers.items())
+            ]
 
         env = None
         proxy = self.params.get('proxy')
@@ -441,6 +443,11 @@ class FFmpegFD(ExternalFD):
                 args += ['-rtmp_conn', conn]
 
         for i, url in enumerate(urls):
+            # We need to specify headers for each http input stream
+            # otherwise, it will only be applied to the first.
+            # https://github.com/yt-dlp/yt-dlp/issues/2696
+            if http_headers is not None and re.match(r'^https?://', url):
+                args += http_headers
             args += self._configuration_args((f'_i{i + 1}', '_i')) + ['-i', url]
 
         args += ['-c', 'copy']


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As we discussed in #2696 , we need to specify our headers on each http input stream, otherwise they will only be applied to the first stream.

This fix allows us to stream to stdout from FranceTv

```bash
yt-dlp -f 'hls-2218+hls-audio-aacl-96-Audio_Français' -N 10 -o - https://www.france.tv/slash/skam-france/saison-1/1980815-seule-au-monde.html
```

Verbose log

```bash
[debug] Command-line config: ['-vU', '-f', 'hls-2218+hls-audio-aacl-96-Audio_Français', '-N', '10', '-o', '-', 'https://www.france.tv/slash/skam-france/saison-1/1980815-seule-au-monde.html']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, err UTF-8, pref UTF-8
[debug] yt-dlp version 2022.04.08 [7884ade65]
[debug] Lazy loading extractors is disabled
[debug] Python version 3.7.3 (CPython 64bit) - Linux-4.19.0-20-amd64-x86_64-with-debian-10.11
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.1.8-0, ffprobe 4.1.8-0
[debug] Optional libraries: Cryptodome, brotli, certifi, mutagen, secretstorage, sqlite3, websockets
[debug] Proxy map: {}
Latest version: 2022.04.08, Current version: 2022.04.08
yt-dlp is up to date (2022.04.08)
[debug] [FranceTVSite] Extracting URL: https://www.france.tv/slash/skam-france/saison-1/1980815-seule-au-monde.html
[FranceTVSite] 1980815-seule-au-monde: Downloading webpage
[debug] [FranceTV] Extracting URL: francetv:833b322d-321e-4201-a43d-c57f6e763eb6
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading desktop video JSON
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading mobile video JSON
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading signed dash manifest URL
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading MPD manifest
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading signed hls manifest URL
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading 1 format(s): hls-2218+hls-audio-aacl-96-Audio_Français
[debug] Invoking downloader on "https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.m3u8", "https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000.m3u8"
[download] Destination: -
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -i https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.m3u8 -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -i https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000.m3u8 -c copy -map 0:0 -map 1:0 -f mpegts -
ffmpeg version 4.1.8-0+deb10u1 Copyright (c) 2000-2021 the FFmpeg developers
  built with gcc 8 (Debian 8.3.0-6)
  configuration: --prefix=/usr --extra-version=0+deb10u1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
  libavutil      56. 22.100 / 56. 22.100
  libavcodec     58. 35.100 / 58. 35.100
  libavformat    58. 20.100 / 58. 20.100
  libavdevice    58.  5.100 / 58.  5.100
  libavfilter     7. 40.101 /  7. 40.101
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  3.100 /  5.  3.100
  libswresample   3.  3.100 /  3.  3.100
  libpostproc    55.  3.100 / 55.  3.100
[tcp @ 0x560a1b4dbe00] Starting connection attempt to 104.117.77.169 port 443
[tcp @ 0x560a1b4dbe00] Successfully connected to 104.117.77.169 port 443
[hls,applehttp @ 0x560a1b4d8b00] HLS request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-1.ts', offset 0, playlist 0
[hls,applehttp @ 0x560a1b4d8b00] Opening 'https://cloudingest.ftven.fr/keys/bfd3.key' for reading
[tcp @ 0x560a1b800200] Starting connection attempt to 104.117.77.169 port 443
[tcp @ 0x560a1b800200] Successfully connected to 104.117.77.169 port 443
[AVIOContext @ 0x560a1b81ffc0] Statistics: 16 bytes read, 0 seeks
[hls,applehttp @ 0x560a1b4d8b00] Opening 'crypto+https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-1.ts' for reading
[tcp @ 0x560a1b7e6280] Starting connection attempt to 104.117.77.169 port 443
[tcp @ 0x560a1b7e6280] Successfully connected to 104.117.77.169 port 443
[h264 @ 0x560a1b8925c0] Reinit context to 1280x720, pix_fmt: yuv420p
[hls,applehttp @ 0x560a1b4d8b00] max_analyze_duration 5000000 reached at 5000000 microseconds st:0
Input #0, hls,applehttp, from 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.m3u8':
  Duration: 00:21:40.52, start: 10.000000, bitrate: 0 kb/s
  Program 0 
    Metadata:
      variant_bitrate : 0
    Stream #0:0: Video: h264 (High), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(tv, bt709, left), 1280x720 [SAR 1:1 DAR 16:9], 25 fps, 25 tbr, 90k tbn, 50 tbc
    Metadata:
      variant_bitrate : 0
[tcp @ 0x560a1bb79640] Starting connection attempt to 104.117.77.169 port 443
[tcp @ 0x560a1bb79640] Successfully connected to 104.117.77.169 port 443
[hls,applehttp @ 0x560a1b88f040] HLS request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000-1.aac', offset 0, playlist 0
[hls,applehttp @ 0x560a1b88f040] Opening 'https://cloudingest.ftven.fr/keys/bfd3.key' for reading
[tcp @ 0x560a1c067300] Starting connection attempt to 104.117.77.169 port 443
[tcp @ 0x560a1c067300] Successfully connected to 104.117.77.169 port 443
[AVIOContext @ 0x560a1c06b340] Statistics: 16 bytes read, 0 seeks
[hls,applehttp @ 0x560a1b88f040] Opening 'crypto+https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000-1.aac' for reading
[tcp @ 0x560a1bbf1c80] Starting connection attempt to 104.117.77.169 port 443
[tcp @ 0x560a1bbf1c80] Successfully connected to 104.117.77.169 port 443
Input #1, hls,applehttp, from 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000.m3u8':
  Duration: 00:21:40.59, start: 10.000000, bitrate: 0 kb/s
  Program 0 
    Metadata:
      variant_bitrate : 0
    Stream #1:0: Audio: aac (LC), 48000 Hz, stereo, fltp, 103 kb/s
    Metadata:
      variant_bitrate : 0
      id3v2_priv.com.apple.streaming.transportStreamTimestamp: \x00\x00\x00\x00\x00\x0d\xbb\xa0
[mpegts @ 0x560a1c093080] muxrate VBR, pcr every 9000 pkts, sdt every 200, pat/pmt every 40 pkts
Output #0, mpegts, to 'pipe:':
  Metadata:
    encoder         : Lavf58.20.100
    Stream #0:0: Video: h264 (High), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(tv, bt709, left), 1280x720 (0x0) [SAR 1:1 DAR 16:9], q=2-31, 25 fps, 25 tbr, 90k tbn, 90k tbc
    Metadata:
      variant_bitrate : 0
    Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, 103 kb/s
    Metadata:
      variant_bitrate : 0
      id3v2_priv.com.apple.streaming.transportStreamTimestamp: \x00\x00\x00\x00\x00\x0d\xbb\xa0
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #1:0 -> #0:1 (copy)
Press [q] to stop, [?] for help
[hls,applehttp @ 0x560a1b4d8b00] Thread message queue blocking; consider raising the thread_queue_size option (current value: 8)
[AVIOContext @ 0x560a1c073f00] Statistics: 98822 bytes read, 0 seeks
[hls,applehttp @ 0x560a1b88f040] HLS request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000-2.aac', offset 0, playlist 0
[hls,applehttp @ 0x560a1b88f040] Opening 'crypto+https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTA5NzQ0MjJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9ZjQ1ODhkNWU4MzhjZDA4ZTM1ZjRjNDMzNjY4MzA5OGI0YjY1OTY3MDU0ZGNhYTYwZGY2MTFhN2IxMmNkNmY1Mw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000-2.aac' for reading
[AVIOContext @ 0x560a1b907800] Statistics: 1883384 bytes read, 0 seeks
```


