### PR TITLE
[extractor/tencent] Add Iflix extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1759,6 +1759,8 @@ from .teletask import TeleTaskIE
 from .telewebion import TelewebionIE
 from .tempo import TempoIE
 from .tencent import (
+    IflixEpisodeIE,
+    IflixSeriesIE,
     VQQSeriesIE,
     VQQVideoIE,
     WeTvEpisodeIE,

--- a/yt_dlp/extractor/tencent.py
+++ b/yt_dlp/extractor/tencent.py
@@ -262,6 +262,41 @@ class WeTvBaseIE(TencentBaseIE):
             traverse_obj(self._search_nextjs_data(webpage, video_id), ('props', 'pageProps', 'data')),
             video_id, fatal=False)
 
+    def _extract_episode(self, url):
+        video_id, series_id = self._match_valid_url(url).group('id', 'series_id')
+        webpage = self._download_webpage(url, video_id)
+        webpage_metadata = self._get_webpage_metadata(webpage, video_id)
+
+        formats, subtitles = self._extract_all_video_formats_and_subtitles(url, video_id, series_id)
+        return {
+            'id': video_id,
+            'title': self._get_clean_title(self._og_search_title(webpage)
+                                           or traverse_obj(webpage_metadata, ('coverInfo', 'title'))),
+            'description': (traverse_obj(webpage_metadata, ('coverInfo', 'description'))
+                            or self._og_search_description(webpage)),
+            'formats': formats,
+            'subtitles': subtitles,
+            'thumbnail': self._og_search_thumbnail(webpage),
+            'duration': int_or_none(traverse_obj(webpage_metadata, ('videoInfo', 'duration'))),
+            'series': traverse_obj(webpage_metadata, ('coverInfo', 'title')),
+            'episode_number': int_or_none(traverse_obj(webpage_metadata, ('videoInfo', 'episode'))),
+        }
+
+    def _extract_series(self, url, ie):
+        series_id = self._match_id(url)
+        webpage = self._download_webpage(url, series_id)
+        webpage_metadata = self._get_webpage_metadata(webpage, series_id)
+
+        episode_paths = ([f'/play/{series_id}/{episode["vid"]}' for episode in webpage_metadata.get('videoList')]
+                         or re.findall(r'<a[^>]+class="play-video__link"[^>]+href="(?P<path>[^"]+)', webpage))
+
+        return self.playlist_from_matches(
+            episode_paths, series_id, ie=ie, getter=functools.partial(urljoin, url),
+            title=self._get_clean_title(traverse_obj(webpage_metadata, ('coverInfo', 'title'))
+                                        or self._og_search_title(webpage)),
+            description=(traverse_obj(webpage_metadata, ('coverInfo', 'description'))
+                         or self._og_search_description(webpage)))
+
 
 class WeTvEpisodeIE(WeTvBaseIE):
     IE_NAME = 'wetv:episode'
@@ -312,24 +347,7 @@ class WeTvEpisodeIE(WeTvBaseIE):
     }]
 
     def _real_extract(self, url):
-        video_id, series_id = self._match_valid_url(url).group('id', 'series_id')
-        webpage = self._download_webpage(url, video_id)
-        webpage_metadata = self._get_webpage_metadata(webpage, video_id)
-
-        formats, subtitles = self._extract_all_video_formats_and_subtitles(url, video_id, series_id)
-        return {
-            'id': video_id,
-            'title': self._get_clean_title(self._og_search_title(webpage)
-                                           or traverse_obj(webpage_metadata, ('coverInfo', 'title'))),
-            'description': (traverse_obj(webpage_metadata, ('coverInfo', 'description'))
-                            or self._og_search_description(webpage)),
-            'formats': formats,
-            'subtitles': subtitles,
-            'thumbnail': self._og_search_thumbnail(webpage),
-            'duration': int_or_none(traverse_obj(webpage_metadata, ('videoInfo', 'duration'))),
-            'series': traverse_obj(webpage_metadata, ('coverInfo', 'title')),
-            'episode_number': int_or_none(traverse_obj(webpage_metadata, ('videoInfo', 'episode'))),
-        }
+        return self._extract_episode(url)
 
 
 class WeTvSeriesIE(WeTvBaseIE):
@@ -354,16 +372,77 @@ class WeTvSeriesIE(WeTvBaseIE):
     }]
 
     def _real_extract(self, url):
-        series_id = self._match_id(url)
-        webpage = self._download_webpage(url, series_id)
-        webpage_metadata = self._get_webpage_metadata(webpage, series_id)
+        return self._extract_series(url, WeTvEpisodeIE)
 
-        episode_paths = ([f'/play/{series_id}/{episode["vid"]}' for episode in webpage_metadata.get('videoList')]
-                         or re.findall(r'<a[^>]+class="play-video__link"[^>]+href="(?P<path>[^"]+)', webpage))
 
-        return self.playlist_from_matches(
-            episode_paths, series_id, ie=WeTvEpisodeIE, getter=functools.partial(urljoin, url),
-            title=self._get_clean_title(traverse_obj(webpage_metadata, ('coverInfo', 'title'))
-                                        or self._og_search_title(webpage)),
-            description=(traverse_obj(webpage_metadata, ('coverInfo', 'description'))
-                         or self._og_search_description(webpage)))
+class IflixBaseIE(WeTvBaseIE):
+    _VALID_URL_BASE = r'https?://(?:www\.)?iflix\.com/(?:[^?#]+/)?play'
+
+    _API_URL = 'https://vplay.iflix.com/getvinfo'
+    _APP_VERSION = '3.5.57'
+    _PLATFORM = '330201'
+    _HOST = 'www.iflix.com'
+    _REFERER = 'www.iflix.com'
+
+
+class IflixEpisodeIE(IflixBaseIE):
+    IE_NAME = 'iflix:episode'
+    _VALID_URL = IflixBaseIE._VALID_URL_BASE + r'/(?P<series_id>\w+)(?:-[^?#]+)?/(?P<id>\w+)(?:-[^?#]+)?'
+
+    _TESTS = [{
+        'url': 'https://www.iflix.com/en/play/daijrxu03yypu0s/a0040kvgaza',
+        'md5': '9740f9338c3a2105290d16b68fb3262f',
+        'info_dict': {
+            'id': 'a0040kvgaza',
+            'ext': 'mp4',
+            'title': 'EP1: Put Your Head On My Shoulder 2021',
+            'description': 'md5:c095a742d3b7da6dfedd0c8170727a42',
+            'thumbnail': r're:^https?://[^?#]+daijrxu03yypu0s',
+            'series': 'Put Your Head On My Shoulder 2021',
+            'episode': 'Episode 1',
+            'episode_number': 1,
+            'duration': 2639,
+        },
+    }, {
+        'url': 'https://www.iflix.com/en/play/fvvrcc3ra9lbtt1-Take-My-Brother-Away/i0029sd3gm1-EP1%EF%BC%9ATake-My-Brother-Away',
+        'md5': '375c9b8478fdedca062274b2c2f53681',
+        'info_dict': {
+            'id': 'i0029sd3gm1',
+            'ext': 'mp4',
+            'title': 'EP1：Take My Brother Away',
+            'description': 'md5:f0f7be1606af51cd94d5627de96b0c76',
+            'thumbnail': r're:^https?://[^?#]+fvvrcc3ra9lbtt1',
+            'series': 'Take My Brother Away',
+            'episode': 'Episode 1',
+            'episode_number': 1,
+            'duration': 228,
+        },
+    }]
+
+    def _real_extract(self, url):
+        return self._extract_episode(url)
+
+
+class IflixSeriesIE(IflixBaseIE):
+    _VALID_URL = IflixBaseIE._VALID_URL_BASE + r'/(?P<id>\w+)(?:-[^/?#]+)?/?(?:[?#]|$)'
+
+    _TESTS = [{
+        'url': 'https://www.iflix.com/en/play/g21a6qk4u1s9x22-You-Are-My-Hero',
+        'info_dict': {
+            'id': 'g21a6qk4u1s9x22',
+            'title': 'You Are My Hero',
+            'description': 'md5:9c4d844bc0799cd3d2b5aed758a2050a',
+        },
+        'playlist_count': 40,
+    }, {
+        'url': 'https://www.iflix.com/play/0s682hc45t0ohll',
+        'info_dict': {
+            'id': '0s682hc45t0ohll',
+            'title': 'Miss Gu Who Is Silent',
+            'description': 'md5:a9651d0236f25af06435e845fa2f8c78',
+        },
+        'playlist_count': 20,
+    }]
+
+    def _real_extract(self, url):
+        return self._extract_series(url, IflixEpisodeIE)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds a new extractor for iflix.com which is like variant of WeTv. 

Iflix extractor needs its own api_url, platform, host and referer, but the extraction code is identical from WeTv. To avoid code duplication I moved the extraction code from WeTvEpisode and WeTvSeries to WeTvBase, and re-use it for Iflix.

Fixes #4823

### Downloading episode
```bash
[debug] Command-line config: ['https://www.iflix.com/en/play/daijrxu03yypu0s/a0040kvgaza', '-v', '-F']
5[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: a8ba287e2
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-125-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.0.1-8-g11eff7739a-20220712 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1673 extractors
[debug] [iflix:episode] Extracting URL: https://www.iflix.com/en/play/daijrxu03yypu0s/a0040kvgaza
[iflix:episode] a0040kvgaza: Downloading webpage
[iflix:episode] a0040kvgaza: Downloading webpage
[iflix:episode] a0040kvgaza: Downloading webpage
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading webpage
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[iflix:episode] a0040kvgaza: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for a0040kvgaza:
ID EXT RESOLUTION │ PROTO │ VCODEC  ACODEC
───────────────────────────────────────────
0  mp4 864x486    │ https │ unknown unknown
1  mp4 864x486    │ https │ unknown unknown
2  mp4 864x486    │ https │ unknown unknown
3  mp4 864x486    │ https │ unknown unknown
4  mp4 1280x720   │ m3u8  │ unknown unknown
5  mp4 1280x720   │ m3u8  │ unknown unknown
6  mp4 1280x720   │ m3u8  │ unknown unknown
7  mp4 1280x720   │ m3u8  │ unknown unknown
8  mp4 1280x720   │ m3u8  │ unknown unknown
9  mp4 1280x720   │ m3u8  │ unknown unknown
10 mp4 1280x720   │ m3u8  │ unknown unknown
11 mp4 1280x720   │ m3u8  │ unknown unknown
```

### Downloading series
```bash
[debug] Command-line config: ['https://www.iflix.com/play/0s682hc45t0ohll', '-v', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: a8ba287e2
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-125-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.0.1-8-g11eff7739a-20220712 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1673 extractors
[debug] [IflixSeries] Extracting URL: https://www.iflix.com/play/0s682hc45t0ohll
[IflixSeries] 0s682hc45t0ohll: Downloading webpage
[download] Downloading playlist: Miss Gu Who Is Silent
[IflixSeries] Playlist Miss Gu Who Is Silent: Downloading 20 videos of 20
[download] Downloading video 1 of 20
[debug] [iflix:episode] Extracting URL: https://www.iflix.com/play/0s682hc45t0ohll/a00340c66f8
[iflix:episode] a00340c66f8: Downloading webpage
[iflix:episode] a00340c66f8: Downloading webpage
[iflix:episode] a00340c66f8: Downloading webpage
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading webpage
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading m3u8 information
[iflix:episode] a00340c66f8: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for a00340c66f8:
ID EXT RESOLUTION │ PROTO │ VCODEC  ACODEC
───────────────────────────────────────────
0  mp4 864x486    │ https │ unknown unknown
1  mp4 864x486    │ https │ unknown unknown
2  mp4 864x486    │ https │ unknown unknown
3  mp4 864x486    │ https │ unknown unknown
4  mp4 1280x720   │ m3u8  │ unknown unknown
5  mp4 1280x720   │ m3u8  │ unknown unknown
6  mp4 1280x720   │ m3u8  │ unknown unknown
7  mp4 1280x720   │ m3u8  │ unknown unknown
8  mp4 1280x720   │ m3u8  │ unknown unknown
9  mp4 1280x720   │ m3u8  │ unknown unknown
10 mp4 1280x720   │ m3u8  │ unknown unknown
11 mp4 1280x720   │ m3u8  │ unknown unknown
[download] Downloading video 2 of 20
[debug] [iflix:episode] Extracting URL: https://www.iflix.com/play/0s682hc45t0ohll/p0034phldfj
[iflix:episode] p0034phldfj: Downloading webpage
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
