### PR TITLE
[freetv] Add an extractor for freetv.com

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -544,7 +544,10 @@ from .frontendmasters import (
     FrontendMastersLessonIE,
     FrontendMastersCourseIE
 )
-from .freetv import FreeTvIE
+from .freetv import (
+    FreeTvMoviesIE,
+    FreeTvSeriesIE,
+)
 from .fujitv import FujiTVFODPlus7IE
 from .funimation import (
     FunimationIE,

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -545,8 +545,8 @@ from .frontendmasters import (
     FrontendMastersCourseIE
 )
 from .freetv import (
+    FreeTvIE,
     FreeTvMoviesIE,
-    FreeTvSeriesIE,
 )
 from .fujitv import FujiTVFODPlus7IE
 from .funimation import (

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -544,6 +544,7 @@ from .frontendmasters import (
     FrontendMastersLessonIE,
     FrontendMastersCourseIE
 )
+from .freetv import FreeTvIE
 from .fujitv import FujiTVFODPlus7IE
 from .funimation import (
     FunimationIE,

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 
 from .common import InfoExtractor
@@ -11,13 +12,11 @@ from ..utils import (
 
 
 class FreeTvBaseIE(InfoExtractor):
-    def _get_api_response(self, content_id, postdata, resource_type):
-        response = self._download_json(
+    def _get_api_response(self, content_id, resource_type, postdata):
+        return self._download_json(
             'https://www.freetv.com/wordpress/wp-admin/admin-ajax.php',
             content_id, data=urlencode_postdata(postdata),
-            note=f'Downloading {content_id} {resource_type} JSON')
-
-        return response['data']
+            note=f'Downloading {content_id} {resource_type} JSON')['data']
 
 
 class FreeTvMoviesIE(FreeTvBaseIE):
@@ -43,19 +42,12 @@ class FreeTvMoviesIE(FreeTvBaseIE):
     }]
 
     def _extract_video(self, content_id, action='olyott_video_play'):
-        api_response = self._get_api_response(
-            content_id, resource_type='video',
-            postdata={
-                'action': action,
-                'contentID': content_id,
-            })
+        api_response = self._get_api_response(content_id, 'video', {
+            'action': action,
+            'contentID': content_id,
+        })
 
-        video_id = api_response['displayMeta']['contentID']
-        video_url = traverse_obj(api_response, ('displayMeta', 'streamURLVideo'), expected_type=str)
-
-        if determine_ext(video_url) != 'm3u8':
-            self.raise_no_formats('Manifest was not found', video_id=video_id)
-
+        video_id, video_url = api_response['displayMeta']['contentID'], api_response['displayMeta']['streamURLVideo']
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4')
         self._sort_formats(formats)
 
@@ -71,13 +63,12 @@ class FreeTvMoviesIE(FreeTvBaseIE):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
 
-        content_id = self._search_regex(
-            (r'class=["\'][^>]+postid-(?P<video_id>\d+)',
-             r'<link[^>]+freetv.com/\?p=(?P<video_id>\d+)'
-             r'<div[^>]+data-params=["\'][^>]+post_id=(?P<video_id>\d+)'),
-            webpage, 'video_id', group='video_id')
-
-        return self._extract_video(content_id)
+        return self._extract_video(
+            self._search_regex((
+                r'class=["\'][^>]+postid-(?P<video_id>\d+)',
+                r'<link[^>]+freetv.com/\?p=(?P<video_id>\d+)',
+                r'<div[^>]+data-params=["\'][^>]+post_id=(?P<video_id>\d+)',
+            ), webpage, 'video id', group='video_id'))
 
 
 class FreeTvIE(FreeTvBaseIE):
@@ -110,68 +101,45 @@ class FreeTvIE(FreeTvBaseIE):
     },
     ]
 
-    def _extract_series_season(self, season_id, series_title, action='olyott_get_dynamic_series_content'):
-        api_response = self._get_api_response(
-            season_id, resource_type='series',
-            postdata={
-                'action': action,
-                'contentID': season_id,
-                'type': 'list',
-                'perPage': '1000',
-            })
+    def _extract_series_season(self, season_id, series_title):
+        episodes = self._get_api_response(season_id, 'series', {
+            'contentID': season_id,
+            'action': 'olyott_get_dynamic_series_content',
+            'type': 'list',
+            'perPage': '1000',
+        })['1']
 
-        season_episodes = traverse_obj(api_response, '1')
+        for episode in episodes:
+            video_id = str(episode['contentID'])
+            formats, subtitles = self._extract_m3u8_formats_and_subtitles(episode['streamURL'], video_id, 'mp4')
+            self._sort_formats(formats)
 
-        entries = []
-        for episode in season_episodes:
-            video_id = str_or_none(episode.get('contentID'))
-            video_url = episode.get('streamURL')
-
-            if determine_ext(video_url) == 'm3u8':
-                formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-                    video_url, video_id, 'mp4', fatal=False)
-                self._sort_formats(formats)
-
-                entries.append({
-                    'id': video_id,
-                    'title': episode.get('fullTitle'),
-                    'description': episode.get('description'),
-                    'formats': formats,
-                    'subtitles': subtitles,
-                    'thumbnail': episode.get('thumbnail'),
-                    'series': series_title,
-                    'series_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seriesID')),
-                    'season_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonID')),
-                    'season_number': int_or_none(
-                        traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonNum'))),
-                    'episode_number': int_or_none(
-                        traverse_obj(episode, ('contentMeta', 'displayMeta', 'episodeNum'))),
-                })
-            else:
-                self.report_warning('Manifest was not found', video_id)
-
-        return entries
-
-    def _extract_all_series_seasons(self, season_ids, series_title):
-        entries = []
-        for season_id in season_ids:
-            entries.extend(self._extract_series_season(season_id, series_title))
-
-        return entries
+            yield {
+                'id': video_id,
+                'title': episode.get('fullTitle'),
+                'description': episode.get('description'),
+                'formats': formats,
+                'subtitles': subtitles,
+                'thumbnail': episode.get('thumbnail'),
+                'series': series_title,
+                'series_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seriesID')),
+                'season_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonID')),
+                'season_number': traverse_obj(
+                    episode, ('contentMeta', 'displayMeta', 'seasonNum'), expected_type=int_or_none),
+                'episode_number': traverse_obj(
+                    episode, ('contentMeta', 'displayMeta', 'episodeNum'), expected_type=int_or_none),
+            }
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
 
-        title = self._html_search_regex(
-            r'<h1[^>]+class=["\']synopis[^>]>(?P<title>[^<]+)',
-            webpage, 'title', fatal=False, group='title')
+        title = self._html_search_regex(r'<h1[^>]+class=["\']synopis[^>]>([^<]+)', webpage, 'title', fatal=False),
         description = self._html_search_regex(
-            r'<div[^>]+class=["\']+synopis content[^>]><p>(?P<description>[^<]+)',
-            webpage, 'description', fatal=False, group='description')
-
-        season_ids = re.findall(r'<option[^>]+value=["\'](?P<content_id>\d+)["\']', webpage)
+            r'<div[^>]+class=["\']+synopis content[^>]><p>([^<]+)', webpage, 'description', fatal=False)
 
         return self.playlist_result(
-            self._extract_all_series_seasons(season_ids, title),
-            playlist_id=display_id, playlist_title=title, playlist_description=description)
+            itertools.chain(
+                self._extract_series_season(season_id, title)
+                for season_id in re.findall(r'<option[^>]+value=["\'](\d+)["\']', webpage)),
+            display_id, title, description)

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -1,19 +1,109 @@
+import re
+
 from .common import InfoExtractor
 from ..utils import (
-    urlencode_postdata,
     determine_ext,
+    ExtractorError,
+    try_get,
+    urlencode_postdata, int_or_none, str_or_none,
 )
 
 
-class FreeTvIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?freetv\.com/(?:peliculas|series)/(?:[^/]+/)*(?P<id>[^/]+)'
+class FreeTvBaseIE(InfoExtractor):
+    def _get_api_response(self, content_id, postdata, resource_type):
+        response = self._download_json(
+            'https://www.freetv.com/wordpress/wp-admin/admin-ajax.php',
+            content_id, data=urlencode_postdata(postdata), fatal=False,
+            note='Downloading {} {} JSON'.format(content_id, resource_type))
+
+        if response is False:
+            raise ExtractorError("Couldn't get response", expected=True)
+
+        if response.get('data') is False:
+            raise ExtractorError("Response doesn't contain {} data".format(resource_type), expected=True)
+
+        return response
+
+    def _extract_video(self, content_id, action="olyott_video_play"):
+        api_response = self._get_api_response(content_id, {'action': action, 'contentID': content_id}, 'video')
+
+        video_id = try_get(api_response, lambda x: x['data']['displayMeta']['contentID'], expected_type=str)
+        title = try_get(api_response, lambda x: x['data']['displayMeta']['title'])
+        description = try_get(api_response, lambda x: x['data']['displayMeta']['desc'])
+        video_url = try_get(api_response, lambda x: x['data']['displayMeta']['streamURLVideo'], expected_type=str)
+
+        ext = determine_ext(video_url)
+        if ext != 'm3u8':
+            raise ExtractorError('No manifest was found', video_id=video_id, expected=True)
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4')
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'formats': formats,
+            'subtitles': subtitles,
+        }
+
+    def _extract_series(self, display_id, season_ids, series_title, series_description,
+                        action="olyott_get_dynamic_series_content"):
+        entries = []
+        for season_id in season_ids:
+            api_response = self._get_api_response(
+                season_id, resource_type='series',
+                postdata={'action': action, 'contentID': season_id, 'type': 'list', 'perPage': '1000'})
+
+            season_episodes = try_get(api_response, lambda x: x['data']['1'])
+
+            if season_episodes is None:
+                raise ExtractorError("Response doesn't contain episode list", expected=True)
+
+            for episode in season_episodes:
+                video_id = str_or_none(episode.get('contentID'))
+                video_url = episode.get('streamURL')
+                title = episode.get('fullTitle')
+                description = episode.get('description')
+                thumbnail = episode.get('thumbnail')
+
+                series_id = try_get(episode, lambda x: x['contentMeta']['displayMeta']['seriesID'])
+                season_id = try_get(episode, lambda x: x['contentMeta']['displayMeta']['seasonID'])
+                season_number = int_or_none(try_get(episode, lambda x: x['contentMeta']['displayMeta']['seasonNum']))
+                episode_number = int_or_none(try_get(episode, lambda x: x['contentMeta']['displayMeta']['episodeNum']))
+
+                ext = determine_ext(video_url)
+                if ext == "m3u8":
+                    formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4', fatal=False)
+                    self._sort_formats(formats)
+
+                    entries.append({
+                        'id': video_id,
+                        'title': title,
+                        'description': description,
+                        'formats': formats,
+                        'subtitles': subtitles,
+                        'thumbnail': thumbnail,
+                        'series': series_title,
+                        'series_id': series_id,
+                        'season_id': season_id,
+                        'season_number': season_number,
+                        'episode_number': episode_number,
+                    })
+                else:
+                    print("No manifest was found for video_id {}".format(video_id))
+
+        return self.playlist_result(entries, display_id, series_title, series_description)
+
+
+class FreeTvMoviesIE(FreeTvBaseIE):
+    _VALID_URL = r'https?://(?:www\.)?freetv\.com/(?:peliculas)/(?:[^/]+/)*(?P<id>[^/]+)'
     _TESTS = [{
         'url': 'https://www.freetv.com/peliculas/atrapame-si-puedes/',
         'md5': 'dc62d5abf0514726640077cd1591aa92',
         'info_dict': {
             'id': '428021',
             'title': 'Atrápame Si Puedes',
-            'full_title': 'Atrápame Si Puedes',
             'description': 'md5:ca63bc00898aeb2f64ec87c6d3a5b982',
             'ext': 'mp4',
         }
@@ -23,85 +113,64 @@ class FreeTvIE(InfoExtractor):
         'info_dict': {
             'id': '377652',
             'title': 'Monstruoso',
-            'full_title': 'Monstruoso',
             'description': 'md5:333fc19ee327b457b980e54a911ea4a3',
             'ext': 'mp4',
         }
     }]
-
-    def _extract_video(self, contentId, action="olyott_video_play"):
-        request_body = {
-            'action': action,
-            'contentID': contentId,
-        }
-
-        response = self._download_json(
-            'https://www.freetv.com/wordpress/wp-admin/admin-ajax.php',
-            contentId,
-            'Downloading %s video JSON' % contentId,
-            data=urlencode_postdata(request_body),
-            fatal=False
-        )
-
-        if response is False:
-            return False
-
-        if response.get('success') is False:
-            return False
-
-        response_data = response.get('data')
-
-        if response_data is False:
-            return False
-
-        video_metadata = response_data.get('displayMeta')
-
-        video_id = video_metadata.get('contentID')
-        title = video_metadata.get('title')
-        full_title = video_metadata.get('fullTitle')
-        description = video_metadata.get('desc')
-        video_url = video_metadata.get('streamURLVideo')
-
-        formats = []
-        subtitles = []
-
-        ext = determine_ext(video_url)
-
-        if ext == "m3u8":
-            fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                video_url, video_id, 'mp4',
-                entry_protocol='m3u8_native',
-                fatal=False)
-            formats.extend(fmts)
-            self._merge_subtitles(subs, target=subtitles)
-        else:
-            if self._is_valid_url(video_url, video_id):
-                formats.append({
-                    'url': video_url,
-                })
-
-        self._sort_formats(formats)
-
-        return {
-            'id': video_id,
-            'title': title,
-            'full_title': full_title,
-            'description': description,
-            'formats': formats,
-            'subtitles': subtitles,
-            'ext': 'mp4',
-        }
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
 
         content_id = self._search_regex(
-            (r'class=.*?postid-(\d+)',
-             r'<link.*?freetv.com\/\?p=(\d+)'),
-            webpage, 'video id', default=None, group=None)
-
-        # If it's a series page, we should extract all episodes
-        # matching <div data-contentid="*" class="episodeListEpisode">
+            (r'class=["\'][^>]+postid-(?P<video_id>\d+)',
+             r'<link[^>]+freetv.com/\?p=(?P<video_id>\d+)'
+             r'<div[^>]+data-params=["\'][^>]+post_id=(?P<video_id>\d+)'),
+            webpage, 'video_id', group='video_id')
 
         return self._extract_video(content_id)
+
+
+class FreeTvSeriesIE(FreeTvBaseIE):
+    _VALID_URL = r'https?://(?:www\.)?freetv\.com/(?:series)/(?:[^/]+/)*(?P<id>[^/]+)'
+    _TESTS = [{
+        'url': 'https://www.freetv.com/series/el-detective-l/',
+        'info_dict': {
+            'id': 'el-detective-l',
+            'title': 'El Detective L',
+            'description': 'md5:f9f1143bc33e9856ecbfcbfb97a759be'
+        },
+        'playlist_count': 24,
+    }, {
+        'url': 'https://www.freetv.com/series/esmeraldas/',
+        'info_dict': {
+            'id': 'esmeraldas',
+            'title': 'Esmeraldas',
+            'description': 'md5:43d7ec45bd931d8268a4f5afaf4c77bf'
+        },
+        'playlist_count': 62,
+    }, {
+        'url': 'https://www.freetv.com/series/las-aventuras-de-leonardo/',
+        'info_dict': {
+            'id': 'las-aventuras-de-leonardo',
+            'title': 'Las Aventuras de Leonardo',
+            'description': 'md5:0c47130846c141120a382aca059288f6'
+        },
+        'playlist_count': 13,
+    },
+    ]
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+
+        title = self._html_search_regex(
+            r'<h1[^>]+class=["\']synopis[^>]>(?P<title>[^<]+)',
+            webpage, 'title', fatal=False, group='title')
+        description = self._html_search_regex(
+            r'<div[^>]+class=["\']+synopis content[^>]><p>(?P<description>[^<]+)',
+            webpage, 'title', fatal=False, group='description')
+
+        season_ids = re.findall(r'<option[^>]+value=["\'](?P<content_id>\d+)["\']', webpage)
+
+        return self._extract_series(display_id, season_ids, title, description)

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -132,9 +132,11 @@ class FreeTvIE(FreeTvBaseIE):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
 
-        title = self._html_search_regex(r'<h1[^>]+class=["\']synopis[^>]>([^<]+)', webpage, 'title', fatal=False),
+        title = self._html_search_regex(
+            r'<h1[^>]+class=["\']synopis[^>]>(?P<title>[^<]+)', webpage, 'title', group='title', fatal=False)
         description = self._html_search_regex(
-            r'<div[^>]+class=["\']+synopis content[^>]><p>([^<]+)', webpage, 'description', fatal=False)
+            r'<div[^>]+class=["\']+synopis content[^>]><p>(?P<description>[^<]+)',
+            webpage, 'description', group='description', fatal=False)
 
         return self.playlist_result(
             itertools.chain.from_iterable(

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -137,7 +137,7 @@ class FreeTvIE(FreeTvBaseIE):
             r'<div[^>]+class=["\']+synopis content[^>]><p>([^<]+)', webpage, 'description', fatal=False)
 
         return self.playlist_result(
-            itertools.chain(
+            itertools.chain.from_iterable(
                 self._extract_series_season(season_id, title)
                 for season_id in re.findall(r'<option[^>]+value=["\'](\d+)["\']', webpage)),
             display_id, title, description)

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -3,7 +3,6 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     determine_ext,
-    ExtractorError,
     int_or_none,
     str_or_none,
     traverse_obj,
@@ -15,89 +14,14 @@ class FreeTvBaseIE(InfoExtractor):
     def _get_api_response(self, content_id, postdata, resource_type):
         response = self._download_json(
             'https://www.freetv.com/wordpress/wp-admin/admin-ajax.php',
-            content_id, data=urlencode_postdata(postdata), fatal=True,
+            content_id, data=urlencode_postdata(postdata),
             note=f'Downloading {content_id} {resource_type} JSON')
 
-        if response.get('data') is False:
-            raise ExtractorError(f"Response doesn't contain {resource_type} data")
-
-        return response
-
-    def _extract_video(self, content_id, action='olyott_video_play'):
-        api_response = self._get_api_response(
-            content_id, resource_type='video',
-            postdata={
-                'action': action,
-                'contentID': content_id,
-            })
-
-        video_id = traverse_obj(api_response, ('data', 'displayMeta', 'contentID'), expected_type=str)
-        video_url = traverse_obj(api_response, ('data', 'displayMeta', 'streamURLVideo'), expected_type=str)
-
-        if determine_ext(video_url) != 'm3u8':
-            raise ExtractorError('Manifest was not found', video_id=video_id)
-
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4')
-        self._sort_formats(formats)
-
-        return {
-            'id': video_id,
-            'title': traverse_obj(api_response, ('data', 'displayMeta', 'title')),
-            'description': traverse_obj(api_response, ('data', 'displayMeta', 'desc')),
-            'formats': formats,
-            'subtitles': subtitles,
-        }
-
-    def _extract_series(self, display_id, season_ids, series_title, series_description,
-                        action='olyott_get_dynamic_series_content'):
-        entries = []
-        for season_id in season_ids:
-            api_response = self._get_api_response(
-                season_id, resource_type='series',
-                postdata={
-                    'action': action,
-                    'contentID': season_id,
-                    'type': 'list',
-                    'perPage': '1000',
-                })
-
-            season_episodes = traverse_obj(api_response, ('data', '1'))
-
-            if season_episodes is None:
-                raise ExtractorError("Response doesn't contain episode list")
-
-            for episode in season_episodes:
-                video_id = str_or_none(episode.get('contentID'))
-                video_url = episode.get('streamURL')
-
-                if determine_ext(video_url) == 'm3u8':
-                    formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-                        video_url, video_id, 'mp4', fatal=False)
-                    self._sort_formats(formats)
-
-                    entries.append({
-                        'id': video_id,
-                        'title': episode.get('fullTitle'),
-                        'description': episode.get('description'),
-                        'formats': formats,
-                        'subtitles': subtitles,
-                        'thumbnail': episode.get('thumbnail'),
-                        'series': series_title,
-                        'series_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seriesID')),
-                        'season_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonID')),
-                        'season_number': int_or_none(
-                            traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonNum'))),
-                        'episode_number': int_or_none(
-                            traverse_obj(episode, ('contentMeta', 'displayMeta', 'episodeNum'))),
-                    })
-                else:
-                    self.report_warning("Manifest was not found", video_id)
-
-        return self.playlist_result(entries, display_id, series_title, series_description)
+        return response['data']
 
 
 class FreeTvMoviesIE(FreeTvBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?freetv\.com/(?:peliculas)/(?:[^/]+/)*(?P<id>[^/]+)'
+    _VALID_URL = r'https?://(?:www\.)?freetv\.com/peliculas/(?P<id>[^/]+)'
     _TESTS = [{
         'url': 'https://www.freetv.com/peliculas/atrapame-si-puedes/',
         'md5': 'dc62d5abf0514726640077cd1591aa92',
@@ -118,6 +42,31 @@ class FreeTvMoviesIE(FreeTvBaseIE):
         }
     }]
 
+    def _extract_video(self, content_id, action='olyott_video_play'):
+        api_response = self._get_api_response(
+            content_id, resource_type='video',
+            postdata={
+                'action': action,
+                'contentID': content_id,
+            })
+
+        video_id = api_response['displayMeta']['contentID']
+        video_url = traverse_obj(api_response, ('displayMeta', 'streamURLVideo'), expected_type=str)
+
+        if determine_ext(video_url) != 'm3u8':
+            self.raise_no_formats('Manifest was not found', video_id=video_id)
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4')
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': traverse_obj(api_response, ('displayMeta', 'title')),
+            'description': traverse_obj(api_response, ('displayMeta', 'desc')),
+            'formats': formats,
+            'subtitles': subtitles,
+        }
+
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
@@ -131,8 +80,9 @@ class FreeTvMoviesIE(FreeTvBaseIE):
         return self._extract_video(content_id)
 
 
-class FreeTvSeriesIE(FreeTvBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?freetv\.com/(?:series)/(?:[^/]+/)*(?P<id>[^/]+)'
+class FreeTvIE(FreeTvBaseIE):
+    IE_NAME = 'freetv:series'
+    _VALID_URL = r'https?://(?:www\.)?freetv\.com/series/(?P<id>[^/]+)'
     _TESTS = [{
         'url': 'https://www.freetv.com/series/el-detective-l/',
         'info_dict': {
@@ -160,6 +110,55 @@ class FreeTvSeriesIE(FreeTvBaseIE):
     },
     ]
 
+    def _extract_series_season(self, season_id, series_title, action='olyott_get_dynamic_series_content'):
+        api_response = self._get_api_response(
+            season_id, resource_type='series',
+            postdata={
+                'action': action,
+                'contentID': season_id,
+                'type': 'list',
+                'perPage': '1000',
+            })
+
+        season_episodes = traverse_obj(api_response, '1')
+
+        entries = []
+        for episode in season_episodes:
+            video_id = str_or_none(episode.get('contentID'))
+            video_url = episode.get('streamURL')
+
+            if determine_ext(video_url) == 'm3u8':
+                formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+                    video_url, video_id, 'mp4', fatal=False)
+                self._sort_formats(formats)
+
+                entries.append({
+                    'id': video_id,
+                    'title': episode.get('fullTitle'),
+                    'description': episode.get('description'),
+                    'formats': formats,
+                    'subtitles': subtitles,
+                    'thumbnail': episode.get('thumbnail'),
+                    'series': series_title,
+                    'series_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seriesID')),
+                    'season_id': traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonID')),
+                    'season_number': int_or_none(
+                        traverse_obj(episode, ('contentMeta', 'displayMeta', 'seasonNum'))),
+                    'episode_number': int_or_none(
+                        traverse_obj(episode, ('contentMeta', 'displayMeta', 'episodeNum'))),
+                })
+            else:
+                self.report_warning('Manifest was not found', video_id)
+
+        return entries
+
+    def _extract_all_series_seasons(self, season_ids, series_title):
+        entries = []
+        for season_id in season_ids:
+            entries.extend(self._extract_series_season(season_id, series_title))
+
+        return entries
+
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
@@ -169,8 +168,10 @@ class FreeTvSeriesIE(FreeTvBaseIE):
             webpage, 'title', fatal=False, group='title')
         description = self._html_search_regex(
             r'<div[^>]+class=["\']+synopis content[^>]><p>(?P<description>[^<]+)',
-            webpage, 'title', fatal=False, group='description')
+            webpage, 'description', fatal=False, group='description')
 
         season_ids = re.findall(r'<option[^>]+value=["\'](?P<content_id>\d+)["\']', webpage)
 
-        return self._extract_series(display_id, season_ids, title, description)
+        return self.playlist_result(
+            self._extract_all_series_seasons(season_ids, title),
+            playlist_id=display_id, playlist_title=title, playlist_description=description)

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -25,7 +25,12 @@ class FreeTvBaseIE(InfoExtractor):
         return response
 
     def _extract_video(self, content_id, action="olyott_video_play"):
-        api_response = self._get_api_response(content_id, {'action': action, 'contentID': content_id}, 'video')
+        api_response = self._get_api_response(
+            content_id, resource_type='video',
+            postdata={
+                'action': action,
+                'contentID': content_id,
+            })
 
         video_id = try_get(api_response, lambda x: x['data']['displayMeta']['contentID'], expected_type=str)
         title = try_get(api_response, lambda x: x['data']['displayMeta']['title'])
@@ -53,7 +58,12 @@ class FreeTvBaseIE(InfoExtractor):
         for season_id in season_ids:
             api_response = self._get_api_response(
                 season_id, resource_type='series',
-                postdata={'action': action, 'contentID': season_id, 'type': 'list', 'perPage': '1000'})
+                postdata={
+                    'action': action,
+                    'contentID': season_id,
+                    'type': 'list',
+                    'perPage': '1000'
+                })
 
             season_episodes = try_get(api_response, lambda x: x['data']['1'])
 

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -1,0 +1,107 @@
+from .common import InfoExtractor
+from ..utils import (
+    urlencode_postdata,
+    determine_ext,
+)
+
+
+class FreeTvIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?freetv\.com/(?:peliculas|series)/(?:[^/]+/)*(?P<id>[^/]+)'
+    _TESTS = [{
+        'url': 'https://www.freetv.com/peliculas/atrapame-si-puedes/',
+        'md5': 'dc62d5abf0514726640077cd1591aa92',
+        'info_dict': {
+            'id': '428021',
+            'title': 'Atrápame Si Puedes',
+            'full_title': 'Atrápame Si Puedes',
+            'description': 'md5:ca63bc00898aeb2f64ec87c6d3a5b982',
+            'ext': 'mp4',
+        }
+    }, {
+        'url': 'https://www.freetv.com/peliculas/monstruoso/',
+        'md5': '509c15c68de41cb708d1f92d071f20aa',
+        'info_dict': {
+            'id': '377652',
+            'title': 'Monstruoso',
+            'full_title': 'Monstruoso',
+            'description': 'md5:333fc19ee327b457b980e54a911ea4a3',
+            'ext': 'mp4',
+        }
+    }]
+
+    def _extract_video(self, contentId, action="olyott_video_play"):
+        request_body = {
+            'action': action,
+            'contentID': contentId,
+        }
+
+        response = self._download_json(
+            'https://www.freetv.com/wordpress/wp-admin/admin-ajax.php',
+            contentId,
+            'Downloading %s video JSON' % contentId,
+            data=urlencode_postdata(request_body),
+            fatal=False
+        )
+
+        if response is False:
+            return False
+
+        if response.get('success') is False:
+            return False
+
+        response_data = response.get('data')
+
+        if response_data is False:
+            return False
+
+        video_metadata = response_data.get('displayMeta')
+
+        video_id = video_metadata.get('contentID')
+        title = video_metadata.get('title')
+        full_title = video_metadata.get('fullTitle')
+        description = video_metadata.get('desc')
+        video_url = video_metadata.get('streamURLVideo')
+
+        formats = []
+        subtitles = []
+
+        ext = determine_ext(video_url)
+
+        if ext == "m3u8":
+            fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                video_url, video_id, 'mp4',
+                entry_protocol='m3u8_native',
+                fatal=False)
+            formats.extend(fmts)
+            self._merge_subtitles(subs, target=subtitles)
+        else:
+            if self._is_valid_url(video_url, video_id):
+                formats.append({
+                    'url': video_url,
+                })
+
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': title,
+            'full_title': full_title,
+            'description': description,
+            'formats': formats,
+            'subtitles': subtitles,
+            'ext': 'mp4',
+        }
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+
+        content_id = self._search_regex(
+            (r'class=.*?postid-(\d+)',
+             r'<link.*?freetv.com\/\?p=(\d+)'),
+            webpage, 'video id', default=None, group=None)
+
+        # If it's a series page, we should extract all episodes
+        # matching <div data-contentid="*" class="episodeListEpisode">
+
+        return self._extract_video(content_id)

--- a/yt_dlp/extractor/freetv.py
+++ b/yt_dlp/extractor/freetv.py
@@ -3,9 +3,7 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
-    determine_ext,
     int_or_none,
-    str_or_none,
     traverse_obj,
     urlencode_postdata,
 )


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR adds support for freetv.com, as requested in #3486 

Currently it only handles correctly movies, since we need a direct link to make this work and series appear in a list (I've added a note about it).

![image](https://user-images.githubusercontent.com/26639800/165854742-60b7798a-f102-42af-aad3-df76263dcced.png)


**Note:** I'm not really used to using regex, so... if they can be improved, let me know 😃 

### Verbose log

```bash
yt-dlp -vU "https://www.freetv.com/peliculas/atrapame-si-puedes"
```

```bash
[debug] Command-line config: ['-vU', 'https://www.freetv.com/peliculas/atrapame-si-puedes']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, err utf-8, pref UTF-8
[debug] yt-dlp version 2022.04.08 [7884ade65] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 099a372fe
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-109-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffprobe -bsfs
[debug] Checking exe version: ffmpeg -bsfs
[debug] exe versions: ffmpeg N-106673-g058a1ff9b4-20220424 (setts), ffprobe N-106673-g058a1ff9b4-20220424, rtmpdump 2.4
[debug] Optional libraries: Cryptodome, brotli, certifi, mutagen, sqlite3, websockets
[debug] Proxy map: {}
Latest version: 2022.04.08, Current version: 2022.04.08
yt-dlp is up to date (2022.04.08)
[debug] [FreeTv] Extracting URL: https://www.freetv.com/peliculas/atrapame-si-puedes
[FreeTv] atrapame-si-puedes: Downloading webpage
[FreeTv] 428021: Downloading 428021 video JSON
[FreeTv] 428021: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 428021: Downloading 1 format(s): 3831
[debug] Invoking downloader on "https://olympusato-mmd-cust.lldns.net/stream.ismd/stream-audio_eng=128000-video_eng=3486000.m3u8?stream=/XH/N5ehbEFW48KQLMK_NpF0IDTM90KQ0jiWAD_3uuQZI/maspue1%3B/zk/XwXuxt7Jfz391mYRtP-9_biMKBgkgM4IL1uzEsXzQ/maspue1%3B/dE/C1IDEBbZu6A2iYezyLhGL-WGPXTWhKof0MxsaNSQw/maspue1%3B/pc/Na16bSbb-syDxvGQVlBD6XOcNY5Agbote_3rLh11M/maspue1"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 1916
[download] Destination: Atrápame Si Puedes [428021].mp4
[download]   2.7% of ~1.96GiB at  2.03MiB/s ETA 06:40 (frag 52/1916)
```