### PR TITLE
Fix `NiconicoIE` login

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -199,24 +199,18 @@ class NiconicoIE(InfoExtractor):
                 'Referer': 'https://account.nicovideo.jp/login',
                 'Content-Type': 'application/x-www-form-urlencoded',
             })
-        need_mfa = 'oneTimePw' in page
-        if need_mfa:
+        if 'oneTimePw' in page:
             post_url = self._search_regex(
-                r'<form[^>]+action=(["\'])(?P<url>.+?)\1', page,
-                'post url', group='url')
-            mfa_form_strs = {
-                'otp': self._get_tfa_info('6 digits code')
-            }
+                r'<form[^>]+action=(["\'])(?P<url>.+?)\1', page, 'post url', group='url')
             page = self._download_webpage(
                 urljoin('https://account.nicovideo.jp', post_url), None,
                 note='Performing MFA', errnote='Unable to complete MFA',
-                data=urlencode_postdata(mfa_form_strs),
-                headers={
+                data=urlencode_postdata({
+                    'otp': self._get_tfa_info('6 digits code')
+                }), headers={
                     'Content-Type': 'application/x-www-form-urlencoded',
                 })
-            need_mfa = 'oneTimePw' in page
-            mfa_error = need_mfa or 'formError' in page
-            if mfa_error:
+            if 'oneTimePw' in page or 'formError' in page:
                 err_msg = self._html_search_regex(
                     r'formError["\']+>(.*?)</div>', page, 'form_error',
                     default='There\'s an error but the message can\'t be parsed.',

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -7,8 +7,6 @@ import time
 
 from .common import InfoExtractor, SearchInfoExtractor
 from ..compat import (
-    compat_parse_qs,
-    compat_urllib_parse_urlparse,
     compat_HTTPError,
 )
 from ..utils import (
@@ -32,6 +30,7 @@ from ..utils import (
     update_url_query,
     url_or_none,
     urlencode_postdata,
+    urljoin,
 )
 
 
@@ -192,7 +191,7 @@ class NiconicoIE(InfoExtractor):
         self._request_webpage(
             'https://account.nicovideo.jp/login', None,
             note='Acquiring Login session')
-        urlh = self._request_webpage(
+        page = self._download_webpage(
             'https://account.nicovideo.jp/login/redirector?show_button_twitter=1&site=niconico&show_button_facebook=1', None,
             note='Logging in', errnote='Unable to log in',
             data=urlencode_postdata(login_form_strs),
@@ -200,14 +199,33 @@ class NiconicoIE(InfoExtractor):
                 'Referer': 'https://account.nicovideo.jp/login',
                 'Content-Type': 'application/x-www-form-urlencoded',
             })
-        if urlh is False:
-            login_ok = False
-        else:
-            parts = compat_urllib_parse_urlparse(urlh.geturl())
-            if compat_parse_qs(parts.query).get('message', [None])[0] == 'cant_login':
-                login_ok = False
+        need_mfa = 'oneTimePw' in page
+        if need_mfa:
+            post_url = self._search_regex(
+                r'<form[^>]+action=(["\'])(?P<url>.+?)\1', page,
+                'post url', group='url')
+            mfa_form_strs = {
+                'otp': self._get_tfa_info('6 digits code')
+            }
+            page = self._download_webpage(
+                urljoin('https://account.nicovideo.jp', post_url), None,
+                note='Performing MFA', errnote='Unable to complete MFA',
+                data=urlencode_postdata(mfa_form_strs),
+                headers={
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                })
+            need_mfa = 'oneTimePw' in page
+            mfa_error = need_mfa or 'formError' in page
+            if mfa_error:
+                err_msg = self._html_search_regex(
+                    r'formError["\']+>(.*?)</div>', page, 'form_error',
+                    default='There\'s an error but the message can\'t be parsed.',
+                    flags=re.DOTALL)
+                self.report_warning(f'Unable to log in: MFA challenge failed, "{err_msg}"')
+                return False
+        login_ok = 'class="notice error"' not in page
         if not login_ok:
-            self.report_warning('unable to log in: bad username or password')
+            self.report_warning('Unable to log in: bad username or password')
         return login_ok
 
     def _get_heartbeat_info(self, info_dict):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

niconico now requires MFA when logging in using username and password, breaking the current login method.  This patch updates the login flow and prompts user to input the code.