### PR TITLE
[extractor/medaltv] Fix extraction and account for new url format

### DIFF
--- a/yt_dlp/extractor/medaltv.py
+++ b/yt_dlp/extractor/medaltv.py
@@ -33,7 +33,7 @@ class MedalTVIE(InfoExtractor):
             'duration': 13,
         }
     }, {
-        'url': 'https://medal.tv/clips/2mA60jWAGQCBH',
+        'url': 'https://medal.tv/games/cod%20cold%20war/clips/2mA60jWAGQCBH',
         'md5': '3d19d426fe0b2d91c26e412684e66a06',
         'info_dict': {
             'id': '2mA60jWAGQCBH',
@@ -52,7 +52,7 @@ class MedalTVIE(InfoExtractor):
             'duration': 23,
         }
     }, {
-        'url': 'https://medal.tv/clips/2um24TWdty0NA',
+        'url': 'https://medal.tv/games/cod%20cold%20war/clips/2um24TWdty0NA',
         'md5': 'b6dc76b78195fff0b4f8bf4a33ec2148',
         'info_dict': {
             'id': '2um24TWdty0NA',
@@ -71,10 +71,10 @@ class MedalTVIE(InfoExtractor):
             'duration': 9,
         }
     }, {
-        'url': 'https://medal.tv/clips/37rMeFpryCC-9',
+        'url': 'https://medal.tv/games/valorant/clips/37rMeFpryCC-9',
         'only_matching': True,
     }, {
-        'url': 'https://medal.tv/clips/2WRj40tpY_EU9',
+        'url': 'https://medal.tv/games/valorant/clips/2WRj40tpY_EU9',
         'only_matching': True,
     }]
 

--- a/yt_dlp/extractor/medaltv.py
+++ b/yt_dlp/extractor/medaltv.py
@@ -15,6 +15,24 @@ from ..utils import (
 class MedalTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?medal\.tv/(?P<path>games/[^/?#&]+/clips)/(?P<id>[^/?#&]+)'
     _TESTS = [{
+        'url': 'https://medal.tv/games/valorant/clips/jTBFnLKdLy15K',
+        'md5': '6930f8972914b6b9fdc2bb3918098ba0',
+        'info_dict': {
+            'id': 'jTBFnLKdLy15K',
+            'ext': 'mp4',
+            'title': "Mornu's clutch",
+            'description': '',
+            'uploader': 'Aciel',
+            'timestamp': 1651628243,
+            'upload_date': '20220504',
+            'uploader_id': '19335460',
+            'uploader_url': 'https://medal.tv/users/19335460',
+            'comment_count': int,
+            'view_count': int,
+            'like_count': int,
+            'duration': 13,
+        }
+    }, {
         'url': 'https://medal.tv/clips/2mA60jWAGQCBH',
         'md5': '3d19d426fe0b2d91c26e412684e66a06',
         'info_dict': {

--- a/yt_dlp/extractor/medaltv.py
+++ b/yt_dlp/extractor/medaltv.py
@@ -16,7 +16,7 @@ class MedalTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?medal\.tv/(?P<path>games/[^/?#&]+/clips)/(?P<id>[^/?#&]+)'
     _TESTS = [{
         'url': 'https://medal.tv/clips/2mA60jWAGQCBH',
-        'md5': '7b07b064331b1cf9e8e5c52a06ae68fa',
+        'md5': '3d19d426fe0b2d91c26e412684e66a06',
         'info_dict': {
             'id': '2mA60jWAGQCBH',
             'ext': 'mp4',
@@ -26,6 +26,12 @@ class MedalTVIE(InfoExtractor):
             'timestamp': 1603165266,
             'upload_date': '20201020',
             'uploader_id': '10619174',
+            'thumbnail': 'https://cdn.medal.tv/10619174/thumbnail-34934644-720p.jpg?t=1080p&c=202042&missing',
+            'uploader_url': 'https://medal.tv/users/10619174',
+            'comment_count': int,
+            'view_count': int,
+            'like_count': int,
+            'duration': 23,
         }
     }, {
         'url': 'https://medal.tv/clips/2um24TWdty0NA',
@@ -39,6 +45,12 @@ class MedalTVIE(InfoExtractor):
             'timestamp': 1605580939,
             'upload_date': '20201117',
             'uploader_id': '5156321',
+            'thumbnail': 'https://cdn.medal.tv/5156321/thumbnail-36787208-360p.jpg?t=1080p&c=202046&missing',
+            'uploader_url': 'https://medal.tv/users/5156321',
+            'comment_count': int,
+            'view_count': int,
+            'like_count': int,
+            'duration': 9,
         }
     }, {
         'url': 'https://medal.tv/clips/37rMeFpryCC-9',


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

It would appear as though medal.tv reworked a lot of their front-end code, breaking the current extraction logic for the site. Although a lot of the functionality is the same, we unfortunately have to make an additional request to their /_next API to get the relevant clip data.

I'm not exactly sure when they made these breaking changes, but I was notified of it today (since I was the one who originally added support for the site).

They also changed the URL format:
Old: https://medal.tv/clips/xitf8v3RqmUcd/DlgzpPE0KSmv
New: https://medal.tv/games/fortnite/clips/xitf8v3RqmUcd/DlgzpPE0KSmv

Fortunately, the old links redirect to the new links, so there is backwards compatibility with the current extractor.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
