### PR TITLE
[core] Verify 'ext' obtained from existing output file

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -55,6 +55,7 @@ from .postprocessor import (
     MoveFilesAfterDownloadPP,
     get_postprocessor,
 )
+from .postprocessor.ffmpeg import EXT_TO_OUT_FORMATS
 from .update import detect_variant
 from .utils import (
     DEFAULT_OUTTMPL,
@@ -3053,7 +3054,9 @@ class YoutubeDL:
                     file = self.existing_file(itertools.chain(*zip(map(converted, filepaths), filepaths)),
                                               default_overwrite=False)
                     if file:
-                        info_dict['ext'] = os.path.splitext(file)[1][1:]
+                        existing_ext = os.path.splitext(file)[1][1:]
+                        if existing_ext in EXT_TO_OUT_FORMATS.keys():
+                            info_dict['ext'] = existing_ext
                     return file
 
                 success = True


### PR DESCRIPTION
<details><summary>Boilerplate (own code, bugfix)</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement
</details>

Currently, if a user-supplied output file exists already, yt-dlp changes the `info_dict['ext']` (output container format) to the file extension obtained from the file name, without checking if the format implied by the extension is valid.

Check if the the extension obtained from the existing file name corresponds to a known output format, and if not, do not change `info_dict['ext']`.