### PR TITLE
[utils] ignore illegal seek on truncate()

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2000,7 +2000,6 @@ class locked_file:
             os.O_RDONLY if not writable else os.O_RDWR if readable else os.O_WRONLY,
         ))
 
-        # if filename is a FIFO os.open() blocks until the named pipe is read from
         self.f = os.fdopen(os.open(filename, flags, 0o666), mode, encoding=encoding)
 
     def __enter__(self):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---
Fixes #3557

#2994 contains an implementation error, where the special case of calling truncate() on a fd representing a FIFO results in a uncaught illegal seek because FIFO's do not support seeking.

[io.open()](https://github.com/python/cpython/blob/ad5e8520f3e117f45481513014548a39879d30d2/Modules/_io/fileio.c#L204) does not need code to handle this special case, because (on Linux) [namei.c](https://github.com/torvalds/linux/blob/b6b2648911bbc13c59def22fd7b4b7c511a4eb92/fs/namei.c#L3093) strips O_TRUNC for FIFO's.

Untested in Windows.