### PR TITLE
[zdf] Identify the best video quality

### DIFF
--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -69,7 +69,7 @@ class ZDFBaseIE(InfoExtractor):
             f.update({
                 'url': format_url,
                 'format_id': join_nonempty('http', meta.get('type'), meta.get('quality')),
-                'tbr': int_or_none(self._search_regex(r'_(?P<tbr>\d+)k_', format_url, 'tbr', default=None, fatal=False))
+                'tbr': int_or_none(self._search_regex(r'_(\d+)k_', format_url, default=None))
             })
             new_formats = [f]
         formats.extend(merge_dicts(f, {

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -69,7 +69,7 @@ class ZDFBaseIE(InfoExtractor):
             f.update({
                 'url': format_url,
                 'format_id': join_nonempty('http', meta.get('type'), meta.get('quality')),
-                'tbr': int_or_none(self._search_regex(r'(?P<tbr>\d+)k', format_url, 'tbr', default=None, fatal=False))
+                'tbr': int_or_none(self._search_regex(r'_(?P<tbr>\d+)k_', format_url, 'tbr', default=None, fatal=False))
             })
             new_formats = [f]
         formats.extend(merge_dicts(f, {

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -69,6 +69,7 @@ class ZDFBaseIE(InfoExtractor):
             f.update({
                 'url': format_url,
                 'format_id': join_nonempty('http', meta.get('type'), meta.get('quality')),
+                'tbr': int_or_none(self._search_regex(r'(?P<tbr>\d+)k', format_url, 'tbr', default=None, fatal=False))
             })
             new_formats = [f]
         formats.extend(merge_dicts(f, {
@@ -108,7 +109,7 @@ class ZDFBaseIE(InfoExtractor):
                                 'class': track.get('class'),
                                 'language': track.get('language'),
                             })
-        self._sort_formats(formats, ('hasaud', 'res', 'quality', 'language_preference'))
+        self._sort_formats(formats, ('tbr', 'hasaud', 'res', 'quality', 'language_preference'))
 
         duration = float_or_none(try_get(
             ptmd, lambda x: x['attributes']['duration']['value']), scale=1000)
@@ -187,7 +188,7 @@ class ZDFIE(ZDFBaseIE):
         },
     }, {
         'url': 'https://www.zdf.de/funk/druck-11790/funk-alles-ist-verzaubert-102.html',
-        'md5': '3d6f1049e9682178a11c54b91f3dd065',
+        'md5': '57af4423db0455a3975d2dc4578536bc',
         'info_dict': {
             'ext': 'mp4',
             'id': 'video_funk_1770473',
@@ -229,6 +230,19 @@ class ZDFIE(ZDFBaseIE):
             'duration': 3193.0,
             'timestamp': 1641355200,
             'upload_date': '20220105',
+        },
+        'skip': 'No longer available "Diese Seite wurde leider nicht gefunden"'
+    }, {
+        'url': 'https://www.zdf.de/serien/soko-stuttgart/das-geld-anderer-leute-100.html',
+        'info_dict': {
+            'id': '191205_1800_sendung_sok8',
+            'ext': 'mp4',
+            'title': 'Das Geld anderer Leute',
+            'description': 'md5:cb6f660850dc5eb7d1ab776ea094959d',
+            'duration': 2581.0,
+            'timestamp': 1654790700,
+            'upload_date': '20220609',
+            'thumbnail': 'https://epg-image.zdf.de/fotobase-webdelivery/images/e2d7e55a-09f0-424e-ac73-6cac4dd65f35?layout=2400x1350',
         },
     }]
 

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -109,7 +109,7 @@ class ZDFBaseIE(InfoExtractor):
                                 'class': track.get('class'),
                                 'language': track.get('language'),
                             })
-        self._sort_formats(formats, ('tbr', 'hasaud', 'res', 'quality', 'language_preference'))
+        self._sort_formats(formats, ('tbr', 'res', 'quality', 'language_preference'))
 
         duration = float_or_none(try_get(
             ptmd, lambda x: x['attributes']['duration']['value']), scale=1000)


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description

By extracting the `tbr` quality from the mp4 urls (if available) and sorting formats by this value, we can do a better work identifying the best video quality

Fixes #4020 

### Formats

```bash
yt-dlp -vU -F https://www.zdf.de/serien/soko-stuttgart/das-geld-anderer-leute-100.html
```

```bash
[debug] Command-line config: ['-vU', '-F', 'https://www.zdf.de/serien/soko-stuttgart/das-geld-anderer-leute-100.html']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.05.18 [b14d52355] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: da5a3dd54
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-113-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
Latest version: 2022.05.18, Current version: 2022.05.18
yt-dlp is up to date (2022.05.18)
[debug] Using fake IP 53.105.237.89 (DE) as X-Forwarded-For
[debug] [ZDF] Extracting URL: https://www.zdf.de/serien/soko-stuttgart/das-geld-anderer-leute-100.html
[ZDF] das-geld-anderer-leute-100: Downloading webpage
[ZDF] das-geld-anderer-leute-100: Downloading JSON content
[ZDF] das-geld-anderer-leute-100: Downloading JSON metadata
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[debug] Sort order given by extractor: tbr, hasaud, res, quality, language_preference
[debug] Formats sorted by: hasvid, ie_pref, tbr, hasaud, res, quality, lang, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, vbr, abr, asr, proto, vext, aext, source, id
[info] Available formats for 191205_1800_sendung_sok8:
ID                                      EXT RESOLUTION FPS │   FILESIZE   TBR PROTO  │ VCODEC        VBR ACODEC     ABR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
hls-audio0-Audiodeskription-0           mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] Audiodeskription
hls-audio0-TV_Ton-0                     mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] TV Ton
hls-audio0-Audiodeskription-1           mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] Audiodeskription
hls-audio0-TV_Ton-1                     mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] TV Ton
hls-audio0-Audiodeskription-2           mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] Audiodeskription
hls-audio0-TV_Ton-2                     mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] TV Ton
hls-audio0-Audiodeskription-3           mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] Audiodeskription
hls-audio0-TV_Ton-3                     mp4 audio only     │                  m3u8_n │ audio only        unknown        [de] TV Ton
hls-381-0                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] auto, ad
hls-381-1                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] auto, ad
hls-381-2                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] auto, main
hls-381-3                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] auto, main
hls-381-4                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] med, ad
hls-381-5                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] med, ad
hls-381-6                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] med, main
hls-381-7                               mp4 480x272     25 │ ~120.28MiB  381k m3u8_n │ avc1.4d401f  381k video only  0k [deu] med, main
http-h264_aac_mp4_http_na_na-low-0      mp4 unknown        │ ~149.97MiB  476k https  │ h264         476k aac         0k [deu] low, ad
http-h264_aac_mp4_http_na_na-low-1      mp4 unknown        │ ~149.97MiB  476k https  │ h264         476k aac         0k [deu] low, main
hls-614-0                               mp4 640x360     25 │ ~193.56MiB  614k m3u8_n │ avc1.4d401f  614k video only  0k [deu] auto, ad
hls-614-1                               mp4 640x360     25 │ ~193.56MiB  614k m3u8_n │ avc1.4d401f  614k video only  0k [deu] auto, main
hls-614-2                               mp4 640x360     25 │ ~193.56MiB  614k m3u8_n │ avc1.4d401f  614k video only  0k [deu] med, ad
hls-614-3                               mp4 640x360     25 │ ~193.56MiB  614k m3u8_n │ avc1.4d401f  614k video only  0k [deu] med, main
http-h264_aac_mp4_http_na_na-high-0     mp4 unknown        │ ~244.49MiB  776k https  │ h264         776k aac         0k [deu] high, ad
http-h264_aac_mp4_http_na_na-high-1     mp4 unknown        │ ~244.49MiB  776k https  │ h264         776k aac         0k [deu] high, ad
http-h264_aac_mp4_http_na_na-high-2     mp4 unknown        │ ~244.49MiB  776k https  │ h264         776k aac         0k [deu] high, main
http-h264_aac_mp4_http_na_na-high-3     mp4 unknown        │ ~244.49MiB  776k https  │ h264         776k aac         0k [deu] high, main
hls-1181-0                              mp4 852x480     25 │ ~372.21MiB 1181k m3u8_n │ avc1.4d401f 1181k video only  0k [deu] auto, ad
hls-1181-1                              mp4 852x480     25 │ ~372.21MiB 1181k m3u8_n │ avc1.4d401f 1181k video only  0k [deu] auto, main
hls-1181-2                              mp4 852x480     25 │ ~372.21MiB 1181k m3u8_n │ avc1.4d401f 1181k video only  0k [deu] med, ad
hls-1181-3                              mp4 852x480     25 │ ~372.21MiB 1181k m3u8_n │ avc1.4d401f 1181k video only  0k [deu] med, main
http-h264_aac_mp4_http_na_na-veryhigh-0 mp4 unknown        │ ~471.33MiB 1496k https  │ h264        1496k aac         0k [deu] veryhigh, ad
http-h264_aac_mp4_http_na_na-veryhigh-1 mp4 unknown        │ ~471.33MiB 1496k https  │ h264        1496k aac         0k [deu] veryhigh, ad
http-h264_aac_mp4_http_na_na-veryhigh-2 mp4 unknown        │ ~471.33MiB 1496k https  │ h264        1496k aac         0k [deu] veryhigh, main
http-h264_aac_mp4_http_na_na-veryhigh-3 mp4 unknown        │ ~471.33MiB 1496k https  │ h264        1496k aac         0k [deu] veryhigh, main
hls-1827-0                              mp4 1024x576    25 │ ~575.84MiB 1827k m3u8_n │ avc1.4d401f 1827k video only  0k [deu] auto, ad
hls-1827-1                              mp4 1024x576    25 │ ~575.84MiB 1827k m3u8_n │ avc1.4d401f 1827k video only  0k [deu] auto, main
hls-2641-0                              mp4 1280x720    50 │ ~832.26MiB 2641k m3u8_n │ avc1.640028 2641k video only  0k [deu] auto, ad
hls-2641-1                              mp4 1280x720    50 │ ~832.26MiB 2641k m3u8_n │ avc1.640028 2641k video only  0k [deu] auto, main
```

### Download

```bash
[debug] Command-line config: ['-vU', 'https://www.zdf.de/serien/soko-stuttgart/das-geld-anderer-leute-100.html']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.05.18 [b14d52355] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: da5a3dd54
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.4.0-113-generic-x86_64-with-glibc2.29
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
Latest version: 2022.05.18, Current version: 2022.05.18
yt-dlp is up to date (2022.05.18)
[debug] Using fake IP 53.75.75.3 (DE) as X-Forwarded-For
[debug] [ZDF] Extracting URL: https://www.zdf.de/serien/soko-stuttgart/das-geld-anderer-leute-100.html
[ZDF] das-geld-anderer-leute-100: Downloading webpage
[ZDF] das-geld-anderer-leute-100: Downloading JSON content
[ZDF] das-geld-anderer-leute-100: Downloading JSON metadata
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[ZDF] 191205_1800_sendung_sok8: Downloading m3u8 information
[debug] Sort order given by extractor: tbr, hasaud, res, quality, language_preference
[debug] Formats sorted by: hasvid, ie_pref, tbr, hasaud, res, quality, lang, fps, hdr:12(7), vcodec:vp9.2(10), acodec, filesize, fs_approx, vbr, abr, asr, proto, vext, aext, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 191205_1800_sendung_sok8: Chapter information is unavailable
[info] 191205_1800_sendung_sok8: Downloading 1 format(s): hls-2641-1+hls-audio0-TV_Ton-3
```