### PR TITLE
turn cookie store detection on it's feet

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -160,8 +160,6 @@ def _firefox_browser_dir():
         return os.path.expandvars(R'%APPDATA%\Mozilla\Firefox\Profiles')
     elif sys.platform == 'darwin':
         return os.path.expanduser('~/Library/Application Support/Firefox')
-
-    # fallthrough case: all the other Linux/BSD/Unix derivatives
     return os.path.expanduser('~/.mozilla/firefox')
 
 
@@ -190,7 +188,6 @@ def _get_chromium_based_browser_settings(browser_name):
             'vivaldi': os.path.join(appdata, 'Vivaldi'),
         }[browser_name]
 
-    # all the other Linux/BSD/Unix derivatives
     else:
         config = _config_home()
         browser_dir = {

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -166,7 +166,7 @@ def _firefox_browser_dir():
     if(os.path.exists(profpath)):
         return profpath
     else:
-      raise ValueError(f'cannot find profiles dir (unsupported platform: {sys.platform}?)')
+        raise ValueError(f'cannot find profiles dir (unsupported platform: {sys.platform}?)')
 
 
 def _get_chromium_based_browser_settings(browser_name):
@@ -219,7 +219,7 @@ def _get_chromium_based_browser_settings(browser_name):
     browsers_without_profiles = {'opera'}
     if browser_name not in browsers_without_profiles:
         if not os.path.exists(browser_dir):
-          raise ValueError(f'browser profile dir not found (unsupported platform: {sys.platform}?)')
+            raise ValueError(f'browser profile dir not found (unsupported platform: {sys.platform}?)')
 
     return {
         'browser_dir': browser_dir,

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -156,22 +156,18 @@ def _extract_firefox_cookies(profile, logger):
 
 
 def _firefox_browser_dir():
-    if sys.platform == 'win32':
-        profpath = os.path.expandvars(R'%APPDATA%\Mozilla\Firefox\Profiles')
+    if sys.platform in ('cygwin', 'win32'):
+        return os.path.expandvars(R'%APPDATA%\Mozilla\Firefox\Profiles')
     elif sys.platform == 'darwin':
-        profpath = os.path.expanduser('~/Library/Application Support/Firefox')
-    else:
-        profpath = os.path.expanduser('~/.mozilla/firefox')
+        return os.path.expanduser('~/Library/Application Support/Firefox')
 
-    if(os.path.exists(profpath)):
-        return profpath
-    else:
-        raise ValueError(f'cannot find profiles dir (unsupported platform: {sys.platform}?)')
+    # fallthrough case: all the other Linux/BSD/Unix derivatives
+    return os.path.expanduser('~/.mozilla/firefox')
 
 
 def _get_chromium_based_browser_settings(browser_name):
     # https://chromium.googlesource.com/chromium/src/+/HEAD/docs/user_data_dir.md
-    if sys.platform == 'win32':
+    if sys.platform in ('cygwin', 'win32'):
         appdata_local = os.path.expandvars('%LOCALAPPDATA%')
         appdata_roaming = os.path.expandvars('%APPDATA%')
         browser_dir = {
@@ -194,6 +190,7 @@ def _get_chromium_based_browser_settings(browser_name):
             'vivaldi': os.path.join(appdata, 'Vivaldi'),
         }[browser_name]
 
+    # all the other Linux/BSD/Unix derivatives
     else:
         config = _config_home()
         browser_dir = {
@@ -217,9 +214,6 @@ def _get_chromium_based_browser_settings(browser_name):
     }[browser_name]
 
     browsers_without_profiles = {'opera'}
-    if browser_name not in browsers_without_profiles:
-        if not os.path.exists(browser_dir):
-            raise ValueError(f'browser profile dir not found (unsupported platform: {sys.platform}?)')
 
     return {
         'browser_dir': browser_dir,


### PR DESCRIPTION
All the Unix-like platforms (Linux, *BSD) use the same location for
the browser profile directories, so it makes some sense to make
that the default instead of tracking all the platform names; and
treat Windows and OSX as the exceptions they are (based on the number
of platform names, not installs). This is especially useful as the
"platform" name on at least FreeBSD changes with each major release
(e.g. freebsd12, freebsd13, ...) and would have to be updated for
every release without this change here.
At the same time, fix the error condition: the question is not whether
we are on a "supported" platform but if the browser profile directory
exists in the place where we expect it. That handles all the cases like
"browser not available", "browser not installed", "profile not
initialized (yet)" and "non-standard profile dir location". Change
error message to match that behaviour.

<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible.
