### PR TITLE
[MLB.tv] New Extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -950,6 +950,7 @@ from .mixcloud import (
 from .mlb import (
     MLBIE,
     MLBVideoIE,
+    MLBTVIE,
 )
 from .mlssoccer import MLSSoccerIE
 from .mnet import MnetIE

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -328,7 +328,8 @@ class MLBTVIE(InfoExtractor):
                     'Accept': 'application/vnd.media-service+json; version=2'
                 })
             m3u8_url = playback['stream']['complete']
-            f, s = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id=airing['feedType'] + '-' + airing['feedLanguage'])
+            f, s = self._extract_m3u8_formats_and_subtitles(
+                m3u8_url, video_id, 'mp4', m3u8_id=join_nonempty(airing.get('feedType'), airing.get('feedLanguage'))
             formats.extend(f)
             self._merge_subtitles(s, subtitles)
             title = traverse_obj(airing, ('titles', 0, 'episodeName'))

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -301,7 +301,7 @@ class MLBTVIE(InfoExtractor):
                 'Authorization': f'Bearer {access_token}'
             })
 
-        data = ('grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=%s&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv') % entitlement
+        data = f'grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token={entitlement}&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv'
         access_token = self._download_json(
             'https://us.edge.bamgrid.com/token', None,
             headers={

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -269,7 +269,7 @@ class MLBVideoIE(MLBBaseIE):
 
 
 class MLBTVIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?mlb\.com/tv/g(?P<id>\d{6})/?.*'
+    _VALID_URL = r'https?://(?:www\.)?mlb\.com/tv/g(?P<id>\d{6})'
 
     _TESTS = [{
         'url': 'https://www.mlb.com/tv/g661581/vee2eff5f-a7df-4c20-bdb4-7b926fa12638',

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -329,7 +329,7 @@ class MLBTVIE(InfoExtractor):
                 })
             m3u8_url = playback['stream']['complete']
             f, s = self._extract_m3u8_formats_and_subtitles(
-                m3u8_url, video_id, 'mp4', m3u8_id=join_nonempty(airing.get('feedType'), airing.get('feedLanguage'))
+                m3u8_url, video_id, 'mp4', m3u8_id=join_nonempty(airing.get('feedType'), airing.get('feedLanguage')))
             formats.extend(f)
             self._merge_subtitles(s, subtitles)
 

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -313,9 +313,12 @@ class MLBTVIE(InfoExtractor):
             f'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings?variables=%7B%22partnerProgramIds%22%3A%5B%22{video_id}%22%5D%2C%22applyEsniMediaRightsLabels%22%3Atrue%7D',
             video_id)['data']['Airings']
         for airing in airings:
-            playback = self._download_json(airing['playbackUrls'][0]['href'].format(scenario='browser~csai'), video_id,
-                                           headers={'Authorization': self._access_token,
-                                                    'Accept': 'application/vnd.media-service+json; version=2'})
+            playback = self._download_json(
+                airing['playbackUrls'][0]['href'].format(scenario='browser~csai'),
+                 video_id, headers={
+                     'Authorization': self._access_token,
+                     'Accept': 'application/vnd.media-service+json; version=2'
+                 })
             m3u8_url = playback['stream']['complete']
             f, s = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id=airing['feedType'] + '-' + airing['feedLanguage'])
             formats.extend(f)

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -310,7 +310,9 @@ class MLBTVIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         formats, subtitles = [], []
-        airings = self._download_json(f'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings?variables=%7B%22partnerProgramIds%22%3A%5B%22{video_id}%22%5D%2C%22applyEsniMediaRightsLabels%22%3Atrue%7D', video_id)['data']['Airings']
+        airings = self._download_json(
+            f'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings?variables=%7B%22partnerProgramIds%22%3A%5B%22{video_id}%22%5D%2C%22applyEsniMediaRightsLabels%22%3Atrue%7D',
+            video_id)['data']['Airings']
         for airing in airings:
             playback = self._download_json(airing['playbackUrls'][0]['href'].format(scenario='browser~csai'), video_id,
                                            headers={'Authorization': self._access_token,

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -310,7 +310,7 @@ class MLBTVIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        formats, subtitles = [], []
+        formats, subtitles = [], {}
         airings = self._download_json(
             f'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings?variables=%7B%22partnerProgramIds%22%3A%5B%22{video_id}%22%5D%2C%22applyEsniMediaRightsLabels%22%3Atrue%7D',
             video_id)['data']['Airings']
@@ -321,7 +321,7 @@ class MLBTVIE(InfoExtractor):
             m3u8_url = playback['stream']['complete']
             f, s = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id=airing['feedType'] + '-' + airing['feedLanguage'])
             formats.extend(f)
-            subtitles.extend(s)
+            self._merge_subtitles(s, subtitles)
             title = traverse_obj(airing, ('titles', 0, 'episodeName'))
 
         self._sort_formats(formats)

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -285,15 +285,13 @@ class MLBTVIE(InfoExtractor):
     }]
 
     def _perform_login(self, username, password):
-
+        data = f'grant_type=password&username={urllib.parse.quote(username)}&password={urllib.parse.quote(password)}&scope=openid offline_access&client_id=0oa3e1nutA1HLzAKG356'
         access_token = self._download_json(
             'https://ids.mlb.com/oauth2/aus1m088yK07noBfh356/v1/token', None,
             headers={
                 'User-Agent': 'okhttp/3.12.1',
-                'Content-Type': 'application/x-www-form-urlencoded'},
-            data=(('grant_type=password&username=%s&password=%s&scope=openid offline_access'
-                  '&client_id=0oa3e1nutA1HLzAKG356') % (urllib.parse.quote(username), urllib.parse.quote(password))).encode()
-        )['access_token']
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }, data=data.encode())['access_token']
 
         entitlement = self._download_webpage(
             f'https://media-entitlement.mlb.com/api/v3/jwt?os=Android&appname=AtBat&did={str(uuid.uuid4())}', None,

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -302,15 +302,13 @@ class MLBTVIE(InfoExtractor):
             })
 
         data = f'grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token={entitlement}&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv'
-        access_token = self._download_json(
+        self._access_token = self._download_json(
             'https://us.edge.bamgrid.com/token', None,
             headers={
                 'Accept': 'application/json',
                 'Authorization': 'Bearer bWxidHYmYW5kcm9pZCYxLjAuMA.6LZMbH2r--rbXcgEabaDdIslpo4RyZrlVfWZhsAgXIk',
                 'Content-Type': 'application/x-www-form-urlencoded'
             }, data=data.encode())['access_token']
-
-        self._access_token = access_token
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -6,6 +6,7 @@ from .common import InfoExtractor
 from ..utils import (
     determine_ext,
     int_or_none,
+    join_nonempty,
     parse_duration,
     parse_iso8601,
     traverse_obj,
@@ -300,17 +301,14 @@ class MLBTVIE(InfoExtractor):
                 'Authorization': f'Bearer {access_token}'
             })
 
+        data = ('grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=%s&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv') % entitlement
         access_token = self._download_json(
             'https://us.edge.bamgrid.com/token', None,
             headers={
                 'Accept': 'application/json',
                 'Authorization': 'Bearer bWxidHYmYW5kcm9pZCYxLjAuMA.6LZMbH2r--rbXcgEabaDdIslpo4RyZrlVfWZhsAgXIk',
                 'Content-Type': 'application/x-www-form-urlencoded'
-            },
-            data=(
-                 ('grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=%s'
-                  '&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv') % entitlement).encode()
-        )['access_token']
+            }, data=data.encode())['access_token']
 
         self._access_token = access_token
 

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -270,6 +270,7 @@ class MLBVideoIE(MLBBaseIE):
 
 class MLBTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?mlb\.com/tv/g(?P<id>\d{6})'
+    _NETRC_MACHINE = 'mlb'
 
     _TESTS = [{
         'url': 'https://www.mlb.com/tv/g661581/vee2eff5f-a7df-4c20-bdb4-7b926fa12638',
@@ -303,10 +304,7 @@ class MLBTVIE(InfoExtractor):
                                                   '&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv') % entitlement)
                                            .encode())['access_token']
 
-        return access_token
-
-    def _real_initialize(self):
-        self._access_token = self._perform_login(self.get_param('username'), self.get_param('password'))
+        self._access_token = access_token
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -333,7 +333,7 @@ class MLBTVIE(InfoExtractor):
             f, s = self._extract_m3u8_formats_and_subtitles(
                 m3u8_url, video_id, 'mp4', m3u8_id=join_nonempty(airing.get('feedType'), airing.get('feedLanguage')))
             formats.extend(f)
-            self._merge_subtitles(s, subtitles)
+            self._merge_subtitles(s, target=subtitles)
 
         self._sort_formats(formats)
         return {

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -330,6 +330,6 @@ class MLBTVIE(InfoExtractor):
             'title': title,
             'formats': formats,
             'subtitles': subtitles,
-            'http_headers': {'Authorization': 'Bearer ' + self._access_token},
+            'http_headers': {'Authorization': f'Bearer {self._access_token}'},
             'id': video_id
         }

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -285,11 +285,12 @@ class MLBTVIE(InfoExtractor):
         },
     }]
     _access_token = None
-    
+
     def _real_initialize(self):
         if not self._access_token:
             self.raise_login_required(
                 'All videos are only available to registered users', method='password')
+
     def _perform_login(self, username, password):
         data = f'grant_type=password&username={urllib.parse.quote(username)}&password={urllib.parse.quote(password)}&scope=openid offline_access&client_id=0oa3e1nutA1HLzAKG356'
         access_token = self._download_json(

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -8,6 +8,7 @@ from ..utils import (
     int_or_none,
     parse_duration,
     parse_iso8601,
+    traverse_obj,
     try_get,
 )
 
@@ -321,7 +322,7 @@ class MLBTVIE(InfoExtractor):
             f, s = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id=airing['feedType'] + '-' + airing['feedLanguage'])
             formats.extend(f)
             subtitles.extend(s)
-            title = airing['titles'][0]['episodeName']
+            title = traverse_obj(airing, ('titles', 0, 'episodeName'))
 
         self._sort_formats(formats)
 

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -284,7 +284,12 @@ class MLBTVIE(InfoExtractor):
             'skip_download': True,
         },
     }]
-
+    _access_token = None
+    
+    def _real_initialize(self):
+        if not self._access_token:
+            self.raise_login_required(
+                'All videos are only available to registered users', method='password')
     def _perform_login(self, username, password):
         data = f'grant_type=password&username={urllib.parse.quote(username)}&password={urllib.parse.quote(password)}&scope=openid offline_access&client_id=0oa3e1nutA1HLzAKG356'
         access_token = self._download_json(

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -286,23 +286,33 @@ class MLBTVIE(InfoExtractor):
 
     def _perform_login(self, username, password):
 
-        access_token = self._download_json('https://ids.mlb.com/oauth2/aus1m088yK07noBfh356/v1/token', None,
-                                           headers={'User-Agent': 'okhttp/3.12.1',
-                                                    'Content-Type': 'application/x-www-form-urlencoded'},
-                                           data=(('grant_type=password&username=%s&password=%s&scope=openid offline_access'
-                                                  '&client_id=0oa3e1nutA1HLzAKG356') % (urllib.parse.quote(username), urllib.parse.quote(password)))
-                                           .encode())['access_token']
+        access_token = self._download_json(
+            'https://ids.mlb.com/oauth2/aus1m088yK07noBfh356/v1/token', None,
+            headers={
+                'User-Agent': 'okhttp/3.12.1',
+                'Content-Type': 'application/x-www-form-urlencoded'},
+            data=(('grant_type=password&username=%s&password=%s&scope=openid offline_access'
+                  '&client_id=0oa3e1nutA1HLzAKG356') % (urllib.parse.quote(username), urllib.parse.quote(password))).encode()
+        )['access_token']
 
-        entitlement = self._download_webpage('https://media-entitlement.mlb.com/api/v3/jwt?os=Android&appname=AtBat&did=' + str(uuid.uuid4()), None,
-                                             headers={'User-Agent': 'okhttp/3.12.1', 'Authorization': f'Bearer {access_token}'})
+        entitlement = self._download_webpage(
+            f'https://media-entitlement.mlb.com/api/v3/jwt?os=Android&appname=AtBat&did={str(uuid.uuid4())}', None,
+            headers={
+                'User-Agent': 'okhttp/3.12.1',
+                'Authorization': f'Bearer {access_token}'
+            })
 
-        access_token = self._download_json('https://us.edge.bamgrid.com/token', None,
-                                           headers={'Accept': 'application/json',
-                                                    'Authorization': 'Bearer bWxidHYmYW5kcm9pZCYxLjAuMA.6LZMbH2r--rbXcgEabaDdIslpo4RyZrlVfWZhsAgXIk',
-                                                    'Content-Type': 'application/x-www-form-urlencoded'},
-                                           data=(('grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=%s'
-                                                  '&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv') % entitlement)
-                                           .encode())['access_token']
+        access_token = self._download_json(
+            'https://us.edge.bamgrid.com/token', None,
+            headers={
+                'Accept': 'application/json',
+                'Authorization': 'Bearer bWxidHYmYW5kcm9pZCYxLjAuMA.6LZMbH2r--rbXcgEabaDdIslpo4RyZrlVfWZhsAgXIk',
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            data=(
+                 ('grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=%s'
+                  '&subject_token_type=urn:ietf:params:oauth:token-type:jwt&platform=android-tv') % entitlement).encode()
+        )['access_token']
 
         self._access_token = access_token
 
@@ -314,11 +324,11 @@ class MLBTVIE(InfoExtractor):
             video_id)['data']['Airings']
         for airing in airings:
             playback = self._download_json(
-                airing['playbackUrls'][0]['href'].format(scenario='browser~csai'),
-                 video_id, headers={
-                     'Authorization': self._access_token,
-                     'Accept': 'application/vnd.media-service+json; version=2'
-                 })
+                airing['playbackUrls'][0]['href'].format(scenario='browser~csai'), video_id,
+                headers={
+                    'Authorization': self._access_token,
+                    'Accept': 'application/vnd.media-service+json; version=2'
+                })
             m3u8_url = playback['stream']['complete']
             f, s = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id=airing['feedType'] + '-' + airing['feedLanguage'])
             formats.extend(f)

--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -332,12 +332,10 @@ class MLBTVIE(InfoExtractor):
                 m3u8_url, video_id, 'mp4', m3u8_id=join_nonempty(airing.get('feedType'), airing.get('feedLanguage'))
             formats.extend(f)
             self._merge_subtitles(s, subtitles)
-            title = traverse_obj(airing, ('titles', 0, 'episodeName'))
 
         self._sort_formats(formats)
-
         return {
-            'title': title,
+            'title': traverse_obj(airings, (..., 'titles', 0, 'episodeName'), get_all=False),
             'formats': formats,
             'subtitles': subtitles,
             'http_headers': {'Authorization': f'Bearer {self._access_token}'},


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Adds a new extractor for MLB.tv videos. MLB.tv contains full video and audio replays of every Major League Baseball game. Videos are probably not actually geolocked, but will require a subscription which unfortunately I am unwilling to share.

This pull request is fully "functional," in that it can extract the m3u8 URLs and appropriate headers for each game. However, there are a number of concerns that need to be addressed before merge.

1. Due to the nature of the streams, and limitations with ffmpeg, the issue raised in #4211 means that videos may not download properly. The stream of the actual game is separate from that for the commercials, even though both alternate in the variant m3u8 file. When cleaning up, ffmpeg will only return the stream that starts the playlist. Most of the time, this is the game itself, so the commercials are filtered out, happy surprise. However, if the video starts with commercials, *the whole video will download*, but then the ffmpeg cleanup will result in a video with just commercials. The workaround I used is mentioned at the end of #4211, but it is inelegant and should definitely not be merged into the project.
2. Right now, the "video id" is really a game ID. Each game has multiple broadcasts, usually one video each for the home and away team, along with at least one radio broadcast for each team. Currently all of these broadcasts are returned as different formats, even though the content is of course different for each one. Here is what I mean:

```
ID                         EXT RESOLUTION FPS │   TBR PROTO │ VCODEC        VBR ACODEC    ABR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Away-en-aac-English_Radio  mp4 audio only     │       m3u8  │ audio only        unknown       [en] English Radio
Away-en-aac-Radio_Española mp4 audio only     │       m3u8  │ audio only        unknown       [es] Radio Española
Home-en-aac-English_Radio  mp4 audio only     │       m3u8  │ audio only        unknown       [en] English Radio
Away-en-50                 mp4 audio only     │   50k m3u8  │ audio only        mp4a.40.2 50k
Away-es-50                 mp4 audio only     │   50k m3u8  │ audio only        mp4a.40.2 50k
Home-en-50                 mp4 audio only     │   50k m3u8  │ audio only        mp4a.40.2 50k
Away-en-153                mp4 320x180     30 │  153k m3u8  │ avc1.4d001f  153k mp4a.40.2  0k
Home-en-153                mp4 320x180     30 │  153k m3u8  │ avc1.4d001f  153k mp4a.40.2  0k
Away-en-620                mp4 384x216     30 │  620k m3u8  │ avc1.4d001f  620k mp4a.40.2  0k
Home-en-620                mp4 384x216     30 │  620k m3u8  │ avc1.4d001f  620k mp4a.40.2  0k
Away-en-960                mp4 512x288     30 │  960k m3u8  │ avc1.4d001f  960k mp4a.40.2  0k
Home-en-960                mp4 512x288     30 │  960k m3u8  │ avc1.4d001f  960k mp4a.40.2  0k
Away-en-1400               mp4 640x360     30 │ 1400k m3u8  │ avc1.4d001f 1400k mp4a.40.2  0k
Home-en-1400               mp4 640x360     30 │ 1400k m3u8  │ avc1.4d001f 1400k mp4a.40.2  0k
Away-en-2120               mp4 896x504     30 │ 2120k m3u8  │ avc1.4d001f 2120k mp4a.40.2  0k
Home-en-2120               mp4 896x504     30 │ 2120k m3u8  │ avc1.4d001f 2120k mp4a.40.2  0k
Away-en-2950               mp4 960x540     30 │ 2950k m3u8  │ avc1.4d001f 2950k mp4a.40.2  0k
Home-en-2950               mp4 960x540     30 │ 2950k m3u8  │ avc1.4d001f 2950k mp4a.40.2  0k
Away-en-4160               mp4 1280x720    30 │ 4160k m3u8  │ avc1.640028 4160k mp4a.40.2  0k
Home-en-4160               mp4 1280x720    30 │ 4160k m3u8  │ avc1.640028 4160k mp4a.40.2  0k
Away-en-6600               mp4 1280x720    60 │ 6600k m3u8  │ avc1.640028 6600k mp4a.40.2  0k
```
It may be better for the extractor to extract at the level of the individual broadcast, rather than the game. However, a key feature of MLB.tv is the ability to play different audio broadcasts that are synced with the selected video, which is why I returned *all* of the broadcasts as a single "video," rather than split by broadcast. This is a question for the prospective users of this extractor and also for the devs, if this violates any hard and fast rules.
3. Currently, the extractor pulls the video by taking in the username (email address) and password for the user's MLB account. However, the program always returns a warning `Login with password is not supported for this website.` Additionally, if no username is supplied, the program just returns `ERROR: quote_from_bytes() expected bytes`. Even though a select few games may be freely available, I would like this extractor to **require** a username and password. Caching the `access_token` might be beneficial as well, but I have no idea how to go about doing that. Dev help would be great in cleaning up the authentication process here.
4. The style is probably really bad. I tried to finesse everything to pass flake8 but it still looks terrible and I'm sure many improvements can be made.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
