### PR TITLE
Add support for holodex

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -640,7 +640,7 @@ from .hidive import HiDiveIE
 from .historicfilms import HistoricFilmsIE
 from .hitbox import HitboxIE, HitboxLiveIE
 from .hitrecord import HitRecordIE
-from .holodex import HolodexIE, HolodexPlaylistIE
+from .holodex import HolodexIE
 from .hotnewhiphop import HotNewHipHopIE
 from .hotstar import (
     HotStarIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -640,6 +640,7 @@ from .hidive import HiDiveIE
 from .historicfilms import HistoricFilmsIE
 from .hitbox import HitboxIE, HitboxLiveIE
 from .hitrecord import HitRecordIE
+from .holodex import HolodexIE, HolodexPlaylistIE
 from .hotnewhiphop import HotNewHipHopIE
 from .hotstar import (
     HotStarIE,

--- a/yt_dlp/extractor/holodex.py
+++ b/yt_dlp/extractor/holodex.py
@@ -36,8 +36,7 @@ class HolodexIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        video_url = f'https://www.youtube.com/watch?v={video_id}'
-        return self.url_result(video_url, ie=YoutubeIE.ie_key())
+        return self.url_result(f'https://www.youtube.com/watch?v={video_id}', ie=YoutubeIE.ie_key())
 
 
 class HolodexPlaylistIE(InfoExtractor):
@@ -53,12 +52,10 @@ class HolodexPlaylistIE(InfoExtractor):
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)
-        apiurl = f"https://holodex.net/api/v2/playlist/{playlist_id}"
-        data = self._download_json(apiurl, playlist_id)
-        title = data.get('name')
+        data = self._download_json(f"https://holodex.net/api/v2/playlist/{playlist_id}", playlist_id)
         entries = []
         for video in data.get('videos'):
-            video_url = f"https://www.youtube.com/watch?v={video.get('id')}"
-            entries.append(self.url_result(video_id=video.get('id'), ie=YoutubeIE.ie_key(), url=video_url))
+            entries.append(self.url_result(video_id=video.get('id'), ie=YoutubeIE.ie_key(),
+                url=f"https://www.youtube.com/watch?v={video.get('id')}"))
 
-        return self.playlist_result(entries, playlist_id, title)
+        return self.playlist_result(entries, playlist_id, data.get('name'))

--- a/yt_dlp/extractor/holodex.py
+++ b/yt_dlp/extractor/holodex.py
@@ -35,8 +35,7 @@ class HolodexIE(InfoExtractor):
     }, ]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        return self.url_result(f'https://www.youtube.com/watch?v={video_id}', ie=YoutubeIE.ie_key())
+        return self.url_result(f'https://www.youtube.com/watch?v={self._match_id(url)}', ie=YoutubeIE.ie_key())
 
 
 class HolodexPlaylistIE(InfoExtractor):
@@ -56,6 +55,6 @@ class HolodexPlaylistIE(InfoExtractor):
         entries = []
         for video in data.get('videos'):
             entries.append(self.url_result(video_id=video.get('id'), ie=YoutubeIE.ie_key(),
-                url=f"https://www.youtube.com/watch?v={video.get('id')}"))
+                           url=f"https://www.youtube.com/watch?v={video.get('id')}"))
 
         return self.playlist_result(entries, playlist_id, data.get('name'))

--- a/yt_dlp/extractor/holodex.py
+++ b/yt_dlp/extractor/holodex.py
@@ -4,7 +4,7 @@ from ..utils import traverse_obj
 
 
 class HolodexIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.|staging\.)?holodex\.net/watch/(?P<id>\w+)'
+    _VALID_URL = r'^(?!.*?playlist)https?://(?:www\.|staging\.)?holodex\.net/watch/(?P<id>\w+)'
     _TESTS = [{
         'url': 'https://holodex.net/watch/9kQ2GtvDV3s',
         'md5': 'be5ffce2f0feae8ba4c01553abc0f175',
@@ -32,6 +32,9 @@ class HolodexIE(InfoExtractor):
             'duration': 263,
             'like_count': int,
         },
+    }, {
+        'url': 'https://staging.holodex.net/watch/s1ifBeukThg',
+        'only_matching': True,
     }, ]
 
     def _real_extract(self, url):
@@ -39,7 +42,7 @@ class HolodexIE(InfoExtractor):
 
 
 class HolodexPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.|staging\.)?holodex\.net/(?:watch/[^\?]\?playlist=|api/v2/playlist/)(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.|staging\.)?holodex\.net/(?:watch/[^?]+?\?playlist=|api/v2/playlist/)(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://holodex.net/api/v2/playlist/239',
         'info_dict': {
@@ -47,7 +50,21 @@ class HolodexPlaylistIE(InfoExtractor):
             'title': 'Songs/Videos that made fall into the rabbit hole (from my google activity history)',
         },
         'playlist_count': 14,
-    }]
+    }, {
+        'url': 'https://holodex.net/watch/_m2mQyaofjI?playlist=69',
+        'info_dict': {
+            'id': '69',
+            'title': '拿著金斧頭的藍髮大姊姊'
+        },
+        'playlist_count': 3,
+    }, {
+        'url': 'https://staging.holodex.net/api/v2/playlist/125',
+        'only_matching': True,
+    }, {
+        'url': 'https://staging.holodex.net/watch/rJJTJA_T_b0?playlist=25',
+        'only_matching': True,
+    },
+    ]
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)

--- a/yt_dlp/extractor/holodex.py
+++ b/yt_dlp/extractor/holodex.py
@@ -1,0 +1,64 @@
+from .common import InfoExtractor
+from .youtube import YoutubeIE
+
+
+class HolodexIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.|staging\.)?holodex\.net/watch/(?P<id>\w+)'
+    _TESTS = [{
+        # Youtube
+        'url': 'https://holodex.net/watch/9kQ2GtvDV3s',
+        'md5': 'be5ffce2f0feae8ba4c01553abc0f175',
+        'info_dict': {
+            'ext': 'mp4',
+            'id': '9kQ2GtvDV3s',
+            'title': '【おちゃめ機能】ホロライブが吹っ切れた【24人で歌ってみた】',
+            'channel_id': 'UCJFZiqLMntJufDCHc6bQixg',
+            'playable_in_embed': True,
+            'tags': 'count:43',
+            'age_limit': 0,
+            'live_status': 'not_live',
+            'description': 'md5:040e866c09dc4ab899b36479f4b7c7a2',
+            'channel_url': 'https://www.youtube.com/channel/UCJFZiqLMntJufDCHc6bQixg',
+            'upload_date': '20200406',
+            'uploader_url': 'http://www.youtube.com/channel/UCJFZiqLMntJufDCHc6bQixg',
+            'view_count': int,
+            'channel': 'hololive ホロライブ - VTuber Group',
+            'categories': ['Music'],
+            'uploader': 'hololive ホロライブ - VTuber Group',
+            'channel_follower_count': int,
+            'uploader_id': 'UCJFZiqLMntJufDCHc6bQixg',
+            'availability': 'public',
+            'thumbnail': 'https://i.ytimg.com/vi_webp/9kQ2GtvDV3s/maxresdefault.webp',
+            'duration': 263,
+            'like_count': int,
+        },
+    }, ]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        video_url = f'https://www.youtube.com/watch?v={video_id}'
+        return self.url_result(video_url, ie=YoutubeIE.ie_key())
+
+
+class HolodexPlaylistIE(InfoExtractor):
+    _VALID_URL = r"https?://(?:www\.|staging\.)?holodex\.net/(?:watch/[^\?]\?playlist=|api/v2/playlist/)(?P<id>\d+)"
+    _TESTS = [{
+        'url': 'https://holodex.net/api/v2/playlist/239',
+        'info_dict': {
+            'id': '239',
+            'title': 'Songs/Videos that made fall into the rabbit hole (from my google activity history)',
+        },
+        'playlist_count': 14,
+    }]
+
+    def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        apiurl = f"https://holodex.net/api/v2/playlist/{playlist_id}"
+        data = self._download_json(apiurl, playlist_id)
+        title = data.get('name')
+        entries = []
+        for video in data.get('videos'):
+            video_url = f"https://www.youtube.com/watch?v={video.get('id')}"
+            entries.append(self.url_result(video_id=video.get('id'), ie=YoutubeIE.ie_key(), url=video_url))
+
+        return self.playlist_result(entries, playlist_id, title)

--- a/yt_dlp/extractor/holodex.py
+++ b/yt_dlp/extractor/holodex.py
@@ -42,7 +42,7 @@ class HolodexIE(InfoExtractor):
 
 
 class HolodexPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.|staging\.)?holodex\.net/(?:watch/[^?]+?\?playlist=|api/v2/playlist/)(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.|staging\.)?holodex\.net/(?:watch/.*?playlist=|api/v2/playlist/)(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://holodex.net/api/v2/playlist/239',
         'info_dict': {


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))

All videos on holodex are youtube embeds so for individual videos we just call out to the YoutubeIE for all the heavy lifting. Playlists are only found in the url as playlist=playlist_id after a video and it's ambiguous whether someone wants to download the playlist or just the video. This extractor assumes the entire playlist because there's no other user-facing way to specify that.

Fixes #726
