### PR TITLE
[WatchESPN] support for free videos and BAM_DTC

### DIFF
--- a/yt_dlp/extractor/espn.py
+++ b/yt_dlp/extractor/espn.py
@@ -322,7 +322,7 @@ class WatchESPNIE(AdobePassIE):
             video_id)['playbackState']
 
         # ESPN+ subscription required, through cookies
-        if video_data.get('sourceId') == 'ESPN_DTC':
+        if 'DTC' in video_data.get('sourceId'):
             cookie = self._get_cookies(url).get('ESPN-ONESITE.WEB-PROD.token')
             if not cookie:
                 self.raise_login_required(method='cookies')
@@ -365,6 +365,13 @@ class WatchESPNIE(AdobePassIE):
                     'Authorization': token
                 })
             m3u8_url, headers = playback['stream']['complete'][0]['url'], {'authorization': token}
+
+        # No login required
+        elif video_data.get('sourceId') == 'ESPN_FREE':
+            asset = self._download_json(
+                f'https://watch.auth.api.espn.com/video/auth/media/{video_id}/asset?apikey=uiqlbgzdwuru14v627vdusswb',
+                video_id)
+            m3u8_url, headers = asset['stream'], {}
 
         # TV Provider required
         else:


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

A couple of improvements to the WatchESPN extractor from #2283.

1. Recognize ESPN+ videos that have the `BAM_DTC` source rather than `ESPN_DTC` (recently some MLS replays switched to this, and the extractor was wrongly treating these as TV provider access rather than cookies)
2. Add support for free videos, that require neither TV login nor cookies. Previously users would have to provide TV provider to download these videos.