### PR TITLE
[exctractor/digitalconcerthall] Fix code logic typo

### DIFF
--- a/yt_dlp/extractor/digitalconcerthall.py
+++ b/yt_dlp/extractor/digitalconcerthall.py
@@ -86,7 +86,7 @@ class DigitalConcertHallIE(InfoExtractor):
                 })
 
             m3u8_url = traverse_obj(
-                stream_info, ('channel', lambda x: x.startswith('vod_mixed'), 'stream', 0, 'url'), get_all=False)
+                stream_info, ('channel', lambda k, v: k.startswith('vod_mixed'), 'stream', 0, 'url'), get_all=False)
             formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', 'm3u8_native', fatal=False)
             self._sort_formats(formats)
 

--- a/yt_dlp/extractor/digitalconcerthall.py
+++ b/yt_dlp/extractor/digitalconcerthall.py
@@ -86,7 +86,7 @@ class DigitalConcertHallIE(InfoExtractor):
                 })
 
             m3u8_url = traverse_obj(
-                stream_info, ('channel', lambda k, v: k.startswith('vod_mixed'), 'stream', 0, 'url'), get_all=False)
+                stream_info, ('channel', lambda _, v: k.startswith('vod_mixed'), 'stream', 0, 'url'), get_all=False)
             formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', 'm3u8_native', fatal=False)
             self._sort_formats(formats)
 


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

Fixing of a critical code error, due to which the digitalconcerthall extractor did not work.

<details>
  <summary>Error debug log</summary>

```bash
[debug] Command-line config: ['https://www.digitalconcerthall.com/en/concert/3439', '--playlist-items', '2', '--username', 'PRIVATE', '--password', 'PRIVATE', '--verbose']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.05.18 [b14d52355] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 44a6fcf
[debug] Python version 3.8.10 (CPython 64bit) - Linux-5.13.0-1017-aws-x86_64-with-glibc2.29
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, pyxattr-0.6.1, secretstorage-2.3.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[DigitalConcertHall] Obtaining token
[DigitalConcertHall] Logging in
[debug] [DigitalConcertHall] Extracting URL: https://www.digitalconcerthall.com/en/concert/3439
[DigitalConcertHall] 3439: Downloading webpage
[DigitalConcertHall] 3439: Downloading JSON metadata
[download] Downloading playlist: Andris Nelsons conducts Mozart, Wagner and Shostakovich
[DigitalConcertHall] 3439-1: Downloading JSON metadata
[DigitalConcertHall] 3439-1: Downloading m3u8 information
ERROR: 'bytes' object has no attribute 'encode'
Traceback (most recent call last):
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/YoutubeDL.py", line 1420, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/utils.py", line 2911, in <lambda>
    return type(self.ydl)._handle_extraction_exceptions(lambda _, i: self._entries[i])(self.ydl, i)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/utils.py", line 2683, in __getitem__
    self._cache.extend(itertools.islice(self._iterable, n))
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/extractor/digitalconcerthall.py", line 90, in _entries
    formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', 'm3u8_native', fatal=False)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/extractor/common.py", line 2102, in _extract_m3u8_formats
    fmts, subs = self._extract_m3u8_formats_and_subtitles(*args, **kwargs)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/extractor/common.py", line 2113, in _extract_m3u8_formats_and_subtitles
    res = self._download_webpage_handle(
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/extractor/common.py", line 828, in _download_webpage_handle
    urlh = self._request_webpage(url_or_request, video_id, note, errnote, fatal, data=data, headers=headers, query=query, expected_status=expected_status)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/extractor/common.py", line 767, in _request_webpage
    return self._downloader.urlopen(self._create_request(url_or_request, data, headers, query))
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/extractor/common.py", line 733, in _create_request
    return sanitized_Request(url_or_request, data, headers)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/utils.py", line 761, in sanitized_Request
    url, auth_header = extract_basic_auth(escape_url(sanitize_url(url)))
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/utils.py", line 2978, in escape_url
    netloc=url_parsed.netloc.encode('idna').decode('ascii'),
AttributeError: 'bytes' object has no attribute 'encode'

ERROR: 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/YoutubeDL.py", line 1420, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/YoutubeDL.py", line 1504, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/YoutubeDL.py", line 1627, in process_ie_result
    return self.__process_playlist(ie_result, download)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/YoutubeDL.py", line 1683, in __process_playlist
    entries = resolved_entries = list(entries)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/utils.py", line 777, in _iter
    for x in iterable:
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/utils.py", line 2884, in get_requested_items
    self.ydl._match_entry(entry, incomplete=True, silent=True)
  File "/home/ubuntu/dch-dl/yt-dlp/yt_dlp/YoutubeDL.py", line 1300, in _match_entry
    video_title = info_dict.get('title', info_dict.get('id', 'video'))
AttributeError: 'NoneType' object has no attribute 'get'
```

</details>