### PR TITLE
[extractor/vevo] Fix extractor

### DIFF
--- a/yt_dlp/extractor/vevo.py
+++ b/yt_dlp/extractor/vevo.py
@@ -148,7 +148,7 @@ class VevoIE(VevoBaseIE):
         'url': 'https://embed.vevo.com/?isrc=USH5V1923499&partnerId=4d61b777-8023-4191-9ede-497ed6c24647&partnerAdCode=',
         'only_matching': True,
     }, {
-        'url': 'ttps://tv.vevo.com/watch/artist/janet-jackson/US0450100550',
+        'url': 'https://tv.vevo.com/watch/artist/janet-jackson/US0450100550',
         'only_matching': True,
     }]
     _VERSIONS = {


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Closes #3809
Closes #3919

<details>
<summary>pre-table output part</summary>

```
$ ./yt-dlp.sh -vF vevo:US0450100550
[debug] Command-line config: ['-vF', 'vevo:US0450100550']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.05.18 [b14d52355] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 1cd6cba30
[debug] Python version 3.10.4 (CPython 64bit) - Linux-5.15.0-30-generic-x86_64-with-glibc2.35
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.4.1 (setts), ffprobe 4.4.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.11.0, brotli-1.0.9, certifi-2020.06.20, mutagen-1.45.1, pyxattr-0.7.2, secretstorage-3.3.1, sqlite3-2.6.0, websockets-9.1
[debug] Proxy map: {}
[debug] [Vevo] Extracting URL: vevo:US0450100550
[Vevo] Retrieving oauth token
[Vevo] US0450100550: Downloading api video info
[Vevo] US0450100550: Downloading video versions info
[Vevo] US0450100550: Downloading level3 m3u8 information
[Vevo] US0450100550: Downloading level3 MPD information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
```

</details>

```
[info] Available formats for US0450100550:
ID               EXT RESOLUTION FPS │  FILESIZE   TBR PROTO  │ VCODEC        VBR ACODEC      ABR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
http-level3-low  mp4 256x144        │ ~11.09MiB  328k http   │ h264         200k aac        128k
dash-level3-v1   mp4 416x234     25 │ ~ 1.90MiB   56k http   │ avc1.4D401F   56k video only      DASH video, mp4_dash
dash-level3-v2   mp4 416x234     25 │ ~ 5.80MiB  171k http   │ avc1.4D401F  171k video only      DASH video, mp4_dash
hls-level3-219   mp4 416x234     25 │ ~ 7.42MiB  219k m3u8_n │ avc1.4d001f  219k mp4a.40.2    0k
hls-level3-363   mp4 416x234     25 │ ~12.28MiB  363k m3u8_n │ avc1.4d001f  363k mp4a.40.2    0k
dash-level3-v3   mp4 480x270     25 │ ~11.54MiB  341k http   │ avc1.4D401F  341k video only      DASH video, mp4_dash
hls-level3-551   mp4 480x270     25 │ ~18.66MiB  551k m3u8_n │ avc1.4d001f  551k mp4a.40.2    0k
http-level3-None mp4 640x360        │ ~24.62MiB  728k http   │ h264         600k aac        128k
dash-level3-v4   mp4 640x360     25 │ ~14.40MiB  425k http   │ avc1.4D401F  425k video only      DASH video, mp4_dash
dash-level3-v5   mp4 640x360     25 │ ~22.95MiB  678k http   │ avc1.4D401F  678k video only      DASH video, mp4_dash
hls-level3-742   mp4 640x360     25 │ ~25.12MiB  742k m3u8_n │ avc1.4d001f  742k mp4a.40.2    0k
hls-level3-944   mp4 768x432     25 │ ~31.95MiB  944k m3u8_n │ avc1.4d001f  944k mp4a.40.2    0k
http-level3-high mp4 1280x720       │ ~71.96MiB 2128k http   │ h264        2000k aac        128k
```

Maybe:
- [x] Support URL formats like `https://tv.vevo.com/watch/artist/janet-jackson/US0450100550`
- [x] Copy tests from youtube-dl