### PR TITLE
[Niconico] Allow using just the video/mylist ID

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -57,6 +57,25 @@ class NiconicoIE(InfoExtractor):
         },
         'skip': 'Requires an account',
     }, {
+        # Same as the last test, but this time using only the ID as the URL
+        'url': 'sm22312215',
+        'md5': 'd1a75c0823e2f629128c43e1212760f9',
+        'info_dict': {
+            'id': 'sm22312215',
+            'ext': 'mp4',
+            'title': 'Big Buck Bunny',
+            'thumbnail': r're:https?://.*',
+            'uploader': 'takuya0301',
+            'uploader_id': '2698420',
+            'upload_date': '20131123',
+            'timestamp': int,  # timestamp is unstable
+            'description': '(c) copyright 2008, Blender Foundation / www.bigbuckbunny.org',
+            'duration': 33,
+            'view_count': int,
+            'comment_count': int,
+        },
+        'skip': 'Requires an account',
+    }, {
         # File downloaded with and without credentials are different, so omit
         # the md5 field
         'url': 'http://www.nicovideo.jp/watch/nm14296458',
@@ -169,7 +188,7 @@ class NiconicoIE(InfoExtractor):
         'only_matching': True,
     }]
 
-    _VALID_URL = r'https?://(?:(?:www\.|secure\.|sp\.)?nicovideo\.jp/watch|nico\.ms)/(?P<id>(?:[a-z]{2})?[0-9]+)'
+    _VALID_URL = r'(?:https?://(?:(?:www\.|secure\.|sp\.)?nicovideo\.jp/watch|nico\.ms)/|^)(?P<id>[a-z]{2}[1-9][0-9]*)(?=[#?]|$)'
     _NETRC_MACHINE = 'niconico'
     _COMMENT_API_ENDPOINTS = (
         'https://nvcomment.nicovideo.jp/legacy/api.json',
@@ -601,7 +620,7 @@ class NiconicoPlaylistBaseIE(InfoExtractor):
 
 class NiconicoPlaylistIE(NiconicoPlaylistBaseIE):
     IE_NAME = 'niconico:playlist'
-    _VALID_URL = r'https?://(?:(?:www\.|sp\.)?nicovideo\.jp|nico\.ms)/(?:user/\d+/)?(?:my/)?mylist/(?:#/)?(?P<id>\d+)'
+    _VALID_URL = r'(?:https?://(?:(?:www\.|sp\.)?nicovideo\.jp|nico\.ms)/)?(?:user/\d+/)?(?:my/)?mylist/(?:#/)?(?P<id>\d+)'
 
     _TESTS = [{
         'url': 'http://www.nicovideo.jp/mylist/27411728',
@@ -613,6 +632,9 @@ class NiconicoPlaylistIE(NiconicoPlaylistBaseIE):
             'uploader_id': '805442',
         },
         'playlist_mincount': 291,
+    }, {
+        'url': 'mylist/27411728',
+        'only_matching': True,
     }, {
         'url': 'https://www.nicovideo.jp/user/805442/mylist/27411728',
         'only_matching': True,


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This makes it so that videos from Niconico can be downloaded by using just the video ID or mylist ID, Ex. `yt-dlp sm22312215` or `yt-dlp mylist/27411728`. I figure this is worthwhile for Niconico as it's extremely common on there to refer to videos in these ways and the they're relatively unique so there shouldn't be major conflicts with any other sites, however it doesn't seem like any site besides YouTube allows this at the moment so I'm fine if this is closed as not wanted.

I made the video ID checking slightly stricter to hopefully prevent any false positives such as from YouTube IDs like `oa79GczkcP` which match the two lowercase letters followed by numbers, but it's exceedingly unlikely for a YouTube ID to be two lowercase letters then numbers all the way to the end of the ID. One additional change that could be done to make it much stricter would be to change the `[a-z]{2}` to `sm|nm|so` as those are the only valid types, but that could potentially change in the future so I didn't do that.

Edit: Force push is because I noticed an unnecessary non-capturing group in the regex, I didn't want to waste a second commit for just removing that


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
