### PR TITLE
[extractor/rtbf] Update stream extractor

### DIFF
--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -69,8 +69,9 @@ class RedBeeBaseIE(InfoExtractor):
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
                     format['mediaLocator'], asset_id, fatal=False)
 
-            for index in range(len(fmts)):
-                fmts[index]['has_drm'] = format.get('drm') is not None
+            if format.get('drm'):
+                for f in fmts:
+                    f['has_drm'] = True
 
             formats.extend(fmts)
             self._merge_subtitles(subs, target=subtitles)

--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -69,6 +69,9 @@ class RedBeeBaseIE(InfoExtractor):
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
                     format['mediaLocator'], asset_id, fatal=False)
 
+            for index in range(len(fmts)):
+                fmts[index]['has_drm'] = format.get('drm') is not None
+
             formats.extend(fmts)
             self._merge_subtitles(subs, target=subtitles)
 

--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -293,10 +293,7 @@ class RTBFIE(RedBeeBaseIE):
         if provider in self._PROVIDERS:
             return self.url_result(data['url'], self._PROVIDERS[provider])
 
-        # In general, we prefer the 'subtitle' because it's a lot more specific than the 'title',
-        # but we need to fallback to 'title' in case 'subtitle' doesn't exist, like for livestreams.
-        # https://github.com/yt-dlp/yt-dlp/issues/4656
-        title = data.get('subtitle') or data['title']
+        title = traverse_obj(data, 'subtitle', 'title')
         is_live = data.get('isLive')
         height_re = r'-(\d+)p\.'
         formats, subtitles = [], {}

--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -283,7 +283,7 @@ class RTBFIE(RedBeeBaseIE):
 
             raise ExtractorError('Could not find media data')
 
-        data = self._parse_json(media_data, media_id, fatal=False)
+        data = self._parse_json(media_data, media_id)
 
         error = data.get('error')
         if error:

--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -298,68 +298,67 @@ class RTBFIE(RedBeeBaseIE):
         height_re = r'-(\d+)p\.'
         formats, subtitles = [], {}
 
-        m3u8_url = data.get('urlHlsAes128') or data.get('urlHls')
         # The old api still returns m3u8 and mpd manifest for livestreams, but these are 'fake'
         # since all they contain is a 20s video that is completely unrelated.
         # https://github.com/yt-dlp/yt-dlp/issues/4656#issuecomment-1214461092
-        if not is_live:
-            if m3u8_url:
-                fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                    m3u8_url, media_id, 'mp4', m3u8_id='hls', fatal=False)
-                formats.extend(fmts)
-                self._merge_subtitles(subs, target=subtitles)
+        m3u8_url = None if data.get('isLive') else traverse_obj(data, 'urlHlsAes128', 'urlHls')
+        if m3u8_url:
+            fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                m3u8_url, media_id, 'mp4', m3u8_id='hls', fatal=False)
+            formats.extend(fmts)
+            self._merge_subtitles(subs, target=subtitles)
 
-            fix_url = lambda x: x.replace('//rtbf-vod.', '//rtbf.') if '/geo/drm/' in x else x
-            http_url = data.get('url')
-            if formats and http_url and re.search(height_re, http_url):
-                http_url = fix_url(http_url)
-                for m3u8_f in formats[:]:
-                    height = m3u8_f.get('height')
-                    if not height:
-                        continue
-                    f = m3u8_f.copy()
-                    del f['protocol']
-                    f.update({
-                        'format_id': m3u8_f['format_id'].replace('hls-', 'http-'),
-                        'url': re.sub(height_re, '-%dp.' % height, http_url),
-                    })
-                    formats.append(f)
-            else:
-                sources = data.get('sources') or {}
-                for key, format_id in self._QUALITIES:
-                    format_url = sources.get(key)
-                    if not format_url:
-                        continue
-                    height = int_or_none(self._search_regex(
-                        height_re, format_url, 'height', default=None))
-                    formats.append({
-                        'format_id': format_id,
-                        'url': fix_url(format_url),
-                        'height': height,
-                    })
-
-            mpd_url = data.get('urlDash')
-            if mpd_url and (self.get_param('allow_unplayable_formats') or not data.get('drm')):
-                fmts, subs = self._extract_mpd_formats_and_subtitles(
-                    mpd_url, media_id, mpd_id='dash', fatal=False)
-                formats.extend(fmts)
-                self._merge_subtitles(subs, target=subtitles)
-
-            audio_url = data.get('urlAudio')
-            if audio_url:
-                formats.append({
-                    'format_id': 'audio',
-                    'url': audio_url,
-                    'vcodec': 'none',
-                })
-
-            for track in (data.get('tracks') or {}).values():
-                sub_url = track.get('url')
-                if not sub_url:
+        fix_url = lambda x: x.replace('//rtbf-vod.', '//rtbf.') if '/geo/drm/' in x else x
+        http_url = data.get('url')
+        if formats and http_url and re.search(height_re, http_url):
+            http_url = fix_url(http_url)
+            for m3u8_f in formats[:]:
+                height = m3u8_f.get('height')
+                if not height:
                     continue
-                subtitles.setdefault(track.get('lang') or 'fr', []).append({
-                    'url': sub_url,
+                f = m3u8_f.copy()
+                del f['protocol']
+                f.update({
+                    'format_id': m3u8_f['format_id'].replace('hls-', 'http-'),
+                    'url': re.sub(height_re, '-%dp.' % height, http_url),
                 })
+                formats.append(f)
+        else:
+            sources = data.get('sources') or {}
+            for key, format_id in self._QUALITIES:
+                format_url = sources.get(key)
+                if not format_url:
+                    continue
+                height = int_or_none(self._search_regex(
+                    height_re, format_url, 'height', default=None))
+                formats.append({
+                    'format_id': format_id,
+                    'url': fix_url(format_url),
+                    'height': height,
+                })
+
+        mpd_url = None if data.get('isLive') else data.get('urlDash')
+        if mpd_url and (self.get_param('allow_unplayable_formats') or not data.get('drm')):
+            fmts, subs = self._extract_mpd_formats_and_subtitles(
+                mpd_url, media_id, mpd_id='dash', fatal=False)
+            formats.extend(fmts)
+            self._merge_subtitles(subs, target=subtitles)
+
+        audio_url = data.get('urlAudio')
+        if audio_url:
+            formats.append({
+                'format_id': 'audio',
+                'url': audio_url,
+                'vcodec': 'none',
+            })
+
+        for track in (data.get('tracks') or {}).values():
+            sub_url = track.get('url')
+            if not sub_url:
+                continue
+            subtitles.setdefault(track.get('lang') or 'fr', []).append({
+                'url': sub_url,
+            })
 
         if not formats:
             fmts, subs = self._get_formats_and_subtitles(url, f'live_{media_id}' if is_live else media_id)

--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -276,9 +276,9 @@ class RTBFIE(RedBeeBaseIE):
 
         media_data = self._html_search_regex(r'data-media="([^"]+)"', embed_page, 'media data', fatal=False)
         if not media_data:
-            if re.findall(r'<div[^>]+id="[^"]*js-error-expired[^"]*"[^>]+class="(?![^"]*hidden)', embed_page):
+            if re.search(r'<div[^>]+id="js-error-expired"[^>]+class="(?![^"]*hidden)', embed_page):
                 raise ExtractorError('Livestream has ended.', expected=True)
-            if re.findall(r'<div[^>]+id="[^"]*js-sso-connect[^"]*"[^>]+class="(?![^"]*hidden)', embed_page):
+            if re.search(r'<div[^>]+id="js-sso-connect"[^>]+class="(?![^"]*hidden)', embed_page):
                 self.raise_login_required()
 
             raise ExtractorError('Could not find media data')

--- a/yt_dlp/extractor/redbee.py
+++ b/yt_dlp/extractor/redbee.py
@@ -280,7 +280,10 @@ class RTBFIE(RedBeeBaseIE):
         if provider in self._PROVIDERS:
             return self.url_result(data['url'], self._PROVIDERS[provider])
 
-        title = data['subtitle']
+        # In general, we prefer the 'subtitle' because it's a lot more specific than the 'title',
+        # but we need to fallback to 'title' in case 'subtitle' doesn't exist, like for livestreams.
+        # https://github.com/yt-dlp/yt-dlp/issues/4656
+        title = data.get('subtitle') or data['title']
         is_live = data.get('isLive')
         height_re = r'-(\d+)p\.'
         formats = []


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

In #4479 I changed the `title` extractor from `title` to `subtitle` because, for videos at least, the `subtitle` is more descriptive. https://github.com/yt-dlp/yt-dlp/pull/4479#issuecomment-1200308965

But unfortunately, livestreams don't contain a `subtitle` so we fail extracting it. This is fixed by adding a fallback to `title` in case `subtitle` doesn't exist.

**Livestreams using RedBee**
Also all streams have started using RedBee, but the previous api still returns m3u8 and mpd manifests that contain a 20s video that is completely unrelated, so we need to ignore them since they're 'fake'. https://github.com/yt-dlp/yt-dlp/issues/4656#issuecomment-1214461092

**RedBee DRM formats**
And last but not least, some RedBee formats have drm but we were not detecting it; these were downloaded completely fine but were unplayable.

Fixes #4656

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
