### PR TITLE
allow to show float fps in format_table

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3529,7 +3529,7 @@ class YoutubeDL:
                 self._format_out(format_field(f, 'format_id'), self.Styles.ID),
                 format_field(f, 'ext'),
                 format_field(f, func=self.format_resolution, ignore=('audio only', 'images')),
-                format_field(f, 'fps', '\t%d'),
+                format_field(f, 'fps', '\t%.1f'),
                 format_field(f, 'dynamic_range', '%s', ignore=(None, 'SDR')).replace('HDR', ''),
                 delim,
                 format_field(f, 'filesize', ' \t%s', func=format_bytes) + format_field(f, 'filesize_approx', '~\t%s', func=format_bytes),


### PR DESCRIPTION
allow to show float fps in format_table

for example:
https://www.bilibili.com/bangumi/play/ss26875

```
ID EXT RESOLUTION  FPS │   FILESIZE   TBR PROTO │ VCODEC                           VBR ACODEC      ABR
──────────────────────────────────────────────────────────────────────────────────────────────────────
0  m4a audio only      │   10.95MiB   67k https │ audio only                           mp4a.40.2   67k
1  m4a audio only      │   21.61MiB  132k https │ audio only                           mp4a.40.2  132k
2  m4a audio only      │   51.95MiB  319k https │ audio only                           mp4a.40.2  319k
3  mp4 1920x1080  23.8 │  142.49MiB  875k https │ hev1.1.6.L150.90                875k video only
4  mp4 1920x1080  23.8 │  210.61MiB 1293k https │ hev1.1.6.L150.90               1293k video only
5  mp4 1920x1080  24.0 │  158.99MiB  974k https │ av01.0.08M.08.0.110.01.01.01.0  974k video only
6  mp4 1920x1080  24.0 │  477.66MiB 2932k https │ av01.0.08M.08.0.110.01.01.01.0 2932k video only
7  mp4 1920x1080  24.4 │  285.52MiB 1753k https │ avc1.640032                    1753k video only
8  mp4 1920x1080  24.4 │  854.83MiB 5250k https │ avc1.640032                    5250k video only
9  mp4 1280x720   23.8 │   66.89MiB  410k https │ hev1.1.6.L120.90                410k video only
10 mp4 1280x720   24.0 │  119.00MiB  729k https │ av01.0.05M.08.0.110.01.01.01.0  729k video only
11 mp4 1280x720   24.4 │  214.17MiB 1315k https │ avc1.640028                    1315k video only
12 mp4 852x480    23.8 │   44.04MiB  270k https │ hev1.1.6.L120.90                270k video only
13 mp4 852x480    24.0 │   64.90MiB  396k https │ av01.0.04M.08.0.110.01.01.01.0  396k video only
14 mp4 852x480    24.4 │  115.69MiB  710k https │ avc1.64001F                     710k video only
15 mp4 640x360    23.8 │   29.94MiB  183k https │ hev1.1.6.L120.90                183k video only
16 mp4 640x360    24.0 │   33.77MiB  205k https │ av01.0.01M.08.0.110.01.01.01.0  205k video only
17 mp4 640x360    24.4 │   57.38MiB  352k https │ avc1.64001E                     352k video only
```


https://www.bilibili.com/video/BV1Er4y1E7cy
```
ID EXT RESOLUTION  FPS │   FILESIZE   TBR PROTO │ VCODEC                           VBR ACODEC      ABR
──────────────────────────────────────────────────────────────────────────────────────────────────────
0  m4a audio only      │ ~  5.97MiB   67k https │ audio only                           mp4a.40.2   67k
1  m4a audio only      │ ~ 11.79MiB  132k https │ audio only                           mp4a.40.2  132k
2  m4a audio only      │ ~ 28.32MiB  319k https │ audio only                           mp4a.40.2  319k
3  mp4 3840x1920  60.1 │ ~283.11MiB 3189k https │ av01.0.13M.08.0.110.01.01.01.0 3189k video only
4  mp4 3840x1920  62.5 │ ~647.26MiB 7292k https │ avc1.640034                    7292k video only
5  mp4 3840x1920  62.5 │ ~363.92MiB 4100k https │ hev1.1.6.L153.90               4100k video only
6  mp4 2160x1080  29.4 │ ~ 68.71MiB  774k https │ avc1.640032                     774k video only
7  mp4 2160x1080  30.0 │ ~ 58.47MiB  658k https │ av01.0.08M.08.0.110.01.01.01.0  658k video only
8  mp4 2160x1080  30.3 │ ~ 61.22MiB  689k https │ hev1.1.6.L150.90                689k video only
9  mp4 2160x1080  58.8 │ ~ 62.63MiB  705k https │ hev1.1.6.L150.90                705k video only
10 mp4 2160x1080  60.1 │ ~ 67.98MiB  765k https │ av01.0.09M.08.0.110.01.01.01.0  765k video only
11 mp4 2160x1080  62.5 │ ~198.23MiB 2233k https │ avc1.640032                    2233k video only
12 mp4 1440x720   29.4 │ ~ 43.65MiB  491k https │ avc1.640028                     491k video only
13 mp4 1440x720   30.0 │ ~ 30.36MiB  342k https │ av01.0.05M.08.0.110.01.01.01.0  342k video only
14 mp4 1440x720   30.3 │ ~ 28.33MiB  319k https │ hev1.1.6.L120.90                319k video only
15 mp4 960x480    29.4 │ ~ 22.58MiB  254k https │ avc1.64001F                     254k video only
16 mp4 960x480    30.0 │ ~ 16.99MiB  191k https │ av01.0.04M.08.0.110.01.01.01.0  191k video only
17 mp4 960x480    30.3 │ ~ 17.82MiB  200k https │ hev1.1.6.L120.90                200k video only
18 mp4 720x360    29.4 │ ~ 13.04MiB  146k https │ avc1.64001E                     146k video only
19 mp4 720x360    30.0 │ ~ 13.63MiB  153k https │ av01.0.01M.08.0.110.01.01.01.0  153k video only
20 mp4 720x360    30.3 │ ~ 12.25MiB  137k https │ hev1.1.6.L120.90                137k video only
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

DESCRIPTION

Fixes #
