### PR TITLE
[InfoQ] Don't fail on missing audio format, Remove 404 test case

### DIFF
--- a/yt_dlp/extractor/infoq.py
+++ b/yt_dlp/extractor/infoq.py
@@ -4,8 +4,10 @@ from ..compat import (
     compat_urlparse,
 )
 from ..utils import (
+    ExtractorError,
     determine_ext,
     update_url_query,
+    try_get,
 )
 from .bokecc import BokeCCBaseIE
 
@@ -86,8 +88,12 @@ class InfoQIE(BokeCCBaseIE):
         }]
 
     def _extract_http_audio(self, webpage, video_id):
-        fields = self._form_hidden_inputs('mp3Form', webpage)
-        http_audio_url = fields.get('filename')
+        try:
+            fields = self._form_hidden_inputs('mp3Form', webpage)
+        except ExtractorError:
+            fields = None
+
+        http_audio_url = try_get(fields, lambda x: x['filename'])
         if not http_audio_url:
             return []
 

--- a/yt_dlp/extractor/infoq.py
+++ b/yt_dlp/extractor/infoq.py
@@ -90,11 +90,9 @@ class InfoQIE(BokeCCBaseIE):
 
     def _extract_http_audio(self, webpage, video_id):
         try:
-            fields = self._form_hidden_inputs('mp3Form', webpage)
+            http_audio_url = traverse_obj(self._form_hidden_inputs('mp3Form', webpage), 'filename')
         except ExtractorError:
-            fields = None
-
-        http_audio_url = try_get(fields, lambda x: x['filename'])
+            http_audio_url = None
         if not http_audio_url:
             return []
 

--- a/yt_dlp/extractor/infoq.py
+++ b/yt_dlp/extractor/infoq.py
@@ -1,3 +1,4 @@
+from .common import InfoExtractor
 from ..compat import (
     compat_b64decode,
     compat_urllib_parse_unquote,
@@ -9,10 +10,9 @@ from ..utils import (
     update_url_query,
     try_get,
 )
-from .bokecc import BokeCCBaseIE
 
 
-class InfoQIE(BokeCCBaseIE):
+class InfoQIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?infoq\.com/(?:[^/]+/)+(?P<id>[^/]+)'
 
     _TESTS = [{
@@ -27,15 +27,6 @@ class InfoQIE(BokeCCBaseIE):
     }, {
         'url': 'http://www.infoq.com/fr/presentations/changez-avis-sur-javascript',
         'only_matching': True,
-    }, {
-        'url': 'http://www.infoq.com/cn/presentations/openstack-continued-delivery',
-        'md5': '4918d0cca1497f2244572caf626687ef',
-        'info_dict': {
-            'id': 'openstack-continued-delivery',
-            'title': 'OpenStack持续交付之路',
-            'ext': 'flv',
-            'description': 'md5:308d981fb28fa42f49f9568322c683ff',
-        },
     }, {
         'url': 'https://www.infoq.com/presentations/Simple-Made-Easy',
         'md5': '0e34642d4d9ef44bf86f66f6399672db',
@@ -120,14 +111,10 @@ class InfoQIE(BokeCCBaseIE):
         video_title = self._html_extract_title(webpage)
         video_description = self._html_search_meta('description', webpage, 'description')
 
-        if '/cn/' in url:
-            # for China videos, HTTP video URL exists but always fails with 403
-            formats = self._extract_bokecc_formats(webpage, video_id)
-        else:
-            formats = (
-                self._extract_rtmp_video(webpage)
-                + self._extract_http_video(webpage)
-                + self._extract_http_audio(webpage, video_id))
+        formats = (
+            self._extract_rtmp_video(webpage)
+            + self._extract_http_video(webpage)
+            + self._extract_http_audio(webpage, video_id))
 
         self._sort_formats(formats)
 

--- a/yt_dlp/extractor/infoq.py
+++ b/yt_dlp/extractor/infoq.py
@@ -36,6 +36,7 @@ class InfoQIE(BokeCCBaseIE):
             'ext': 'flv',
             'description': 'md5:308d981fb28fa42f49f9568322c683ff',
         },
+        'skip': 'Sorry, the page you visited does not exist',
     }, {
         'url': 'https://www.infoq.com/presentations/Simple-Made-Easy',
         'md5': '0e34642d4d9ef44bf86f66f6399672db',

--- a/yt_dlp/extractor/infoq.py
+++ b/yt_dlp/extractor/infoq.py
@@ -7,7 +7,7 @@ from ..utils import (
     ExtractorError,
     determine_ext,
     update_url_query,
-    try_get,
+    traverse_obj,
 )
 from .bokecc import BokeCCBaseIE
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Extractor will no longer fail on missing audio only format, closes #3441
Removed test case and handling of /cn/ urls since both the /cn/ test case and http://www.infoq.com/cn/presentations do not seem to exist anymore.
