### PR TITLE
Add nocopy flag

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -453,6 +453,7 @@ class YoutubeDL:
                        Use 'default' as the name for arguments to passed to all PP
                        For compatibility with youtube-dl, a single list of args
                        can also be used
+    nocopy:            If True, omit '-c copy' when downloading with ffmpeg.
 
     The following options are used by the extractors:
     extractor_retries: Number of times to retry for known errors

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -721,6 +721,7 @@ def parse_options(argv=None):
         'http_chunk_size': opts.http_chunk_size,
         'continuedl': opts.continue_dl,
         'noprogress': opts.quiet if opts.noprogress is None else opts.noprogress,
+        'nocopy': opts.nocopy,
         'progress_with_newline': opts.progress_with_newline,
         'progress_template': opts.progress_template,
         'playliststart': opts.playliststart,

--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -459,7 +459,9 @@ class FFmpegFD(ExternalFD):
                 args += http_headers
             args += self._configuration_args((f'_i{i + 1}', '_i')) + ['-i', url]
 
-        args += ['-c', 'copy']
+        if not self.params.get('nocopy'):
+            args += ['-c', 'copy']
+
         if info_dict.get('requested_formats') or protocol == 'http_dash_segments':
             for (i, fmt) in enumerate(info_dict.get('requested_formats') or [info_dict]):
                 stream_number = fmt.get('manifest_stream_number', 0)

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -946,6 +946,10 @@ def create_parser():
             'For ffmpeg, arguments can be passed to different positions using the same syntax as --postprocessor-args. '
             'You can use this option multiple times to give different arguments to different downloaders '
             '(Alias: --external-downloader-args)'))
+    downloader.add_option(
+        '--nocopy',
+        dest='nocopy', action='store_true', default=False,
+        help=('TODO Do not copy the video files to the destination directory'))
 
     workarounds = optparse.OptionGroup(parser, 'Workarounds')
     workarounds.add_option(


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Closes: https://github.com/yt-dlp/yt-dlp/issues/3932

At the moment, calling `yt-dlp --downloader ffmpeg --downloader-args "ffmpeg_i:-ss 00:00:08 -to 00:00:24" 'https://www.youtube.com/watch?v=S9HdPi9Ikhk'` to download a section of a video produces a corrupted video output. This is due to the `-c copy` flag which is always passed to ffmpeg.

It is possible to override this flag by specifying codecs, but this prevents ffmpeg from selecting reasonable default codecs, and requires the user to know the proper codec for every source URL they would like to download beforehand. 

This small change which introduces a `--nocopy` option, allows the user to omit the `-c copy` flag which previously was always passed to ffmpeg.

---

Thank you for your work creating and maintaining youtube-dlp :heart: 