### PR TITLE
Add optional firefox container selection to --cookies-from-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,13 +706,14 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                     and dump cookie jar in
     --no-cookies                    Do not read/dump cookies from/to file
                                     (default)
-    --cookies-from-browser BROWSER[+KEYRING][:PROFILE]
+    --cookies-from-browser BROWSER[+KEYRING][:PROFILE[:CONTAINER]]
                                     The name of the browser and (optionally) the
                                     name/path of the profile to load cookies
-                                    from, separated by a ":". Currently
-                                    supported browsers are: brave, chrome,
-                                    chromium, edge, firefox, opera, safari,
-                                    vivaldi. By default, the most recently
+                                    from (and container name if Firefox)
+                                    separated by a ":". Currently supported
+                                    browsers are: brave, chrome, chromium, edge,
+                                    firefox, opera, safari, vivaldi. By default,
+                                    the default container of the most recently
                                     accessed profile is used. The keyring used
                                     for decrypting Chromium cookies on Linux can
                                     be (optionally) specified after the browser

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -303,8 +303,9 @@ class YoutubeDL:
                        should act on each input URL as opposed to for the entire queue
     cookiefile:        File name or text stream from where cookies should be read and dumped to
     cookiesfrombrowser:  A tuple containing the name of the browser, the profile
-                       name/path from where cookies are loaded, and the name of the
-                       keyring, e.g. ('chrome', ) or ('vivaldi', 'default', 'BASICTEXT')
+                       name/path from where cookies are loaded, the name of the keyring,
+                       and the container name, e.g. ('chrome', ) or
+                       ('vivaldi', 'default', 'BASICTEXT') or ('firefox', 'default', None, 'Meta')
     legacyserverconnect: Explicitly allow HTTPS connection to servers that do not
                        support RFC 5746 secure renegotiation
     nocheckcertificate:  Do not verify SSL certificates

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -353,10 +353,9 @@ def validate_options(opts):
         if browser_name not in SUPPORTED_BROWSERS:
             raise ValueError(f'unsupported browser specified for cookies: "{browser_name}". '
                              f'Supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}')
-        elif browser_name == 'firefox':
+        elif profile and browser_name == 'firefox':
             if ':' in profile and not os.path.exists(profile):
-                container = ':'.join(profile.split(':')[1:])
-                profile = profile.split(':')[0]
+                profile, container = profile.split(':', 1)
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -344,6 +344,7 @@ def validate_options(opts):
 
     # Cookies from browser
     if opts.cookiesfrombrowser:
+        container = None
         mobj = re.match(r'(?P<name>[^+:]+)(\s*\+\s*(?P<keyring>[^:]+))?(\s*:(?P<profile>.+))?', opts.cookiesfrombrowser)
         if mobj is None:
             raise ValueError(f'invalid cookies from browser arguments: {opts.cookiesfrombrowser}')
@@ -352,12 +353,16 @@ def validate_options(opts):
         if browser_name not in SUPPORTED_BROWSERS:
             raise ValueError(f'unsupported browser specified for cookies: "{browser_name}". '
                              f'Supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}')
+        elif browser_name == 'firefox':
+            if ':' in profile and not os.path.exists(profile):
+                container = ':'.join(profile.split(':')[1:])
+                profile = profile.split(':')[0]
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:
                 raise ValueError(f'unsupported keyring specified for cookies: "{keyring}". '
                                  f'Supported keyrings are: {", ".join(sorted(SUPPORTED_KEYRINGS))}')
-        opts.cookiesfrombrowser = (browser_name, profile, keyring)
+        opts.cookiesfrombrowser = (browser_name, profile, keyring, container)
 
     # MetadataParser
     def metadataparser_actions(f):

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -156,9 +156,13 @@ def _extract_firefox_cookies(profile, container, logger):
                 origin_attributes = f'^userContextId={container_id}'
                 logger.debug(
                     f'Only loading cookies from firefox container "{container}", ID {container_id}')
-            cursor.execute(
-                'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
-                (origin_attributes, ))
+            try:
+                cursor.execute(
+                    'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
+                    (origin_attributes, ))
+            except sqlite3.OperationalError:
+                logger.debug('Database exception, loading all cookies')
+                cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
             jar = YoutubeDLCookieJar()
             with _create_progress_bar(logger) as progress_bar:
                 table = cursor.fetchall()

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1399,7 +1399,7 @@ def create_parser():
         help='Do not read/dump cookies from/to file (default)')
     filesystem.add_option(
         '--cookies-from-browser',
-        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE]',
+        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE[:CONTAINER]]',
         help=(
             'The name of the browser and (optionally) the name/path of '
             'the profile to load cookies from, separated by a ":". '
@@ -1407,7 +1407,9 @@ def create_parser():
             'By default, the most recently accessed profile is used. '
             'The keyring used for decrypting Chromium cookies on Linux can be '
             '(optionally) specified after the browser name separated by a "+". '
-            f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'))
+            f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'
+            'Optionally, a Firefox container name can be specified after the '
+            'profile (which must then be specified), separated by a ":".'))
     filesystem.add_option(
         '--no-cookies-from-browser',
         action='store_const', const=None, dest='cookiesfrombrowser',

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1409,7 +1409,7 @@ def create_parser():
             '(optionally) specified after the browser name separated by a "+". '
             f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'
             'Optionally, a Firefox container name can be specified after the '
-            'profile (which must then be specified), separated by a ":".'))
+            'profile separated by a ":".'))
     filesystem.add_option(
         '--no-cookies-from-browser',
         action='store_const', const=None, dest='cookiesfrombrowser',

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1401,15 +1401,13 @@ def create_parser():
         '--cookies-from-browser',
         dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE[:CONTAINER]]',
         help=(
-            'The name of the browser and (optionally) the name/path of '
-            'the profile to load cookies from, separated by a ":". '
+            'The name of the browser and (optionally) the name/path of the profile to load cookies from '
+            '(and container name if Firefox) separated by a ":". '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '
-            'By default, the most recently accessed profile is used. '
+            'By default, the default container of the most recently accessed profile is used. '
             'The keyring used for decrypting Chromium cookies on Linux can be '
             '(optionally) specified after the browser name separated by a "+". '
-            f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'
-            'Optionally, a Firefox container name can be specified after the '
-            'profile separated by a ":".'))
+            f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'))
     filesystem.add_option(
         '--no-cookies-from-browser',
         action='store_const', const=None, dest='cookiesfrombrowser',


### PR DESCRIPTION
</details>

This adds support for Firefox containers to the `--cookies-from-browser` option.

Containers are a relatively new [built-in Firefox feature](https://support.mozilla.org/en-US/kb/containers#w_for-advanced-users) that allow for cookie isolation. A user may have multiple containers that are logged in to the same site with different accounts. As such, using the `--cookies-from-browser firefox` option as it currently stands can cause issues with overlapping/conflicting auth cookies for users of Firefox containers, since the current behavior loads all cookies from FF's cookie database. This PR is intended to solve that problem.

The proposed new argument syntax is:
`--cookies-from-browser BROWSER[+KEYRING][:PROFILE[:CONTAINER]]`

The name of the Firefox container can be passed as optional argument `CONTAINER` that is appended to `PROFILE` with another `:` as a separator.
If the user wishes to specify a container, the `PROFILE` arg is then required.
Because `PROFILE` is allowed to be a path as well as a profile name, yt-dlp will check if the entire `[PROFILE[:CONTAINER]]` string is an existing path before splitting it into separate `profile` and `container` values.

yt-dlp then only loads cookies associated with that specifed container. 
If there are multiple Firefox containers with the same name, the first match is used. I thought this would be better than loading from all matching containers, since the problem that this improvement intends to solve is overlapping/conflicting cookies.
If no container is specified, the default behavior is to only load cookies that have no container.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
