### PR TITLE
Extract referrer policy and apply the correct header in parse_html5_media_entries

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -128,6 +128,7 @@ from yt_dlp.utils import (
     xpath_element,
     xpath_text,
     xpath_with_ns,
+    get_referrer_url
 )
 
 
@@ -339,6 +340,37 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(unescapeHTML('&a&quot;'), '&a"')
         # HTML5 entities
         self.assertEqual(unescapeHTML('&period;&apos;'), '.\'')
+
+    def test_get_referrer_url(self):
+        # No-Referrer
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "no-referrer"), None)
+        # Origin
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com", "origin"), "https://example.com")
+        # Unsafe-Url
+        self.assertEqual(get_referrer_url("https://example.com/page?q=123", "https://example.com/page?q=123", "unsafe-url"), "https://example.com/page?q=123")
+        self.assertEqual(get_referrer_url("https://example.com/page?q=123", "https://mozilla.org", "unsafe-url"), "https://example.com/page?q=123")
+        self.assertEqual(get_referrer_url("https://example.com/page?q=123", "https://example.com/page?q=123", "unsafe-url"), "https://example.com/page?q=123")
+        # Strict-Origin
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "strict-origin"), "https://example.com")
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.org", "strict-origin"), None)
+        self.assertEqual(get_referrer_url("http://example.com/page", "http://example.com", "strict-origin"), "http://example.com")
+        # Strict-Origin-When-Cross-Origin
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "strict-origin-when-cross-origin"), "https://example.com/page")
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "strict-origin-when-cross-origin"), "https://example.com")
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com/otherpage", "strict-origin-when-cross-origin"), None)
+        # Same-Origin
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "same-origin"), "https://example.com/page")
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "same-origin"), None)
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com/page", "same-origin"), None)
+        # Origin-When-Cross-Origin
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "origin-when-cross-origin"), "https://example.com/page")
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://mozilla.org", "origin-when-cross-origin"), "https://example.com")
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com/page", "origin-when-cross-origin"), "https://example.com")
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://mozilla.org", "origin-when-cross-origin"), "https://example.com")
+        # No-Referrer-When-Downgrade
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "no-referrer-when-downgrade"), "https://example.com/page")
+        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "no-referrer-when-downgrade"), "https://example.com/page")
+        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com", "no-referrer-when-downgrade"), None)
 
     def test_date_from_str(self):
         self.assertEqual(date_from_str('yesterday'), date_from_str('now-1day'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -343,6 +343,7 @@ class TestUtil(unittest.TestCase):
 
     def test_get_referrer_url(self):
         example_page_url = 'https://example.com/page'
+        example_page_url_insecure = 'http://example.com/page'
         example_page_url_with_query = 'https://example.com/page?q=123'
         example_org_url_insecure = 'http://example.org'
         example_url_insecure = 'http://example.com'
@@ -357,16 +358,16 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, "unsafe-url"), example_page_url_with_query)
         self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "strict-origin"), example_url)
         self.assertEqual(get_referrer_url(example_page_url, example_org_url_insecure, "strict-origin"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "strict-origin"), example_url_insecure)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "strict-origin"), None)
         self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "strict-origin-when-cross-origin"), example_page_url)
         self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "strict-origin-when-cross-origin"), example_url)
         self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url_insecure, "strict-origin-when-cross-origin"), None)
         self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "same-origin"), example_page_url)
         self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "same-origin"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_page_url, "same-origin"), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_page_url, "same-origin"), example_page_url)
         self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "origin-when-cross-origin"), example_page_url)
         self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "origin-when-cross-origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_page_url, "origin-when-cross-origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_page_url_insecure, "origin-when-cross-origin"), example_url)
         self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "origin-when-cross-origin"), example_url)
         self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "no-referrer-when-downgrade"), example_page_url)
         self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "no-referrer-when-downgrade"), example_page_url)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -128,7 +128,7 @@ from yt_dlp.utils import (
     xpath_attr,
     xpath_element,
     xpath_text,
-    xpath_with_ns
+    xpath_with_ns,
 )
 
 
@@ -351,27 +351,34 @@ class TestUtil(unittest.TestCase):
         example_otherpage_url = 'https://example.com/otherpage'
         example_otherpage_url_insecure = 'http://example.com/otherpage'
         mozilla_url = 'https://mozilla.org'
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "no-referrer"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, "unsafe-url"), example_page_url_with_query)
-        self.assertEqual(get_referrer_url(example_page_url_with_query, mozilla_url, "unsafe-url"), example_page_url_with_query)
-        self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, "unsafe-url"), example_page_url_with_query)
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "strict-origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_org_url_insecure, "strict-origin"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "strict-origin"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "strict-origin-when-cross-origin"), example_page_url)
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "strict-origin-when-cross-origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url_insecure, "strict-origin-when-cross-origin"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "same-origin"), example_page_url)
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "same-origin"), None)
-        self.assertEqual(get_referrer_url(example_page_url, example_page_url, "same-origin"), example_page_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "origin-when-cross-origin"), example_page_url)
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "origin-when-cross-origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_page_url_insecure, "origin-when-cross-origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "origin-when-cross-origin"), example_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "no-referrer-when-downgrade"), example_page_url)
-        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "no-referrer-when-downgrade"), example_page_url)
-        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "no-referrer-when-downgrade"), None)
+
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'no-referrer'), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, 'origin'), example_url)
+        
+        self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, 'unsafe-url'), example_page_url_with_query)
+        self.assertEqual(get_referrer_url(example_page_url_with_query, mozilla_url, 'unsafe-url'), example_page_url_with_query)
+        self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, 'unsafe-url'), example_page_url_with_query)
+        
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'strict-origin'), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_org_url_insecure, 'strict-origin'), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, 'strict-origin'), None)
+        
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, 'strict-origin-when-cross-origin'), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'strict-origin-when-cross-origin'), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url_insecure, 'strict-origin-when-cross-origin'), None)
+        
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, 'same-origin'), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'same-origin'), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_page_url, 'same-origin'), example_page_url)
+        
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, 'origin-when-cross-origin'), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'origin-when-cross-origin'), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_page_url_insecure, 'origin-when-cross-origin'), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'origin-when-cross-origin'), example_url)
+        
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, 'no-referrer-when-downgrade'), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, 'no-referrer-when-downgrade'), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, 'no-referrer-when-downgrade'), None)
 
     def test_date_from_str(self):
         self.assertEqual(date_from_str('yesterday'), date_from_str('now-1day'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -65,6 +65,7 @@ from yt_dlp.utils import (
     get_elements_html_by_attribute,
     get_elements_html_by_class,
     get_elements_text_and_html_by_attribute,
+    get_referrer_url,
     int_or_none,
     intlist_to_bytes,
     iri_to_uri,
@@ -127,8 +128,7 @@ from yt_dlp.utils import (
     xpath_attr,
     xpath_element,
     xpath_text,
-    xpath_with_ns,
-    get_referrer_url
+    xpath_with_ns
 )
 
 
@@ -342,35 +342,35 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(unescapeHTML('&period;&apos;'), '.\'')
 
     def test_get_referrer_url(self):
-        # No-Referrer
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "no-referrer"), None)
-        # Origin
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com", "origin"), "https://example.com")
-        # Unsafe-Url
-        self.assertEqual(get_referrer_url("https://example.com/page?q=123", "https://example.com/page?q=123", "unsafe-url"), "https://example.com/page?q=123")
-        self.assertEqual(get_referrer_url("https://example.com/page?q=123", "https://mozilla.org", "unsafe-url"), "https://example.com/page?q=123")
-        self.assertEqual(get_referrer_url("https://example.com/page?q=123", "https://example.com/page?q=123", "unsafe-url"), "https://example.com/page?q=123")
-        # Strict-Origin
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "strict-origin"), "https://example.com")
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.org", "strict-origin"), None)
-        self.assertEqual(get_referrer_url("http://example.com/page", "http://example.com", "strict-origin"), "http://example.com")
-        # Strict-Origin-When-Cross-Origin
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "strict-origin-when-cross-origin"), "https://example.com/page")
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "strict-origin-when-cross-origin"), "https://example.com")
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com/otherpage", "strict-origin-when-cross-origin"), None)
-        # Same-Origin
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "same-origin"), "https://example.com/page")
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "same-origin"), None)
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com/page", "same-origin"), None)
-        # Origin-When-Cross-Origin
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "origin-when-cross-origin"), "https://example.com/page")
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://mozilla.org", "origin-when-cross-origin"), "https://example.com")
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com/page", "origin-when-cross-origin"), "https://example.com")
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://mozilla.org", "origin-when-cross-origin"), "https://example.com")
-        # No-Referrer-When-Downgrade
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://example.com/otherpage", "no-referrer-when-downgrade"), "https://example.com/page")
-        self.assertEqual(get_referrer_url("https://example.com/page", "https://mozilla.org", "no-referrer-when-downgrade"), "https://example.com/page")
-        self.assertEqual(get_referrer_url("https://example.com/page", "http://example.com", "no-referrer-when-downgrade"), None)
+        example_page_url = 'https://example.com/page'
+        example_page_url_with_query = 'https://example.com/page?q=123'
+        example_org_url_insecure = 'http://example.org'
+        example_url_insecure = 'http://example.com'
+        example_url = 'https://example.com'
+        example_otherpage_url = 'https://example.com/otherpage'
+        example_otherpage_url_insecure = 'http://example.com/otherpage'
+        mozilla_url = 'https://mozilla.org'
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "no-referrer"), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, "unsafe-url"), example_page_url_with_query)
+        self.assertEqual(get_referrer_url(example_page_url_with_query, mozilla_url, "unsafe-url"), example_page_url_with_query)
+        self.assertEqual(get_referrer_url(example_page_url_with_query, example_page_url_with_query, "unsafe-url"), example_page_url_with_query)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "strict-origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_org_url_insecure, "strict-origin"), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "strict-origin"), example_url_insecure)
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "strict-origin-when-cross-origin"), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "strict-origin-when-cross-origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url_insecure, "strict-origin-when-cross-origin"), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "same-origin"), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "same-origin"), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_page_url, "same-origin"), None)
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "origin-when-cross-origin"), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "origin-when-cross-origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_page_url, "origin-when-cross-origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "origin-when-cross-origin"), example_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_otherpage_url, "no-referrer-when-downgrade"), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, mozilla_url, "no-referrer-when-downgrade"), example_page_url)
+        self.assertEqual(get_referrer_url(example_page_url, example_url_insecure, "no-referrer-when-downgrade"), None)
 
     def test_date_from_str(self):
         self.assertEqual(date_from_str('yesterday'), date_from_str('now-1day'))

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -45,6 +45,7 @@ from ..utils import (
     deprecation_warning,
     determine_ext,
     dict_get,
+    get_referrer_url,
     encode_data_uri,
     error_to_compat_str,
     extract_attributes,
@@ -87,7 +88,7 @@ from ..utils import (
     variadic,
     xpath_element,
     xpath_text,
-    xpath_with_ns,
+    xpath_with_ns
 )
 
 
@@ -3028,6 +3029,7 @@ class InfoExtractor:
             return is_plain_url, formats
 
         entries = []
+        referrer_policy = get_referrer_policy_from_meta_element(webpage)
         # amp-video and amp-audio are very similar to their HTML5 counterparts
         # so we will include them right here (see
         # https://www.ampproject.org/docs/reference/components/amp-video)
@@ -3110,7 +3112,9 @@ class InfoExtractor:
                             'url': absolute_url(src),
                         })
             for f in media_info['formats']:
-                f.setdefault('http_headers', {})['Referer'] = base_url
+                referrer = get_referrer_url(base_url, f["url"], referrer_policy)
+                if referrer:
+                    f.setdefault('http_headers', {})['Referer'] = referrer
             if media_info['formats'] or media_info['subtitles']:
                 entries.append(media_info)
         return entries

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -3029,7 +3029,7 @@ class InfoExtractor:
             return is_plain_url, formats
 
         entries = []
-        referrer_policy = get_referrer_policy_from_meta_element(webpage)
+        referrer_policy = self._html_search_meta('referrer', webpage) or 'strict-origin-when-cross-origin'
         # amp-video and amp-audio are very similar to their HTML5 counterparts
         # so we will include them right here (see
         # https://www.ampproject.org/docs/reference/components/amp-video)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -88,7 +88,7 @@ from ..utils import (
     variadic,
     xpath_element,
     xpath_text,
-    xpath_with_ns
+    xpath_with_ns,
 )
 
 
@@ -3112,7 +3112,7 @@ class InfoExtractor:
                             'url': absolute_url(src),
                         })
             for f in media_info['formats']:
-                referrer = get_referrer_url(base_url, f["url"], referrer_policy)
+                referrer = get_referrer_url(base_url, f['url'], referrer_policy)
                 if referrer:
                     f.setdefault('http_headers', {})['Referer'] = referrer
             if media_info['formats'] or media_info['subtitles']:

--- a/yt_dlp/extractor/goplay.py
+++ b/yt_dlp/extractor/goplay.py
@@ -76,11 +76,11 @@ class GoPlayIE(InfoExtractor):
             }
 
         api = self._download_json(
-            f'https://api.viervijfzes.be/content/{video_id}',
-            video_id, headers={'Authorization': self._id_token})
+            f'https://api.goplay.be/web/v1/videos/long-form/{video_id}',
+            video_id, headers={'Authorization': 'Bearer %s' % self._id_token})
 
         formats, subs = self._extract_m3u8_formats_and_subtitles(
-            api['video']['S'], video_id, ext='mp4', m3u8_id='HLS')
+            api['manifestUrls']['hls'], video_id, ext='mp4', m3u8_id='HLS')
 
         info_dict.update({
             'id': video_id,

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1067,7 +1067,7 @@ def get_referrer_url(referrer_source, request_url, policy):
     # Strip URL as per https://w3c.github.io/webappsec-referrer-policy/#strip-url
     def strip_url(url, origin_only=False):
         if url is None:
-            return "no-referrer"
+            return 'no-referrer'
         parsed_url = compat_urllib_parse_urlparse(url)
         if parsed_url.username:
             parsed_url = parsed_url._replace(username=None)
@@ -1086,35 +1086,38 @@ def get_referrer_url(referrer_source, request_url, policy):
         return compat_urllib_parse_urlparse(url).scheme in ('https', 'ftps')
     referrer_url = strip_url(referrer_source)
     referrer_origin = strip_url(referrer_source, origin_only=True)
+    is_origin_only = (referrer_origin == strip_url(request_url, True))
+    is_tls_referrer = is_tls(referrer_url)
+    is_not_tls_requester = not is_tls(request_url)
     if len(referrer_url) > 4096:
         referrer_url = referrer_origin
-    if policy == "no-referrer":
+    if policy == 'no-referrer':
         return None
-    elif policy == "origin":
+    elif policy == 'origin':
         return referrer_origin
-    elif policy == "unsafe-url":
+    elif policy == 'unsafe-url':
         return referrer_url
-    elif policy == "strict-origin":
-        if is_tls(referrer_url) and not is_tls(request_url):
+    elif policy == 'strict-origin':
+        if is_tls_referrer and is_not_tls_requester:
             return None
         else:
             return referrer_origin
-    elif policy == "strict-origin-when-cross-origin":
-        if referrer_origin == strip_url(request_url, True):
+    elif policy == 'strict-origin-when-cross-origin':
+        if is_origin_only:
             return referrer_url
-        elif is_tls(referrer_url) and not is_tls(request_url):
+        elif is_tls_referrer and is_not_tls_requester:
             return None
         return referrer_origin
-    elif policy == "same-origin":
-        if referrer_origin == strip_url(request_url, True):
+    elif policy == 'same-origin':
+        if is_origin_only:
             return referrer_url
         return None
-    elif policy == "origin-when-cross-origin":
-        if referrer_origin == strip_url(request_url, True):
+    elif policy == 'origin-when-cross-origin':
+        if is_origin_only:
             return referrer_url
         return referrer_origin
-    elif policy == "no-referrer-when-downgrade":
-        if is_tls(referrer_url) and not is_tls(request_url):
+    elif policy == 'no-referrer-when-downgrade':
+        if is_tls_referrer and is_not_tls_requester:
             return None
         return referrer_url
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1057,6 +1057,68 @@ def bug_reports_message(before=';'):
     return (before + ' ' if before else '') + msg
 
 
+def get_referrer_url(referrer_source, request_url, policy):
+    # Returns correct referrer url based on the site policy
+    # Resources used:
+    # https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples
+    # https://github.com/scrapy/scrapy/blob/master/scrapy/spidermiddlewares/referer.py
+
+    # Strip URL as per https://w3c.github.io/webappsec-referrer-policy/#strip-url
+    def strip_url(url, origin_only=False):
+        if url is None:
+            return "no-referrer"
+        parsed_url = compat_urllib_parse_urlparse(url)
+        if parsed_url.username:
+            parsed_url = parsed_url._replace(username=None)
+        if parsed_url.password:
+            parsed_url = parsed_url._replace(password=None)
+        if parsed_url.fragment:
+            parsed_url = parsed_url._replace(fragment='')
+        if origin_only:
+            parsed_url = parsed_url._replace(path='')
+            parsed_url = parsed_url._replace(query='')
+        return parsed_url.geturl()
+
+    # https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
+    # More checks to determine the trustworthiness of a URL, the URL scheme is one check
+    def is_tls(url):
+        return compat_urllib_parse_urlparse(url).scheme in ('https', 'ftps')
+    referrer_url = strip_url(referrer_source)
+    referrer_origin = strip_url(referrer_source, origin_only=True)
+    if len(referrer_url) > 4096:
+        referrer_url = referrer_origin
+    if policy == "no-referrer":
+        return None
+    elif policy == "origin":
+        return referrer_origin
+    elif policy == "unsafe-url":
+        return referrer_url
+    elif policy == "strict-origin":
+        if is_tls(referrer_url) and not is_tls(request_url):
+            return None
+        else:
+            return referrer_origin
+    elif policy == "strict-origin-when-cross-origin":
+        if referrer_origin == strip_url(request_url, True):
+            return referrer_url
+        elif is_tls(referrer_url) and not is_tls(request_url):
+            return None
+        return referrer_origin
+    elif policy == "same-origin":
+        if referrer_origin == strip_url(request_url, True):
+            return referrer_url
+        return None
+    elif policy == "origin-when-cross-origin":
+        if referrer_origin == strip_url(request_url, True):
+            return referrer_url
+        return referrer_origin
+    elif policy == "no-referrer-when-downgrade":
+        if is_tls(referrer_url) and not is_tls(request_url):
+            return None
+        return referrer_url
+
+
 class YoutubeDLError(Exception):
     """Base exception for YoutubeDL errors."""
     msg = None

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1068,7 +1068,7 @@ def get_referrer_url(referrer_source, request_url, policy):
     def strip_url(url, origin_only=False):
         if url is None:
             return 'no-referrer'
-        parsed_url = compat_urllib_parse_urlparse(url)
+        parsed_url = urllib.parse.urlparse(url)
         if parsed_url.username:
             parsed_url = parsed_url._replace(username=None)
         if parsed_url.password:
@@ -1083,7 +1083,7 @@ def get_referrer_url(referrer_source, request_url, policy):
     # https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
     # More checks to determine the trustworthiness of a URL, the URL scheme is one check
     def is_tls(url):
-        return compat_urllib_parse_urlparse(url).scheme in ('https', 'ftps')
+        return urllib.parse.urlparse(url).scheme in ('https', 'ftps')
     referrer_url = strip_url(referrer_source)
     referrer_origin = strip_url(referrer_source, origin_only=True)
     is_origin_only = (referrer_origin == strip_url(request_url, True))

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1080,19 +1080,18 @@ def get_referrer_url(referrer_source, request_url, policy):
             parsed_url = parsed_url._replace(query='')
         return parsed_url.geturl()
 
-    
-    referrer_url = strip_url(referrer_source)
     referrer_origin = strip_url(referrer_source, origin_only=True)
     is_origin_only = referrer_origin == strip_url(request_url, True)
-    
+    referrer_url = strip_url(referrer_source)
+    if len(referrer_url) > 4096:
+        referrer_url = referrer_origin
+
     # https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
     def is_tls(url):
         return urllib.parse.urlparse(url).scheme in ('https', 'ftps')
 
     insecure = is_tls(referrer_url) and not is_tls(request_url)
 
-    if len(referrer_url) > 4096:
-        referrer_url = referrer_origin
     if policy == 'no-referrer':
         return None
     elif policy == 'origin':


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Currently the `_parse_html5_media_entries` applies the Base URL in the Referer header for all the format entries. This will not set the correct Referer header based on the specified Referrer-Policy.

[Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) 

The pull request adds code to:
- Get the referrer policy from the meta element
- Return the correct Referrer URL based on the extracted policy
- Set Referer header to the correct URL

Points to note:
- The Referrer Policy can be set/extracted from the request header instead of just the meta element
- The policy can also be applied as an [attribute per element](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#integration_with_html) 

