### PR TITLE
[HLS] Extract audio channels from m3u8

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2274,6 +2274,9 @@ class InfoExtractor:
                 subtitles.setdefault(lang, []).append(sub_info)
             if media_type not in ('VIDEO', 'AUDIO'):
                 return
+            channels = media.get('CHANNELS')
+            if not channels is None and channels.isdigit():
+                channels = int(channels)
             media_url = media.get('URI')
             if media_url:
                 manifest_url = format_url(media_url)
@@ -2284,7 +2287,7 @@ class InfoExtractor:
                     'url': manifest_url,
                     'manifest_url': m3u8_url,
                     'language': media.get('LANGUAGE'),
-                    'audio_channels': media.get('CHANNELS'),
+                    'audio_channels': channels,
                     'ext': ext,
                     'protocol': entry_protocol,
                     'preference': preference,

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2284,6 +2284,7 @@ class InfoExtractor:
                     'url': manifest_url,
                     'manifest_url': m3u8_url,
                     'language': media.get('LANGUAGE'),
+                    'audio_channels': media.get('CHANNELS'),
                     'ext': ext,
                     'protocol': entry_protocol,
                     'preference': preference,


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

Yt-dlp prefers 5.1 audio over stereo thanks to the default format sort order. However, this doesn't work for HLS/m3u8 streams because the field `audio_channels` is not extracted. As a consequence, yt-dlp may choose stereo AAC over 5.1 AC3.

The PR extracts the `CHANNELS` field from m3u8 playlist when available, and the format selection works as expected. There's a playlist with audio `CHANNELS` in the repository already https://github.com/yt-dlp/yt-dlp/blob/master/test/testdata/m3u8/img_bipbop_adv_example_fmp4.m3u8

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
