### PR TITLE
Revert default behavior of --cookies-from-browser and firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,17 +706,19 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                     and dump cookie jar in
     --no-cookies                    Do not read/dump cookies from/to file
                                     (default)
-    --cookies-from-browser BROWSER[+KEYRING][:PROFILE[:CONTAINER]]
-                                    The name of the browser and (optionally) the
-                                    name/path of the profile to load cookies
-                                    from (and container name if Firefox)
-                                    separated by a ":". Currently supported
-                                    browsers are: brave, chrome, chromium, edge,
-                                    firefox, opera, safari, vivaldi. By default,
-                                    the default container of the most recently
-                                    accessed profile is used. The keyring used
-                                    for decrypting Chromium cookies on Linux can
-                                    be (optionally) specified after the browser
+    --cookies-from-browser BROWSER[+KEYRING][:PROFILE][:CONTAINER]
+                                    The name of the browser to load cookies
+                                    from. Currently supported browsers are:
+                                    brave, chrome, chromium, edge, firefox,
+                                    opera, safari, vivaldi. Optionally, the
+                                    name/path of the PROFILE to load cookies
+                                    from and the CONTAINER name (if Firefox)
+                                    ("none" for no container) can be given,
+                                    separated by a ":". By default, all
+                                    containers of the most recently accessed
+                                    profile are used. The keyring used for
+                                    decrypting Chromium cookies on Linux can be
+                                    (optionally) specified after the browser
                                     name separated by a "+". Currently supported
                                     keyrings are: basictext, gnomekeyring, kwallet
     --no-cookies-from-browser       Do not load cookies from browser (default)

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                     and dump cookie jar in
     --no-cookies                    Do not read/dump cookies from/to file
                                     (default)
-    --cookies-from-browser BROWSER[+KEYRING][:[CONTAINER:]PROFILE]
+    --cookies-from-browser BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]
                                     The name of the browser to load cookies
                                     from. Currently supported browsers are:
                                     brave, chrome, chromium, edge, firefox,

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                     and dump cookie jar in
     --no-cookies                    Do not read/dump cookies from/to file
                                     (default)
-    --cookies-from-browser BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]
+    --cookies-from-browser BROWSER[+KEYRING][:[CONTAINER:]PROFILE]
                                     The name of the browser to load cookies
                                     from. Currently supported browsers are:
                                     brave, chrome, chromium, edge, firefox,

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                     and dump cookie jar in
     --no-cookies                    Do not read/dump cookies from/to file
                                     (default)
-    --cookies-from-browser BROWSER[+KEYRING][:PROFILE][:CONTAINER]
+    --cookies-from-browser BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]
                                     The name of the browser to load cookies
                                     from. Currently supported browsers are:
                                     brave, chrome, chromium, edge, firefox,

--- a/README.md
+++ b/README.md
@@ -706,21 +706,20 @@ You can also fork the project on github and run your fork's [build workflow](.gi
                                     and dump cookie jar in
     --no-cookies                    Do not read/dump cookies from/to file
                                     (default)
-    --cookies-from-browser BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]
+    --cookies-from-browser BROWSER[+KEYRING][:PROFILE][::CONTAINER]
                                     The name of the browser to load cookies
                                     from. Currently supported browsers are:
                                     brave, chrome, chromium, edge, firefox,
                                     opera, safari, vivaldi. Optionally, the
-                                    name/path of the PROFILE to load cookies
-                                    from and the CONTAINER name (if Firefox)
-                                    ("none" for no container) can be given,
-                                    separated by a ":". By default, all
-                                    containers of the most recently accessed
-                                    profile are used. The keyring used for
-                                    decrypting Chromium cookies on Linux can be
-                                    (optionally) specified after the browser
-                                    name separated by a "+". Currently supported
-                                    keyrings are: basictext, gnomekeyring, kwallet
+                                    KEYRING used for decrypting Chromium cookies
+                                    on Linux, the name/path of the PROFILE to
+                                    load cookies from, and the CONTAINER name
+                                    (if Firefox) ("none" for no container) can
+                                    be given with their respective seperators.
+                                    By default, all containers of the most
+                                    recently accessed profile are used.
+                                    Currently supported keyrings are: basictext,
+                                    gnomekeyring, kwallet
     --no-cookies-from-browser       Do not load cookies from browser (default)
     --cache-dir DIR                 Location in the filesystem where youtube-dl
                                     can store some downloaded information (such

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -347,17 +347,19 @@ def validate_options(opts):
     # Cookies from browser
     if opts.cookiesfrombrowser:
         container = None
-        mobj = re.match(r'(?P<name>[^+:]+)(\s*\+\s*(?P<keyring>[^:]+))?(\s*:(?P<profile>.+))?', opts.cookiesfrombrowser)
+        mobj = re.fullmatch(r'''(?x)
+            (?P<name>[^+:]+)
+            (?:\s*\+\s*(?P<keyring>[^:]+))?
+            (?:\s*:\s*(?P<profile>.+?))?
+            (?:\s*::\s*(?P<container>.+))?
+        ''', opts.cookiesfrombrowser)
         if mobj is None:
             raise ValueError(f'invalid cookies from browser arguments: {opts.cookiesfrombrowser}')
-        browser_name, keyring, profile = mobj.group('name', 'keyring', 'profile')
+        browser_name, keyring, profile, container = mobj.group('name', 'keyring', 'profile', 'container')
         browser_name = browser_name.lower()
         if browser_name not in SUPPORTED_BROWSERS:
             raise ValueError(f'unsupported browser specified for cookies: "{browser_name}". '
                              f'Supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}')
-        elif profile and browser_name == 'firefox':
-            if ':' in profile and not os.path.exists(profile):
-                profile, container = profile.split(':', 1)
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -358,6 +358,10 @@ def validate_options(opts):
         elif profile and browser_name == 'firefox':
             if ':' in profile and not os.path.exists(profile):
                 profile, container = profile.split(':', 1)
+                if profile == '':
+                    profile = None
+                if container == '':
+                    container = None
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -347,28 +347,23 @@ def validate_options(opts):
     # Cookies from browser
     if opts.cookiesfrombrowser:
         container = None
-        mobj = re.match(r'''(?x)
-            (?P<name>[^+:]+)
-            (?:\s*\+\s*(?P<keyring>[^:]+))?
-            (?:
-                (?:\s*:\s*(?P<container>(?:(?<!\\)(\\\\)*\\:|[^:])+))?
-                \s*:\s*(?P<profile>.+)?
-            )?''', opts.cookiesfrombrowser)
+        mobj = re.match(r'(?P<name>[^+:]+)(\s*\+\s*(?P<keyring>[^:]+))?(\s*:(?P<profile>.+))?', opts.cookiesfrombrowser)
         if mobj is None:
             raise ValueError(f'invalid cookies from browser arguments: {opts.cookiesfrombrowser}')
-        browser_name, keyring, profile, container = mobj.group('name', 'keyring', 'profile', 'container')
-        if container:
-            container = container.replace('\\:', ':').replace('\\\\', '\\')
+        browser_name, keyring, profile = mobj.group('name', 'keyring', 'profile')
         browser_name = browser_name.lower()
         if browser_name not in SUPPORTED_BROWSERS:
             raise ValueError(f'unsupported browser specified for cookies: "{browser_name}". '
                              f'Supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}')
+        elif profile and browser_name == 'firefox':
+            if ':' in profile and not os.path.exists(profile):
+                profile, container = profile.split(':', 1)
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:
                 raise ValueError(f'unsupported keyring specified for cookies: "{keyring}". '
                                  f'Supported keyrings are: {", ".join(sorted(SUPPORTED_KEYRINGS))}')
-        opts.cookiesfrombrowser = (browser_name, profile, keyring, container)
+        opts.cookiesfrombrowser = (browser_name, profile or None, keyring, container or None)
 
     # MetadataParser
     def metadataparser_actions(f):

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -347,23 +347,28 @@ def validate_options(opts):
     # Cookies from browser
     if opts.cookiesfrombrowser:
         container = None
-        mobj = re.match(r'(?P<name>[^+:]+)(\s*\+\s*(?P<keyring>[^:]+))?(\s*:(?P<profile>.+))?', opts.cookiesfrombrowser)
+        mobj = re.match(r'''(?x)
+            (?P<name>[^+:]+)
+            (?:\s*\+\s*(?P<keyring>[^:]+))?
+            (?:
+                (?:\s*:\s*(?P<container>(?:(?<!\\)(\\\\)*\\:|[^:])+))?
+                \s*:\s*(?P<profile>.+)?
+            )?''', opts.cookiesfrombrowser)
         if mobj is None:
             raise ValueError(f'invalid cookies from browser arguments: {opts.cookiesfrombrowser}')
-        browser_name, keyring, profile = mobj.group('name', 'keyring', 'profile')
+        browser_name, keyring, profile, container = mobj.group('name', 'keyring', 'profile', 'container')
+        if container:
+            container = container.replace('\\:', ':').replace('\\\\', '\\')
         browser_name = browser_name.lower()
         if browser_name not in SUPPORTED_BROWSERS:
             raise ValueError(f'unsupported browser specified for cookies: "{browser_name}". '
                              f'Supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}')
-        elif profile and browser_name == 'firefox':
-            if ':' in profile and not os.path.exists(profile):
-                profile, container = profile.split(':', 1)
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:
                 raise ValueError(f'unsupported keyring specified for cookies: "{keyring}". '
                                  f'Supported keyrings are: {", ".join(sorted(SUPPORTED_KEYRINGS))}')
-        opts.cookiesfrombrowser = (browser_name, profile or None, keyring, container or None)
+        opts.cookiesfrombrowser = (browser_name, profile, keyring, container)
 
     # MetadataParser
     def metadataparser_actions(f):

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -358,14 +358,12 @@ def validate_options(opts):
         elif profile and browser_name == 'firefox':
             if ':' in profile and not os.path.exists(profile):
                 profile, container = profile.split(':', 1)
-                profile = profile if profile else None
-                container = container if container else None
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:
                 raise ValueError(f'unsupported keyring specified for cookies: "{keyring}". '
                                  f'Supported keyrings are: {", ".join(sorted(SUPPORTED_KEYRINGS))}')
-        opts.cookiesfrombrowser = (browser_name, profile, keyring, container)
+        opts.cookiesfrombrowser = (browser_name, profile or None, keyring, container or None)
 
     # MetadataParser
     def metadataparser_actions(f):

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -358,10 +358,8 @@ def validate_options(opts):
         elif profile and browser_name == 'firefox':
             if ':' in profile and not os.path.exists(profile):
                 profile, container = profile.split(':', 1)
-                if profile == '':
-                    profile = None
-                if container == '':
-                    container = None
+                profile = profile if profile else None
+                container = container if container else None
         if keyring is not None:
             keyring = keyring.upper()
             if keyring not in SUPPORTED_KEYRINGS:

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -154,7 +154,8 @@ def _extract_firefox_cookies(profile, container, logger):
             if container is not None and isinstance(container_id, int):
                 logger.debug(
                     f'Only loading cookies from firefox container "{container}", ID {container_id}')
-                cursor.execute(f'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes LIKE ? OR originAttributes LIKE ?',
+                cursor.execute(
+                    'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes LIKE ? OR originAttributes LIKE ?',
                     (f'%userContextId={container_id}', f'%userContextId={container_id}&%'))
             elif container == 'none':
                 logger.debug('Only loading cookies not belonging to any container')

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -160,7 +160,7 @@ def _extract_firefox_cookies(profile, container, logger):
             elif container == 'none':
                 logger.debug('Only loading cookies not belonging to any container')
                 cursor.execute(
-                    'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=""')
+                    'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE NOT INSTR(originAttributes,"userContextId=")')
             else:
                 cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
             jar = YoutubeDLCookieJar()

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -128,9 +128,14 @@ def _extract_firefox_cookies(profile, container, logger):
     else:
         search_root = os.path.join(_firefox_browser_dir(), profile)
 
+    cookie_database_path = _find_most_recently_used_file(search_root, 'cookies.sqlite', logger)
+    if cookie_database_path is None:
+        raise FileNotFoundError(f'could not find firefox cookies database in {search_root}')
+    logger.debug(f'Extracting cookies from: "{cookie_database_path}"')
+
     container_id = None
-    if container is not None:
-        containers_path = os.path.join(search_root, 'containers.json')
+    if container is not None and container != 'none':
+        containers_path = os.path.join(os.path.dirname(cookie_database_path), 'containers.json')
         if not os.path.isfile(containers_path) or not os.access(containers_path, os.R_OK):
             raise FileNotFoundError(f'could not read containers.json in {search_root}')
         with open(containers_path, 'r') as containers:
@@ -142,26 +147,26 @@ def _extract_firefox_cookies(profile, container, logger):
         if not isinstance(container_id, int):
             raise ValueError(f'could not find firefox container "{container}" in containers.json')
 
-    cookie_database_path = _find_most_recently_used_file(search_root, 'cookies.sqlite', logger)
-    if cookie_database_path is None:
-        raise FileNotFoundError(f'could not find firefox cookies database in {search_root}')
-    logger.debug(f'Extracting cookies from: "{cookie_database_path}"')
-
     with tempfile.TemporaryDirectory(prefix='yt_dlp') as tmpdir:
         cursor = None
         try:
             cursor = _open_database_copy(cookie_database_path, tmpdir)
-            origin_attributes = ''
-            if isinstance(container_id, int):
-                origin_attributes = f'^userContextId={container_id}'
-                logger.debug(
-                    f'Only loading cookies from firefox container "{container}", ID {container_id}')
-            try:
-                cursor.execute(
-                    'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
-                    (origin_attributes, ))
-            except sqlite3.OperationalError:
-                logger.debug('Database exception, loading all cookies')
+            if container is not None:
+                origin_attributes = ''
+                if isinstance(container_id, int):
+                    origin_attributes = f'^userContextId={container_id}'
+                    logger.debug(
+                        f'Only loading cookies from firefox container "{container}", ID {container_id}')
+                else:
+                    logger.debug('Only loading cookies not belonging to any container')
+                try:
+                    cursor.execute(
+                        'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
+                        (origin_attributes, ))
+                except sqlite3.OperationalError:
+                    logger.debug('Database exception, loading all cookies')
+                    cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
+            else:
                 cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
             jar = YoutubeDLCookieJar()
             with _create_progress_bar(logger) as progress_bar:

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -159,13 +159,9 @@ def _extract_firefox_cookies(profile, container, logger):
                         f'Only loading cookies from firefox container "{container}", ID {container_id}')
                 else:
                     logger.debug('Only loading cookies not belonging to any container')
-                try:
-                    cursor.execute(
-                        'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
-                        (origin_attributes, ))
-                except sqlite3.OperationalError:
-                    logger.debug('Database exception, loading all cookies')
-                    cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
+                cursor.execute(
+                   'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
+                   (origin_attributes, ))
             else:
                 cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
             jar = YoutubeDLCookieJar()

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -134,7 +134,7 @@ def _extract_firefox_cookies(profile, container, logger):
     logger.debug(f'Extracting cookies from: "{cookie_database_path}"')
 
     container_id = None
-    if container is not None and container != 'none':
+    if container not in (None, 'none'):
         containers_path = os.path.join(os.path.dirname(cookie_database_path), 'containers.json')
         if not os.path.isfile(containers_path) or not os.access(containers_path, os.R_OK):
             raise FileNotFoundError(f'could not read containers.json in {search_root}')
@@ -151,7 +151,7 @@ def _extract_firefox_cookies(profile, container, logger):
         cursor = None
         try:
             cursor = _open_database_copy(cookie_database_path, tmpdir)
-            if container is not None and isinstance(container_id, int):
+            if isinstance(container_id, int):
                 logger.debug(
                     f'Only loading cookies from firefox container "{container}", ID {container_id}')
                 cursor.execute(

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -160,8 +160,8 @@ def _extract_firefox_cookies(profile, container, logger):
                 else:
                     logger.debug('Only loading cookies not belonging to any container')
                 cursor.execute(
-                   'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
-                   (origin_attributes, ))
+                    'SELECT host, name, value, path, expiry, isSecure FROM moz_cookies WHERE originAttributes=?',
+                    (origin_attributes, ))
             else:
                 cursor.execute('SELECT host, name, value, path, expiry, isSecure FROM moz_cookies')
             jar = YoutubeDLCookieJar()

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1400,12 +1400,14 @@ def create_parser():
         help='Do not read/dump cookies from/to file (default)')
     filesystem.add_option(
         '--cookies-from-browser',
-        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE[:CONTAINER]]',
+        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE][:CONTAINER]',
         help=(
             'The name of the browser and (optionally) the name/path of the profile to load cookies from '
             '(and container name if Firefox) separated by a ":". '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '
-            'By default, the default container of the most recently accessed profile is used. '
+            'By default, all containers of the most recently accessed profile are used. '
+            'If specifying a container, PROFILE may be left empty to use the most recent profile.'
+            'To specify only cookies not belonging to any container, use the keyword "none".'
             'The keyring used for decrypting Chromium cookies on Linux can be '
             '(optionally) specified after the browser name separated by a "+". '
             f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'))

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1400,15 +1400,15 @@ def create_parser():
         help='Do not read/dump cookies from/to file (default)')
     filesystem.add_option(
         '--cookies-from-browser',
-        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]',
+        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE][::CONTAINER]',
         help=(
             'The name of the browser to load cookies from. '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '
-            'Optionally, the name/path of the PROFILE to load cookies from and '
-            'the CONTAINER name (if Firefox) ("none" for no container) can be given, separated by a ":". '
+            'Optionally, the KEYRING used for decrypting Chromium cookies on Linux, '
+            'the name/path of the PROFILE to load cookies from, '
+            'and the CONTAINER name (if Firefox) ("none" for no container) '
+            'can be given with their respective seperators. '
             'By default, all containers of the most recently accessed profile are used. '
-            'The keyring used for decrypting Chromium cookies on Linux can be '
-            '(optionally) specified after the browser name separated by a "+". '
             f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'))
     filesystem.add_option(
         '--no-cookies-from-browser',

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1400,7 +1400,7 @@ def create_parser():
         help='Do not read/dump cookies from/to file (default)')
     filesystem.add_option(
         '--cookies-from-browser',
-        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]',
+        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:[CONTAINER:]PROFILE]',
         help=(
             'The name of the browser to load cookies from. '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1400,7 +1400,7 @@ def create_parser():
         help='Do not read/dump cookies from/to file (default)')
     filesystem.add_option(
         '--cookies-from-browser',
-        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:[CONTAINER:]PROFILE]',
+        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]',
         help=(
             'The name of the browser to load cookies from. '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1402,12 +1402,11 @@ def create_parser():
         '--cookies-from-browser',
         dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE][:CONTAINER]',
         help=(
-            'The name of the browser and (optionally) the name/path of the profile to load cookies from '
-            '(and container name if Firefox) separated by a ":". '
+            'The name of the browser to load cookies from. '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '
+            'Optionally, the name/path of the PROFILE to load cookies from and '
+            'the CONTAINER name (if Firefox) ("none" for no container) can be given, separated by a ":". '
             'By default, all containers of the most recently accessed profile are used. '
-            'If specifying a container, PROFILE may be left empty to use the most recent profile.'
-            'To specify only cookies not belonging to any container, use the keyword "none".'
             'The keyring used for decrypting Chromium cookies on Linux can be '
             '(optionally) specified after the browser name separated by a "+". '
             f'Currently supported keyrings are: {", ".join(map(str.lower, sorted(SUPPORTED_KEYRINGS)))}'))

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1400,7 +1400,7 @@ def create_parser():
         help='Do not read/dump cookies from/to file (default)')
     filesystem.add_option(
         '--cookies-from-browser',
-        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:PROFILE][:CONTAINER]',
+        dest='cookiesfrombrowser', metavar='BROWSER[+KEYRING][:[PROFILE][:CONTAINER]]',
         help=(
             'The name of the browser to load cookies from. '
             f'Currently supported browsers are: {", ".join(sorted(SUPPORTED_BROWSERS))}. '


### PR DESCRIPTION
</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Reverts default behavior of `--cookies-from-browser` and firefox containers to what it was before 9bd13fe

 - `--cookies-from-browser firefox` will load all cookies from all containers and those not belonging to any container
 - `--cookies-from-browser firefox:PROFILE:CONTAINER` will load cookies only from the container name specified as `CONTAINER`
 - `--cookies-from-browser firefox:PROFILE:none` will only load cookies not belonging to any container
 
`PROFILE` may also now be left empty when specifying a container, e.g:
- `--cookies-from-browser firefox::none` will load cookies not belonging to any container from the most recently used profile
- `--cookies-from-browser firefox::` behaves the same as `--cookies-from-browser firefox`

Fixes #4800 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
