### PR TITLE
Calculate correct end_time

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2617,9 +2617,10 @@ class YoutubeDL:
                 new_info.update(fmt)
                 offset, duration = info_dict.get('section_start') or 0, info_dict.get('duration') or float('inf')
                 if chapter or offset:
+                    chapter_duration = chapter.get('end_time', 0) - chapter.get('start_time', 0) if chapter else float('inf')
                     new_info.update({
                         'section_start': offset + chapter.get('start_time', 0),
-                        'section_end': offset + min(chapter.get('end_time', 0), duration),
+                        'section_end': offset + min(chapter_duration, duration),
                         'section_title': chapter.get('title'),
                         'section_number': chapter.get('index'),
                     })


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

The current code wrongly calculates the `section_end` to be the same as `section_start`, creating an empty file, when the range is requested by extractors (e.g. youtube:clip)

Disclaimer: I haven't tested for much more cases

Related https://github.com/yt-dlp/yt-dlp/issues/2543#issuecomment-1165505838

<details>
<summary>Full verbose log</summary>

```
[debug] Command-line config: ['https://youtube.com/clip/UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod', '-v']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8 (No ANSI), error utf-8 (No ANSI), screen utf-8 (No ANSI)
[debug] yt-dlp version 2022.06.22.1 [a86e01e74] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 379a4f161
[debug] Python version 3.10.4 (CPython 64bit) - Linux-5.15.0-39-generic-x86_64-with-glibc2.35
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.4.2 (setts), ffprobe 4.4.2, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.11.0, brotli-1.0.9, certifi-2020.06.20, mutagen-1.45.1, pyxattr-0.7.2, secretstorage-3.3.1, sqlite3-2.6.0, websockets-9.1
[debug] Proxy map: {}
[debug] [youtube:clip] Extracting URL: https://youtube.com/clip/UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod
[youtube:clip] UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod: Downloading webpage
[debug] [youtube] Extracting URL: https://www.youtube.com/watch?v=qXLlUSAbei8
[youtube] qXLlUSAbei8: Downloading webpage
[youtube] qXLlUSAbei8: Downloading android player API JSON
[debug] Sort order given by extractor: quality, res, fps, hdr:12, source, codec:vp9.2, lang, proto
[debug] Formats sorted by: hasvid, ie_pref, quality, res, fps, hdr:12(7), source, vcodec:vp9.2(10), acodec, lang, proto, filesize, fs_approx, tbr, vbr, abr, asr, vext, aext, hasaud, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod: Downloading 1 format(s): 248+251
[debug] Invoking ffmpeg downloader on "https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=248&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=video%2Fwebm&gir=yes&clen=127208771&dur=724.160&lmt=1654427283368913&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5535434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRQIhAOw4ccv_ic1LbCkxiDrV-CZYuLlaheK7K-iGRGeMRvNXAiA57vi5nhCX99xzw9pQtm7Yfw7PE8cCUo35vmIcu_Nvlw%3D%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D", "https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=251&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=audio%2Fwebm&gir=yes&clen=11357394&dur=724.181&lmt=1654413381134432&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRgIhAOKXHG2RCv2oyP3xV2wCe1xXhlsTWdlISkp965QOArNKAiEA6puTeBWfAAMJsFFap-URbUD_eTGHJnDArcxx8AWaykY%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D"
[download] Destination: Smash or Pass - asdfmovie [UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod].webm
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -ss 136.041 -t 5.0 -i 'https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=248&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=video%2Fwebm&gir=yes&clen=127208771&dur=724.160&lmt=1654427283368913&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5535434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRQIhAOw4ccv_ic1LbCkxiDrV-CZYuLlaheK7K-iGRGeMRvNXAiA57vi5nhCX99xzw9pQtm7Yfw7PE8cCUo35vmIcu_Nvlw%3D%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D' -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -ss 136.041 -t 5.0 -i 'https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=251&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=audio%2Fwebm&gir=yes&clen=11357394&dur=724.181&lmt=1654413381134432&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRgIhAOKXHG2RCv2oyP3xV2wCe1xXhlsTWdlISkp965QOArNKAiEA6puTeBWfAAMJsFFap-URbUD_eTGHJnDArcxx8AWaykY%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D' -c copy -map 0:0 -map 1:0 -f webm 'file:Smash or Pass - asdfmovie [UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod].webm.part'
ffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright (c) 2000-2021 the FFmpeg developers
  built with gcc 11 (Ubuntu 11.2.0-19ubuntu1)
  configuration: --prefix=/usr --extra-version=0ubuntu0.22.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librabbitmq --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-pocketsphinx --enable-librsvg --enable-libmfx --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
[tcp @ 0x563906f73800] Starting connection attempt to 210.139.253.205 port 443
[tcp @ 0x563906f73800] Successfully connected to 210.139.253.205 port 443
[tcp @ 0x56390709bd00] Starting connection attempt to 173.194.22.232 port 443
[tcp @ 0x56390709bd00] Successfully connected to 173.194.22.232 port 443
[tcp @ 0x563907055000] Starting connection attempt to 173.194.22.232 port 443
[tcp @ 0x563907055000] Successfully connected to 173.194.22.232 port 443
Input #0, matroska,webm, from 'https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=248&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=video%2Fwebm&gir=yes&clen=127208771&dur=724.160&lmt=1654427283368913&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5535434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRQIhAOw4ccv_ic1LbCkxiDrV-CZYuLlaheK7K-iGRGeMRvNXAiA57vi5nhCX99xzw9pQtm7Yfw7PE8cCUo35vmIcu_Nvlw%3D%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D':
  Metadata:
    encoder         : google/video-file
  Duration: 00:12:04.16, start: 0.000000, bitrate: 1405 kb/s
  Stream #0:0(eng): Video: vp9 (Profile 0), 1 reference frame, yuv420p(tv, bt709), 1920x1080, SAR 1:1 DAR 16:9, 25 fps, 25 tbr, 1k tbn, 1k tbc (default)
[tcp @ 0x56390723a8c0] Starting connection attempt to 210.139.253.205 port 443
[tcp @ 0x56390723a8c0] Successfully connected to 210.139.253.205 port 443
[tcp @ 0x563907286b40] Starting connection attempt to 210.139.253.205 port 443
[tcp @ 0x563907286b40] Successfully connected to 210.139.253.205 port 443
Input #1, matroska,webm, from 'https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=251&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=audio%2Fwebm&gir=yes&clen=11357394&dur=724.181&lmt=1654413381134432&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRgIhAOKXHG2RCv2oyP3xV2wCe1xXhlsTWdlISkp965QOArNKAiEA6puTeBWfAAMJsFFap-URbUD_eTGHJnDArcxx8AWaykY%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D':
  Metadata:
    encoder         : google/video-file
  Duration: 00:12:04.18, start: -0.007000, bitrate: 125 kb/s
  Stream #1:0(eng): Audio: opus, 48000 Hz, stereo, fltp, delay 312 (default)
Output #0, webm, to 'file:Smash or Pass - asdfmovie [UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod].webm.part':
  Metadata:
    encoder         : Lavf58.76.100
  Stream #0:0(eng): Video: vp9 (Profile 0), 1 reference frame, yuv420p(tv, bt709), 1920x1080 (0x0) [SAR 1:1 DAR 16:9], q=2-31, 25 fps, 25 tbr, 1k tbn, 1k tbc (default)
  Stream #0:1(eng): Audio: opus, 48000 Hz, stereo, fltp, delay 312 (default)
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #1:0 -> #0:1 (copy)
Press [q] to stop, [?] for help
Automatically inserted bitstream filter 'vp9_superframe'; args=''
frame=    1 fps=0.0 q=-1.0 size=       1kB time=00:00:00.00 bitrate=N/A speed=   0x    
frame=   40 fps=0.0 q=-1.0 size=      29kB time=-00:00:02.72 bitrate=N/A speed=N/A    
frame=   44 fps= 35 q=-1.0 size=      29kB time=-00:00:02.56 bitrate=N/A speed=N/A    
frame=   47 fps= 26 q=-1.0 size=     183kB time=-00:00:02.44 bitrate=N/A speed=N/A    
frame=   59 fps= 26 q=-1.0 size=     256kB time=-00:00:01.96 bitrate=N/A speed=N/A    
frame=   60 fps= 21 q=-1.0 size=     256kB time=-00:00:01.92 bitrate=N/A speed=N/A    
frame=   90 fps= 23 q=-1.0 size=     256kB time=-00:00:00.72 bitrate=N/A speed=N/A    
frame=   92 fps= 21 q=-1.0 size=     256kB time=-00:00:00.64 bitrate=N/A speed=N/A    
frame=  105 fps= 21 q=-1.0 size=     256kB time=-00:00:00.12 bitrate=N/A speed=N/A    
frame=  132 fps= 23 q=-1.0 size=     256kB time=00:00:00.96 bitrate=2184.5kbits/s speed=0.171x    
frame=  145 fps= 24 q=-1.0 size=     512kB time=00:00:01.48 bitrate=2834.0kbits/s speed=0.241x    
frame=  180 fps= 26 q=-1.0 size=    1024kB time=00:00:02.88 bitrate=2912.7kbits/s speed=0.417x    
frame=  205 fps= 28 q=-1.0 size=    1024kB time=00:00:03.88 bitrate=2162.0kbits/s speed=0.522x    
frame=  218 fps= 27 q=-1.0 size=    1024kB time=00:00:04.40 bitrate=1906.5kbits/s speed=0.553x    
frame=  230 fps= 26 q=-1.0 size=    1024kB time=00:00:04.88 bitrate=1719.0kbits/s speed=0.544x    
No more output streams to write to, finishing.
frame=  233 fps= 24 q=-1.0 Lsize=    1720kB time=00:00:05.00 bitrate=2818.3kbits/s speed=0.505x    
video:1544kB audio:170kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.362955%
Input file #0 (https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=248&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=video%2Fwebm&gir=yes&clen=127208771&dur=724.160&lmt=1654427283368913&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5535434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRQIhAOw4ccv_ic1LbCkxiDrV-CZYuLlaheK7K-iGRGeMRvNXAiA57vi5nhCX99xzw9pQtm7Yfw7PE8cCUo35vmIcu_Nvlw%3D%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D):
  Input stream #0:0 (video): 234 packets read (1613355 bytes); 
  Total: 234 packets (1613355 bytes) demuxed
Input file #1 (https://rr2---sn-nvoxu-ioqes.googlevideo.com/videoplayback?expire=1656098508&ei=a7q1YoiAPYTDkgas7YcY&ip=92.202.97.64&id=o-AOE7RGbvalW1qkHX7z8mLHk4mlo2GNLWNk8BP1pRnzOd&itag=251&source=youtube&requiressl=yes&mh=hq&mm=31%2C29&mn=sn-nvoxu-ioqes%2Csn-oguelnsl&ms=au%2Crdu&mv=m&mvi=2&pl=17&initcwndbps=740000&vprv=1&mime=audio%2Fwebm&gir=yes&clen=11357394&dur=724.181&lmt=1654413381134432&mt=1656076636&fvip=4&keepalive=yes&fexp=24001373%2C24007246&c=ANDROID&txp=5532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRgIhAOKXHG2RCv2oyP3xV2wCe1xXhlsTWdlISkp965QOArNKAiEA6puTeBWfAAMJsFFap-URbUD_eTGHJnDArcxx8AWaykY%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRQIhALYxB6_bsGA1rGCBlwBvJXjG0ZGOXVpRrSy3R9Lps0qsAiBJ18Bq1QN74KDAxDCGaiDGvkw72Z3cQah14xJvs5_SPA%3D%3D):
  Input stream #1:0 (audio): 552 packets read (174023 bytes); 
  Total: 552 packets (174023 bytes) demuxed
Output file #0 (file:Smash or Pass - asdfmovie [UgkxdIc_hmqiDzYn3zoGbskyrVEnI4t_1Sod].webm.part):
  Output stream #0:0 (video): 233 packets muxed (1581301 bytes); 
  Output stream #0:1 (audio): 551 packets muxed (173736 bytes); 
  Total: 784 packets (1755037 bytes) muxed
[AVIOContext @ 0x563907826640] Statistics: 2 seeks, 8 writeouts
[AVIOContext @ 0x563907048480] Statistics: 1731725 bytes read, 1 seeks
[AVIOContext @ 0x563907107500] Statistics: 202153 bytes read, 1 seeks

[ffmpeg] Downloaded 1761407 bytes

[download] 100% of 1.68MiB in 00:11
```
</details>