### PR TITLE
When looking for cookie database and loading cookies, don't update the progress bar every time

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -135,7 +135,8 @@ def _extract_firefox_cookies(profile, logger):
                 table = cursor.fetchall()
                 total_cookie_count = len(table)
                 for i, (host, name, value, path, expiry, is_secure) in enumerate(table):
-                    progress_bar.print(f'Loading cookie {i: 6d}/{total_cookie_count: 6d}')
+                    if i % 100 == 0:
+                        progress_bar.print(f'Loading cookie {i: 6d}/{total_cookie_count: 6d}')
                     cookie = compat_cookiejar_Cookie(
                         version=0, name=name, value=value, port=None, port_specified=False,
                         domain=host, domain_specified=bool(host), domain_initial_dot=host.startswith('.'),
@@ -263,7 +264,8 @@ def _extract_chrome_cookies(browser_name, profile, keyring, logger):
                 table = cursor.fetchall()
                 total_cookie_count = len(table)
                 for i, line in enumerate(table):
-                    progress_bar.print(f'Loading cookie {i: 6d}/{total_cookie_count: 6d}')
+                    if i % 100 == 0:
+                        progress_bar.print(f'Loading cookie {i: 6d}/{total_cookie_count: 6d}')
                     is_encrypted, cookie = _process_chrome_cookie(decryptor, *line)
                     if not cookie:
                         failed_cookies += 1
@@ -566,7 +568,8 @@ def _parse_safari_cookies_page(data, jar, logger):
 
     with _create_progress_bar(logger) as progress_bar:
         for i, record_offset in enumerate(record_offsets):
-            progress_bar.print(f'Loading cookie {i: 6d}/{number_of_cookies: 6d}')
+            if i % 100 == 0:
+                progress_bar.print(f'Loading cookie {i: 6d}/{number_of_cookies: 6d}')
             p.skip_to(record_offset, 'space between records')
             record_length = _parse_safari_cookies_record(data[record_offset:], jar, logger)
             p.read_bytes(record_length)
@@ -952,7 +955,8 @@ def _find_most_recently_used_file(root, filename, logger):
         for curr_root, dirs, files in os.walk(root):
             for file in files:
                 i += 1
-                progress_bar.print(f'Searching for "{filename}": {i: 6d} files searched')
+                if i % 1000 == 0:
+                    progress_bar.print(f'Searching for "{filename}": {i: 6d} files searched')
                 if file == filename:
                     paths.append(os.path.join(curr_root, file))
     return None if not paths else max(paths, key=lambda path: os.lstat(path).st_mtime)


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

When looking for the cookie database with `--cookies-from-browser`, the progress bar is updated once for every file scanned. As the Windows console isn't very fast, this creates a lot of overhead. Something recently changed in Firefox that caused the number of files in my profile to get very large, and now yt-dlp takes _3 minutes_ to search through ~32000 files just to find the most recently used `cookies.sqlite`.

I changed it to only update the progress bar every 1000 files, which brings the lookup time down to only a couple of seconds. The same problem happens with _loading_ the cookies, so I changed those loops to only update once every 100 cookies (bringing the time down from ~10 seconds to almost nothing).

I suppose the risk here is that on slow filesystems there might be a lot of time between updates. A more sophisticated fix would be to only update the progress bar once every second or so, but I don't know if it's worth the extra logic.