### PR TITLE
[angel] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -60,6 +60,9 @@ from .americastestkitchen import (
     AmericasTestKitchenIE,
     AmericasTestKitchenSeasonIE,
 )
+from .angel import (
+    AngelIE
+)
 from .animeondemand import AnimeOnDemandIE
 from .anvato import AnvatoIE
 from .aol import AolIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -60,9 +60,7 @@ from .americastestkitchen import (
     AmericasTestKitchenIE,
     AmericasTestKitchenSeasonIE,
 )
-from .angel import (
-    AngelIE
-)
+from .angel import AngelIE
 from .animeondemand import AnimeOnDemandIE
 from .anvato import AnvatoIE
 from .aol import AolIE

--- a/yt_dlp/extractor/angel.py
+++ b/yt_dlp/extractor/angel.py
@@ -12,9 +12,9 @@ class AngelIE(InfoExtractor):
         'info_dict': {
             'id': '2f3d0382-ea82-4cdc-958e-84fbadadc710',
             'ext': 'mp4',
-            'title': 'Tuttle Twins S1 E1: When Laws Give You Lemons',
+            'title': 'Tuttle Twins Season 1, Episode 1: When Laws Give You Lemons',
             'description': 'md5:73b704897c20ab59c433a9c0a8202d5e',
-            'thumbnail': r're:^https?://images.angelstudios.com/.*\.jpeg$',
+            'thumbnail': r're:^https?://images.angelstudios.com/image/upload/angel-app/.*$',
             'duration': 1359.0
         }
     }, {
@@ -23,9 +23,9 @@ class AngelIE(InfoExtractor):
         'info_dict': {
             'id': '8dfb714d-bca5-4812-8125-24fb9514cd10',
             'ext': 'mp4',
-            'title': 'The Chosen S1 E1: I Have Called You By Name',
+            'title': 'The Chosen Season 1, Episode 1: I Have Called You By Name',
             'description': 'md5:aadfb4827a94415de5ff6426e6dee3be',
-            'thumbnail': r're:^https?://images.angelstudios.com/.*\.jpeg$',
+            'thumbnail': r're:^https?://images.angelstudios.com/image/upload/angel-app/.*$',
             'duration': 3276.0
         }
     }]
@@ -39,14 +39,18 @@ class AngelIE(InfoExtractor):
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
             json_ld.pop('url'), video_id, note='Downloading HD m3u8 information')
 
-        return merge_dicts(json_ld, {
+        info_dict = {
             'id': video_id,
-            'title': self._og_search_title,
+            'title': self._og_search_title(webpage),
             'description': self._og_search_description(webpage),
-            'thumbnails': [{
-                # Second group has unnecessary data about transformations of the thumbnail
-                'url': re.sub(r'(/upload)/.+(/angel-app/.+)$', r'\1\2.jpeg', item['url'])
-            } for item in json_ld.pop('thumbnails') or [] if url_or_none(item.get('url'))],
             'formats': formats,
             'subtitles': subtitles
-        })
+        }
+
+        # Angel uses cloudinary in the background and supports image transformations.
+        # We remove these transformations and return the source file
+        base_thumbnail_url = url_or_none(self._og_search_thumbnail(webpage)) or json_ld.pop('thumbnails')
+        if base_thumbnail_url:
+            info_dict['thumbnail'] = re.sub(r'(/upload)/.+(/angel-app/.+)$', r'\1\2', base_thumbnail_url)
+
+        return merge_dicts(info_dict, json_ld)

--- a/yt_dlp/extractor/angel.py
+++ b/yt_dlp/extractor/angel.py
@@ -1,0 +1,50 @@
+from yt_dlp.utils import url_or_none
+from .common import InfoExtractor
+import re
+
+
+class AngelIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?angel\.com/watch/(?P<series>[a-zA-Z\-]+)/episode/(?P<id>[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12})/season-(?P<season_number>[0-9]+)/episode-(?P<episode_number>[0-9]+)/(?P<title>[a-zA-Z\-]+)'
+    _TESTS = [{
+        'url': 'https://www.angel.com/watch/tuttle-twins/episode/2f3d0382-ea82-4cdc-958e-84fbadadc710/season-1/episode-1/when-laws-give-you-lemons',
+        'md5': '4734e5cfdd64a568e837246aa3eaa524',
+        'info_dict': {
+            'id': '2f3d0382-ea82-4cdc-958e-84fbadadc710',
+            'ext': 'mp4',
+            'title': 'Tuttle Twins S1 E1: When Laws Give You Lemons',
+            'description': 'When Grandma Gabby moves in with the Tuttle family, she takes her twin grandkids on a wheelchair time machine to France and the Old West to learn about laws and try to save their lemonade stand.',
+            'thumbnail': r're:^https?://images.angelstudios.com/.*\.jpeg$'
+        }
+    }, {
+        'url': 'https://www.angel.com/watch/the-chosen/episode/8dfb714d-bca5-4812-8125-24fb9514cd10/season-1/episode-1/i-have-called-you-by-name',
+        'md5': 'e4774bad0a5f0ad2e90d175cafdb797d',
+        'info_dict': {
+            'id': '8dfb714d-bca5-4812-8125-24fb9514cd10',
+            'ext': 'mp4',
+            'title': 'The Chosen S1 E1: I Have Called You By Name',
+            'description': 'Two brothers struggle with their tax debts to Rome while a woman in the Red Quarter wrestles with her demons.',
+            'thumbnail': r're:^https?://images.angelstudios.com/.*\.jpeg$'
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        json_ld = self._search_json_ld(webpage, video_id)
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            json_ld.get('url'), video_id, m3u8_id='hls', note='Downloading HD m3u8 information',
+            errnote='Unable to download HD m3u8 information')
+
+        return {
+            'id': video_id,
+            'title': json_ld.get('title') or self._og_search_title or '',
+            'description': json_ld.get('description') or self._og_search_description(webpage) or None,
+            'thumbnails': [{
+                # Second group has unnecessary data about transformations of the thumbnail
+                'url': re.sub(r'^(.+/upload)(/.+)(/angel-app/.+)$', r'\1\3.jpeg', item.get('url'))
+            } for item in json_ld.get('thumbnails') if url_or_none(item.get('url'))],
+            'formats': formats,
+            'subtitles': subtitles
+        }


### PR DESCRIPTION
<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

### Description of your *pull request* and other information

</details>

This PR adds an extractor for the angel (https://www.angel.com/). All of the information required for the episodes were in an `application/ld+json` tag in the webpage.

One thing to note is that there were several transformations on the thumbnail url in the JSON-LD in the that I have removed. I thought it would be best to remove all transformations and just return the original thumbnail. These transformations can result in returning smaller thumbnails for example:
1. https://images.angelstudios.com/image/upload/f_auto,c_limit,w_3840,q_auto/c_fill,q_auto,ar_16:9,g_north/v1643403801/angel-app/tuttle-twins/videos/season_1/Episode_1_App_Thumbnail.jpeg
2. https://images.angelstudios.com/image/upload/b_rgb:000000,c_fill,h_630,w_1200,g_north/v1643403801/angel-app/tuttle-twins/videos/season_1/Episode_1_App_Thumbnail

Indirectly fixes #1243. There are several links from https://watch.angelstudios.com that lead to https://www.angel.com where The Chosen series is also hosted, but supporting angel.com leads to support of more series.
