### PR TITLE
Allow users to specify encoding in each config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,19 @@ Note that options in configuration file are just the same options aka switches u
 
 You can use `--ignore-config` if you want to disable all configuration files for a particular yt-dlp run. If `--ignore-config` is found inside any configuration file, no further configuration will be loaded. For example, having the option in the portable configuration file prevents loading of home, user, and system configurations. Additionally, (for backward compatibility) if `--ignore-config` is found inside the system configuration file, the user configuration is not loaded.
 
+### Specifying encoding of config files
+
+By default, config files are read by UTF-8.
+If you saved your config file in a different encoding than that, you may write any of these to the first line of the file:
+
+1. `# -*- coding: ENCODING -*-` (e.g. `# -*- coding: gbk -*-`)
+1. `# coding: ENCODING` (e.g. `# coding: shift-jis`)
+1. `# vi: set fileencoding=ENCODING` (e.g. `# vi: set fileencoding=euc-kr`)
+
+There must not be any characters before that, including spaces.
+
+To use UTF-32 and UTF-16, save your file with BOM enabled. The method above cannot be used in this case.
+
 ### Authentication with `.netrc` file
 
 You may also want to configure automatic credentials storage for extractors that support authentication (by providing login and password with `--username` and `--password`) in order not to pass credentials as command line arguments on every yt-dlp execution and prevent tracking plain text passwords in the shell command history. You can achieve this using a [`.netrc` file](https://stackoverflow.com/tags/.netrc/info) on a per extractor basis. For that you will need to create a `.netrc` file in `--netrc-location` and restrict permissions to read/write by only you:

--- a/README.md
+++ b/README.md
@@ -1164,11 +1164,7 @@ You can use `--ignore-config` if you want to disable all configuration files for
 ### Specifying encoding of config files
 
 By default, config files are read in the encoding from system locale.
-If you saved your config file in a different encoding than that, you may write any of these to the first line of the file:
-
-1. `# -*- coding: ENCODING -*-` (e.g. `# -*- coding: gbk -*-`)
-1. `# coding: ENCODING` (e.g. `# coding: shift-jis`)
-1. `# vi: set fileencoding=ENCODING` (e.g. `# vi: set fileencoding=euc-kr`)
+If you saved your config file in a different encoding than that, you may write `# coding: ENCODING` to the beginning of the file. (e.g. `# coding: shift-jis`)
 
 There must not be any characters before that, including spaces.
 

--- a/README.md
+++ b/README.md
@@ -1163,7 +1163,7 @@ You can use `--ignore-config` if you want to disable all configuration files for
 
 ### Specifying encoding of config files
 
-By default, config files are read by UTF-8.
+By default, config files are read in the encoding from system locale.
 If you saved your config file in a different encoding than that, you may write any of these to the first line of the file:
 
 1. `# -*- coding: ENCODING -*-` (e.g. `# -*- coding: gbk -*-`)

--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,7 @@ If you saved your config file in a different encoding than that, you may write a
 
 There must not be any characters before that, including spaces.
 
-To use UTF-32 and UTF-16, save your file with BOM enabled. The method above cannot be used in this case.
+If you have BOM enabled, it will be used instead.
 
 ### Authentication with `.netrc` file
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -39,6 +39,7 @@ from yt_dlp.utils import (
     datetime_from_str,
     detect_exe_version,
     determine_ext,
+    determine_file_encoding,
     dfxp2srt,
     dict_get,
     encode_base_n,
@@ -1821,6 +1822,26 @@ Line 1
         finally:
             with contextlib.suppress(OSError):
                 os.remove(FILE)
+
+    def test_determine_file_encoding(self):
+        self.assertEqual(determine_file_encoding(b''), (None, 0))
+        self.assertEqual(determine_file_encoding(b'--verbose -x --audio-format mkv\n'), (None, 0))
+
+        self.assertEqual(determine_file_encoding(b'\xef\xbb\xbf'), ('utf-8', 3))
+        self.assertEqual(determine_file_encoding(b'\x00\x00\xfe\xff'), ('utf-32-be', 4))
+        self.assertEqual(determine_file_encoding(b'\xff\xfe'), ('utf-16-le', 2))
+
+        self.assertEqual(determine_file_encoding(b'# -*- coding: cp932 -*-'), ('cp932', 0))
+        self.assertEqual(determine_file_encoding(b'# -*- coding: cp932 -*-\n'), ('cp932', 0))
+        self.assertEqual(determine_file_encoding(b'# -*- coding: cp932 -*-\r\n'), ('cp932', 0))
+
+        self.assertEqual(determine_file_encoding(b'# coding: utf-8\n--verbose'), ('utf-8', 0))
+        self.assertEqual(determine_file_encoding(b'# coding: someencodinghere-12345\n--verbose'), ('someencodinghere-12345', 0))
+
+        self.assertEqual(determine_file_encoding(b'# vi: set fileencoding=cp932'), ('cp932', 0))
+        self.assertEqual(determine_file_encoding(b'# vi: set fileencoding=cp932\n'), ('cp932', 0))
+        self.assertEqual(determine_file_encoding(b'# vi: set fileencoding=cp932\r\n'), ('cp932', 0))
+        self.assertEqual(determine_file_encoding(b'# vi: set fileencoding=cp932,euc-jp\r\n'), ('cp932', 0))
 
 
 if __name__ == '__main__':

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1843,6 +1843,12 @@ Line 1
         self.assertEqual(determine_file_encoding(b'# vi: set fileencoding=cp932\r\n'), ('cp932', 0))
         self.assertEqual(determine_file_encoding(b'# vi: set fileencoding=cp932,euc-jp\r\n'), ('cp932', 0))
 
+        self.assertEqual(determine_file_encoding(
+            b'\0\0\0#\0\0\0 \0\0\0c\0\0\0o\0\0\0d\0\0\0i\0\0\0n\0\0\0g\0\0\0:\0\0\0 \0\0\0u\0\0\0t\0\0\0f\0\0\0-\0\0\x003\0\0\x002\0\0\0-\0\0\0b\0\0\0e'),
+            ('utf-32-be', 0))
+        self.assertEqual(determine_file_encoding(
+            b'#\0 \0c\0o\0d\0i\0n\0g\0:\0 \0u\0t\0f\0-\x001\x006\0-\0l\0e\0'),
+            ('utf-16-le', 0))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1850,5 +1850,6 @@ Line 1
             b'#\0 \0c\0o\0d\0i\0n\0g\0:\0 \0u\0t\0f\0-\x001\x006\0-\0l\0e\0'),
             ('utf-16-le', 0))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5410,6 +5410,10 @@ def determine_file_encoding(data):
         if data.startswith(bom):
             return enc, len(bom)
 
+    # strip off all null bytes to match even when UTF-16 or UTF-32 is used
+    # endians don't matter
+    data = data.replace(b'\0', b'')
+
     PREAMBLES = [
         # "# -*- coding: utf-8 -*-"
         # "# coding: utf-8"

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5423,7 +5423,7 @@ def determine_file_encoding(data):
             continue
         # preambles aren't skipped since they're just ignored when reading as config
         return mobj.group('encoding').decode(), 0
-    
+
     return None, 0
 
 


### PR DESCRIPTION
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

DESCRIPTION

Fixes #840

This allows you to create config files having different encodings. Preexisting config files continues to work with this method.

With this, you can have 3 config files with different encodings each other:

```
$ ./yt-dlp.sh --config sjis_config.conf --config euc_config.conf --config utf8_config.conf -v
[debug] Command-line config: ['--config', 'sjis_config.conf', '--config', 'euc_config.conf', '--config', 'utf8_config.conf', '-v']
[debug] | Config "sjis_config.conf": ['--exec', 'echo 日本語']
[debug] | Config "euc_config.conf": ['--exec', 'echo 日本語']
[debug] | Config "utf8_config.conf": ['--exec', 'echo 日本語']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.06.29 [9d339c41e] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 5f2da312f
[debug] Python 3.9.13 (CPython 64bit) - Linux-5.15.0-40-generic-x86_64-with-glibc2.35 (glibc 2.35)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 4.4.2 (setts), ffprobe 4.4.2
[debug] Optional libraries: Crypto-3.10.1, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.1
[debug] Proxy map: {}

Usage: yt-dlp [OPTIONS] URL [URL...]

yt-dlp: error: You must provide at least one URL.
Type yt-dlp --help to see a list of all options.
```
