### PR TITLE
[utils] YoutubeDLCookieJar: Detect and reject JSON file

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1509,8 +1509,8 @@ class YoutubeDLCookieJar(compat_cookiejar.MozillaCookieJar):
                 # most likely a JSON-formatted cookies file created by EditThisCookie
                 # at least, these 3 characters are invalid for host names
                 raise compat_cookiejar.LoadError(
-                    'the file supplied for --cookies is JSON-formatted, which is not supported. '
-                    'follow instructions at https://www.reddit.com/r/youtubedl/wiki/cookies to get a correct format.')
+                    'Cookies file must be Netscape formatted, not JSON. See  '
+                    'https://github.com/ytdl-org/youtube-dl#how-do-i-pass-cookies-to-youtube-dl')
             elif fstp:
                 f = itertools.chain([f_first], f)
             for line in f:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1503,6 +1503,16 @@ class YoutubeDLCookieJar(compat_cookiejar.MozillaCookieJar):
 
         cf = io.StringIO()
         with open(filename, encoding='utf-8') as f:
+            f_first = next(f, '')
+            fstp = f_first.strip()
+            if fstp and fstp[0] in '[{"':
+                # most likely a JSON-formatted cookies file created by EditThisCookie
+                # at least, these 3 characters are invalid for host names
+                raise compat_cookiejar.LoadError(
+                    'the file supplied for --cookies is JSON-formatted, which is not supported. '
+                    'follow instructions at https://www.reddit.com/r/youtubedl/wiki/cookies to get a correct format.')
+            elif fstp:
+                f = itertools.chain([f_first], f)
             for line in f:
                 try:
                     cf.write(prepare_line(line))

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1503,20 +1503,14 @@ class YoutubeDLCookieJar(compat_cookiejar.MozillaCookieJar):
 
         cf = io.StringIO()
         with open(filename, encoding='utf-8') as f:
-            f_first = next(f, '')
-            fstp = f_first.strip()
-            if fstp and fstp[0] in '[{"':
-                # most likely a JSON-formatted cookies file created by EditThisCookie
-                # at least, these 3 characters are invalid for host names
-                raise compat_cookiejar.LoadError(
-                    'Cookies file must be Netscape formatted, not JSON. See  '
-                    'https://github.com/ytdl-org/youtube-dl#how-do-i-pass-cookies-to-youtube-dl')
-            elif fstp:
-                f = itertools.chain([f_first], f)
             for line in f:
                 try:
                     cf.write(prepare_line(line))
                 except compat_cookiejar.LoadError as e:
+                    if f'{line.strip()} '[0] in '[{"':
+                        raise compat_cookiejar.LoadError(
+                            'Cookies file must be Netscape formatted, not JSON. See  '
+                            'https://github.com/ytdl-org/youtube-dl#how-do-i-pass-cookies-to-youtube-dl')
                     write_string(f'WARNING: skipping cookie file entry due to {e}: {line!r}\n')
                     continue
         cf.seek(0)


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

This PR lets `YoutubeDLCookieJar` reject JSON files for input. 
Such files seem to contain cookies for a specific site, and as yt-dlp will overwrite JSON file with a text file, I don't think it's appropriate to convert to a valid cookie jar.

Confirmed example which dumps in the format: https://addons.mozilla.org/en-US/firefox/addon/etc2/
Sample file: https://gist.github.com/b33ae9cadae3e2a954853d7e50e8dd1d