### PR TITLE
Fix setting window vt mode

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -541,7 +541,7 @@ class YoutubeDL:
             self._vt_mode = windows_enable_vt_mode()
         except Exception:
             self._vt_mode = None
-            self.report_warning('Failed to set Windows console to VT mode')
+            self.write_debug('Failed to set Windows console to VT mode')
 
         self._out_files = {
             'error': sys.stderr,

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -541,7 +541,6 @@ class YoutubeDL:
             self._vt_mode = windows_enable_vt_mode()
         except Exception:
             self._vt_mode = None
-            self.report_warning('Failed to set Windows console to VT mode')
 
         self._out_files = {
             'error': sys.stderr,
@@ -554,6 +553,9 @@ class YoutubeDL:
             type_: not self.params.get('no_color') and supports_terminal_sequences(self._out_files[type_])
             for type_ in ('screen', 'error')
         }
+
+        if self._vt_mode is False:
+            self.write_debug('Failed to set Windows console to VT mode')
 
         if sys.version_info < (3, 6):
             self.report_warning(

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -541,7 +541,7 @@ class YoutubeDL:
             self._vt_mode = windows_enable_vt_mode()
         except Exception:
             self._vt_mode = None
-            self.write_debug('Failed to set Windows console to VT mode')
+            self.report_warning('Failed to set Windows console to VT mode')
 
         self._out_files = {
             'error': sys.stderr,

--- a/yt_dlp/compat/__init__.py
+++ b/yt_dlp/compat/__init__.py
@@ -35,8 +35,6 @@ compat_os_name = os._name if os.name == 'java' else os.name
 
 if compat_os_name == 'nt':
     import ctypes
-    import msvcrt
-    from ctypes import wintypes
 
     def compat_shlex_quote(s):
         return s if re.match(r'^[-_\w./]+$', s) else '"%s"' % s.replace('"', '\\"')
@@ -88,6 +86,8 @@ WINDOWS_VT_MODE = False if compat_os_name == 'nt' else None
 def set_windows_conout_mode(new_mode, mask=0xffffffff):
     # based on https://github.com/python/cpython/issues/74261#issuecomment-1093745755
     kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+    import msvcrt
+    from ctypes import wintypes
 
     def _check_bool(result, func, args):
         if not result:

--- a/yt_dlp/compat/__init__.py
+++ b/yt_dlp/compat/__init__.py
@@ -126,6 +126,6 @@ def windows_enable_vt_mode():
         mode = set_windows_conout_mode(mode, mask)
         WINDOWS_VT_MODE = True
         return mode
-    except WindowsError as e:
+    except OSError as e:
         if e.winerror != ERROR_INVALID_PARAMETER:  # any other error than not supported os
             raise e

--- a/yt_dlp/compat/__init__.py
+++ b/yt_dlp/compat/__init__.py
@@ -120,8 +120,9 @@ def windows_enable_vt_mode():
     global WINDOWS_VT_MODE
     ERROR_INVALID_PARAMETER = 0x0057
     ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+    DISABLE_NEWLINE_AUTO_RETURN = 0x0008
 
-    mode = mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    mode = mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN
     try:
         mode = set_windows_conout_mode(mode, mask)
         WINDOWS_VT_MODE = True

--- a/yt_dlp/compat/__init__.py
+++ b/yt_dlp/compat/__init__.py
@@ -134,3 +134,4 @@ def windows_enable_vt_mode():
     except OSError as e:
         if e.winerror != ERROR_INVALID_PARAMETER:  # any other error than not supported os
             raise e
+        return False


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I sets windows vt mode based on https://github.com/python/cpython/issues/74261#issuecomment-1093745755.

Closes #1863

### TODO:
- [ ] original problem (lines sticking together)
- [ ] error handling: 
   -  `stdout` is not a console,
   -  incompatible function signature, (due to installed lib), and
   -  errors sent by   `GetConsoleMode`, `SetConsoleMode` and `GetStdHandle`.
- [ ] documentation, e.g. `set_windows_conout_mode` is called on other os, `ImportError` will be raised.

### Tests run

Following test script
```py
import os

from yt_dlp import YoutubeDL
from yt_dlp.compat import WINDOWS_VT_MODE

ydl = YoutubeDL()
print('WINDOWS_VT_MODE:', WINDOWS_VT_MODE, '_vt_mode:', ydl._vt_mode)

size = os.get_terminal_size()
for width in range(size.columns - 1, size.columns + 2):
    print('\n', 'width', width)
    ydl.to_screen('\n'.join(
        '{line:=^{fill}}'.format(line=' %s ' % width, fill=width)
        for i in range(3)
    ))
```
was run on

- [x] not windows
   <img src="https://user-images.githubusercontent.com/4058656/165291913-c471a09f-a0d0-4092-b73b-9dd2792b9c4d.png" alt="linux-vt-mode-test" width="50%">

- [x] window not 10
   <img src="https://user-images.githubusercontent.com/4058656/165291920-0c886a47-bcbb-4994-8a30-c9f542b6dac4.png" alt="win7-vt-mode-test" width="50%"> and

- [ ] windows 10 (resizing console window needs to be also checked in this case)
   <img src="https://cdn.discordapp.com/attachments/808027148308840478/969222183190683758/unknown.png" alt="win10-vt-mode-test" width="50%">
.

**Please feel free to review and provide suggestions even when this is a draft :grinning:**