### PR TITLE
[Update] Check last tags instead of last release link in API

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -49,7 +49,7 @@ def run_update(ydl):
     Returns whether the program should terminate
     """
 
-    JSON_URL = 'https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest'
+    JSON_URL = 'https://api.github.com/repos/yt-dlp/yt-dlp/tags'
 
     def report_error(msg, expected=False):
         ydl.report_error(msg, tb='' if expected else None)
@@ -74,7 +74,9 @@ def run_update(ydl):
 
     # Download and check versions info
     try:
-        version_info = ydl._opener.open(JSON_URL).read().decode()
+        tags = ydl._opener.open(JSON_URL).read().decode()
+        last_name = json.loads(tags)[0]['name']
+        version_info = ydl._opener.open(f'https://api.github.com/repos/yt-dlp/yt-dlp/releases/tags/{last_name}').read().decode()
         version_info = json.loads(version_info)
     except Exception:
         return report_network_error('obtain version info', delim='; Please try again later or')

--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -49,7 +49,7 @@ def run_update(ydl):
     Returns whether the program should terminate
     """
 
-    JSON_URL = 'https://api.github.com/repos/yt-dlp/yt-dlp/tags'
+    JSON_URL = 'https://api.github.com/repos/yt-dlp/yt-dlp'
 
     def report_error(msg, expected=False):
         ydl.report_error(msg, tb='' if expected else None)
@@ -61,7 +61,7 @@ def run_update(ydl):
         report_unable(f'write to {file}; Try running as administrator', True)
 
     def report_network_error(action, delim=';'):
-        report_unable(f'{action}{delim} Visit  https://github.com/yt-dlp/yt-dlp/releases/latest', True)
+        report_unable(f'{action}{delim} Visit https://github.com/yt-dlp/yt-dlp/tags', True)
 
     def calc_sha256sum(path):
         h = hashlib.sha256()
@@ -74,9 +74,8 @@ def run_update(ydl):
 
     # Download and check versions info
     try:
-        tags = ydl._opener.open(JSON_URL).read().decode()
-        last_name = json.loads(tags)[0]['name']
-        version_info = ydl._opener.open(f'https://api.github.com/repos/yt-dlp/yt-dlp/releases/tags/{last_name}').read().decode()
+        last_name = json.loads(ydl._opener.open(f'{JSON_URL}/tags').read().decode())[0]['name']
+        version_info = ydl._opener.open(f'{JSON_URL}/releases/tags/{last_name}').read().decode()
         version_info = json.loads(version_info)
     except Exception:
         return report_network_error('obtain version info', delim='; Please try again later or')


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Git Hub is having recurrent issues of not reporting last release in last release button and API.

So, change the code to get last tag name from API and then, get last release data.

#3653
#3699

```
D:\ytdlp\yt-dlp>flake8 yt_dlp\update.py

D:\ytdlp\yt-dlp>python -m yt_dlp -vU
[debug] Command-line config: ['-vU']
[debug] User config "C:\Users\User\AppData\Roaming\yt-dlp\config.txt": ['--ffmpeg-location', 'D:\\ytdlp\\ffmpeg\\bin']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8 (No ANSI), err utf-8 (No ANSI), pref cp1252
[debug] yt-dlp version 2022.04.08 [7884ade65] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: fe1daad3c
[debug] Python version 3.8.10 (CPython 64bit) - Windows-7-6.1.7601-SP1
[debug] Checking exe version: "D:\ytdlp\ffmpeg\bin\ffprobe" -bsfs
[debug] Checking exe version: "D:\ytdlp\ffmpeg\bin\ffmpeg" -bsfs
[debug] exe versions: ffmpeg N-105453-gcc5eb2e662-20220204 (setts), ffprobe N-105453-gcc5eb2e662-20220204
[debug] Optional libraries: Cryptodome-3.14.1, certifi-2021.10.08, sqlite3-2.6.0
[debug] Proxy map: {}
Latest version: 2022.04.08, Current version: 2022.04.08
yt-dlp is up to date (2022.04.08)

D:\ytdlp\yt-dlp>
```