### PR TITLE
[YoutubeDL] extend `all` format selector

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2149,7 +2149,7 @@ class YoutubeDL:
                 mobj = re.match(
                     r'(?P<m>merge)?all(?P<t>video|audio)?(?P<l>lang)?', format_spec)
                 if mobj:
-                    mg, tp, la = mobj.groups()
+                    mg, tp, la = mobj.group('m', 't', 'l')
                     def selector_function(ctx):
                         formats = ctx['formats'][::-1]
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2150,6 +2150,7 @@ class YoutubeDL:
                     r'(?P<m>merge)?all(?P<t>video|audio)?(?P<l>lang)?', format_spec)
                 if mobj:
                     mg, tp, la = mobj.group('m', 't', 'l')
+
                     def selector_function(ctx):
                         formats = ctx['formats'][::-1]
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2146,21 +2146,64 @@ class YoutubeDL:
 
             elif selector.type == SINGLE:  # atom
                 format_spec = selector.selector or 'best'
+                mobj = re.match(
+                    r'(?P<m>merge)?all(?P<t>video|audio)?(?P<l>lang)?', format_spec)
+                if mobj:
+                    mg, tp, la = mobj.groups()
+                    def selector_function(ctx):
+                        formats = ctx['formats'][::-1]
 
-                # TODO: Add allvideo, allaudio etc by generalizing the code with best/worst selector
-                if format_spec == 'all':
-                    def selector_function(ctx):
-                        yield from _check_formats(ctx['formats'][::-1])
-                elif format_spec == 'mergeall':
-                    def selector_function(ctx):
-                        formats = list(_check_formats(
-                            f for f in ctx['formats'] if f.get('vcodec') != 'none' or f.get('acodec') != 'none'))
-                        if not formats:
-                            return
-                        merged_format = formats[-1]
-                        for f in formats[-2::-1]:
-                            merged_format = _merge((merged_format, f))
-                        yield merged_format
+                        if tp == 'video':
+                            formats = (f for f in formats if f.get('vcodec') != 'none')
+                        elif tp == 'audio':
+                            formats = (f for f in formats if f.get('acodec') != 'none')
+                        elif mg:
+                            # exclude storyboards
+                            formats = (
+                                f for f in formats if f.get('vcodec') != 'none' or f.get('acodec') != 'none')
+
+                        if la:
+                            all_fmts = formats if isinstance(formats, list) else list(formats)
+                            langs = set(filter(None, traverse_obj(all_fmts, (..., 'language'), default=[])))
+                            formats = []
+                            if not langs:
+                                self.report_warning('This video has no track with language tag')
+                                formats = all_fmts
+                            elif tp:
+                                # only audio or video
+                                for f in all_fmts:
+                                    if not langs:
+                                        break
+                                    lang = f.get('language')
+                                    if not lang or lang not in langs:
+                                        continue
+                                    langs.remove(lang)
+                                    formats.append(f)
+                            else:
+                                # no video/audio specified
+                                # vcodec, acodec, language
+                                langs = set(itertools.product((True, False), (True, False), langs))
+                                for f in all_fmts:
+                                    if not langs:
+                                        break
+                                    lang = f.get('language')
+                                    tu = (f.get('vcodec') != 'none', f.get('acodec') != 'none', lang)
+                                    if not lang or tu not in langs:
+                                        continue
+                                    langs.remove(tu)
+                                    formats.append(f)
+
+                        formats = _check_formats(formats)
+                        if mg:
+                            formats = iter(formats)
+                            merged_format = next(formats, None)
+                            if merged_format is None:
+                                return
+                            for f in formats:
+                                merged_format = _merge((merged_format, f))
+                            yield merged_format
+                        else:
+                            yield from formats
 
                 else:
                     format_fallback, seperate_fallback, format_reverse, format_idx = False, None, True, 1


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR extends format selector to allow more patterns, like `-f mergeallaudio`.

Closes #1176
Related #389

Here's some examples:

### Download one video stream and all audio languages
```
$ yt-dlp -s -f bv+mergeallaudiolang --audio-multistreams LnlKwzc_TNA
[youtube] LnlKwzc_TNA: Downloading webpage
[youtube] LnlKwzc_TNA: Downloading android player API JSON
[info] LnlKwzc_TNA: Downloading 1 format(s): 248+251-6+251-5+251-4+251-3+251-2+251-1+251-0
```

### Download all audio languages
```
$ yt-dlp -s -f allaudiolang LnlKwzc_TNA
[youtube] LnlKwzc_TNA: Downloading webpage
[youtube] LnlKwzc_TNA: Downloading android player API JSON
[info] LnlKwzc_TNA: Downloading 7 format(s): 251-6, 251-5, 251-4, 251-3, 251-2, 251-1, 251-0
```

### Download all formats
```
$ yt-dlp -s -f allvideo LnlKwzc_TNA
[youtube] LnlKwzc_TNA: Downloading webpage
[youtube] LnlKwzc_TNA: Downloading android player API JSON
[info] LnlKwzc_TNA: Downloading 21 format(s): 248, 137, 399, 247, 22, 136, 398, 244, 135, 397, 243, 18, 134, 396, 242, 133, 395, 278, 160, 394, 17
```

### Appendix: list of all formats
```
$ yt-dlp -s -F LnlKwzc_TNA
[youtube] LnlKwzc_TNA: Downloading webpage
[youtube] LnlKwzc_TNA: Downloading android player API JSON
[info] Available formats for LnlKwzc_TNA:
ID    EXT   RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC      ABR     ASR MORE INFO
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
sb2   mhtml 48x27          │                  mhtml │ images                                      storyboard
sb1   mhtml 80x45          │                  mhtml │ images                                      storyboard
sb0   mhtml 160x90         │                  mhtml │ images                                      storyboard
139-0 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [fr] French, low, m4a_dash
139-1 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [ru] Russian, low, m4a_dash
139-2 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [ar] Arabic, low, m4a_dash
139-3 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [hi] Hindi, low, m4a_dash
139-4 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [pt] Portuguese, low, m4a_dash
139-5 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [es] Spanish, low, m4a_dash
139-6 m4a   audio only     │    3.14MiB   48k https │ audio only          mp4a.40.5   48k 22050Hz [en] English (default), low, m4a_dash
249-0 webm  audio only     │    3.10MiB   48k https │ audio only          opus        48k 48000Hz [ar] Arabic, low, webm_dash
249-1 webm  audio only     │    3.21MiB   49k https │ audio only          opus        49k 48000Hz [ru] Russian, low, webm_dash
249-2 webm  audio only     │    3.26MiB   50k https │ audio only          opus        50k 48000Hz [fr] French, low, webm_dash
249-3 webm  audio only     │    3.27MiB   50k https │ audio only          opus        50k 48000Hz [pt] Portuguese, low, webm_dash
249-4 webm  audio only     │    3.32MiB   51k https │ audio only          opus        51k 48000Hz [es] Spanish, low, webm_dash
249-5 webm  audio only     │    3.40MiB   52k https │ audio only          opus        52k 48000Hz [hi] Hindi, low, webm_dash
250-0 webm  audio only     │    3.82MiB   59k https │ audio only          opus        59k 48000Hz [ar] Arabic, low, webm_dash
250-1 webm  audio only     │    4.17MiB   64k https │ audio only          opus        64k 48000Hz [ru] Russian, low, webm_dash
250-2 webm  audio only     │    4.22MiB   65k https │ audio only          opus        65k 48000Hz [pt] Portuguese, low, webm_dash
250-3 webm  audio only     │    4.22MiB   65k https │ audio only          opus        65k 48000Hz [fr] French, low, webm_dash
250-4 webm  audio only     │    4.30MiB   66k https │ audio only          opus        66k 48000Hz [es] Spanish, low, webm_dash
250-5 webm  audio only     │    4.44MiB   68k https │ audio only          opus        68k 48000Hz [hi] Hindi, low, webm_dash
249-6 webm  audio only     │    3.20MiB   49k https │ audio only          opus        49k 48000Hz [en] English (default), low, webm_dash
250-6 webm  audio only     │    4.16MiB   64k https │ audio only          opus        64k 48000Hz [en] English (default), low, webm_dash
140-0 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [fr] French, medium, m4a_dash
140-1 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [es] Spanish, medium, m4a_dash
140-2 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [ru] Russian, medium, m4a_dash
140-3 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [ar] Arabic, medium, m4a_dash
140-4 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [pt] Portuguese, medium, m4a_dash
140-5 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [hi] Hindi, medium, m4a_dash
140-6 m4a   audio only     │    8.33MiB  129k https │ audio only          mp4a.40.2  129k 44100Hz [en] English (default), medium, m4a_dash
251-0 webm  audio only     │    6.91MiB  107k https │ audio only          opus       107k 48000Hz [ar] Arabic, medium, webm_dash
251-1 webm  audio only     │    8.07MiB  125k https │ audio only          opus       125k 48000Hz [ru] Russian, medium, webm_dash
251-2 webm  audio only     │    8.12MiB  126k https │ audio only          opus       126k 48000Hz [pt] Portuguese, medium, webm_dash
251-3 webm  audio only     │    8.19MiB  127k https │ audio only          opus       127k 48000Hz [fr] French, medium, webm_dash
251-4 webm  audio only     │    8.32MiB  129k https │ audio only          opus       129k 48000Hz [es] Spanish, medium, webm_dash
251-5 webm  audio only     │    8.58MiB  133k https │ audio only          opus       133k 48000Hz [hi] Hindi, medium, webm_dash
251-6 webm  audio only     │    8.05MiB  125k https │ audio only          opus       125k 48000Hz [en] English (default), medium, webm_dash
17    3gp   176x144      7 │    5.06MiB   78k https │ mp4v.20.3       78k mp4a.40.2    0k 22050Hz 144p
394   mp4   256x144     30 │    4.56MiB   70k https │ av01.0.00M.08   70k video only              144p, mp4_dash
160   mp4   256x144     30 │    7.08MiB  109k https │ avc1.4d400c    109k video only              144p, mp4_dash
278   webm  256x144     30 │    6.00MiB   93k https │ vp9             93k video only              144p, webm_dash
395   mp4   426x240     30 │    9.46MiB  146k https │ av01.0.00M.08  146k video only              240p, mp4_dash
133   mp4   426x240     30 │   15.49MiB  240k https │ avc1.4d4015    240k video only              240p, mp4_dash
242   webm  426x240     30 │   13.72MiB  213k https │ vp9            213k video only              240p, webm_dash
396   mp4   640x360     30 │   19.65MiB  305k https │ av01.0.01M.08  305k video only              360p, mp4_dash
134   mp4   640x360     30 │   36.09MiB  560k https │ avc1.4d401e    560k video only              360p, mp4_dash
18    mp4   640x360     30 │   45.16MiB  701k https │ avc1.42001E    701k mp4a.40.2    0k 44100Hz 360p
243   webm  640x360     30 │   25.29MiB  392k https │ vp9            392k video only              360p, webm_dash
397   mp4   854x480     30 │   35.04MiB  544k https │ av01.0.04M.08  544k video only              480p, mp4_dash
135   mp4   854x480     30 │   66.90MiB 1039k https │ avc1.4d401f   1039k video only              480p, mp4_dash
244   webm  854x480     30 │   45.67MiB  709k https │ vp9            709k video only              480p, webm_dash
398   mp4   1280x720    30 │   68.46MiB 1063k https │ av01.0.05M.08 1063k video only              720p, mp4_dash
136   mp4   1280x720    30 │  130.67MiB 2030k https │ avc1.4d401f   2030k video only              720p, mp4_dash
22    mp4   1280x720    30 │ ~176.29MiB 2674k https │ avc1.64001F   2674k mp4a.40.2    0k 44100Hz 720p
247   webm  1280x720    30 │   90.95MiB 1413k https │ vp9           1413k video only              720p, webm_dash
399   mp4   1920x1080   30 │  120.74MiB 1876k https │ av01.0.08M.08 1876k video only              1080p, mp4_dash
137   mp4   1920x1080   30 │  249.55MiB 3877k https │ avc1.640028   3877k video only              1080p, mp4_dash
248   webm  1920x1080   30 │  161.00MiB 2501k https │ vp9           2501k video only              1080p, webm_dash
[info] LnlKwzc_TNA: Downloading 1 format(s): 248+251-6
```