### PR TITLE
[phantomjs] Fix error in get function

### DIFF
--- a/yt_dlp/extractor/openload.py
+++ b/yt_dlp/extractor/openload.py
@@ -212,7 +212,7 @@ class PhantomJSwrapper:
             'jscode': jscode,
         }))
 
-        stdout = self.execute(jscode, video_id, note2)
+        stdout = self.execute(jscode, video_id, note=note2)
 
         with open(self._TMP_FILES['html'].name, 'rb') as f:
             html = f.read().decode('utf-8')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I was taking a look at #4292, but I was getting a different error related to phantomjs:

```bash
[debug] Command-line config: ['https://www.iq.com/play/hikaru-no-go-episode-1-slxk4ry5to?lang=en_us', '-F', '--verbose']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 1a7c9fad9
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-125-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.1.1-20220901 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1671 extractors
[debug] [iq.com] Extracting URL: https://www.iq.com/play/hikaru-no-go-episode-1-slxk4ry5to?lang=en_us
[iq.com] slxk4ry5to: Downloading webpage
[debug] Loading iq.player_js from cache
WARNING: [iq.com] slxk4ry5to: Failed to parse JSON: Expecting value: line 1 column 1 (char 0)
[debug] Loading iq.player_js from cache
ERROR: execute() takes from 2 to 3 positional arguments but 4 were given
Traceback (most recent call last):
  File "/home/amish/Documents/Programming/yt-dlp/yt_dlp/YoutubeDL.py", line 1459, in wrapper
    return func(self, *args, **kwargs)
  File "/home/amish/Documents/Programming/yt-dlp/yt_dlp/YoutubeDL.py", line 1535, in __extract_info
    ie_result = ie.extract(url)
  File "/home/amish/Documents/Programming/yt-dlp/yt_dlp/extractor/common.py", line 670, in extract
    ie_result = self._real_extract(url)
  File "/home/amish/Documents/Programming/yt-dlp/yt_dlp/extractor/iqiyi.py", line 591, in _real_extract
    dash_paths = self._parse_json(PhantomJSwrapper(self).get(
  File "/home/amish/Documents/Programming/yt-dlp/yt_dlp/extractor/openload.py", line 215, in get
    stdout = self.execute(jscode, video_id, note2)
TypeError: execute() takes from 2 to 3 positional arguments but 4 were given
```

I fixed it by using `note=note2` in the self.execute() call. I don't think #4292 is still fixed, because it seems like Phantomjs works for a while and then it doesn't https://github.com/yt-dlp/yt-dlp/issues/4292#issuecomment-1178535148

```bash
[debug] Command-line config: ['https://www.iq.com/play/hikaru-no-go-episode-1-slxk4ry5to?lang=en_us', '-F', '--verbose']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 74cb4f951
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-125-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.1.1-20220901 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1671 extractors
[debug] [iq.com] Extracting URL: https://www.iq.com/play/hikaru-no-go-episode-1-slxk4ry5to?lang=en_us
[iq.com] slxk4ry5to: Downloading webpage
[debug] Loading iq.player_js from cache
WARNING: [iq.com] slxk4ry5to: Failed to parse JSON: Expecting value: line 1 column 1 (char 0)
[debug] Loading iq.player_js from cache
[iq.com] slxk4ry5to: Executing signature code
[debug] [iq.com] PhantomJS command line: phantomjs --ssl-protocol=any /tmp/tmp7xu2v9fs
[iq.com] slxk4ry5to: Downloading initial video format info
[iq.com] slxk4ry5to: Downloading format data for 720P
[iq.com] slxk4ry5to: Downloading format data for 480P
[iq.com] slxk4ry5to: Downloading format data for 1080P
WARNING: [iq.com] 1080P format is restricted
[iq.com] slxk4ry5to: Downloading format data for 240P
[iq.com] slxk4ry5to: Downloading format data for 360P
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for slxk4ry5to:
ID  EXT RESOLUTION │ PROTO │ VCODEC  ACODEC  MORE INFO
──────────────────────────────────────────────────────
100 mp4 512x216    │ m3u8  │ unknown unknown 240P
200 mp4 856x360    │ m3u8  │ unknown unknown 360P
300 mp4 896x376    │ m3u8  │ unknown unknown 480P
500 mp4 1280x536   │ m3u8  │ unknown unknown 720P
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
