### PR TITLE
[extractor/eurosport] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -491,6 +491,7 @@ from .espn import (
 from .esri import EsriVideoIE
 from .europa import EuropaIE
 from .europeantour import EuropeanTourIE
+from .eurosport import EurosportIE
 from .euscreen import EUScreenIE
 from .expotv import ExpoTVIE
 from .expressen import ExpressenIE

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -40,7 +40,7 @@ class EurosportIE(InfoExtractor):
             # actually they also serve mss, but i don't know how to extract that
             if stream_type == "hls":
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                    traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
+                    traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id, ext='mp4')
             elif stream_type == "dash":
                 fmts, subs = self._extract_mpd_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -45,7 +45,9 @@ class EurosportIE(InfoExtractor):
             'upload_date': '20220727',
         }
     }]
+
     _TOKEN = None
+
     # actually defined in https://netsport.eurosport.io/?variables={"databaseId":<databaseId>,"playoutType":"VDP"}&extensions={"persistedQuery":{"version":1 ..
     # but this method require to get sha256 hash
     _GEO_COUNTRIES = ['DE', 'NL', 'EU', 'IT', 'FR']  # Not complete list but it should work
@@ -68,15 +70,18 @@ class EurosportIE(InfoExtractor):
 
         formats, subtitles = [], {}
         for stream_type in json_data['attributes']['streaming']:
-            # actually they also serve mss, but i don't know how to extract that
-            if stream_type == "hls":
+            if stream_type == 'hls':
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id, ext='mp4')
                 for f in fmts:
                     f.update({'protocol': 'm3u8'})
-            elif stream_type == "dash":
+            elif stream_type == 'dash':
                 fmts, subs = self._extract_mpd_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
+            elif stream_type == 'mss':
+                fmts, subs = self._extract_ism_formats_and_subtitles(
+                    traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
+
             formats.extend(fmts)
             self._merge_subtitles(subs, target=subtitles)
 

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -19,11 +19,15 @@ class EurosportIE(InfoExtractor):
         }
     }]
     _TOKEN = None
+    # actually defined in https://netsport.eurosport.io/?variables={"databaseId":<databaseId>,"playoutType":"VDP"}&extensions={"persistedQuery":{"version":1 ..
+    # but this method require to get sha256 hash
+    _GEO_COUNTRIES = ['de', 'lb', 'nl', 'it', 'fr', 'gb', 'eu']  # this is not complete list but countries in EU should work
 
     def _real_initialize(self):
-        EurosportIE._TOKEN = self._download_json(
-            'https://eu3-prod-direct.eurosport.com/token?realm=eurosport', None,
-            'Trying to get token')['data']['attributes']['token']
+        if EurosportIE._TOKEN is None:
+            EurosportIE._TOKEN = self._download_json(
+                'https://eu3-prod-direct.eurosport.com/token?realm=eurosport', None,
+                'Trying to get token')['data']['attributes']['token']
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
@@ -31,7 +35,7 @@ class EurosportIE(InfoExtractor):
 
         json_data = self._download_json(
             f'https://eu3-prod-direct.eurosport.com/playback/v2/videoPlaybackInfo/sourceSystemId/eurosport-{display_id}',
-            display_id, query={'usePreAuth': True})['data']
+            display_id, query={'usePreAuth': True}, headers={'Authorization': f'Bearer {EurosportIE._TOKEN}'})['data']
 
         json_ld_data = self._search_json_ld(webpage, display_id)
 

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -74,7 +74,7 @@ class EurosportIE(InfoExtractor):
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id, ext='mp4')
                 for f in fmts:
                     f.update({'protocol': 'm3u8'})
-            if stream_type == "dash":
+            elif stream_type == "dash":
                 fmts, subs = self._extract_mpd_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
             formats.extend(fmts)

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -73,8 +73,6 @@ class EurosportIE(InfoExtractor):
             if stream_type == 'hls':
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id, ext='mp4')
-                for f in fmts:
-                    f.update({'protocol': 'm3u8'})
             elif stream_type == 'dash':
                 fmts, subs = self._extract_mpd_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -21,7 +21,7 @@ class EurosportIE(InfoExtractor):
     _TOKEN = None
     # actually defined in https://netsport.eurosport.io/?variables={"databaseId":<databaseId>,"playoutType":"VDP"}&extensions={"persistedQuery":{"version":1 ..
     # but this method require to get sha256 hash
-    _GEO_COUNTRIES = ['de', 'lb', 'nl', 'it', 'fr', 'gb', 'eu']  # this is not complete list but countries in EU should work
+    _GEO_COUNTRIES = ['DE', 'NL', 'EU', 'IT', 'FR']  # Not complete list but it should work
 
     def _real_initialize(self):
         if EurosportIE._TOKEN is None:

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -30,6 +30,9 @@ class EurosportIE(InfoExtractor):
             'display_id': 'vid1694283',
             'timestamp': 1654456090,
             'upload_date': '20220605',
+        },
+        'params': {
+            'fixup': 'never',
         }
     }]
     _TOKEN = None

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -17,6 +17,20 @@ class EurosportIE(InfoExtractor):
             'timestamp': 1654446698,
             'upload_date': '20220605',
         }
+    }, {
+        # geo-blocked but can bypassed by xff
+        'url': 'https://www.eurosport.com/tennis/roland-garros/2022/watch-the-top-five-shots-from-men-s-final-as-rafael-nadal-beats-casper-ruud-to-seal-14th-french-open_vid1694283/video.shtml',
+        'info_dict': {
+            'id': '2481254',
+            'ext': 'mp4',
+            'title': 'md5:149dcc5dfb38ab7352acc008cc9fb071',
+            'duration': 130.0,
+            'thumbnail': 'https://imgresizer.eurosport.com/unsafe/1280x960/smart/filters:format(jpeg)/origin-imgresizer.eurosport.com/2022/06/05/3388422-69248708-2560-1440.png',
+            'description': 'md5:a0c8a7f6b285e48ae8ddbe7aa85cfee6',
+            'display_id': 'vid1694283',
+            'timestamp': 1654456090,
+            'upload_date': '20220605',
+        }
     }]
     _TOKEN = None
     # actually defined in https://netsport.eurosport.io/?variables={"databaseId":<databaseId>,"playoutType":"VDP"}&extensions={"persistedQuery":{"version":1 ..

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -18,7 +18,6 @@ class EurosportIE(InfoExtractor):
             'upload_date': '20220605',
         }
     }, {
-        # geo-blocked but can bypassed by xff
         'url': 'https://www.eurosport.com/tennis/roland-garros/2022/watch-the-top-five-shots-from-men-s-final-as-rafael-nadal-beats-casper-ruud-to-seal-14th-french-open_vid1694283/video.shtml',
         'info_dict': {
             'id': '2481254',
@@ -30,9 +29,20 @@ class EurosportIE(InfoExtractor):
             'display_id': 'vid1694283',
             'timestamp': 1654456090,
             'upload_date': '20220605',
-        },
-        'params': {
-            'fixup': 'never',
+        }
+    }, {
+        # geo-fence but can bypassed by xff
+        'url': 'https://www.eurosport.com/cycling/tour-de-france-femmes/2022/incredible-ride-marlen-reusser-storms-to-stage-4-win-at-tour-de-france-femmes_vid1722221/video.shtml',
+        'info_dict': {
+            'id': '2582552',
+            'ext': 'mp4',
+            'title': '‘Incredible ride!’ - Marlen Reusser storms to Stage 4 win at Tour de France Femmes',
+            'duration': 188.0,
+            'display_id': 'vid1722221',
+            'timestamp': 1658936167,
+            'thumbnail': 'https://imgresizer.eurosport.com/unsafe/1280x960/smart/filters:format(jpeg)/origin-imgresizer.eurosport.com/2022/07/27/3423347-69852108-2560-1440.jpg',
+            'description': 'md5:32bbe3a773ac132c57fb1e8cca4b7c71',
+            'upload_date': '20220727',
         }
     }]
     _TOKEN = None
@@ -62,7 +72,9 @@ class EurosportIE(InfoExtractor):
             if stream_type == "hls":
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id, ext='mp4')
-            elif stream_type == "dash":
+                for f in fmts:
+                    f.update({'protocol': 'm3u8'})
+            if stream_type == "dash":
                 fmts, subs = self._extract_mpd_formats_and_subtitles(
                     traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
             formats.extend(fmts)

--- a/yt_dlp/extractor/eurosport.py
+++ b/yt_dlp/extractor/eurosport.py
@@ -1,0 +1,63 @@
+from .common import InfoExtractor
+from ..utils import traverse_obj
+
+
+class EurosportIE(InfoExtractor):
+    _VALID_URL = r'https?://www\.eurosport\.com/\w+/[\w-]+/\d+/[\w-]+_(?P<id>vid\d+)'
+    _TESTS = [{
+        'url': 'https://www.eurosport.com/tennis/roland-garros/2022/highlights-rafael-nadal-brushes-aside-caper-ruud-to-win-record-extending-14th-french-open-title_vid1694147/video.shtml',
+        'info_dict': {
+            'id': '2480939',
+            'ext': 'mp4',
+            'title': 'Highlights: Rafael Nadal brushes aside Caper Ruud to win record-extending 14th French Open title',
+            'description': 'md5:b564db73ecfe4b14ebbd8e62a3692c76',
+            'thumbnail': 'https://imgresizer.eurosport.com/unsafe/1280x960/smart/filters:format(jpeg)/origin-imgresizer.eurosport.com/2022/06/05/3388285-69245968-2560-1440.png',
+            'duration': 195.0,
+            'display_id': 'vid1694147',
+            'timestamp': 1654446698,
+            'upload_date': '20220605',
+        }
+    }]
+    _TOKEN = None
+
+    def _real_initialize(self):
+        EurosportIE._TOKEN = self._download_json(
+            'https://eu3-prod-direct.eurosport.com/token?realm=eurosport', None,
+            'Trying to get token')['data']['attributes']['token']
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+
+        json_data = self._download_json(
+            f'https://eu3-prod-direct.eurosport.com/playback/v2/videoPlaybackInfo/sourceSystemId/eurosport-{display_id}',
+            display_id, query={'usePreAuth': True})['data']
+
+        json_ld_data = self._search_json_ld(webpage, display_id)
+
+        formats, subtitles = [], {}
+        for stream_type in json_data['attributes']['streaming']:
+            # actually they also serve mss, but i don't know how to extract that
+            if stream_type == "hls":
+                fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                    traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
+            elif stream_type == "dash":
+                fmts, subs = self._extract_mpd_formats_and_subtitles(
+                    traverse_obj(json_data, ('attributes', 'streaming', stream_type, 'url')), display_id)
+            formats.extend(fmts)
+            self._merge_subtitles(subs, target=subtitles)
+
+        self._sort_formats(formats)
+
+        return {
+            'id': json_data['id'],
+            'title': json_ld_data.get('title') or self._og_search_title(webpage),
+            'display_id': display_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            'thumbnails': json_ld_data.get('thumbnails'),
+            'description': (json_ld_data.get('description')
+                            or self._html_search_meta(['og:description', 'description'], webpage)),
+            'duration': json_ld_data.get('duration'),
+            'timestamp': json_ld_data.get('timestamp'),
+        }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE
This PR add site support for www.eurosport.com. At the moment, this PR didn't include geo-block detection and not tested geo-blocked link. Any help to test geo-blocked video is appreciated.

Fixes #2487 

KNOWN ISSUE:
- ~Some link (eg: https://www.eurosport.com/tennis/roland-garros/2022/watch-the-top-five-shots-from-men-s-final-as-rafael-nadal-beats-casper-ruud-to-seal-14th-french-open_vid1694283/video.shtml) raise PostProcessorError, but it works when we input the url manually to ffmpeg~ fixed by setting `m3u8` at `protocol`
- ~Eurosport actually support video file in mss type. I didn't know how to extract this type, so this is unsupported at the moment~ already supported
TO DO:
- ~Set better error on geo-blocked url~ Not needed as now, the extractor will have geo-bypass mechanism

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
