### PR TITLE
Skip some PPs if Remux or VideoConvertor is also queued

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -43,9 +43,11 @@ from .postprocessor import (
     FFmpegFixupTimestampPP,
     FFmpegMergerPP,
     FFmpegPostProcessor,
+    FFmpegVideoConvertorPP,
     MoveFilesAfterDownloadPP,
     get_postprocessor,
 )
+from .postprocessor.ffmpeg import resolve_mapping
 from .update import detect_variant
 from .utils import (
     DEFAULT_OUTTMPL,
@@ -3172,6 +3174,23 @@ class YoutubeDL:
                         else:
                             self.report_warning(f'{vid}: {msg}. Install ffmpeg to fix this automatically')
 
+                    def gets_converted(ext):
+                        """
+                        Returns True if the given ext is going to be converted to some other container than ext
+                        """
+
+                        if not ext:
+                            return False
+                        pps = self._pps['post_process']
+                        for p in pps:
+                            # Remux is covered here
+                            if not isinstance(p, FFmpegVideoConvertorPP):
+                                continue
+                            nex, _ = resolve_mapping(ext, p.mapping)
+                            if nex and nex != ext:
+                                return True
+                        return False
+
                     stretched_ratio = info_dict.get('stretched_ratio')
                     ffmpeg_fixup(
                         stretched_ratio not in (1, None),
@@ -3181,14 +3200,15 @@ class YoutubeDL:
                     ffmpeg_fixup(
                         (info_dict.get('requested_formats') is None
                          and info_dict.get('container') == 'm4a_dash'
-                         and info_dict.get('ext') == 'm4a'),
+                         and info_dict.get('ext') == 'm4a'
+                         and not gets_converted('m4a')),
                         'writing DASH m4a. Only some players support this container',
                         FFmpegFixupM4aPP)
 
                     downloader = get_suitable_downloader(info_dict, self.params) if 'protocol' in info_dict else None
                     downloader = downloader.FD_NAME if downloader else None
 
-                    if info_dict.get('requested_formats') is None:  # Not necessary if doing merger
+                    if info_dict.get('requested_formats') is None and not gets_converted(info_dict.get('ext')):  # Not necessary if doing merger
                         ffmpeg_fixup(downloader == 'hlsnative' and not self.params.get('hls_use_mpegts')
                                      or info_dict.get('is_live') and self.params.get('hls_use_mpegts') is None,
                                      'Possible MPEG-TS in MP4 container or malformed AAC timestamps',

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -47,7 +47,7 @@ from .postprocessor import (
     MoveFilesAfterDownloadPP,
     get_postprocessor,
 )
-from .postprocessor.ffmpeg import resolve_mapping
+from .postprocessor.ffmpeg import resolve_mapping as resolve_recode_mapping
 from .update import detect_variant
 from .utils import (
     DEFAULT_OUTTMPL,
@@ -3174,41 +3174,24 @@ class YoutubeDL:
                         else:
                             self.report_warning(f'{vid}: {msg}. Install ffmpeg to fix this automatically')
 
-                    def gets_converted(ext):
-                        """
-                        Returns True if the given ext is going to be converted to some other container than ext
-                        """
-
-                        if not ext:
-                            return False
-                        pps = self._pps['post_process']
-                        for p in pps:
-                            # Remux is covered here
-                            if not isinstance(p, FFmpegVideoConvertorPP):
-                                continue
-                            nex, _ = resolve_mapping(ext, p.mapping)
-                            if nex and nex != ext:
-                                return True
-                        return False
-
                     stretched_ratio = info_dict.get('stretched_ratio')
-                    ffmpeg_fixup(
-                        stretched_ratio not in (1, None),
-                        f'Non-uniform pixel ratio {stretched_ratio}',
-                        FFmpegFixupStretchedPP)
-
-                    ffmpeg_fixup(
-                        (info_dict.get('requested_formats') is None
-                         and info_dict.get('container') == 'm4a_dash'
-                         and info_dict.get('ext') == 'm4a'
-                         and not gets_converted('m4a')),
-                        'writing DASH m4a. Only some players support this container',
-                        FFmpegFixupM4aPP)
+                    ffmpeg_fixup(stretched_ratio not in (1, None),
+                                 f'Non-uniform pixel ratio {stretched_ratio}',
+                                 FFmpegFixupStretchedPP)
 
                     downloader = get_suitable_downloader(info_dict, self.params) if 'protocol' in info_dict else None
                     downloader = downloader.FD_NAME if downloader else None
 
-                    if info_dict.get('requested_formats') is None and not gets_converted(info_dict.get('ext')):  # Not necessary if doing merger
+                    ext = info_dict.get('ext')
+                    postprocessed_by_ffmpeg = info_dict.get('requested_formats') or any((
+                        isinstance(pp, FFmpegVideoConvertorPP)
+                        and resolve_recode_mapping(ext, pp.mapping)[0] not in (ext, None)
+                    ) for pp in self._pps['post_process'])
+
+                    if not postprocessed_by_ffmpeg:
+                        ffmpeg_fixup(ext == 'm4a' and info_dict.get('container') == 'm4a_dash',
+                                    'writing DASH m4a. Only some players support this container',
+                                    FFmpegFixupM4aPP)
                         ffmpeg_fixup(downloader == 'hlsnative' and not self.params.get('hls_use_mpegts')
                                      or info_dict.get('is_live') and self.params.get('hls_use_mpegts') is None,
                                      'Possible MPEG-TS in MP4 container or malformed AAC timestamps',


### PR DESCRIPTION
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

### Description of your *pull request* and other information

</details>

This is to skip some PPs if container conversion is to be done per user request.
These PPs (FixupM4a, FixupM3u8, FixupDuplicateMoov) are completely unnecessary as ffmpeg gracefully handles without doing before conversion.

They still run if the conversion doesn't change extension, e.g. `--remux mp4` when downloading a mp4 file.