### PR TITLE
[extractor/crackle] Adds support for channels, playlists, and series

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -349,7 +349,11 @@ from .cpac import (
 )
 from .cozytv import CozyTVIE
 from .cracked import CrackedIE
-from .crackle import CrackleIE
+from .crackle import (
+    CrackleVideoIE,
+    CrackleChannelIE,
+    CracklePlaylistIE
+)
 from .craftsy import CraftsyIE
 from .crooksandliars import CrooksAndLiarsIE
 from .crowdbunker import (

--- a/yt_dlp/extractor/crackle.py
+++ b/yt_dlp/extractor/crackle.py
@@ -248,7 +248,7 @@ class CrackleBaseIE(InfoExtractor):
 
 
 class CrackleVideoIE(CrackleBaseIE):
-    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?:\d+|playlist/\d+|(?!playlist|watch)[^/]+)/(?P<video_id>\d+)$'
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?:\d+|playlist/\d+|(?!playlist|watch)[^/]+)/(?P<id>\d+)$'
     _TESTS = [
         {
             # Crackle is available in the United States and territories
@@ -333,7 +333,7 @@ class CrackleVideoIE(CrackleBaseIE):
 
 
 class CrackleChannelIE(CrackleBaseIE):
-    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<channel_id>\d+)/?$'
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<id>\d+)/?$'
     _TESTS = [{
         # series
         'url': 'https://www.crackle.com/watch/5851',
@@ -365,12 +365,12 @@ class CrackleChannelIE(CrackleBaseIE):
     }]
 
     def _real_extract(self, url):
-        channel_id = self._match_valid_url(url).group('channel_id')
+        channel_id = self._match_id(url)
         channel, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL, channel_id)
         channel_type = channel['ChannelTypeId']
 
         if channel_type == 1:  # Movies
-            return self._get_video_info(traverse_obj['FeaturedMedia']['ID'], country)
+            return self._get_video_info(channel['FeaturedMedia']['ID'], country)
 
         elif channel_type in (11, 13):  # TV Shows
             playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL_PLAYLIST, channel_id, country)

--- a/yt_dlp/extractor/crackle.py
+++ b/yt_dlp/extractor/crackle.py
@@ -273,7 +273,7 @@ class CrackleBaseIE(InfoExtractor):
 
 class CrackleVideoIE(CrackleBaseIE):
 
-    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?:\d+|playlist/\d+|(?!playlist|watch)[^/]+)/(?P<video_id>\d+)'
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?:\d+|playlist/\d+|(?!playlist|watch)[^/]+)/(?P<video_id>\d+)$'
 
     _TESTS = [
         {
@@ -317,7 +317,7 @@ class CrackleChannelIE(CrackleBaseIE):
         MOVIE_PAGE = 1
         TV_PAGE = 11
 
-    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<channel_id>\d+)'
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<channel_id>\d+)/?$'
 
     _TESTS = [
         {
@@ -388,7 +388,7 @@ class CrackleChannelIE(CrackleBaseIE):
 
 class CracklePlaylistIE(CrackleBaseIE):
 
-    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(watch/)?playlist/(?P<playlist_id>\d+)'
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(watch/)?playlist/(?P<playlist_id>\d+)/?$'
 
     _TESTS = [
         {

--- a/yt_dlp/extractor/crackle.py
+++ b/yt_dlp/extractor/crackle.py
@@ -20,102 +20,38 @@ from ..utils import (
 from enum import Enum
 
 
-class UrlType(Enum):
-    MEDIA = "media"
-    CHANNEL = "channel"
-    CHANNEL_PLAYLIST = "channel playlist"
-    PLAYLIST = "playlist"
+class CrackleBaseIE(InfoExtractor):
 
-
-class ChannelType(Enum):
-    MOVIE_PAGE = 1
-    TV_PAGE = 11
-
-
-class CrackleIE(InfoExtractor):
-    _VALID_URL = r'(?:crackle:|https?://(?:(?:www|m)\.)?(?:sony)?crackle\.com/)((watch/)?(?:(?P<channel_id>\d+)|playlist/(?P<playlist_id>\d+)|(?:[^/]+)+))(/(?P<video_id>\d+))?'
-    _TESTS = [
-        {
-            # Crackle is available in the United States and territories
-            'url': 'https://www.crackle.com/thanksgiving/2510064',
-            'info_dict': {
-                'id': '2510064',
-                'ext': 'mp4',
-                'title': 'Touch Football',
-                'description': 'md5:cfbb513cf5de41e8b56d7ab756cff4df',
-                'duration': 1398,
-                'view_count': int,
-                'average_rating': 0,
-                'age_limit': 17,
-                'genre': 'Comedy',
-                'creator': 'Daniel Powell',
-                'artist': 'Chris Elliott, Amy Sedaris',
-                'release_year': 2016,
-                'series': 'Thanksgiving',
-                'episode': 'Touch Football',
-                'season_number': 1,
-                'episode_number': 1,
-                'season': 'Season 1',
-            },
-            'params': {
-                # m3u8 download
-                'skip_download': True,
-            },
-            'expected_warnings': [
-                'Trying with a list of known countries'
-            ],
-        }, {
-            'url': 'https://www.sonycrackle.com/thanksgiving/2510064',
-            'only_matching': True,
-        }, {
-            # entire series provided as channel URL
-            'url': 'https://www.crackle.com/watch/5851',
-            'playlist_count': 8,
-            'info_dict': {
-                'id': '5851',
-                'title': 'Thanksgiving',
-            },
-            'expected_warnings': [
-                'Trying with a list of known countries'
-            ],
-        }, {
-            # entire series provided as playlist URL
-            'url': 'https://www.crackle.com/watch/playlist/2130982',
-            'playlist_count': 8,
-            'info_dict': {
-                'id': '2130982',
-                'title': 'Episodes',
-            },
-            'expected_warnings': [
-                'Trying with a list of known countries'
-            ],
-        }, {
-            # movie provided as channel URL
-            'url': 'https://www.crackle.com/watch/7484',
-            'info_dict': {
-                'id': '2516266',
-                'title': '1 Mile To You',
-                'release_year': 2017,
-                'ext': 'mp4',
-                'creator': 'Leif Tilden',
-                'age_limit': 14,
-                'description': 'md5:13806df170014c4c9dd7c9b5b8b4921d',
-                'average_rating': float,
-                'duration': 6277,
-                'view_count': int,
-                'artist': 'md5:54868aa9fb6781c75f427da428735df4',
-                'genre': 'Drama, Sports, Romance',
-            },
-            'params': {
-                # m3u8 download
-                'skip_download': True,
-            },
-            'expected_warnings': [
-                'Trying with a list of known countries'
-            ],
+    class TestData:
+        EPISODE_INFO = {
+            'id': '2510064',
+            'ext': 'mp4',
+            'title': 'Touch Football',
+            'description': 'md5:cfbb513cf5de41e8b56d7ab756cff4df',
+            'duration': 1398,
+            'view_count': int,
+            'average_rating': 0,
+            'age_limit': 17,
+            'genre': 'Comedy',
+            'creator': 'Daniel Powell',
+            'artist': 'Chris Elliott, Amy Sedaris',
+            'release_year': 2016,
+            'series': 'Thanksgiving',
+            'episode': 'Touch Football',
+            'season_number': 1,
+            'episode_number': 1,
+            'season': 'Season 1',
         }
-    ]
+        EXPECTED_WARNINGS = ['Trying with a list of known countries']
+        PARAMS_SKIP_DOWNLOAD = {'skip_download': True}
 
+    class UrlType(Enum):
+        MEDIA = "media"
+        CHANNEL = "channel"
+        CHANNEL_PLAYLIST = "channel playlist"
+        PLAYLIST = "playlist"
+
+    _URL_PREFIX = r'(?:crackle:|https?://(?:(?:www|m)\.)?(?:sony)?crackle\.com/)'
     _MEDIA_FILE_SLOTS = {
         '360p.mp4': {
             'width': 640,
@@ -146,9 +82,9 @@ class CrackleIE(InfoExtractor):
 
         url = 'https://web-api-us.crackle.com/Service.svc/'
 
-        if json_type == UrlType.CHANNEL_PLAYLIST:
+        if json_type == self.UrlType.CHANNEL_PLAYLIST:
             url += 'channel/%s/playlists/all/'
-        elif json_type == UrlType.PLAYLIST:
+        elif json_type == self.UrlType.PLAYLIST:
             url += 'playlist/%s/info/'
         else:
             url += 'details/%s/%%s/' % json_type.value
@@ -207,7 +143,7 @@ class CrackleIE(InfoExtractor):
                     raise
 
                 # Found video formats
-                if json_type != UrlType.MEDIA or isinstance(details.get('MediaURLs'), list):
+                if json_type != self.UrlType.MEDIA or isinstance(details.get('MediaURLs'), list):
                     break
         else:
             details = self._download_crackle_details_direct(json_type, json_id, country)
@@ -216,7 +152,7 @@ class CrackleIE(InfoExtractor):
 
     def _get_video_info(self, video_id, country):
 
-        media, country = self._download_crackle_details(UrlType.MEDIA, video_id, country)
+        media, country = self._download_crackle_details(self.UrlType.MEDIA, video_id, country)
 
         ignore_no_formats = self.get_param('ignore_no_formats_error')
 
@@ -334,23 +270,150 @@ class CrackleIE(InfoExtractor):
         }
         return video, country
 
+
+class CrackleVideoIE(CrackleBaseIE):
+
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?:\d+|playlist/\d+|(?!playlist|watch)[^/]+)/(?P<video_id>\d+)'
+
+    _TESTS = [
+        {
+            # Crackle is available in the United States and territories
+            'url': 'https://www.crackle.com/thanksgiving/2510064',
+            'info_dict': CrackleBaseIE.TestData.EPISODE_INFO,
+            'params': CrackleBaseIE.TestData.PARAMS_SKIP_DOWNLOAD,
+            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+        }, {
+            # episode provided with playlist URL
+            'url': 'https://www.crackle.com/watch/playlist/2130982/2510064',
+            'info_dict': CrackleBaseIE.TestData.EPISODE_INFO,
+            'params': CrackleBaseIE.TestData.PARAMS_SKIP_DOWNLOAD,
+            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+        }, {
+            # episode provided with channel URL
+            'url': 'https://www.crackle.com/watch/5851/2510064',
+            'info_dict': CrackleBaseIE.TestData.EPISODE_INFO,
+            'params': CrackleBaseIE.TestData.PARAMS_SKIP_DOWNLOAD,
+            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+        }, {
+            'url': 'https://www.sonycrackle.com/thanksgiving/2510064',
+            'only_matching': True,
+        }
+    ]
+
     def _real_extract(self, url):
 
         mobj = self._match_valid_url(url).groupdict()
         video_id = mobj.get('video_id')
+
+        country = None
+        # get video of specific page
+        video, country = self._get_video_info(video_id, country)
+        return video
+
+
+class CrackleChannelIE(CrackleBaseIE):
+
+    class ChannelType(Enum):
+        MOVIE_PAGE = 1
+        TV_PAGE = 11
+
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<channel_id>\d+)'
+
+    _TESTS = [
+        {
+            # entire series provided as channel URL
+            'url': 'https://www.crackle.com/watch/5851',
+            'playlist_count': 8,
+            'info_dict': {
+                'id': '5851',
+                'title': 'Thanksgiving',
+            },
+            'expected_warnings': [
+                'Trying with a list of known countries'
+            ],
+        }, {
+            # movie provided as channel URL
+            'url': 'https://www.crackle.com/watch/7484',
+            'info_dict': {
+                'id': '2516266',
+                'title': '1 Mile To You',
+                'release_year': 2017,
+                'ext': 'mp4',
+                'creator': 'Leif Tilden',
+                'age_limit': 14,
+                'description': 'md5:13806df170014c4c9dd7c9b5b8b4921d',
+                'average_rating': float,
+                'duration': 6277,
+                'view_count': int,
+                'artist': 'md5:54868aa9fb6781c75f427da428735df4',
+                'genre': 'Drama, Sports, Romance',
+            },
+            'params': {
+                # m3u8 download
+                'skip_download': True,
+            },
+            'expected_warnings': [
+                'Trying with a list of known countries'
+            ],
+        }
+    ]
+
+    def _real_extract(self, url):
+
+        mobj = self._match_valid_url(url).groupdict()
         channel_id = mobj.get('channel_id')
+
+        videos = []
+        channel, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL, channel_id, None)
+
+        channel_type = channel.get('ChannelTypeId')
+
+        if channel_type == self.ChannelType.MOVIE_PAGE.value:
+            # movie channel - get featured media
+            v_id = str(traverse_obj(channel, ('FeaturedMedia', 'ID')))
+            video, country = self._get_video_info(v_id, country)
+            return video
+        elif channel_type == self.ChannelType.TV_PAGE.value:
+            # series channel - enumerate videos in channel
+            playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL_PLAYLIST, channel_id, country)
+            for p in playlist.get('Playlists') or []:
+                if p.get('PlaylistName') == 'Episodes':
+                    for x in p.get('Items') or []:
+                        v_id = str(traverse_obj(x, ('MediaInfo', 'Id')))
+                        video, country = self._get_video_info(v_id, country)
+                        videos.append(video)
+
+        return self.playlist_result(videos, channel_id, channel.get('Name'))
+
+
+class CracklePlaylistIE(CrackleBaseIE):
+
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(watch/)?playlist/(?P<playlist_id>\d+)'
+
+    _TESTS = [
+        {
+            # entire series provided as playlist URL
+            'url': 'https://www.crackle.com/watch/playlist/2130982',
+            'playlist_count': 8,
+            'info_dict': {
+                'id': '2130982',
+                'title': 'Episodes',
+            },
+            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+        }
+    ]
+
+    def _real_extract(self, url):
+
+        mobj = self._match_valid_url(url).groupdict()
         playlist_id = mobj.get('playlist_id')
 
         country = None
 
-        if video_id is not None:
-            # get video of specific page
-            video, country = self._get_video_info(video_id, country)
-            return video
-        elif playlist_id is not None:
+        if playlist_id is not None:
             # enumerate videos in playlist
             videos = []
-            playlist, country = self._download_crackle_details(UrlType.PLAYLIST, playlist_id, country)
+            playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.PLAYLIST, playlist_id, country)
             result = playlist and playlist.get('Result')
             for x in (result and result.get('Medias')) or []:
                 v_id = str(traverse_obj(x, ('MediaInfo', 'Id')))
@@ -358,25 +421,3 @@ class CrackleIE(InfoExtractor):
                 videos.append(video)
 
             return self.playlist_result(videos, playlist_id, result and result.get('Name'))
-        else:
-            videos = []
-            channel, country = self._download_crackle_details(UrlType.CHANNEL, channel_id, country)
-
-            channel_type = channel.get('ChannelTypeId')
-
-            if channel_type == ChannelType.MOVIE_PAGE.value:
-                # movie channel - get featured media
-                v_id = str(traverse_obj(channel, ('FeaturedMedia', 'ID')))
-                video, country = self._get_video_info(v_id, country)
-                return video
-            elif channel_type == ChannelType.TV_PAGE.value:
-                # series channel - enumerate videos in channel
-                playlist, country = self._download_crackle_details(UrlType.CHANNEL_PLAYLIST, channel_id, country)
-                for p in playlist.get('Playlists') or []:
-                    if p.get('PlaylistName') == 'Episodes':
-                        for x in p.get('Items') or []:
-                            v_id = str(traverse_obj(x, ('MediaInfo', 'Id')))
-                            video, country = self._get_video_info(v_id, country)
-                            videos.append(video)
-
-            return self.playlist_result(videos, channel_id, channel.get('Name'))

--- a/yt_dlp/extractor/crackle.py
+++ b/yt_dlp/extractor/crackle.py
@@ -22,29 +22,6 @@ from enum import Enum
 
 class CrackleBaseIE(InfoExtractor):
 
-    class TestData:
-        EPISODE_INFO = {
-            'id': '2510064',
-            'ext': 'mp4',
-            'title': 'Touch Football',
-            'description': 'md5:cfbb513cf5de41e8b56d7ab756cff4df',
-            'duration': 1398,
-            'view_count': int,
-            'average_rating': 0,
-            'age_limit': 17,
-            'genre': 'Comedy',
-            'creator': 'Daniel Powell',
-            'artist': 'Chris Elliott, Amy Sedaris',
-            'release_year': 2016,
-            'series': 'Thanksgiving',
-            'episode': 'Touch Football',
-            'season_number': 1,
-            'episode_number': 1,
-            'season': 'Season 1',
-        }
-        EXPECTED_WARNINGS = ['Trying with a list of known countries']
-        PARAMS_SKIP_DOWNLOAD = {'skip_download': True}
-
     class UrlType(Enum):
         MEDIA = "media"
         CHANNEL = "channel"
@@ -104,7 +81,7 @@ class CrackleBaseIE(InfoExtractor):
 
         return details
 
-    def _download_crackle_details(self, json_type: UrlType, json_id, country):
+    def _download_crackle_details(self, json_type: UrlType, json_id, country=None):
 
         details = {}
 
@@ -150,8 +127,8 @@ class CrackleBaseIE(InfoExtractor):
 
         return details, country
 
-    def _get_video_info(self, video_id, country):
-
+    def _get_video_info(self, video_id, country=None):
+        video_id = str(video_id)
         media, country = self._download_crackle_details(self.UrlType.MEDIA, video_id, country)
 
         ignore_no_formats = self.get_param('ignore_no_formats_error')
@@ -248,7 +225,7 @@ class CrackleBaseIE(InfoExtractor):
                     'height': int(mobj.group(2)),
                 })
 
-        video = {
+        return {
             'id': video_id,
             'title': title,
             'description': description,
@@ -268,32 +245,83 @@ class CrackleBaseIE(InfoExtractor):
             'subtitles': subtitles,
             'formats': formats,
         }
-        return video, country
 
 
 class CrackleVideoIE(CrackleBaseIE):
-
     _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?:\d+|playlist/\d+|(?!playlist|watch)[^/]+)/(?P<video_id>\d+)$'
-
     _TESTS = [
         {
             # Crackle is available in the United States and territories
             'url': 'https://www.crackle.com/thanksgiving/2510064',
-            'info_dict': CrackleBaseIE.TestData.EPISODE_INFO,
-            'params': CrackleBaseIE.TestData.PARAMS_SKIP_DOWNLOAD,
-            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+            'info_dict': {
+                'id': '2510064',
+                'ext': 'mp4',
+                'title': 'Touch Football',
+                'description': 'md5:cfbb513cf5de41e8b56d7ab756cff4df',
+                'duration': 1398,
+                'view_count': int,
+                'average_rating': 0,
+                'age_limit': 17,
+                'genre': 'Comedy',
+                'creator': 'Daniel Powell',
+                'artist': 'Chris Elliott, Amy Sedaris',
+                'release_year': 2016,
+                'series': 'Thanksgiving',
+                'episode': 'Touch Football',
+                'season_number': 1,
+                'episode_number': 1,
+                'season': 'Season 1',
+            },
+            'params': {'skip_download': True},
+            'expected_warnings': ['Trying with a list of known countries']
         }, {
             # episode provided with playlist URL
             'url': 'https://www.crackle.com/watch/playlist/2130982/2510064',
-            'info_dict': CrackleBaseIE.TestData.EPISODE_INFO,
-            'params': CrackleBaseIE.TestData.PARAMS_SKIP_DOWNLOAD,
-            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+            'info_dict': {
+                'id': '2510064',
+                'ext': 'mp4',
+                'title': 'Touch Football',
+                'description': 'md5:cfbb513cf5de41e8b56d7ab756cff4df',
+                'duration': 1398,
+                'view_count': int,
+                'average_rating': 0,
+                'age_limit': 17,
+                'genre': 'Comedy',
+                'creator': 'Daniel Powell',
+                'artist': 'Chris Elliott, Amy Sedaris',
+                'release_year': 2016,
+                'series': 'Thanksgiving',
+                'episode': 'Touch Football',
+                'season_number': 1,
+                'episode_number': 1,
+                'season': 'Season 1',
+            },
+            'params': {'skip_download': True},
+            'expected_warnings': ['Trying with a list of known countries']
         }, {
             # episode provided with channel URL
             'url': 'https://www.crackle.com/watch/5851/2510064',
-            'info_dict': CrackleBaseIE.TestData.EPISODE_INFO,
-            'params': CrackleBaseIE.TestData.PARAMS_SKIP_DOWNLOAD,
-            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
+            'info_dict': {
+                'id': '2510064',
+                'ext': 'mp4',
+                'title': 'Touch Football',
+                'description': 'md5:cfbb513cf5de41e8b56d7ab756cff4df',
+                'duration': 1398,
+                'view_count': int,
+                'average_rating': 0,
+                'age_limit': 17,
+                'genre': 'Comedy',
+                'creator': 'Daniel Powell',
+                'artist': 'Chris Elliott, Amy Sedaris',
+                'release_year': 2016,
+                'series': 'Thanksgiving',
+                'episode': 'Touch Football',
+                'season_number': 1,
+                'episode_number': 1,
+                'season': 'Season 1',
+            },
+            'params': {'skip_download': True},
+            'expected_warnings': ['Trying with a list of known countries']
         }, {
             'url': 'https://www.sonycrackle.com/thanksgiving/2510064',
             'only_matching': True,
@@ -301,124 +329,76 @@ class CrackleVideoIE(CrackleBaseIE):
     ]
 
     def _real_extract(self, url):
-
-        mobj = self._match_valid_url(url).groupdict()
-        video_id = mobj.get('video_id')
-
-        country = None
-        # get video of specific page
-        video, country = self._get_video_info(video_id, country)
-        return video
+        return self._get_video_info(self._match_id(url))
 
 
 class CrackleChannelIE(CrackleBaseIE):
-
-    class ChannelType(Enum):
-        MOVIE_PAGE = 1
-        TV_PAGE = 11
-        TV_PAGE_MULTILANGUAGE = 13
-
     _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<channel_id>\d+)/?$'
-
-    _TESTS = [
-        {
-            # entire series provided as channel URL
-            'url': 'https://www.crackle.com/watch/5851',
-            'playlist_count': 8,
-            'info_dict': {
-                'id': '5851',
-                'title': 'Thanksgiving',
-            },
-            'expected_warnings': [
-                'Trying with a list of known countries'
-            ],
-        }, {
-            # movie provided as channel URL
-            'url': 'https://www.crackle.com/watch/7484',
-            'info_dict': {
-                'id': '2516266',
-                'title': '1 Mile To You',
-                'release_year': 2017,
-                'ext': 'mp4',
-                'creator': 'Leif Tilden',
-                'age_limit': 14,
-                'description': 'md5:13806df170014c4c9dd7c9b5b8b4921d',
-                'average_rating': float,
-                'duration': 6277,
-                'view_count': int,
-                'artist': 'md5:54868aa9fb6781c75f427da428735df4',
-                'genre': 'Drama, Sports, Romance',
-            },
-            'params': {
-                # m3u8 download
-                'skip_download': True,
-            },
-            'expected_warnings': [
-                'Trying with a list of known countries'
-            ],
-        }
-    ]
+    _TESTS = [{
+        # series
+        'url': 'https://www.crackle.com/watch/5851',
+        'playlist_count': 8,
+        'info_dict': {
+            'id': '5851',
+            'title': 'Thanksgiving',
+        },
+        'expected_warnings': ['Trying with a list of known countries'],
+    }, {
+        # movie
+        'url': 'https://www.crackle.com/watch/7484',
+        'info_dict': {
+            'id': '2516266',
+            'title': '1 Mile To You',
+            'release_year': 2017,
+            'ext': 'mp4',
+            'creator': 'Leif Tilden',
+            'age_limit': 14,
+            'description': 'md5:13806df170014c4c9dd7c9b5b8b4921d',
+            'average_rating': float,
+            'duration': 6277,
+            'view_count': int,
+            'artist': 'md5:54868aa9fb6781c75f427da428735df4',
+            'genre': 'Drama, Sports, Romance',
+        },
+        'params': {'skip_download': 'm3u8'},
+        'expected_warnings': ['Trying with a list of known countries'],
+    }]
 
     def _real_extract(self, url):
+        channel_id = self._match_valid_url(url).group('channel_id')
+        channel, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL, channel_id)
+        channel_type = channel['ChannelTypeId']
 
-        mobj = self._match_valid_url(url).groupdict()
-        channel_id = mobj.get('channel_id')
+        if channel_type == 1:  # Movies
+            return self._get_video_info(traverse_obj['FeaturedMedia']['ID'], country)
 
-        videos = []
-        channel, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL, channel_id, None)
-
-        channel_type = channel.get('ChannelTypeId')
-
-        if channel_type == self.ChannelType.MOVIE_PAGE.value:
-            # movie channel - get featured media
-            v_id = str(traverse_obj(channel, ('FeaturedMedia', 'ID')))
-            video, country = self._get_video_info(v_id, country)
-            return video
-        elif channel_type in (self.ChannelType.TV_PAGE.value, self.ChannelType.TV_PAGE_MULTILANGUAGE.value):
-            # series channel - enumerate videos in channel
+        elif channel_type in (11, 13):  # TV Shows
             playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL_PLAYLIST, channel_id, country)
-            for p in playlist.get('Playlists') or []:
-                if p.get('PlaylistName') == 'Episodes':
-                    for x in p.get('Items') or []:
-                        v_id = str(traverse_obj(x, ('MediaInfo', 'Id')))
-                        video, country = self._get_video_info(v_id, country)
-                        videos.append(video)
+            videos = (
+                self._get_video_info(media['MediaInfo']['Id'], country)
+                for media in traverse_obj(
+                    playlist, ('Playlists', lambda _, v: v['PlaylistName'] == 'Episodes', 'Items', ...)))
+            return self.playlist_result(videos, channel_id, channel.get('Name'))
 
-        return self.playlist_result(videos, channel_id, channel.get('Name'))
+        raise ExtractorError(f'Unknown channel type {channel_type}')
 
 
 class CracklePlaylistIE(CrackleBaseIE):
-
-    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(watch/)?playlist/(?P<playlist_id>\d+)/?$'
-
-    _TESTS = [
-        {
-            # entire series provided as playlist URL
-            'url': 'https://www.crackle.com/watch/playlist/2130982',
-            'playlist_count': 8,
-            'info_dict': {
-                'id': '2130982',
-                'title': 'Episodes',
-            },
-            'expected_warnings': CrackleBaseIE.TestData.EXPECTED_WARNINGS
-        }
-    ]
+    _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(watch/)?playlist/(?P<id>\d+)/?$'
+    _TESTS = [{
+        'url': 'https://www.crackle.com/watch/playlist/2130982',
+        'playlist_count': 8,
+        'info_dict': {
+            'id': '2130982',
+            'title': 'Episodes',
+        },
+        'expected_warnings': ['Trying with a list of known countries']
+    }]
 
     def _real_extract(self, url):
+        playlist_id = self._match_id(url)
+        playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.PLAYLIST, playlist_id)
 
-        mobj = self._match_valid_url(url).groupdict()
-        playlist_id = mobj.get('playlist_id')
-
-        country = None
-
-        if playlist_id is not None:
-            # enumerate videos in playlist
-            videos = []
-            playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.PLAYLIST, playlist_id, country)
-            result = playlist and playlist.get('Result')
-            for x in (result and result.get('Medias')) or []:
-                v_id = str(traverse_obj(x, ('MediaInfo', 'Id')))
-                video, country = self._get_video_info(v_id, country)
-                videos.append(video)
-
-            return self.playlist_result(videos, playlist_id, result and result.get('Name'))
+        videos = (self._get_video_info(media['MediaInfo']['Id'], country)
+                  for media in traverse_obj(playlist, ('Result', 'Medias', ...)))
+        return self.playlist_result(videos, playlist_id, traverse_obj(playlist, ('Result', 'Name')))

--- a/yt_dlp/extractor/crackle.py
+++ b/yt_dlp/extractor/crackle.py
@@ -316,6 +316,7 @@ class CrackleChannelIE(CrackleBaseIE):
     class ChannelType(Enum):
         MOVIE_PAGE = 1
         TV_PAGE = 11
+        TV_PAGE_MULTILANGUAGE = 13
 
     _VALID_URL = CrackleBaseIE._URL_PREFIX + r'(?:watch/)?(?P<channel_id>\d+)/?$'
 
@@ -373,7 +374,7 @@ class CrackleChannelIE(CrackleBaseIE):
             v_id = str(traverse_obj(channel, ('FeaturedMedia', 'ID')))
             video, country = self._get_video_info(v_id, country)
             return video
-        elif channel_type == self.ChannelType.TV_PAGE.value:
+        elif channel_type in (self.ChannelType.TV_PAGE.value, self.ChannelType.TV_PAGE_MULTILANGUAGE.value):
             # series channel - enumerate videos in channel
             playlist, country = self._download_crackle_details(CrackleBaseIE.UrlType.CHANNEL_PLAYLIST, channel_id, country)
             for p in playlist.get('Playlists') or []:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

Updates Crackle extractor to allow downloading of entire series and to support a wider variety of URLs. Previously, a specific video ID had to be provided in the URL, but this is often not included in the URL when browsing the site normally. This change allows a channel or playlist ID to be provided in the URL instead.

URLs in the following formats are now supported:
 - ### Channel 
   - Format: https://www.crackle.com/watch/CHANNEL_ID
   - Channel can be a movie or a series. Extractor will check the JSON object for the channel to determine the type and download accordingly.
 - ### Playlist
   - Format: https://www.crackle.com/watch/playlist/PLAYLIST_ID
   - This will probably not be used much if at all in practice since Crackle tends to use channel IDs and/or specific video IDs in their links, but if a playlist URL is provided then the extractor will download all videos in the playlist.
 - ### Video
   - Formats include but are not limited to the following:
     - https://www.crackle.com/watch/playlist/PLAYLIST_ID/VIDEO_ID
     - https://www.crackle.com/watch/CHANNEL_ID/VIDEO_ID
   - Any channel or playlist ID will be ignored if a video ID is included and only the specific video will be downloaded.
   - Note: Some URLs which include the name of a series with a video ID are still supported but will redirect to a URL with a channel ID in it. I am guessing this was an older convention and they keep a mapping to handle routing to the new scheme.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
