### PR TITLE
[youtube-dash] update ytInitialData HTML/json boundary

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1033,12 +1033,19 @@ class InfoExtractor:
             expected_status=expected_status)
         return res if res is False else res[0]
 
-    def _parse_json(self, json_string, video_id, transform_source=None, fatal=True):
+    def _parse_json(self, json_string, video_id, transform_source=None, fatal=True, lenient=False):
         if transform_source:
             json_string = transform_source(json_string)
         try:
-            return json.loads(json_string, strict=False)
-        except ValueError as ve:
+            try:
+                return json.loads(json_string, strict=False)
+            except json.JSONDecodeError as e:
+                if not lenient:
+                    raise
+                try:
+                    return json.loads(json_string[:e.pos], strict=False)
+                except ValueError:
+                    raise e        except ValueError as ve:
             errmsg = '%s: Failed to parse JSON ' % video_id
             if fatal:
                 raise ExtractorError(errmsg, cause=ve)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1046,6 +1046,8 @@ class InfoExtractor:
                     return json.loads(json_string[:e.pos], strict=False)
                 except ValueError:
                     raise e        except ValueError as ve:
+                    raise e
+        except ValueError as ve:
             errmsg = '%s: Failed to parse JSON ' % video_id
             if fatal:
                 raise ExtractorError(errmsg, cause=ve)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1045,7 +1045,6 @@ class InfoExtractor:
                 try:
                     return json.loads(json_string[:e.pos], strict=False)
                 except ValueError:
-                    raise e        except ValueError as ve:
                     raise e
         except ValueError as ve:
             errmsg = '%s: Failed to parse JSON ' % video_id

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1033,19 +1033,11 @@ class InfoExtractor:
             expected_status=expected_status)
         return res if res is False else res[0]
 
-    def _parse_json(self, json_string, video_id, transform_source=None, fatal=True, lenient=False):
+    def _parse_json(self, json_string, video_id, transform_source=None, fatal=True):
         if transform_source:
             json_string = transform_source(json_string)
         try:
-            try:
-                return json.loads(json_string, strict=False)
-            except json.JSONDecodeError as e:
-                if not lenient:
-                    raise
-                try:
-                    return json.loads(json_string[:e.pos], strict=False)
-                except ValueError:
-                    raise e
+            return json.loads(json_string, strict=False)
         except ValueError as ve:
             errmsg = '%s: Failed to parse JSON ' % video_id
             if fatal:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -399,7 +399,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     _YT_INITIAL_DATA_RE = r'(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+})\s*;'
     _YT_INITIAL_PLAYER_RESPONSE_RE = r'ytInitialPlayerResponse\s*=\s*({.+})\s*;'
-    _YT_INITIAL_BOUNDARY_RE = r'(?:var\s+meta|</script|\n)'
+    _YT_INITIAL_BOUNDARY_RE = r'(?:var\s+(?:head|meta)|</script|\n)'
 
     def _get_default_ytcfg(self, client='web'):
         return copy.deepcopy(INNERTUBE_CLIENTS[client])

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2780,7 +2780,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def _extract_yt_initial_variable(self, webpage, regex, video_id, name):
         return self._parse_json(self._search_regex(
             (fr'{regex}\s*{self._YT_INITIAL_BOUNDARY_RE}',
-             regex), webpage, name, default='{}'), video_id, fatal=False)
+             regex), webpage, name, default='{}'), video_id, fatal=False, lenient=True)
 
     def _extract_comment(self, comment_renderer, parent=None):
         comment_id = comment_renderer.get('commentId')

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2780,7 +2780,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def _extract_yt_initial_variable(self, webpage, regex, video_id, name):
         return self._parse_json(self._search_regex(
             (fr'{regex}\s*{self._YT_INITIAL_BOUNDARY_RE}',
-             regex), webpage, name, default='{}'), video_id, fatal=False, lenient=True)
+             regex), webpage, name, default='{}'), video_id, fatal=False)
 
     def _extract_comment(self, comment_renderer, parent=None):
         comment_id = comment_renderer.get('commentId')


### PR DESCRIPTION
This is a bug fix/update for the youtube extractor related to the initialization of the MPD manifest download. In rare cases, the javascript that follows after the `ytInitialData` json island in the initial HTML download continues in a different way. For example, instead of...

`...26326","nanos":81314983}}}};var head = document.getElementsByTagName('head')[0]; var meta = document.createEl...`

which happens most of the time, we might instead get...

`...26326","nanos":81314983}}}};var meta = document.createElement('meta'); var head = document.getElementsByTagNa...`

This certainly corrupts the initial extracted json, since it has some irrelevant data tacked on at the end. The app reports the error message "Failed to parse JSON" and continues with the download, but I believe the problem is not that benign. It seems like the exception delays or otherwise interferes with the `ytcfg` initialization somehow, which may cause further complicated and far-reaching problems, such as perhaps eventual inconsistencies in the detected DASH formats?

In any case, the simple fix is to allow `var meta` in addition to `var head` when scraping the `ytInitialData` json. This makes the extracted json clean and valid so that it successfully parses on the first try.

<strike>It appears that ee27297, two days ago, was a different attempt to fix this, but it only applies a stopgap measure to cover over the issue. Now that the actual problem has been identified, it is not needed, so this PR also offers--for your consideration--the opportunity to revert those few lines of code.</strike>

cc: @coletdjnz