### PR TITLE
Specifies required pycryptodomex version, from implicit 3.15.0 to required 3.9.7 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mutagen
-pycryptodomex
+pycryptodomex==3.9.7
 websockets
 brotli; platform_python_implementation=='CPython'
 brotlicffi; platform_python_implementation!='CPython'


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>


Upon running the compilation prereqs: `python3 -m pip install -U pyinstaller -r requirements.txt`, the file `requirements.txt` contains `pycryptodomex` without a specified version, which therefore leads to the downloading of  `v3.15.0` instead of the required `v3.9.7`. This leads to an error, which is fixed by specifying the version explicitly in `requirements.txt`

`python3 -m pip install -U pyinstaller -r requirements.txt`

```
Requirement already satisfied: pycryptodomex in /usr/local/lib/python3.9/site-packages (from -r requirements.txt (line 2)) (3.9.7)
Collecting pycryptodomex
  Downloading pycryptodomex-3.15.0-cp35-abi3-macosx_10_9_x86_64.whl (1.6 MB)

Attempting uninstall: pycryptodomex
    Found existing installation: pycryptodomex 3.9.7
    Uninstalling pycryptodomex-3.9.7:
      Successfully uninstalled pycryptodomex-3.9.7

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
cryptosteganography 0.8.3 requires pycryptodomex==3.9.7, but you have pycryptodomex 3.15.0 which is incompatible.
```

When updating `requirements.txt`, replacing `pycryptodomex` with `pycryptodomex==3.9.7`, the correct version is pulled, the incorrect version is uninstalled and the compilation process finishes successfully.

```
python3 -m pip install -U pyinstaller -r requirements.txt
DEPRECATION: Configuring installation scheme with distutils config files is deprecated and will no longer work in the near future. If you are using a Homebrew or Linuxbrew Python, please see discussion at https://github.com/Homebrew/homebrew-core/issues/76621
Ignoring brotlicffi: markers 'platform_python_implementation != "CPython"' don't match your environment
Requirement already satisfied: pyinstaller in /usr/local/lib/python3.9/site-packages (5.3)
Requirement already satisfied: mutagen in /usr/local/lib/python3.9/site-packages (from -r requirements.txt (line 1)) (1.45.1)
Collecting pycryptodomex==3.9.7
  Using cached pycryptodomex-3.9.7-cp39-cp39-macosx_12_0_x86_64.whl
Requirement already satisfied: websockets in /usr/local/lib/python3.9/site-packages (from -r requirements.txt (line 3)) (10.3)
Requirement already satisfied: brotli in /usr/local/lib/python3.9/site-packages (from -r requirements.txt (line 4)) (1.0.9)
Requirement already satisfied: certifi in /usr/local/lib/python3.9/site-packages (from -r requirements.txt (line 6)) (2022.6.15)
Requirement already satisfied: altgraph in /usr/local/lib/python3.9/site-packages (from pyinstaller) (0.17.2)
Requirement already satisfied: pyinstaller-hooks-contrib>=2021.4 in /usr/local/lib/python3.9/site-packages (from pyinstaller) (2022.8)
Requirement already satisfied: setuptools in /usr/local/lib/python3.9/site-packages (from pyinstaller) (62.3.2)
Requirement already satisfied: macholib>=1.8 in /usr/local/lib/python3.9/site-packages (from pyinstaller) (1.16)
Installing collected packages: pycryptodomex
  Attempting uninstall: pycryptodomex
    Found existing installation: pycryptodomex 3.15.0
    Uninstalling pycryptodomex-3.15.0:
      Successfully uninstalled pycryptodomex-3.15.0
  DEPRECATION: Configuring installation scheme with distutils config files is deprecated and will no longer work in the near future. If you are using a Homebrew or Linuxbrew Python, please see discussion at https://github.com/Homebrew/homebrew-core/issues/76621
DEPRECATION: Configuring installation scheme with distutils config files is deprecated and will no longer work in the near future. If you are using a Homebrew or Linuxbrew Python, please see discussion at https://github.com/Homebrew/homebrew-core/issues/76621
Successfully installed pycryptodomex-3.9.7
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
