### PR TITLE
[screencastomatic] Add support for protected videos

### DIFF
--- a/yt_dlp/extractor/screencastomatic.py
+++ b/yt_dlp/extractor/screencastomatic.py
@@ -1,10 +1,12 @@
 from .common import InfoExtractor
 from ..utils import (
+    ExtractorError,
     get_element_by_class,
     int_or_none,
     remove_start,
     strip_or_none,
     unified_strdate,
+    urlencode_postdata,
 )
 
 
@@ -34,6 +36,28 @@ class ScreencastOMaticIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(
             'https://screencast-o-matic.com/player/' + video_id, video_id)
+
+        if (self._html_extract_title(webpage) == 'Protected Content'
+                or 'This video is private and requires a password' in webpage):
+            password = self.get_param('videopassword')
+
+            if not password:
+                raise ExtractorError('Password protected video, use --video-password <password>', expected=True)
+
+            form = self._search_regex(
+                r'(?is)<form[^>]*>(?P<form>.+?)</form>', webpage, 'login form', group='form')
+            form_data = self._hidden_inputs(form)
+            form_data.update({
+                'scPassword': password,
+            })
+
+            webpage = self._download_webpage(
+                'https://screencast-o-matic.com/player/password', video_id, 'Logging in',
+                data=urlencode_postdata(form_data))
+
+            if '<small class="text-danger">Invalid password</small>' in webpage:
+                raise ExtractorError('Unable to login: Invalid password', expected=True)
+
         info = self._parse_html5_media_entries(url, webpage, video_id)[0]
         info.update({
             'id': video_id,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

Adds support for password-protected videos to the ScreencastOMatic extractor.

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)