### PR TITLE
[StarTrek] Add extractor for startrek.com videos

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1606,6 +1606,7 @@ from .spike import (
     BellatorIE,
     ParamountNetworkIE,
 )
+from .startrek import StarTrekIE
 from .stitcher import (
     StitcherIE,
     StitcherShowIE,

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1501,7 +1501,7 @@ class InfoExtractor:
                 'url': url_or_none(e.get('contentUrl')),
                 'title': unescapeHTML(e.get('name')),
                 'description': unescapeHTML(e.get('description')),
-                'thumbnails': [{'url': url}
+                'thumbnails': [{'url': unescapeHTML(url)}
                                for url in variadic(traverse_obj(e, 'thumbnailUrl', 'thumbnailURL'))
                                if url_or_none(url)],
                 'duration': parse_duration(e.get('duration')),

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -27,12 +27,12 @@ class StarTrekIE(InfoExtractor):
         description = self._html_search_regex(
             r'(?s)<div class="header-body">(.+?)</div>',
             webpage, 'description', fatal=False)
-        ld = self._search_json_ld(webpage, video_id, fatal=False)
+        json_ld = self._search_json_ld(webpage, video_id, fatal=False)
 
         player = self._search_regex(r'(<div id="cvp-player-[^<]+</div>)', webpage, 'player')
 
         hls = self._html_search_regex(r' data-hls="([^"]+)" ', player, 'HLS URL')
-        title = self._html_search_regex(r' data-title="([^"]+)" ', player, 'title', ld.get('title'))
+        title = self._html_search_regex(r' data-title="([^"]+)" ', player, 'title', json_ld.get('title'))
         duration = int_or_none(
             self._html_search_regex(r' data-duration="(\d+)" ', player, 'duration', None))
         poster = self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', None)
@@ -52,5 +52,5 @@ class StarTrekIE(InfoExtractor):
             'formats': formats,
             'subtitles': subtitles,
             'thumbnail': poster,
-            'timestamp': ld.get('timestamp'),
+            'timestamp': json_ld.get('timestamp'),
         }

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -34,9 +34,9 @@ class StarTrekIE(InfoExtractor):
         hls = self._html_search_regex(r' data-hls="([^"]+)" ', player, 'HLS URL')
         title = self._html_search_regex(r' data-title="([^"]+)" ', player, 'title', json_ld.get('title'))
         duration = int_or_none(
-            self._html_search_regex(r' data-duration="(\d+)" ', player, 'duration', None))
+            self._html_search_regex(r' data-duration="(\d+)" ', player, 'duration', fatal=False))
         poster = urljoin(urlbase,
-                         self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', None))
+                         self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', fatal=False))
 
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)
         self._sort_formats(formats)

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -29,13 +29,13 @@ class StarTrekIE(InfoExtractor):
             webpage, 'description', fatal=False)
         ld = self._search_json_ld(webpage, video_id, fatal=False)
 
-        player = self._search_regex(r'(<div id="cvp-player-.+?></div>)', webpage, 'player')
+        player = self._search_regex(r'(<div id="cvp-player-[^<]+</div>)', webpage, 'player')
 
-        hls = self._html_search_regex(r' data-hls="(.+?)" ', player, 'HLS URL')
-        title = self._html_search_regex(r' data-title="(.+?)" ', player, 'title', ld.get('title'))
+        hls = self._html_search_regex(r' data-hls="([^"]+)" ', player, 'HLS URL')
+        title = self._html_search_regex(r' data-title="([^"]+)" ', player, 'title', ld.get('title'))
         duration = int_or_none(
-            self._html_search_regex(r' data-duration="(\d+?)" ', player, 'duration', None))
-        poster = self._html_search_regex(r' data-poster-url="(.+?)" ', player, 'thumbnail', None)
+            self._html_search_regex(r' data-duration="(\d+)" ', player, 'duration', None))
+        poster = self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', None)
 
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)
         self._sort_formats(formats)

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from ..utils import int_or_none
+from ..utils import int_or_none, urljoin
 
 
 class StarTrekIE(InfoExtractor):
@@ -35,14 +35,11 @@ class StarTrekIE(InfoExtractor):
         title = self._html_search_regex(r' data-title="([^"]+)" ', player, 'title', json_ld.get('title'))
         duration = int_or_none(
             self._html_search_regex(r' data-duration="(\d+)" ', player, 'duration', None))
-        poster = self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', None)
+        poster = urljoin(urlbase,
+                         self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', None))
 
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)
         self._sort_formats(formats)
-
-        # Usually, these are just an absolute path. Add the host.
-        if poster is not None and poster.startswith("/"):
-            poster = urlbase + poster
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -16,9 +16,9 @@ class StarTrekIE(InfoExtractor):
             'upload_date': '20220616',
             'description': 'md5:1ffee884e3920afbdd6dd04e926a1221',
             'thumbnail': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14794_rr_thumb_107_yt_16x9\.jpg(?:\?.+)?',
-            'subtitles': {'en-US':[{
+            'subtitles': {'en-US': [{
                 'url': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/video/captions/2022-06/TRR_SNW_107_v4\.vtt',
-            },{
+            }, {
                 'url': 'https://media.startrek.com/2022/06/16/2043801155561/1069981_hls/trr_snw_107_v4-c4bfc25d/stream_vtt.m3u8',
             }]},
         }
@@ -34,7 +34,7 @@ class StarTrekIE(InfoExtractor):
             'upload_date': '20220603',
             'description': 'md5:b3aa0edacfe119386567362dec8ed51b',
             'thumbnail': r're:https://www\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14792_rr_thumb_105_yt_16x9_1.jpg(?:\?.+)?',
-            'subtitles': {'en-US':[{
+            'subtitles': {'en-US': [{
                 'url': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/video/captions/2022-06/TRR_SNW_105_v5\.vtt',
             }]},
         }

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -28,9 +28,7 @@ class StarTrekIE(InfoExtractor):
             r'(?s)<div class="header-body">(.+?)</div>',
             webpage, 'description', fatal=False)
         ld = self._search_json_ld(webpage, video_id, fatal=False)
-        self.write_debug(ld)
 
-        # Extract the player element so that the rest of the matching will be done only there.
         player = self._search_regex(r'(<div id="cvp-player-.+?></div>)', webpage, 'player')
 
         hls = self._html_search_regex(r' data-hls="(.+?)" ', player, 'HLS URL')

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -25,18 +25,20 @@ class StarTrekIE(InfoExtractor):
         webpage = self._download_webpage(url, video_id)
 
         description = self._html_search_regex(
-            r'(?s)<div class="header-body">(.+?)</div>',
+            r'(?s)<\s*div\s+class\s*=\s*"header-body"\s*>(.+?)<\s*/div\s*>',
             webpage, 'description', fatal=False)
         json_ld = self._search_json_ld(webpage, video_id, fatal=False)
 
-        player = self._search_regex(r'(<div id="cvp-player-[^<]+</div>)', webpage, 'player')
+        player = self._search_regex(
+            r'(<\s*div\s+id\s*=\s*"cvp-player-[^<]+<\s*/div\s*>)', webpage, 'player')
 
-        hls = self._html_search_regex(r' data-hls="([^"]+)" ', player, 'HLS URL')
-        title = self._html_search_regex(r' data-title="([^"]+)" ', player, 'title', json_ld.get('title'))
+        hls = self._html_search_regex(r'\bdata-hls\s*=\s*"([^"]+)"', player, 'HLS URL')
+        title = self._html_search_regex(r'\bdata-title\s*=\s*"([^"]+)"', player, 'title', json_ld.get('title'))
         duration = int_or_none(
-            self._html_search_regex(r' data-duration="(\d+)" ', player, 'duration', fatal=False))
-        poster = urljoin(urlbase,
-                         self._html_search_regex(r' data-poster-url="([^"]+)" ', player, 'thumbnail', fatal=False))
+            self._html_search_regex(r'\bdata-duration\s*=\s*"(\d+)"', player, 'duration', fatal=False))
+        poster = urljoin(
+            urlbase,
+            self._html_search_regex(r'\bdata-poster-url\s*=\s*"([^"]+)"', player, 'thumbnail', fatal=False))
 
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)
         self._sort_formats(formats)

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -1,5 +1,5 @@
-from yt_dlp.utils import int_or_none
 from .common import InfoExtractor
+from ..utils import int_or_none
 
 
 class StarTrekIE(InfoExtractor):

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -56,6 +56,7 @@ class StarTrekIE(InfoExtractor):
         if captions:
             subtitles.setdefault('en-US', [])[:0] = [{'url': urljoin(urlbase, captions)}]
 
+        # NB: Most of the data in the json_ld is undesirable
         json_ld = self._search_json_ld(webpage, video_id, fatal=False)
 
         return {

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -15,8 +15,7 @@ class StarTrekIE(InfoExtractor):
             'timestamp': 1655388000,
             'upload_date': '20220616',
             'description': 'md5:1ffee884e3920afbdd6dd04e926a1221',
-            # Thumbnail seems to have some tracking parameters added, ignore those.
-            'thumbnail': r're:https://intl\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14794_rr_thumb_107_yt_16x9.jpg(?:\?.+)?',
+            'thumbnail': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14794_rr_thumb_107_yt_16x9\.jpg(?:\?.+)?',
         }
     }]
 

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -16,6 +16,27 @@ class StarTrekIE(InfoExtractor):
             'upload_date': '20220616',
             'description': 'md5:1ffee884e3920afbdd6dd04e926a1221',
             'thumbnail': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14794_rr_thumb_107_yt_16x9\.jpg(?:\?.+)?',
+            'subtitles': {'en-US':[{
+                'url': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/video/captions/2022-06/TRR_SNW_107_v4\.vtt',
+            },{
+                'url': 'https://media.startrek.com/2022/06/16/2043801155561/1069981_hls/trr_snw_107_v4-c4bfc25d/stream_vtt.m3u8',
+            }]},
+        }
+    }, {
+        'url': 'https://www.startrek.com/videos/watch-ethan-peck-and-gia-sandhu-beam-down-to-the-ready-room',
+        'md5': 'f5ad74fbb86e91e0882fc0a333178d1d',
+        'info_dict': {
+            'id': 'watch-ethan-peck-and-gia-sandhu-beam-down-to-the-ready-room',
+            'ext': 'mp4',
+            'title': 'WATCH: Ethan Peck and Gia Sandhu Beam Down to The Ready Room',
+            'duration': 1986,
+            'timestamp': 1654221600,
+            'upload_date': '20220603',
+            'description': 'md5:b3aa0edacfe119386567362dec8ed51b',
+            'thumbnail': r're:https://www\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14792_rr_thumb_105_yt_16x9_1.jpg(?:\?.+)?',
+            'subtitles': {'en-US':[{
+                'url': r're:https://(?:intl|www)\.startrek\.com/sites/default/files/video/captions/2022-06/TRR_SNW_105_v5\.vtt',
+            }]},
         }
     }]
 
@@ -29,6 +50,16 @@ class StarTrekIE(InfoExtractor):
         hls = self._html_search_regex(r'\bdata-hls\s*=\s*"([^"]+)"', player, 'HLS URL')
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)
         self._sort_formats(formats)
+
+        # The player will usually have a subtitle attribute, too. If it does, prefer that one
+        # because it will be downloaded much faster than the HLS segmented one from the m3u8.
+        # Also, sometimes there are `data-` subtitles but not HLS ones.
+        captions = self._html_search_regex(
+            r'\bdata-captions-url\s*=\s*"([^"]+)"', player, 'captions URL', fatal=False)
+        if captions:
+            en_subs = subtitles.get('en-US', [])
+            en_subs.insert(0, {'url': urljoin(urlbase, captions)})
+            subtitles['en-US'] = en_subs
 
         json_ld = self._search_json_ld(webpage, video_id, fatal=False)
 

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -21,9 +21,8 @@ class StarTrekIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
+        urlbase, video_id = self._match_valid_url(url).group('base', 'id')
         webpage = self._download_webpage(url, video_id)
-        urlbase = self._match_valid_url(url).group('base')
 
         description = self._html_search_regex(
             r'(?s)<div class="header-body">(.+?)</div>',
@@ -37,7 +36,7 @@ class StarTrekIE(InfoExtractor):
         hls = self._html_search_regex(r' data-hls="(.+?)" ', player, 'HLS URL')
         title = self._html_search_regex(r' data-title="(.+?)" ', player, 'title', ld.get('title'))
         duration = int_or_none(
-            self._html_search_regex(r' data-duration="([0-9]+?)" ', player, 'duration', None))
+            self._html_search_regex(r' data-duration="(\d+?)" ', player, 'duration', None))
         poster = self._html_search_regex(r' data-poster-url="(.+?)" ', player, 'thumbnail', None)
 
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -3,7 +3,7 @@ from ..utils import int_or_none, urljoin
 
 
 class StarTrekIE(InfoExtractor):
-    _VALID_URL = r'(?P<base>https://(?:intl|www)\.startrek\.com)/videos/(?P<id>[^/]+)'
+    _VALID_URL = r'(?P<base>https?://(?:intl|www)\.startrek\.com)/videos/(?P<id>[^/]+)'
     _TESTS = [{
         'url': 'https://intl.startrek.com/videos/watch-welcoming-jess-bush-to-the-ready-room',
         'md5': '491df5035c9d4dc7f63c79caaf9c839e',

--- a/yt_dlp/extractor/startrek.py
+++ b/yt_dlp/extractor/startrek.py
@@ -1,0 +1,59 @@
+from yt_dlp.utils import int_or_none
+from .common import InfoExtractor
+
+
+class StarTrekIE(InfoExtractor):
+    _VALID_URL = r'(?P<base>https://(?:intl|www)\.startrek\.com)/videos/(?P<id>[^/]+)'
+    _TESTS = [{
+        'url': 'https://intl.startrek.com/videos/watch-welcoming-jess-bush-to-the-ready-room',
+        'md5': '491df5035c9d4dc7f63c79caaf9c839e',
+        'info_dict': {
+            'id': 'watch-welcoming-jess-bush-to-the-ready-room',
+            'ext': 'mp4',
+            'title': 'WATCH: Welcoming Jess Bush to The Ready Room',
+            'duration': 1888,
+            'timestamp': 1655388000,
+            'upload_date': '20220616',
+            'description': 'md5:1ffee884e3920afbdd6dd04e926a1221',
+            # Thumbnail seems to have some tracking parameters added, ignore those.
+            'thumbnail': r're:https://intl\.startrek\.com/sites/default/files/styles/video_1920x1080/public/images/2022-06/pp_14794_rr_thumb_107_yt_16x9.jpg(?:\?.+)?',
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        urlbase = self._match_valid_url(url).group('base')
+
+        description = self._html_search_regex(
+            r'(?s)<div class="header-body">(.+?)</div>',
+            webpage, 'description', fatal=False)
+        ld = self._search_json_ld(webpage, video_id, fatal=False)
+        self.write_debug(ld)
+
+        # Extract the player element so that the rest of the matching will be done only there.
+        player = self._search_regex(r'(<div id="cvp-player-.+?></div>)', webpage, 'player')
+
+        hls = self._html_search_regex(r' data-hls="(.+?)" ', player, 'HLS URL')
+        title = self._html_search_regex(r' data-title="(.+?)" ', player, 'title', ld.get('title'))
+        duration = int_or_none(
+            self._html_search_regex(r' data-duration="([0-9]+?)" ', player, 'duration', None))
+        poster = self._html_search_regex(r' data-poster-url="(.+?)" ', player, 'thumbnail', None)
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls, video_id)
+        self._sort_formats(formats)
+
+        # Usually, these are just an absolute path. Add the host.
+        if poster is not None and poster.startswith("/"):
+            poster = urlbase + poster
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'duration': duration,
+            'formats': formats,
+            'subtitles': subtitles,
+            'thumbnail': poster,
+            'timestamp': ld.get('timestamp'),
+        }


### PR DESCRIPTION
<!--
# Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

This adds a new extractor for single video pages on [StarTrek.com](https://www.startrek.com/).

Note that apparently non-US users will be redirected to `intl.startrek.com` instead of `www.`. Since I live in Germany, I have developed the extractor against `intl.` and also tested it against that host. I’d appreciate **US and Canadian citizens** to test whether it works for them, too, and whether the test works (because that’s using `intl.`).

Also, I don’t know what exactly the geo restrictions for StarTrek.com are, which is why I haven’t added any code about them.

Thumbnail extraction works, as do the subtitles and description.

There is apparently an internal, numerical ID for each of the videos (search for `mpx-id` in the source), but since it’s not shown anywhere, I have decided to use the URL slug as the `video_id` instead.

This is my first extractor, I have paid attention to the contributing guidelines and code style as far as I can see, but please let me know if you have additional change requests or any questions. Thanks for maintaining yt-dlp.