### PR TITLE
Make the build reproducible

### DIFF
--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -94,7 +94,7 @@ def sort_ies(ies, ignored_bases):
         for c in classes[:]:
             bases = set(c.__bases__) - {object, *ignored_bases}
             restart = False
-            for b in bases:
+            for b in sorted(bases, key=lambda x: x.__name__):
                 if b not in classes and b not in returned_classes:
                     assert b.__name__ != 'GenericIE', 'Cannot inherit from GenericIE'
                     classes.insert(0, b)


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that yt-dlp could not be built reproducibly.

This is due to `sort_ies` iterating over a Python `set()` data structure in a nondeterminstic order. This patch sorts the `type` objects according to their name.

I originally filed this in Debian as [bug #1014041](https://bugs.debian.org/1014041).
