### PR TITLE
[nebula] Add support for subscriptions

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1018,7 +1018,8 @@ from .ndr import (
 from .ndtv import NDTVIE
 from .nebula import (
     NebulaIE,
-    NebulaCollectionIE,
+    NebulaSubscriptionsIE,
+    NebulaChannelIE,
 )
 from .nerdcubed import NerdCubedFeedIE
 from .netzkino import NetzkinoIE

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -167,20 +167,16 @@ class NebulaIE(NebulaBaseIE):
                 'channel_id': 'lindsayellis',
                 'uploader': 'Lindsay Ellis',
                 'uploader_id': 'lindsayellis',
-
                 'timestamp': 1533009600,
                 'uploader_url': 'https://nebula.app/lindsayellis',
                 'series': 'Lindsay Ellis',
-                'average_rating': 0,
+                'average_rating': int,
                 'display_id': 'that-time-disney-remade-beauty-and-the-beast',
                 'channel_url': 'https://nebula.app/lindsayellis',
                 'creator': 'Lindsay Ellis',
                 'duration': 2212,
                 'view_count': int,
-                'thumbnail': 'https://dj423fildxgac.cloudfront.net/d45d597a-8a81-4580-bc8c-69ab4ec6a8f1.jpeg?height=720&',
-            },
-            'params': {
-                'usenetrc': True,
+                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
         },
         {
@@ -197,19 +193,15 @@ class NebulaIE(NebulaBaseIE):
                 'channel_id': 'realengineering',
                 'uploader': 'Real Engineering',
                 'uploader_id': 'realengineering',
-
                 'view_count': int,
                 'series': 'Real Engineering',
-                'average_rating': 0,
+                'average_rating': int,
                 'display_id': 'the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
                 'creator': 'Real Engineering',
                 'duration': 841,
                 'channel_url': 'https://nebula.app/realengineering',
                 'uploader_url': 'https://nebula.app/realengineering',
-                'thumbnail': 'https://dj423fildxgac.cloudfront.net/1239f02b-c6aa-4c4c-ba11-581a1db181ce.jpeg?height=720&',
-            },
-            'params': {
-                'usenetrc': True,
+                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
         },
         {
@@ -226,19 +218,15 @@ class NebulaIE(NebulaBaseIE):
                 'channel_id': 'tom-scott-presents-money',
                 'uploader': 'Tom Scott Presents: Money',
                 'uploader_id': 'tom-scott-presents-money',
-
                 'uploader_url': 'https://nebula.app/tom-scott-presents-money',
                 'duration': 825,
                 'channel_url': 'https://nebula.app/tom-scott-presents-money',
                 'view_count': int,
                 'series': 'Tom Scott Presents: Money',
                 'display_id': 'money-episode-1-the-draw',
-                'thumbnail': 'https://dj423fildxgac.cloudfront.net/516d7e3d-ba6d-4f76-ab07-c34bc1639800.jpeg?height=720&',
-                'average_rating': 0,
+                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
+                'average_rating': int,
                 'creator': 'Tom Scott Presents: Money',
-            },
-            'params': {
-                'usenetrc': True,
             },
         },
         {
@@ -269,19 +257,14 @@ class NebulaSubscriptionsIE(NebulaBaseIE):
             'info_dict': {
                 'id': 'myshows',
             },
-            'params': {
-                'usenetrc': True,
-            },
         },
     ]
 
-    CHANNEL_URL = 'https://content.watchnebula.com/library/video/?page_size=100'
-
     def _generate_playlist_entries(self):
-        next_url = self.CHANNEL_URL
+        next_url = 'https://content.watchnebula.com/library/video/?page_size=100'
         page_num = 1
         while next_url:
-            channel = self._call_nebula_api(next_url, 'subscriptions', auth_type='bearer',
+            channel = self._call_nebula_api(next_url, 'myshows', auth_type='bearer',
                                             note=f'Retrieving subscriptions page {page_num}')
             for episode in channel['results']:
                 yield self._build_video_info(episode)
@@ -289,15 +272,12 @@ class NebulaSubscriptionsIE(NebulaBaseIE):
             page_num += 1
 
     def _real_extract(self, url):
-        return self.playlist_result(
-            entries=self._generate_playlist_entries(),
-            playlist_id='myshows'
-        )
+        return self.playlist_result(self._generate_playlist_entries(), 'myshows')
 
 
 class NebulaChannelIE(NebulaBaseIE):
     IE_NAME = 'nebula:channel'
-    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/(?!myshows)(?!videos/)(?P<id>[-\w]+)'
+    _VALID_URL = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app)/(?!myshows|videos/)(?P<id>[-\w]+)'
     _TESTS = [
         {
             'url': 'https://nebula.app/tom-scott-presents-money',
@@ -307,9 +287,6 @@ class NebulaChannelIE(NebulaBaseIE):
                 'description': 'Tom Scott hosts a series all about trust, negotiation and money.',
             },
             'playlist_count': 5,
-            'params': {
-                'usenetrc': True,
-            },
         }, {
             'url': 'https://nebula.app/lindsayellis',
             'info_dict': {
@@ -317,10 +294,7 @@ class NebulaChannelIE(NebulaBaseIE):
                 'title': 'Lindsay Ellis',
                 'description': 'Enjoy these hottest of takes on Disney, Transformers, and Musicals.',
             },
-            'playlist_mincount': 10,
-            'params': {
-                'usenetrc': True,
-            },
+            'playlist_mincount': 100,
         },
     ]
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

As requested by and closing #3609.

Nebula has a feed of all episodes from channels/collections the user is following, called `myshows` or `My Videos` in URLs and UI respectively.
This is the equivalent to YouTube's 'Subscriptions' page.

This change adds support for downloading this feed via the `/myshows` URL.

It also fixes extractor tests and replaces the call to `_get_login_info()` with the new `_perform_login()` system.
