### PR TITLE
[motherless] Add gallery support

### DIFF
--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -932,6 +932,7 @@ from .mojvideo import MojvideoIE
 from .morningstar import MorningstarIE
 from .motherless import (
     MotherlessIE,
+    MotherlessGalleryIE,
     MotherlessGroupIE
 )
 from .motorsport import MotorsportIE

--- a/yt_dlp/extractor/motherless.py
+++ b/yt_dlp/extractor/motherless.py
@@ -1,6 +1,5 @@
 import datetime
 import re
-from abc import ABC
 
 from .common import InfoExtractor
 from ..compat import compat_urlparse
@@ -147,7 +146,7 @@ class MotherlessIE(InfoExtractor):
         }
 
 
-class MotherlessPaginatedIE(InfoExtractor, ABC):
+class MotherlessPaginatedIE(InfoExtractor):
     _PAGE_SIZE = 60
 
     def _extract_entries(self, webpage, base):

--- a/yt_dlp/extractor/motherless.py
+++ b/yt_dlp/extractor/motherless.py
@@ -180,7 +180,7 @@ class MotherlessPaginatedIE(InfoExtractor, ABC):
 
 
 class MotherlessGroupIE(MotherlessPaginatedIE):
-    _VALID_URL = r'https?://(?:www\.)?motherless\.com/gv?/(?P<id>[a-z0-9_]+)'
+    _VALID_URL = r'https?://(?:www\.)?motherless\.com/gv/(?P<id>[a-z0-9_]+)'
     _TESTS = [{
         'url': 'http://motherless.com/gv/movie_scenes',
         'info_dict': {
@@ -209,7 +209,7 @@ class MotherlessGroupIE(MotherlessPaginatedIE):
 
 
 class MotherlessGalleryIE(MotherlessPaginatedIE):
-    _VALID_URL = r'https?://(?:www\.)?motherless\.com/GV?(?P<id>[A-F0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?motherless\.com/GV(?P<id>[A-F0-9]+)'
     _TESTS = [{
         'url': 'https://motherless.com/GV338999F',
         'info_dict': {

--- a/yt_dlp/extractor/motherless.py
+++ b/yt_dlp/extractor/motherless.py
@@ -151,7 +151,7 @@ class MotherlessPaginatedIE(InfoExtractor):
 
     def _extract_entries(self, webpage, base):
         for mobj in re.finditer(r'href=".*(?P<href>\/[A-F0-9]+)"\s+title="(?P<title>[^"]+)', webpage):
-            video_url = compat_urlparse.urljoin(base, mobj.group("href"))
+            video_url = compat_urlparse.urljoin(base, mobj.group('href'))
             video_id = MotherlessIE.get_temp_id(video_url)
 
             if video_id:

--- a/yt_dlp/extractor/motherless.py
+++ b/yt_dlp/extractor/motherless.py
@@ -186,7 +186,7 @@ class MotherlessGroupIE(MotherlessPaginatedIE):
             'id': 'movie_scenes',
             'title': 'Movie Scenes',
         },
-        'playlist_mincount': 8*MotherlessPaginatedIE._PAGE_SIZE+1,
+        'playlist_mincount': 8 * MotherlessPaginatedIE._PAGE_SIZE + 1,
     }, {
         'url': 'http://motherless.com/gv/sex_must_be_funny',
         'info_dict': {
@@ -203,7 +203,7 @@ class MotherlessGroupIE(MotherlessPaginatedIE):
             'id': 'beautiful_cock',
             'title': 'Beautiful Cock',
         },
-        'playlist_mincount': 33*MotherlessPaginatedIE._PAGE_SIZE+1,
+        'playlist_mincount': 33 * MotherlessPaginatedIE._PAGE_SIZE + 1,
     }]
 
 
@@ -215,7 +215,7 @@ class MotherlessGalleryIE(MotherlessPaginatedIE):
             'id': '338999F',
             'title': 'Random',
         },
-        'playlist_mincount': 3*MotherlessPaginatedIE._PAGE_SIZE+1,
+        'playlist_mincount': 3 * MotherlessPaginatedIE._PAGE_SIZE + 1,
     }, {
         'url': 'https://motherless.com/GVABD6213',
         'info_dict': {

--- a/yt_dlp/extractor/motherless.py
+++ b/yt_dlp/extractor/motherless.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class MotherlessIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?motherless\.com/(?:g/[a-z0-9_]+/)?(?P<id>[A-Z0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?motherless\.com/(?:g/[a-z0-9_]+/)?(?P<id>[A-F0-9]+)'
     _TESTS = [{
         'url': 'http://motherless.com/AC3FFE1',
         'md5': '310f62e325a9fafe64f68c0bccb6e75f',


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Fixes the pattern that the MotherlessIE uses for IDs. The site uses hexadecimal ids, so we can restrict the match here appropriately. Implements supports for galleries, which uses IDs prefixed with `G` or `GV`, which in the previous step we prevented the generic IE from matching.