### PR TITLE
perf: speedup startup times by ~10% by skipping site initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DESTDIR ?= .
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/man
 SHAREDIR ?= $(PREFIX)/share
-PYTHON ?= /usr/bin/env python3
+PYTHON ?= /usr/bin/env python3 -S
 
 # set SYSCONFDIR to /etc if PREFIX=/usr or PREFIX=/usr/local
 SYSCONFDIR = $(shell if [ $(PREFIX) = /usr -o $(PREFIX) = /usr/local ]; then echo /etc; else echo $(PREFIX)/etc; fi)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Because yt-dlp only depends on the standard library and doesn't use bare `exit()`, it's safe to skip site initialization which gives a nontrivial startup boost.

before:
```
$ hyperfine --warmup=3 -N './yt-dlp --help'
Benchmark 1: ./yt-dlp --help
  Time (mean ± σ):     700.8 ms ±   2.6 ms    [User: 623.4 ms, System: 67.3 ms]
  Range (min … max):   697.7 ms … 705.0 ms    10 runs
```

after:
```
$ hyperfine --warmup=3 -N './yt-dlp --help'
Benchmark 1: ./yt-dlp --help
  Time (mean ± σ):     621.5 ms ±   1.8 ms    [User: 558.4 ms, System: 53.0 ms]
  Range (min … max):   618.3 ms … 623.8 ms    10 runs
```
