### PR TITLE
[extractor/instagram] Fix post extraction error with non logged in users

### DIFF
--- a/yt_dlp/extractor/instagram.py
+++ b/yt_dlp/extractor/instagram.py
@@ -395,7 +395,7 @@ class InstagramIE(InstagramBaseIE):
             r'window\.__additionalDataLoaded\s*\(\s*[^,]+,\s*', webpage, 'additional data', video_id, fatal=False)
         if not additional_data:
             self.raise_login_required('Requested content was not found, the content might be private')
-        
+
         product_item = traverse_obj(additional_data, ('items', 0), expected_type=dict)
         if product_item:
             media.update(product_item)

--- a/yt_dlp/extractor/instagram.py
+++ b/yt_dlp/extractor/instagram.py
@@ -134,7 +134,7 @@ class InstagramBaseIE(InfoExtractor):
             }
 
     def _extract_product_media(self, product_media):
-        media_id = product_media.get('code') or product_media.get('id')
+        media_id = product_media.get('code') or _pk_to_id(product_media.get('pk'))
         vcodec = product_media.get('video_codec')
         dash_manifest_raw = product_media.get('video_dash_manifest')
         videos_list = product_media.get('video_versions')
@@ -179,7 +179,7 @@ class InstagramBaseIE(InfoExtractor):
 
         user_info = product_info.get('user') or {}
         info_dict = {
-            'id': product_info.get('code') or product_info.get('id'),
+            'id': product_info.get('code') or _pk_to_id(product_info.get('pk')),
             'title': product_info.get('title') or f'Video by {user_info.get("username")}',
             'description': traverse_obj(product_info, ('caption', 'text'), expected_type=str_or_none),
             'timestamp': int_or_none(product_info.get('taken_at')),

--- a/yt_dlp/extractor/instagram.py
+++ b/yt_dlp/extractor/instagram.py
@@ -373,7 +373,7 @@ class InstagramIE(InstagramBaseIE):
             })
         media = traverse_obj(general_info, ('data', 'shortcode_media')) or {}
         if not media:
-            self.report_warning('General metadata extraction failed', video_id)
+            self.report_warning('General metadata extraction failed (You might not be logged in).', video_id)
 
         info = self._download_json(
             f'https://i.instagram.com/api/v1/media/{_id_to_pk(video_id)}/info/', video_id,
@@ -391,11 +391,11 @@ class InstagramIE(InstagramBaseIE):
         webpage = self._download_webpage(
             f'https://www.instagram.com/p/{video_id}/embed/', video_id,
             note='Downloading embed webpage', fatal=False)
-        if not webpage:
-            self.raise_login_required('Requested content was not found, the content might be private')
-
         additional_data = self._search_json(
             r'window\.__additionalDataLoaded\s*\(\s*[^,]+,\s*', webpage, 'additional data', video_id, fatal=False)
+        if not additional_data:
+            self.raise_login_required('Requested content was not found, the content might be private')
+        
         product_item = traverse_obj(additional_data, ('items', 0), expected_type=dict)
         if product_item:
             media.update(product_item)

--- a/yt_dlp/extractor/instagram.py
+++ b/yt_dlp/extractor/instagram.py
@@ -390,9 +390,9 @@ class InstagramIE(InstagramBaseIE):
 
         webpage, urlh = self._download_webpage_handle(url, video_id)
         shared_data = self._search_json(
-                r'window\._sharedData\s*=', webpage, 'shared data', video_id, fatal=False)
+            r'window\._sharedData\s*=', webpage, 'shared data', video_id, fatal=False)
 
-        if not 'www.instagram.com/accounts/login' in urlh.geturl():
+        if 'www.instagram.com/accounts/login' not in urlh.geturl():
             media.update(traverse_obj(
                 shared_data, ('entry_data', 'PostPage', 0, 'graphql', 'shortcode_media'),
                 ('entry_data', 'PostPage', 0, 'media'), expected_type=dict) or {})

--- a/yt_dlp/extractor/instagram.py
+++ b/yt_dlp/extractor/instagram.py
@@ -389,7 +389,7 @@ class InstagramIE(InstagramBaseIE):
             return self._extract_product(media)
 
         webpage = self._download_webpage(
-            f'https://www.instagram.com/p/{video_id}/embed/', video_id,
+            f'{url}/embed/', video_id,
             note='Downloading embed webpage', fatal=False)
         additional_data = self._search_json(
             r'window\.__additionalDataLoaded\s*\(\s*[^,]+,\s*', webpage, 'additional data', video_id, fatal=False)


### PR DESCRIPTION
### Description of *pull request* and other information

Fixes the current issue faced by non logged in users with post extractor by adding main webpage extraction. Current extraction order: GraphQL (mandatory) -> web API (for logged in users) -> webpage (for non logged in users) -> embed page (for non logged in users)

Fixes #4532

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
