### PR TITLE
[TF1/wat] Fix extraction of multi-language videos and subtitles

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2861,6 +2861,7 @@ class InfoExtractor:
                         }
                     elif content_type == 'text':
                         f = {
+                            'name': format_id,
                             'ext': mimetype2ext(mime_type),
                             'manifest_url': mpd_url,
                             'filesize': filesize,

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2861,7 +2861,6 @@ class InfoExtractor:
                         }
                     elif content_type == 'text':
                         f = {
-                            'name': format_id,
                             'ext': mimetype2ext(mime_type),
                             'manifest_url': mpd_url,
                             'filesize': filesize,

--- a/yt_dlp/extractor/wat.py
+++ b/yt_dlp/extractor/wat.py
@@ -54,7 +54,7 @@ class WatIE(InfoExtractor):
         #     'http://www.wat.tv/interface/contentv4s/' + video_id, video_id)
         video_data = self._download_json(
             'https://mediainfo.tf1.fr/mediainfocombo/' + video_id,
-            video_id, query={'context': 'MYTF1'})
+            video_id, query={'context': 'MYTF1', 'pver': '4020003'})
         video_info = video_data['media']
 
         error_desc = video_info.get('error_desc')


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description

Fixes #982
Fixes #1683

As described in the linked issues, the extractor was missing non-french streams and subtitles.

This is fixed by passing ` 'pver': '4020003'` as query parameter in the video request (I'm not sure what this value means, but TF1 always sends it).

The last commit is a small fix in `_parse_mpd_formats_and_subtitles`, because we weren't setting a `name` for mpd subtitles.

### Verbose log

Extracting multi-language formats

```bash
yt-dlp -vU -F "https://www.tf1.fr/tf1/under-the-dome/videos/under-the-dome-s01-e01-coupes-du-monde-06184003.html"
```

```diff
[debug] Command-line config: ['-vU', '-F', 'https://www.tf1.fr/tf1/under-the-dome/videos/under-the-dome-s01-e01-coupes-du-monde-06184003.html']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, err utf-8, pref UTF-8
[debug] yt-dlp version 2022.04.08 [7884ade65] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 7d6296f97
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-110-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffprobe -bsfs
[debug] Checking exe version: ffmpeg -bsfs
[debug] exe versions: ffmpeg N-106673-g058a1ff9b4-20220424 (setts), ffprobe N-106673-g058a1ff9b4-20220424, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
Latest version: 2022.04.08, Current version: 2022.04.08
yt-dlp is up to date (2022.04.08)
[debug] [TF1] Extracting URL: https://www.tf1.fr/tf1/under-the-dome/videos/under-the-dome-s01-e01-coupes-du-monde-06184003.html
[TF1] under-the-dome-s01-e01-coupes-du-monde-06184003: Downloading JSON metadata
[debug] [wat.tv] Extracting URL: wat:13812181
[wat.tv] 13812181: Downloading JSON metadata
[wat.tv] 13812181: Downloading MPD manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 13812181:
ID                    EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC      ABR     ASR MORE INFO
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
dash-audio_eng=64000  m4a audio only     │ ~ 19.99MiB   64k dash  │ audio only        mp4a.40.2   64k 48000Hz [en] DASH audio, m4a_dash
dash-audio_fra=64000  m4a audio only     │ ~ 19.99MiB   64k dash  │ audio only        mp4a.40.2   64k 48000Hz [fr] DASH audio, m4a_dash
dash-audio_eng=128000 m4a audio only     │ ~ 39.98MiB  128k dash  │ audio only        mp4a.40.2  128k 48000Hz [en] DASH audio, m4a_dash
dash-audio_fra=128000 m4a audio only     │ ~ 39.98MiB  128k dash  │ audio only        mp4a.40.2  128k 48000Hz [fr] DASH audio, m4a_dash
dash-video=200082     mp4 416x234     25 │ ~ 62.50MiB  200k dash  │ avc1.42C01E  200k video only              DASH video, mp4_dash
dash-video=400178     mp4 480x270     25 │ ~125.01MiB  400k dash  │ avc1.42C01E  400k video only              DASH video, mp4_dash
dash-video=600247     mp4 640x360     25 │ ~187.50MiB  600k dash  │ avc1.42C01E  600k video only              DASH video, mp4_dash
dash-video=1200870    mp4 1024x576    25 │ ~375.13MiB 1200k dash  │ avc1.4D401F 1200k video only              DASH video, mp4_dash
dash-video=1701215    mp4 1024x576    25 │ ~531.42MiB 1701k dash  │ avc1.4D401F 1701k video only              DASH video, mp4_dash
dash-video=2501709    mp4 1280x720    25 │ ~781.48MiB 2501k dash  │ avc1.4D401F 2501k video only              DASH video, mp4_dash
```

Extracting subtitles

```bash
yt-dlp -vU --list-subs "https://www.tf1.fr/tf1/les-douze-coups-de-midi/videos/les-12-coups-de-midi-du-14-mai-2022-90552929.html"
```

```bash
[debug] Command-line config: ['-vU', '--list-subs', 'https://www.tf1.fr/tf1/les-douze-coups-de-midi/videos/les-12-coups-de-midi-du-14-mai-2022-90552929.html']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, err utf-8, pref UTF-8
[debug] yt-dlp version 2022.04.08 [7884ade65] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 7d6296f97
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-110-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffprobe -bsfs
[debug] Checking exe version: ffmpeg -bsfs
[debug] exe versions: ffmpeg N-106673-g058a1ff9b4-20220424 (setts), ffprobe N-106673-g058a1ff9b4-20220424, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
Latest version: 2022.04.08, Current version: 2022.04.08
yt-dlp is up to date (2022.04.08)
[debug] [TF1] Extracting URL: https://www.tf1.fr/tf1/les-douze-coups-de-midi/videos/les-12-coups-de-midi-du-14-mai-2022-90552929.html
[TF1] les-12-coups-de-midi-du-14-mai-2022-90552929: Downloading JSON metadata
[debug] [wat.tv] Extracting URL: wat:13879810
[wat.tv] 13879810: Downloading JSON metadata
[wat.tv] 13879810: Downloading MPD manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available subtitles for 13879810:
Language Name                                      Formats
fr       dash-4150766452, dash-textstream_fra=1000 vtt, mp4
```
