### PR TITLE
Fix Update for macos_legacy

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -25,10 +25,8 @@ def _get_variant_and_executable_path():
             return 'py2exe', path
         if sys._MEIPASS == os.path.dirname(path):
             return f'{sys.platform}_dir', path
-        if sys.platform == 'darwin':
-            release, _, _ = platform.mac_ver()
-            if release < '10.15':
-                return 'darwin_legacy_exe', path
+        if sys.platform == 'darwin' and version_tuple(platform.mac_ver()[0]) < (10, 15):
+            return 'darwin_legacy_exe', path
         return f'{sys.platform}_exe', path
 
     path = os.path.dirname(__file__)

--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -25,6 +25,10 @@ def _get_variant_and_executable_path():
             return 'py2exe', path
         if sys._MEIPASS == os.path.dirname(path):
             return f'{sys.platform}_dir', path
+        if sys.platform == 'darwin':
+            release, _, _ = platform.mac_ver()
+            if release < '10.15':
+                return 'darwin_legacy_exe', path
         return f'{sys.platform}_exe', path
 
     path = os.path.dirname(__file__)
@@ -45,6 +49,7 @@ _FILE_SUFFIXES = {
     'py2exe': '_min.exe',
     'win32_exe': '.exe',
     'darwin_exe': '_macos',
+    'darwin_legacy_exe': '_macos_legacy',
     'linux_exe': '_linux',
 }
 


### PR DESCRIPTION

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

See https://github.com/yt-dlp/yt-dlp/pull/4106#issuecomment-1168672707

The way I implemented it:
When I am on an early macos version it should upgrade to the legacy version. An alternative approach would be to somehow mark the binary to upgrade to legacy, but I am not sure how I would go about doing that. I doubt that anyone is using yt-dlp on Mojave that would be bothered by this upgrade, since it previously did not work on Mojave and older
