### PR TITLE
Check to see if a filter's comparison_value is itself a key in the di…

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3790,7 +3790,6 @@ def match_filter_func(filters):
         else:
             video_title = info_dict.get('title') or info_dict.get('id') or 'entry'
             filter_str = ') | ('.join(map(str.strip, filters))
-            print ("%s %s" % (info_dict['uploader_id'], info_dict['playlist_uploader_id']))
             return f'{video_title} does not pass filter ({filter_str}), skipping ..'
     return _match_func
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3723,6 +3723,8 @@ def _match_one(filter_part, dct, incomplete):
         if m['quote']:
             comparison_value = comparison_value.replace(r'\%s' % m['quote'], m['quote'])
         actual_value = dct.get(m['key'])
+        if comparison_value in dct:
+            comparison_value = dct.get(comparison_value)
         numeric_comparison = None
         if isinstance(actual_value, (int, float)):
             # If the original field is a string and matching comparisonvalue is
@@ -3788,6 +3790,7 @@ def match_filter_func(filters):
         else:
             video_title = info_dict.get('title') or info_dict.get('id') or 'entry'
             filter_str = ') | ('.join(map(str.strip, filters))
+            print ("%s %s" % (info_dict['uploader_id'], info_dict['playlist_uploader_id']))
             return f'{video_title} does not pass filter ({filter_str}), skipping ..'
     return _match_func
 


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

Per #4168 a filter in --match-filter would assume that the RHS of a comparison was a static value.  This change enables the right hand side to be a key in the info dictionary as well.

This will fix #4168.