### PR TITLE
[extractor/audioboom] Sanitize webpage URL before downloading

### DIFF
--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -40,8 +40,7 @@ class AudioBoomIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        webpage = self._download_webpage(
-            'https://audioboom.com/posts/' + video_id, video_id)
+        webpage = self._download_webpage(f'https://audioboom.com/posts/{video_id}', video_id)
 
         clip = None
 

--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -28,7 +28,8 @@ class AudioBoomIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        webpage = self._download_webpage(url, video_id)
+        webpage = self._download_webpage(
+            'https://audioboom.com/posts/' + video_id, video_id)
 
         clip = None
 

--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -3,6 +3,7 @@ from ..utils import (
     clean_html,
     float_or_none,
     unescapeHTML,
+    traverse_obj,
 )
 
 
@@ -10,7 +11,7 @@ class AudioBoomIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?audioboom\.com/(?:boos|posts)/(?P<id>[0-9]+)'
     _TESTS = [{
         'url': 'https://audioboom.com/posts/7398103-asim-chaudhry',
-        'md5': '7b00192e593ff227e6a315486979a42d',
+        'md5': '4d68be11c9f9daf3dab0778ad1e010c3',
         'info_dict': {
             'id': '7398103',
             'ext': 'mp3',
@@ -39,46 +40,23 @@ class AudioBoomIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         webpage = self._download_webpage(f'https://audioboom.com/posts/{video_id}', video_id)
 
-        clip = None
-
-        clip_store = self._parse_json(
-            unescapeHTML(self._html_search_regex(
-                r'data-react-class="V5DetailPagePlayer"\s*data-react-props=(["\'])(?P<json>{.+?})\1',
-                webpage, 'clip store', default='{}', group='json')),
-            video_id, fatal=False)
-        if clip_store:
-            clips = clip_store.get('clips')
-            if clips and isinstance(clips, list) and isinstance(clips[0], dict):
-                clip = clips[0]
-
-        def from_clip(field):
-            if clip:
-                return clip.get(field)
-
-        audio_url = from_clip('clipURLPriorToLoading') or self._og_search_property(
-            'audio', webpage, 'audio url')
-        title = from_clip('title') or self._html_search_meta(
-            ['og:title', 'og:audio:title', 'audio_title'], webpage)
-        description = from_clip('description') or clean_html(from_clip('formattedDescription')) or self._og_search_description(webpage)
-
-        duration = float_or_none(from_clip('duration') or self._html_search_meta(
-            'weibo:audio:duration', webpage))
-
-        uploader = from_clip('author') or self._html_search_meta(
-            ['og:audio:artist', 'twitter:audio:artist_name', 'audio_artist'], webpage, 'uploader')
-        uploader_url = from_clip('author_url') or self._html_search_regex(
-            r'<div class="avatar flex-shrink-0">\s*<a href="(?P<uploader_url>http[^"]+)"',
-            webpage, 'uploader url', fatal=False)
+        clip_store = self._search_json(
+            r'data-react-class="V5DetailPagePlayer"\s*data-react-props=["\']',
+            webpage, 'clip store', video_id, fatal=False, transform_source=unescapeHTML)
+        clip = traverse_obj(clip_store, ('clips', 0), expected_type=dict) or {}
 
         return {
             'id': video_id,
-            'url': audio_url,
-            'title': title,
-            'description': description,
-            'duration': duration,
-            'uploader': uploader,
-            'uploader_url': uploader_url,
+            'url': clip.get('clipURLPriorToLoading') or self._og_search_property('audio', webpage, 'audio url'),
+            'title': clip.get('title') or self._html_search_meta(['og:title', 'og:audio:title', 'audio_title'], webpage),
+            'description': (clip.get('description') or clean_html(clip.get('formattedDescription'))
+                            or self._og_search_description(webpage)),
+            'duration': float_or_none(clip.get('duration') or self._html_search_meta('weibo:audio:duration', webpage)),
+            'uploader': clip.get('author') or self._html_search_meta(
+                ['og:audio:artist', 'twitter:audio:artist_name', 'audio_artist'], webpage, 'uploader'),
+            'uploader_url': clip.get('author_url') or self._html_search_regex(
+                r'<div class="avatar flex-shrink-0">\s*<a href="(?P<uploader_url>http[^"]+)"',
+                webpage, 'uploader url', fatal=False),
         }

--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -2,6 +2,7 @@ from .common import InfoExtractor
 from ..utils import (
     clean_html,
     float_or_none,
+    unescapeHTML,
 )
 
 
@@ -32,9 +33,9 @@ class AudioBoomIE(InfoExtractor):
         clip = None
 
         clip_store = self._parse_json(
-            self._html_search_regex(
-                r'data-new-clip-store=(["\'])(?P<json>{.+?})\1',
-                webpage, 'clip store', default='{}', group='json'),
+            unescapeHTML(self._html_search_regex(
+                r'data-react-class="V5DetailPagePlayer" *data-react-props=(["\'])(?P<json>{.+?})\1',
+                webpage, 'clip store', default='{}', group='json')),
             video_id, fatal=False)
         if clip_store:
             clips = clip_store.get('clips')

--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -46,7 +46,7 @@ class AudioBoomIE(InfoExtractor):
 
         clip_store = self._parse_json(
             unescapeHTML(self._html_search_regex(
-                r'data-react-class="V5DetailPagePlayer" *data-react-props=(["\'])(?P<json>{.+?})\1',
+                r'data-react-class="V5DetailPagePlayer"\s*data-react-props=(["\'])(?P<json>{.+?})\1',
                 webpage, 'clip store', default='{}', group='json')),
             video_id, fatal=False)
         if clip_store:

--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -15,7 +15,7 @@ class AudioBoomIE(InfoExtractor):
             'id': '7398103',
             'ext': 'mp3',
             'title': 'Asim Chaudhry',
-            'description': 'md5:2f3fef17dacc2595b5362e1d7d3602fc',
+            'description': 'md5:0ed714ae0e81e5d9119cac2f618ad679',
             'duration': 4000.99,
             'uploader': 'Sue Perkins: An hour or so with...',
             'uploader_url': r're:https?://(?:www\.)?audioboom\.com/channel/perkins',
@@ -57,8 +57,9 @@ class AudioBoomIE(InfoExtractor):
 
         uploader = from_clip('author') or self._html_search_meta(
             ['og:audio:artist', 'twitter:audio:artist_name', 'audio_artist'], webpage, 'uploader')
-        uploader_url = from_clip('author_url') or self._html_search_meta(
-            'audioboo:channel', webpage, 'uploader url')
+        uploader_url = from_clip('author_url') or self._html_search_regex(
+            r'<div class="avatar flex-shrink-0">\s*<a href="(?P<uploader_url>http[^"]+)"',
+            webpage, 'uploader url', fatal=False)
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/audioboom.py
+++ b/yt_dlp/extractor/audioboom.py
@@ -20,6 +20,18 @@ class AudioBoomIE(InfoExtractor):
             'uploader': 'Sue Perkins: An hour or so with...',
             'uploader_url': r're:https?://(?:www\.)?audioboom\.com/channel/perkins',
         }
+    }, {  # Direct mp3-file link
+        'url': 'https://audioboom.com/posts/8128496.mp3',
+        'md5': 'e329edf304d450def95c7f86a9165ee1',
+        'info_dict': {
+            'id': '8128496',
+            'ext': 'mp3',
+            'title': 'TCRNo8 / DAILY 03 - In Control',
+            'description': 'md5:44665f142db74858dfa21c5b34787948',
+            'duration': 1689.7,
+            'uploader': 'Lost Dot Podcast: The Trans Pyrenees and Transcontinental Race',
+            'uploader_url': r're:https?://(?:www\.)?audioboom\.com/channels/5003904',
+        }
     }, {
         'url': 'https://audioboom.com/posts/4279833-3-09-2016-czaban-hour-3?t=0',
         'only_matching': True,


### PR DESCRIPTION
Fix JSON extraction and `uploader_url`  extraction.

When given a direct mp3 URL this extractor currently downloads the mp3 file as a webpage to be scraped and fails.
Sanitize the URL before downloading to be of type `https://audioboom.com/posts/<video_id>` to get the correct page.

I get random ads inserted into the beginning of the downloaded mp3 file, so the md5 tests fail.

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
