### PR TITLE
[utils] Do not ignore base_url path components that contain ampersand

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -566,6 +566,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(base_url('http://foo.de/bar/'), 'http://foo.de/bar/')
         self.assertEqual(base_url('http://foo.de/bar/baz'), 'http://foo.de/bar/')
         self.assertEqual(base_url('http://foo.de/bar/baz?x=z/x/c'), 'http://foo.de/bar/')
+        self.assertEqual(base_url('http://foo.de/bar/baz&x=z&w=y/x/c'), 'http://foo.de/bar/baz&x=z&w=y/x/')
 
     def test_urljoin(self):
         self.assertEqual(urljoin('http://foo.de/', '/a/b/c.txt'), 'http://foo.de/a/b/c.txt')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2479,7 +2479,7 @@ def url_basename(url):
 
 
 def base_url(url):
-    return re.match(r'https?://[^?#&]+/', url).group()
+    return re.match(r'https?://[^?#]+/', url).group()
 
 
 def urljoin(base, path):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The DiscoveryPlus extractor was failing because most of the stream urls contain a signature and expiration inside the url, e. g.

```bash
https://dplus-northamerica.media-edge.prod-vod.h264.io/bc116fee-6065-46e7-908d-debae79aaf99/dash_clear_fmp4/edge-cache-token=Expires=1662321057&KeyName=media-edge-key-prod-northamerica-200d417&Signature=jmhv-P8gPV6XVlhC5Xp1KOh-2YGTnDJWnjdKuzVYAONdRawTPr-2S6PSqdpbndDuoJPeoCxifKgZl666WRfGBA/master.mpd
```

The problem is that without this fix, we ignore these values when getting our base_url
```diff
- https://dplus-northamerica.media-edge.prod-vod.h264.io/bc116fee-6065-46e7-908d-debae79aaf99/dash_clear_fmp4/

+ https://dplus-northamerica.media-edge.prod-vod.h264.io/bc116fee-6065-46e7-908d-debae79aaf99/dash_clear_fmp4/edge-cache-token=Expires=1662321057&KeyName=media-edge-key-prod-northamerica-200d417&Signature=jmhv-P8gPV6XVlhC5Xp1KOh-2YGTnDJWnjdKuzVYAONdRawTPr-2S6PSqdpbndDuoJPeoCxifKgZl666WRfGBA/
```

### Without this fix
```bash
[debug] Command-line config: ['https://www.discoveryplus.com/video/jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos', '--cookies-from-browser', 'firefox', '--verbose']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 07a1250e0
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-125-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.1.1-20220901 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[Cookies] Extracting cookies from firefox
[debug] Extracting cookies from: "/home/amish/.mozilla/firefox/ckczlffq.default-release/cookies.sqlite"
[Cookies] Extracted 48 cookies from firefox
[debug] Proxy map: {}
[debug] Loaded 1671 extractors
[debug] [DiscoveryPlus] Extracting URL: https://www.discoveryplus.com/video/jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos
[debug] Using fake IP 6.193.132.202 (US) as X-Forwarded-For
[DiscoveryPlus] jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos: Downloading JSON metadata
[DiscoveryPlus] 4911883: Downloading JSON metadata
[DiscoveryPlus] jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos: Downloading MPD manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 4911883: Downloading 1 format(s): dash-video=9674000+dash-audio_eng=125000
[debug] Invoking dashsegments downloader on "https://dplus-northamerica-cloudfront-gcs.prod-vod.h264.io/bc116fee-6065-46e7-908d-debae79aaf99/dash_clear_fmp4/x-discovery-token=Expires=1662321771&KeyName=primary&Signature=grAH6gCslBqQ_G0ICA8ixHX5CLc/master.mpd"
[dashsegments] Total fragments: 1273
[download] Destination: Night of Terror： UFOs [4911883].fdash-video=9674000.mp4
[download] Got error: HTTP Error 403: Forbidden. Retrying fragment 9 (1/10)...
[download] Got error: HTTP Error 403: Forbidden. Retrying fragment 9 (2/10)...
[download] Got error: HTTP Error 403: Forbidden. Retrying fragment 9 (3/10)...
[download] Got error: HTTP Error 403: Forbidden. Retrying fragment 9 (4/10)...
[download] Got error: HTTP Error 403: Forbidden. Retrying fragment 9 (5/10)...
```

### With this fix

```bash
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 9a4485944
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-125-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.1.1-20220901 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[Cookies] Extracting cookies from firefox
[debug] Extracting cookies from: "/home/amish/.mozilla/firefox/ckczlffq.default-release/cookies.sqlite"
[Cookies] Extracted 49 cookies from firefox
[debug] Proxy map: {}
[debug] Loaded 1671 extractors
[debug] [DiscoveryPlus] Extracting URL: https://www.discoveryplus.com/video/jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos
[debug] Using fake IP 6.158.14.23 (US) as X-Forwarded-For
[DiscoveryPlus] jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos: Downloading JSON metadata
[DiscoveryPlus] 4911883: Downloading JSON metadata
[DiscoveryPlus] jack-osbournes-night-of-terror-ufos-us/night-of-terror-ufos: Downloading MPD manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 4911883: Downloading 1 format(s): dash-video=9674000+dash-audio_eng=125000
[debug] Invoking dashsegments downloader on "https://dplus-northamerica.media-edge.prod-vod.h264.io/bc116fee-6065-46e7-908d-debae79aaf99/dash_clear_fmp4/edge-cache-token=Expires=1662321642&KeyName=media-edge-key-prod-northamerica-200d417&Signature=n7SoFP6bpH-cyONqsLd727w0Nm8uJO_4CbjYTcGO46tBW2jXVYDh-ci1mD6JNw8E35h3OKQkLa8z0NGtavf8Cg/master.mpd"
[dashsegments] Total fragments: 1273
[download] Destination: Night of Terror： UFOs [4911883].fdash-video=9674000.mp4
[download]   0.6% of ~4.94GiB at    2.52MiB/s ETA 35:14 (frag 8/1273)
```

Fixes #4187
Maybe #3757 ? It's a site request but the comments are related to this 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
