### PR TITLE
Append 'ext' to ffmpeg temporary files

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -839,8 +839,8 @@ class FFmpegMergerPP(FFmpegPostProcessor):
 
 
 class FFmpegFixupPostProcessor(FFmpegPostProcessor):
-    def _fixup(self, msg, filename, options):
-        temp_filename = prepend_extension(filename, 'temp')
+    def _fixup(self, msg, filename, ext, options):
+        temp_filename = prepend_extension(filename, 'temp') + '.' + ext
 
         self.to_screen(f'{msg} of "{filename}"')
         self.run_ffmpeg(filename, temp_filename, options)
@@ -853,7 +853,7 @@ class FFmpegFixupStretchedPP(FFmpegFixupPostProcessor):
     def run(self, info):
         stretched_ratio = info.get('stretched_ratio')
         if stretched_ratio not in (None, 1):
-            self._fixup('Fixing aspect ratio', info['filepath'], [
+            self._fixup('Fixing aspect ratio', info['filepath'], info['ext'], [
                 *self.stream_copy_opts(), '-aspect', '%f' % stretched_ratio])
         return [], info
 
@@ -862,7 +862,8 @@ class FFmpegFixupM4aPP(FFmpegFixupPostProcessor):
     @PostProcessor._restrict_to(images=False, video=False)
     def run(self, info):
         if info.get('container') == 'm4a_dash':
-            self._fixup('Correcting container', info['filepath'], [*self.stream_copy_opts(), '-f', 'mp4'])
+            self._fixup('Correcting container', info['filepath'], info['ext'], [
+                *self.stream_copy_opts(), '-f', 'mp4'])
         return [], info
 
 
@@ -881,7 +882,7 @@ class FFmpegFixupM3u8PP(FFmpegFixupPostProcessor):
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
         if all(self._needs_fixup(info)):
-            self._fixup('Fixing MPEG-TS in MP4 container', info['filepath'], [
+            self._fixup('Fixing MPEG-TS in MP4 container', info['filepath'], info['ext'], [
                 *self.stream_copy_opts(), '-f', 'mp4', '-bsf:a', 'aac_adtstoasc'])
         return [], info
 
@@ -903,7 +904,8 @@ class FFmpegFixupTimestampPP(FFmpegFixupPostProcessor):
             opts = ['-vf', 'setpts=PTS-STARTPTS']
         else:
             opts = ['-c', 'copy', '-bsf', 'setts=ts=TS-STARTPTS']
-        self._fixup('Fixing frame timestamp', info['filepath'], opts + [*self.stream_copy_opts(False), '-ss', self.trim])
+        self._fixup('Fixing frame timestamp', info['filepath'], info['ext'], opts + [
+            *self.stream_copy_opts(False), '-ss', self.trim])
         return [], info
 
 
@@ -912,7 +914,7 @@ class FFmpegCopyStreamPP(FFmpegFixupPostProcessor):
 
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
-        self._fixup(self.MESSAGE, info['filepath'], self.stream_copy_opts())
+        self._fixup(self.MESSAGE, info['filepath'], info['ext'], self.stream_copy_opts())
         return [], info
 
 

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -642,7 +642,7 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
                 opts.extend(['-metadata:s:s:%d' % i, 'handler_name=%s' % name,
                              '-metadata:s:s:%d' % i, 'title=%s' % name])
 
-        temp_filename = prepend_extension(filename, 'temp')
+        temp_filename = prepend_extension(filename, 'temp') + '.' + ext
         self.to_screen('Embedding subtitles in "%s"' % filename)
         self.run_ffmpeg_multiple_files(input_files, temp_filename, opts)
         os.replace(temp_filename, filename)
@@ -690,7 +690,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             self.to_screen('There isn\'t any metadata to add')
             return [], info
 
-        temp_filename = prepend_extension(filename, 'temp')
+        temp_filename = prepend_extension(filename, 'temp') + '.' + info['ext']
         self.to_screen('Adding metadata to "%s"' % filename)
         self.run_ffmpeg_multiple_files(
             (filename, metadata_filename), temp_filename,
@@ -804,7 +804,7 @@ class FFmpegMergerPP(FFmpegPostProcessor):
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
         filename = info['filepath']
-        temp_filename = prepend_extension(filename, 'temp')
+        temp_filename = prepend_extension(filename, 'temp') + '.' + info['ext']
         args = ['-c', 'copy']
         audio_streams = 0
         for (i, fmt) in enumerate(info['requested_formats']):


### PR DESCRIPTION
<details><summary>Boilerplate (own code, bugfix)</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement
</details>

Append the extension from `info['ext']` to temporary output files in some ffmpeg postprocessors, so that ffmpeg detects the output format.

Progress towards fixing #1844.