### PR TITLE
[extractor/common] Use validated url for mpd extractor

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2676,7 +2676,10 @@ class InfoExtractor:
         mpd_doc, urlh = res
         if mpd_doc is None:
             return [], {}
-        mpd_base_url = base_url(urlh.geturl())
+
+        # We could have been redirected to a new url when we retrieved our mpd file.
+        mpd_url = urlh.geturl()
+        mpd_base_url = base_url(mpd_url)
 
         return self._parse_mpd_formats_and_subtitles(
             mpd_doc, mpd_id, mpd_base_url, mpd_url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As I explained in #2696 , we were getting 403 Forbidden when we tried using ffmpeg+bash because we were passing the wrong **base path** as input to ffmpeg.

The issue was that we were being redirected when we tried getting our **manifest.mpd**, but we didn't store this new redirected url, instead we used the original.

![image](https://user-images.githubusercontent.com/26639800/165463890-d4433b2e-39d6-46b2-bd17-7bcd3f6b6e32.png)

With this fix we're able to stream from FranceTv using Dash to stdout

**Note:** It's necessary to have a recent version of Ffmpeg ([builds](https://github.com/yt-dlp/FFmpeg-Builds/releases)) otherwise a parsing error might appear

```bash
yt-dlp -vU -o - "https://www.france.tv/slash/skam-france/saison-1/1980815-seule-au-monde.html"
```
Verbose log

```bash
[debug] Command-line config: ['-vU', '-o', '-', 'https://www.france.tv/slash/skam-france/saison-1/1980815-seule-au-monde.html']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, err utf-8, pref UTF-8
[debug] yt-dlp version 2022.04.08 [7884ade65]
[debug] Lazy loading extractors is disabled
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-109-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffprobe -bsfs
[debug] Checking exe version: ffmpeg -bsfs
[debug] exe versions: ffmpeg N-106673-g058a1ff9b4-20220424 (setts), ffprobe N-106673-g058a1ff9b4-20220424, rtmpdump 2.4
[debug] Optional libraries: Cryptodome, brotli, certifi, mutagen, secretstorage, sqlite3, websockets
[debug] Proxy map: {}
Latest version: 2022.04.08, Current version: 2022.04.08
yt-dlp is up to date (2022.04.08)
[debug] [FranceTVSite] Extracting URL: https://www.france.tv/slash/skam-france/saison-1/1980815-seule-au-monde.html
[FranceTVSite] 1980815-seule-au-monde: Downloading webpage
[debug] [FranceTV] Extracting URL: francetv:833b322d-321e-4201-a43d-c57f6e763eb6
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading desktop video JSON
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading mobile video JSON
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading signed dash manifest URL
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading MPD manifest
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading signed hls manifest URL
[FranceTV] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: best/bestvideo+bestaudio
[info] 833b322d-321e-4201-a43d-c57f6e763eb6: Downloading 1 format(s): hls-2218+dash-audio_fre=96000
[debug] Invoking downloader on "https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.m3u8", "https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/manifest.mpd"
[download] Destination: -
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -i https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.m3u8 -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -i https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/manifest.mpd -c copy -map 0:0 -map 1:0 -f mpegts -
ffmpeg version N-106673-g058a1ff9b4-20220424 Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 11.2.0 (crosstool-NG 1.24.0.533_681aaef)
  configuration: --prefix=/ffbuild/prefix --pkg-config-flags=--static --pkg-config=pkg-config --cross-prefix=x86_64-ffbuild-linux-gnu- --arch=x86_64 --target-os=linux --enable-gpl --enable-version3 --disable-debug --enable-iconv --enable-libxml2 --enable-zlib --enable-libfreetype --enable-libfribidi --enable-gmp --enable-lzma --enable-fontconfig --enable-libvorbis --enable-opencl --enable-libpulse --enable-libvmaf --enable-libxcb --enable-xlib --enable-amf --enable-libaom --enable-avisynth --enable-libdav1d --enable-libdavs2 --disable-libfdk-aac --enable-ffnvcodec --enable-cuda-llvm --enable-frei0r --enable-libgme --enable-libass --enable-libbluray --enable-libmp3lame --enable-libopus --enable-mbedtls --enable-librist --enable-libtheora --enable-libvpx --enable-libwebp --enable-lv2 --enable-libmfx --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenh264 --enable-libopenjpeg --enable-libopenmpt --enable-librav1e --enable-librubberband --disable-schannel --enable-sdl2 --enable-libsoxr --enable-libsrt --enable-libsvtav1 --enable-libtwolame --enable-libuavs3d --enable-libdrm --enable-vaapi --enable-libvidstab --enable-vulkan --enable-libshaderc --enable-libplacebo --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxvid --enable-libzimg --enable-libzvbi --extra-cflags=-DLIBTWOLAME_STATIC --extra-cxxflags= --extra-ldflags=-pthread --extra-ldexeflags=-pie --extra-libs='-ldl -lgomp' --extra-version=20220424
  libavutil      57. 24.101 / 57. 24.101
  libavcodec     59. 27.100 / 59. 27.100
  libavformat    59. 23.100 / 59. 23.100
  libavdevice    59.  6.100 / 59.  6.100
  libavfilter     8. 36.100 /  8. 36.100
  libswscale      6.  6.100 /  6.  6.100
  libswresample   4.  6.100 /  4.  6.100
  libpostproc    56.  5.100 / 56.  5.100
[tcp @ 0x55fb3a919100] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a919100] Successfully connected to 96.17.206.8 port 443
[hls @ 0x55fb3a913c80] Skip ('#EXT-X-VERSION:5')
[hls @ 0x55fb3a913c80] Skip ('## Created with Unified Streaming Platform(version=1.8.3)')
[hls @ 0x55fb3a913c80] Skip ('#EXT-X-INDEPENDENT-SEGMENTS')
[hls @ 0x55fb3a913c80] Skip ('#USP-X-TIMESTAMP-MAP:MPEGTS=900000,LOCAL=1970-01-01T00:00:00Z')
[hls @ 0x55fb3a913c80] HLS request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-1.ts', offset 0, playlist 0
[hls @ 0x55fb3a913c80] Opening 'https://cloudingest.ftven.fr/keys/bfd3.key' for reading
[tcp @ 0x55fb3a95f700] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a95f700] Starting connection attempt to 96.17.206.25 port 443
[tcp @ 0x55fb3a95f700] Successfully connected to 96.17.206.8 port 443
[AVIOContext @ 0x55fb3a969500] Statistics: 16 bytes read, 0 seeks
[hls @ 0x55fb3a913c80] Opening 'crypto+https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-1.ts' for reading
[tcp @ 0x55fb3a96bc80] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a96bc80] Starting connection attempt to 96.17.206.25 port 443
[tcp @ 0x55fb3a96bc80] Successfully connected to 96.17.206.8 port 443
[h264 @ 0x55fb3a980c80] Reinit context to 1280x720, pix_fmt: yuv420p
[hls @ 0x55fb3a913c80] max_analyze_duration 5000000 reached at 5000000 microseconds st:0
Input #0, hls, from 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.m3u8':
  Duration: 00:21:40.52, start: 10.000000, bitrate: 0 kb/s
  Program 0 
    Metadata:
      variant_bitrate : 0
  Stream #0:0: Video: h264 (High), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(tv, bt709, left), 1280x720 [SAR 1:1 DAR 16:9], 25 fps, 25 tbr, 90k tbn
    Metadata:
      variant_bitrate : 0
[tcp @ 0x55fb3a984b00] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a984b00] Starting connection attempt to 96.17.206.25 port 443
[tcp @ 0x55fb3a984b00] Successfully connected to 96.17.206.8 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000.dash', offset 0
[tcp @ 0x55fb3ac7dfc0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3ac7dfc0] Successfully connected to 96.17.206.8 port 443
[AVIOContext @ 0x55fb3ac7ea40] Statistics: 723 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-0.dash', offset 0
[tcp @ 0x55fb3a927cc0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a927cc0] Successfully connected to 96.17.206.8 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=950000.dash', offset 0
[tcp @ 0x55fb3aa117c0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3aa117c0] Successfully connected to 96.17.206.8 port 443
[AVIOContext @ 0x55fb3aa12a00] Statistics: 722 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=950000-0.dash', offset 0
[tcp @ 0x55fb3aa127c0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3aa127c0] Successfully connected to 96.17.206.8 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=1400000.dash', offset 0
[tcp @ 0x55fb3a95c640] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a95c640] Successfully connected to 96.17.206.8 port 443
[AVIOContext @ 0x55fb3aa0bf40] Statistics: 722 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=1400000-0.dash', offset 0
[tcp @ 0x55fb3a95c700] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a95c700] Successfully connected to 96.17.206.8 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000.dash', offset 0
[tcp @ 0x55fb3aa28100] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3aa28100] Starting connection attempt to 96.17.206.25 port 443
[tcp @ 0x55fb3aa28100] Successfully connected to 96.17.206.8 port 443
[AVIOContext @ 0x55fb3aa28cc0] Statistics: 725 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-0.dash', offset 0
[tcp @ 0x55fb3aa0e080] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3aa0e080] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3aa0e080] Successfully connected to 96.17.206.30 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000.dash', offset 0
[tcp @ 0x55fb3aa27940] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3aa27940] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x55fb3a9f7a40] Statistics: 689 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_fre=96000-0.dash', offset 0
[tcp @ 0x55fb3a9f8e00] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3a9f8e00] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a9f8e00] Successfully connected to 96.17.206.30 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_qtz=96000.dash', offset 0
[tcp @ 0x55fb3aa1a3c0] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3aa1a3c0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3aa1a3c0] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x55fb3a99ea80] Statistics: 693 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-audio_qtz=96000-0.dash', offset 0
[tcp @ 0x55fb3aa19200] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3aa19200] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3aa19200] Successfully connected to 96.17.206.30 port 443
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-textstream_fre=1000.dash', offset 0
[tcp @ 0x55fb3a99cbc0] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3a99cbc0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a99cbc0] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x55fb3acf1540] Statistics: 658 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-textstream_fre=1000-0.dash', offset 0
[tcp @ 0x55fb3a99cbc0] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3a99cbc0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a99cbc0] Successfully connected to 96.17.206.30 port 443
[h264 @ 0x55fb3a9a1040] Reinit context to 384x224, pix_fmt: yuv420p
[h264 @ 0x55fb3a9b7700] Reinit context to 640x368, pix_fmt: yuv420p
[h264 @ 0x55fb3aa0cc40] Reinit context to 960x544, pix_fmt: yuv420p
[h264 @ 0x55fb3a9f9ac0] Reinit context to 1280x720, pix_fmt: yuv420p
[AVIOContext @ 0x55fb3acf1ac0] Statistics: 2173 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-textstream_fre=1000-10000.dash', offset 0
[tcp @ 0x55fb3a9d99c0] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x55fb3a9d99c0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x55fb3a9d99c0] Successfully connected to 96.17.206.30 port 443
Input #1, dash, from 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/manifest.mpd':
  Duration: 00:21:40.00, start: 0.000000, bitrate: N/A
  Program 0 
  Stream #1:0: Video: h264 (Constrained Baseline), 1 reference frame (avc1 / 0x31637661), yuv420p(tv, bt709, left), 384x216 (384x224) [SAR 1:1 DAR 16:9], 330 kb/s, 25 fps, 25 tbr, 25 tbn (default)
    Metadata:
      variant_bitrate : 400000
      id              : video=400000
  Stream #1:1: Video: h264 (Main), 1 reference frame (avc1 / 0x31637661), yuv420p(tv, bt709, left), 640x360 (640x368) [SAR 1:1 DAR 16:9], 738 kb/s, 25 fps, 25 tbr, 25 tbn (default)
    Metadata:
      variant_bitrate : 950000
      id              : video=950000
  Stream #1:2: Video: h264 (Main), 1 reference frame (avc1 / 0x31637661), yuv420p(tv, bt709, left), 960x540 (960x544) [SAR 1:1 DAR 16:9], 1098 kb/s, 25 fps, 25 tbr, 25 tbn (default)
    Metadata:
      variant_bitrate : 1400000
      id              : video=1400000
  Stream #1:3: Video: h264 (High), 1 reference frame (avc1 / 0x31637661), yuv420p(tv, bt709, left), 1280x720 [SAR 1:1 DAR 16:9], 1494 kb/s, 25 fps, 25 tbr, 25 tbn (default)
    Metadata:
      variant_bitrate : 2000000
      id              : video=2000000
  Stream #1:4(fr): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 96 kb/s (default)
    Metadata:
      variant_bitrate : 96000
      id              : audio_fre=96000
  Stream #1:5(qtz): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 191 kb/s (default) (visual impaired) (descriptions)
    Metadata:
      variant_bitrate : 96000
      id              : audio_qtz=96000
  Stream #1:6(fr): Data: none (stpp / 0x70707473), 1 kb/s (default)
    Metadata:
      id              : textstream_fre=1000
[mpegts @ 0x55fb3b0c9300] service 1 using PCR in pid=256, pcr_period=80ms
[mpegts @ 0x55fb3b0c9300] muxrate VBR, sdt every 500 ms, pat/pmt every 100 ms
Output #0, mpegts, to 'pipe:':
  Metadata:
    encoder         : Lavf59.23.100
  Stream #0:0: Video: h264 (High), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(tv, bt709, left), 1280x720 (0x0) [SAR 1:1 DAR 16:9], q=2-31, 25 fps, 25 tbr, 90k tbn
    Metadata:
      variant_bitrate : 0
  Stream #0:1: Video: h264 (Constrained Baseline), 1 reference frame (avc1 / 0x31637661), yuv420p(tv, bt709, left), 384x216 (0x0) [SAR 1:1 DAR 16:9], q=2-31, 330 kb/s, 25 fps, 25 tbr, 90k tbn (default)
    Metadata:
      variant_bitrate : 400000
      id              : video=400000
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #1:0 -> #0:1 (copy)
Press [q] to stop, [?] for help
[hls @ 0x55fb3a913c80] Thread message queue blocking; consider raising the thread_queue_size option (current value: 8)
[dash @ 0x55fb3aa2ea00] Thread message queue blocking; consider raising the thread_queue_size option (current value: 8)
Automatically inserted bitstream filter 'h264_mp4toannexb'; args=''
[AVIOContext @ 0x55fb3a9b6bc0] Statistics: 177103 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] No longer receiving stream_index 1
[AVIOContext @ 0x55fb3aa0c2c0] Statistics: 234585 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] No longer receiving stream_index 2
[AVIOContext @ 0x55fb3a9f8fc0] Statistics: 294943 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] No longer receiving stream_index 3
[AVIOContext @ 0x55fb3aa16cc0] Statistics: 24789 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] No longer receiving stream_index 4
[AVIOContext @ 0x55fb3a99d9c0] Statistics: 48559 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] No longer receiving stream_index 5
[AVIOContext @ 0x55fb3acfaf40] Statistics: 1969 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] No longer receiving stream_index 6
[AVIOContext @ 0x55fb3ac7d300] Statistics: 82998 bytes read, 0 seeks
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-50.dash', offset 0
[tcp @ 0x7fbae0006d80] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0006d80] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x7fbae0006d80] Successfully connected to 96.17.206.30 port 443rate=1942.4kbits/s speed=3.92x    
[AVIOContext @ 0x7fbae001c2c0] Statistics: 125099 bytes read, 0 seekstrate=2023.3kbits/s speed=0.844x    
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-100.dash', offset 0
[tcp @ 0x7fbae0005f80] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0005f80] Starting connection attempt to 96.17.206.8 port 443=2378.2kbits/s speed=1.13x    
[tcp @ 0x7fbae0005f80] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x7fbae001ac40] Statistics: 112962 bytes read, 0 seekstrate=2471.0kbits/s speed=0.803x    
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-150.dash', offset 0
[tcp @ 0x7fbae0002140] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0002140] Starting connection attempt to 96.17.206.8 port 443=2459.0kbits/s speed=0.792x    
[tcp @ 0x7fbae0002140] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x55fb3a973840] Statistics: 1883384 bytes read, 0 seeksrate=2376.6kbits/s speed=0.745x    
[AVIOContext @ 0x7fbae0059140] Statistics: 80792 bytes read, 0 seeks
[hls @ 0x55fb3a913c80] HLS request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-2.ts', offset 0, playlist 0
[hls @ 0x55fb3a913c80] Opening 'crypto+https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-2.ts' for reading
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-200.dash', offset 0
[tcp @ 0x7fbae8006180] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0008540] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0008540] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x7fbae8006180] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x7fbae8006180] Successfully connected to 96.17.206.30 port 443
[tcp @ 0x7fbae0008540] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x7fbae0008e40] Statistics: 108986 bytes read, 0 seekstrate=2462.0kbits/s speed=0.683x    
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-250.dash', offset 0
[tcp @ 0x7fbae0004340] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0004340] Starting connection attempt to 96.17.206.8 port 443=2491.0kbits/s speed=0.713x    
[tcp @ 0x7fbae0004340] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x7fbae0005ec0] Statistics: 112658 bytes read, 0 seekstrate=2525.1kbits/s speed=0.667x    
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-300.dash', offset 0
[tcp @ 0x7fbae0008540] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0008540] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x7fbae0059180] Statistics: 91018 bytes read, 0 seeksitrate=2517.2kbits/s speed=0.699x    
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-350.dash', offset 0
[tcp @ 0x7fbae0021380] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0021380] Successfully connected to 96.17.206.30 port 443rate=2490.8kbits/s speed=0.792x    
[AVIOContext @ 0x7fbae005aa00] Statistics: 96037 bytes read, 0 seeksitrate=2490.8kbits/s speed=0.73x     
[AVIOContext @ 0x7fbae800a180] Statistics: 2069880 bytes read, 0 seeks
[hls @ 0x55fb3a913c80] HLS request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-3.ts', offset 0, playlist 0
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-400.dash', offset 0
[hls @ 0x55fb3a913c80] Opening 'crypto+https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNTJ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9OTAxOTczOTc2ZjMyMTJjYjE1MmEyNzgwZTcxZWFkMzg0NGUyN2FmOWM1YmQ4NDVkYzBmODBmZjUzZTViZjNkNw==/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=2000000-3.ts' for reading
[tcp @ 0x7fbae005d500] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae8004fc0] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae005d500] Starting connection attempt to 96.17.206.8 port 443=2441.7kbits/s speed=0.806x    
[tcp @ 0x7fbae8004fc0] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x7fbae8004fc0] Successfully connected to 96.17.206.30 port 443
[tcp @ 0x7fbae005d500] Successfully connected to 96.17.206.30 port 443
[AVIOContext @ 0x7fbae0011c00] Statistics: 121091 bytes read, 0 seekstrate=2477.4kbits/s speed=0.796x    
[dash @ 0x55fb3aa2ea00] DASH request for url 'https://cloudingest.ftven.fr/2b43723d56716/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA.ism/ZXhwPTE2NTEwNjcwNDZ+YWNsPSUyZjJiNDM3MjNkNTY3MTYlMmY4MzNiMzIyZC0zMjFlLTQyMDEtYTQzZC1jNTdmNmU3NjNlYjZfZnJhbmNlLWRvbXRvbV9UQS5pc20qfmhtYWM9MzM0Zjk5ZTdjYjEwZDAxNjMwNmJjNTdmYmY0OTMyOWZjYzBiZDI1NDllN2FkMjQ3NzRmMWExOWJmODEyNmMzNQ==/dash/833b322d-321e-4201-a43d-c57f6e763eb6_france-domtom_TA-video=400000-450.dash', offset 0
[tcp @ 0x7fbae0021380] Starting connection attempt to 96.17.206.30 port 443
[tcp @ 0x7fbae0021380] Starting connection attempt to 96.17.206.8 port 443
[tcp @ 0x7fbae0021380] Successfully connected to 96.17.206.30 port 443
^Cframe=  451 fps= 19 q=-1.0 Lq=-1.0 size=    5476kB time=00:00:18.00 bitrate=2492.1kbits/s speed=0.769x    
video:5193kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 5.448336%
```