### PR TITLE
[extractor/youtube] Guard against YouTube returning a player response of a different video

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3111,6 +3111,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         if initial_pr:
             pr = dict(initial_pr)
             pr['streamingData'] = None
+            prs.append(pr)
 
         last_error = None
         tried_iframe_fallback = False

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3076,7 +3076,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         return orderedSet(requested_clients)
 
     def _validate_player_response(self, player_response, video_id, client):
-        # YouTube may sometimes return a different video than expected.
+        # YouTube may return a different video player response than expected.
         # See: https://github.com/TeamNewPipe/NewPipe/issues/8713
         pr_video_id = traverse_obj(player_response, ('videoDetails', 'videoId'))
         if pr_video_id and pr_video_id != video_id:
@@ -3111,8 +3111,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         if initial_pr:
             pr = dict(initial_pr)
             pr['streamingData'] = None
-            if self._validate_player_response(pr, video_id, 'web'):
-                prs.append(pr)
 
         last_error = None
         tried_iframe_fallback = False


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
YouTube is currently A/B testing a change where, at least for the android Innertube client, it detects third party use and replaces the player response _for any video_ with one for https://www.youtube.com/watch?v=aQvGIIdgFDM.

Unfortunately updating the client versions (as done in https://github.com/yt-dlp/yt-dlp/commit/a0c830f488170db9007979da0ba13ebf9ebad5b1) supposedly doesn't help.

See: https://github.com/TeamNewPipe/NewPipe/issues/8713, https://github.com/iv-org/invidious/issues/3230, https://github.com/Tyrrrz/YoutubeExplode/issues/647

In this case, depending on the format sorting and requested video's formats, the bad video's formats may be downloaded as if they were the requested video's. **In other words, we'll end up downloading `aQvGIIdgFDM ` but under the metadata (i.e. title, video id) of the requested video.** (hence the high priority)

While we still to figure out the actual fix, this PR aims to mitigate the above issue by adding a guard to skip player responses of an unexpected video id.

We have not had any report of this happening in yt-dlp. However due to it's rare and silent occurrence, along with the fact that our parameters for the relevant request are similar to the other affected projects, I am assuming it can occur in yt-dlp too.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
