### PR TITLE
[ina] Update extractor

### DIFF
--- a/yt_dlp/extractor/ina.py
+++ b/yt_dlp/extractor/ina.py
@@ -1,23 +1,18 @@
 from .common import InfoExtractor
-from ..utils import (
-    determine_ext,
-    int_or_none,
-    strip_or_none,
-    xpath_attr,
-    xpath_text,
-)
 
 
 class InaIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:(?:www|m)\.)?ina\.fr/(?:video|audio)/(?P<id>[A-Z0-9_]+)'
+    _VALID_URL = r'https?://(?:(?:www|m)\.)?ina\.fr/.*(?:video|audio)/(?P<id>[\w\d_]+).*'
     _TESTS = [{
-        'url': 'http://www.ina.fr/video/I12055569/francois-hollande-je-crois-que-c-est-clair-video.html',
-        'md5': 'a667021bf2b41f8dc6049479d9bb38a3',
+        'url': 'https://www.ina.fr/video/I12055569/francois-hollande-je-crois-que-c-est-clair-video.html',
+        'md5': 'c5a09e5cb5604ed10709f06e7a377dda',
         'info_dict': {
             'id': 'I12055569',
             'ext': 'mp4',
             'title': 'François Hollande "Je crois que c\'est clair"',
-            'description': 'md5:3f09eb072a06cb286b8f7e4f77109663',
+            'description': 'md5:08201f1c86fb250611f0ba415d21255a',
+            'date': 're:2007-07-12T.*',
+            'thumbnail': 'https://cdn-hub.ina.fr/notice/690x517/3c4/I12055569.jpeg',
         }
     }, {
         'url': 'https://www.ina.fr/video/S806544_001/don-d-organes-des-avancees-mais-d-importants-besoins-video.html',
@@ -31,53 +26,36 @@ class InaIE(InfoExtractor):
     }, {
         'url': 'http://m.ina.fr/video/I12055569',
         'only_matching': True,
+    }, {
+        'url': 'https://www.ina.fr/ina-eclaire-actu/video/cpb8205116303/les-jeux-electroniques',
+        'md5': '4b8284a9a3a184fdc7e744225b8251e7',
+        'info_dict': {
+            'id': 'CPB8205116303',
+            'ext': 'mp4',
+            'title': 'Les jeux électroniques',
+            'description': 'md5:e09f7683dad1cc60b74950490127d233',
+            'date': 're:1982-12-04T.*',
+            'duration': 657,
+            'thumbnail': 'https://cdn-hub.ina.fr/notice/690x517/203/CPB8205116303.jpeg',
+        }
     }]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        info_doc = self._download_xml(
-            'http://player.ina.fr/notices/%s.mrss' % video_id, video_id)
-        item = info_doc.find('channel/item')
-        title = xpath_text(item, 'title', fatal=True)
-        media_ns_xpath = lambda x: self._xpath_ns(x, 'http://search.yahoo.com/mrss/')
-        content = item.find(media_ns_xpath('content'))
+        video_id = self._match_id(url).upper()
+        webpage = self._download_webpage(url, video_id)
 
-        get_furl = lambda x: xpath_attr(content, media_ns_xpath(x), 'url')
-        formats = []
-        for q, w, h in (('bq', 400, 300), ('mq', 512, 384), ('hq', 768, 576)):
-            q_url = get_furl(q)
-            if not q_url:
-                continue
-            formats.append({
-                'format_id': q,
-                'url': q_url,
-                'width': w,
-                'height': h,
-            })
-        if not formats:
-            furl = get_furl('player') or content.attrib['url']
-            ext = determine_ext(furl)
-            formats = [{
-                'url': furl,
-                'vcodec': 'none' if ext == 'mp3' else None,
-                'ext': ext,
-            }]
+        api_url = self._html_search_regex(r'asset-details-url=["\'](?P<api_url>[^"\']+)', webpage, 'api_url')
+        api_url = api_url.replace(video_id, f'{video_id}.json')
 
-        thumbnails = []
-        for thumbnail in content.findall(media_ns_xpath('thumbnail')):
-            thumbnail_url = thumbnail.get('url')
-            if not thumbnail_url:
-                continue
-            thumbnails.append({
-                'url': thumbnail_url,
-                'height': int_or_none(thumbnail.get('height')),
-                'width': int_or_none(thumbnail.get('width')),
-            })
+        api_response = self._download_json(api_url, video_id)
 
         return {
             'id': video_id,
-            'formats': formats,
-            'title': title,
-            'description': strip_or_none(xpath_text(item, 'description')),
-            'thumbnails': thumbnails,
+            'url': api_response['resourceUrl'],
+            'ext': "mp4" if api_response['type'] == "video" else "mp3",
+            'title': api_response['title'],
+            'description': api_response.get('description'),
+            'date': api_response.get('dateOfBroadcast'),
+            'duration': api_response.get('duration'),
+            'thumbnail': api_response.get('resourceThumbnail'),
         }

--- a/yt_dlp/extractor/ina.py
+++ b/yt_dlp/extractor/ina.py
@@ -55,7 +55,7 @@ class InaIE(InfoExtractor):
             'id': video_id,
             'url': api_response['resourceUrl'],
             'ext': {'video': 'mp4', 'audio': 'mp3'}.get(api_response.get('type')),
-            'title': api_response['title'],
+            'title': api_response.get('title'),
             'description': api_response.get('description'),
             'upload_date': unified_strdate(api_response.get('dateOfBroadcast')),
             'duration': api_response.get('duration'),


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description

This PR updates the extractor for https://www.ina.fr/ because the rss feed that it was using, no longer works

Fixes #2463

### Verbose log

```bash
yt-dlp -vU "https://www.ina.fr/ina-eclaire-actu/video/cpb8205116303/les-jeux-electroniques"
```

```bash
[debug] Command-line config: ['-vU', 'https://www.ina.fr/ina-eclaire-actu/video/cpb8205116303/les-jeux-electroniques']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.05.18 [b14d52355] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: f5bd59f7f
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-110-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffprobe -bsfs
[debug] Checking exe version: ffmpeg -bsfs
[debug] exe versions: ffmpeg N-106673-g058a1ff9b4-20220424 (setts), ffprobe N-106673-g058a1ff9b4-20220424, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
Latest version: 2022.05.18, Current version: 2022.05.18
yt-dlp is up to date (2022.05.18)
[debug] [Ina] Extracting URL: https://www.ina.fr/ina-eclaire-actu/video/cpb8205116303/les-jeux-electroniques
[Ina] CPB8205116303: Downloading webpage
[Ina] CPB8205116303: Downloading JSON metadata
[debug] Default format spec: bestvideo*+bestaudio/best
[info] CPB8205116303: Downloading 1 format(s): 0
[debug] Invoking http downloader on "https://media-hub.ina.fr/video/nHatNlONyxWOkFFMtQK4/hhd9r6xs5ACYCcVNkJEtIvinXdHlS5KQQMtEP75SUQuwMqqtF/8huxmkN5CYnDFAl8GxtAAksyXfdbgEEukpI5Ci1JKBWRJxuCxuT/WL3q5jNEnoX2nXRGPYsIXHYISXw==/sl_iv/pt0Zx39xxkcYoJRDPJxeJA==/sl_hm/GgHhZuPMcqat0+VHexr36N0cEMjNNYJseGO4fP7kN2vsF87PN+JYtiT1hD6crLAXCo2QJ4bkwhjwEJfUamhX0w==/sl_e/1654212190"
[download] Resuming download at byte 130048
[download] Destination: Les jeux électroniques [CPB8205116303].mp4
[download]   0.7% of 89.17MiB at 405.50KiB/s ETA 03:43
```


