### PR TITLE
Fix bug when handling HTTP requests

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1343,7 +1343,7 @@ class YoutubeDLHandler(compat_urllib_request.HTTPHandler):
 
         req.headers = handle_youtubedl_headers(req.headers)
 
-        return req
+        return super().do_request_(req)
 
     def http_response(self, req, resp):
         old_resp = resp


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

Back-porting from #2861 

Fixes (rare) bug introduced in https://github.com/ytdl-org/youtube-dl/commit/be4a824d74add1a3b78b8244dff12f4f078f168a

There is a function in `AbstractHTTPHandler` that adds a bunch of default headers to the request.

 In particular, it adds `'Content-type':  'application/x-www-form-urlencoded'` header when data is present and no content-type header is added. Some extractors rely on this behaviour and sites may reject requests without (dailymotion)

The issue is this method is only called for HTTPS requests, not HTTP (hence this header not being added by default for HTTP). `YoutubeDLHandler` does not call `do_request_` (as it overrides both `http_request` and `https_request`). It is only called for `https_request` because of `YoutubeDLHTTPSHandler` which inherits `HTTPSHandler` which has `https_request = AbstractHTTPHandler.do_request_` set.

This PR provides one of the many possible fixes for this. The downside of this solution is `do_request_` is called twice (in `YoutubeDLHandler` and `YoutubeDLHTTPSHandler` for HTTPS requests. However it should not be a problem since the function  has checks in place to not e.g. add headers twice.