### PR TITLE
[extractor/tubitv]

### DIFF
--- a/yt_dlp/extractor/tubitv.py
+++ b/yt_dlp/extractor/tubitv.py
@@ -169,9 +169,6 @@ class TubiTvIE(TubiTvBaseIE):
         url, smuggle_data = unsmuggle_url(url)
 
         video_id = self._match_id(url)
-        video_data = self._download_json(f'https://tubitv.com/oz/videos/{video_id}/content', video_id, query={
-            'video_resources': ['dash', 'hlsv3', 'hlsv6', *self._UNPLAYABLE_FORMATS],
-        })
         series = None
 
         if smuggle_data:
@@ -180,12 +177,12 @@ class TubiTvIE(TubiTvBaseIE):
             video_data = smuggle_data.get('show_data')
         else:
             # Get metadata from page
-            video_data = self._download_json(f'https://tubitv.com/oz/videos/{video_id}/content', video_id, query={
-                'video_resources': ['dash', 'hlsv3', 'hlsv6', *self._UNPLAYABLE_FORMATS],
-            })
-            # webpage = self._download_webpage(f'https://tubitv.com/video/{video_id}/{video_id}', video_id)
-            # page_json = self._parse_page_data(webpage, video_id)
-            # video_data = traverse_obj(page_json, ('byId', video_id))
+            #video_data = self._download_json(f'https://tubitv.com/oz/videos/{video_id}/content', video_id, query={
+            #    'video_resources': ['dash', 'hlsv3', 'hlsv6', *self._UNPLAYABLE_FORMATS],
+            #})
+            webpage = self._download_webpage(f'https://tubitv.com/video/{video_id}/{video_id}', video_id)
+            page_json = self._parse_page_data(webpage, video_id)
+            video_data = traverse_obj(page_json, ('byId', video_id))
             series_id = video_data.get('series_id')
             if series_id:
                 series = self._get_show_title(page_json, series_id)

--- a/yt_dlp/extractor/tubitv.py
+++ b/yt_dlp/extractor/tubitv.py
@@ -13,7 +13,18 @@ from ..utils import (
 )
 
 
-class TubiTvIE(InfoExtractor):
+class TubiTvBaseIE(InfoExtractor):
+
+    def _parse_page_data(self, webpage, show_id):
+        return self._parse_json(self._search_regex(
+            r'window\.__data\s*=\s*({[^<]+});\s*</script>',
+            webpage, 'data'), show_id, transform_source=js_to_json)['video']
+
+    def _get_show_title(self, show_json, show_id):
+        return traverse_obj(show_json, ('byId', '0' + show_id, 'title'))
+
+
+class TubiTvIE(TubiTvBaseIE):
     _VALID_URL = r'''(?x)
                     (?:
                         tubitv:|
@@ -47,6 +58,75 @@ class TubiTvIE(InfoExtractor):
             'uploader_id': 'bc168bee0d18dd1cb3b86c68706ab434',
         },
         'skip': 'Content Unavailable'
+    }, {
+        # "video" (redirects to "movies" or "tv-shows" in browser depending on media type)
+        'url': 'https://tubitv.com/video/674931/tow',
+        'md5': 'afa0cb28a37be3fec2cc9a4a99758e9c',
+        'info_dict': {
+            'id': '674931',
+            'ext': 'mp4',
+            'title': 'Tow',
+            'duration': 5171,
+            'uploader_id': 'bd17d1b5fd5e1188493651ac8bce8ded',
+            'release_year': 2022,
+            'description': 'Twin sisters must confront their past when their attempted killer re-enters their lives.',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        },
+    }, {
+        # movie
+        'url': 'https://tubitv.com/movies/613766/swim?start=true',
+        'md5': 'acde434a720fb2e22cb96bf8b99a102d',
+        'info_dict': {
+            'id': '613766',
+            'ext': 'mp4',
+            'title': 'Swim',
+            'uploader_id': '6b82d97d873a91e75936a79c984c9b65',
+            'release_year': 2021,
+            'duration': 5208,
+            'description': 'md5:77a9064861aedbe0761ce7b2b4fce26e',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        }
+    }, {
+        # episode
+        'url': 'https://tubitv.com/tv-shows/624837/s01-e01-pilot?start=true',
+        'md5': 'c38ef60e8b3ff8b15d4c5780a2cae5f6',
+        'info_dict': {
+            'id': '624837',
+            'ext': 'mp4',
+            'uploader_id': '8362002ebcb54c3aeee2431cbf075e8e',
+            'series': 'The Freak Brothers',
+            'duration': 1536,
+            'season_number': 1,
+            'title': 'S01:E01 - Pilot',
+            'release_year': 2021,
+            'episode_number': 1,
+            'season': 'Season 1',
+            'episode': 'Pilot',
+            'description': 'After smoking the magical weed sauce, four stoners get flung fifty years into the future.',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        }
+    }, {
+        # special episode
+        'url': 'https://tubitv.com/tv-shows/519013/specials-e12-garfield-s-halloween-adventure?start=true',
+        'md5': '282f6d33eafc76f33b749e361984b8ae',
+        'info_dict': {
+            'id': '519013',
+            'ext': 'mp4',
+            'title': 'Specials E12 - Garfield’s Halloween Adventure',
+            'description': 'When Garfield and Odie are out trick-or-treating, they end up at a haunted house.',
+            'duration': 1445,
+            'release_year': 1985,
+            'episode': 'Garfield’s Halloween Adventure',
+            'episode_number': 12,
+            'season_number': 0,
+            'uploader_id': '009dc61cc7f358e7ea96b6b018244659',
+            'season': 'Season 0',
+            'series': 'Garfield and Friends',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        }
+    }, {
+        'url': 'tubitv:674931',
+        'only_matching': True,
     }, {
         'url': 'http://tubitv.com/tv-shows/321886/s01_e01_on_nom_stories',
         'only_matching': True,
@@ -84,12 +164,32 @@ class TubiTvIE(InfoExtractor):
 
     def _real_extract(self, url):
 
+        video_id = self._match_id(url)
+
         url, smuggle_data = unsmuggle_url(url)
 
         video_id = self._match_id(url)
         video_data = self._download_json(f'https://tubitv.com/oz/videos/{video_id}/content', video_id, query={
             'video_resources': ['dash', 'hlsv3', 'hlsv6', *self._UNPLAYABLE_FORMATS],
         })
+        series = None
+
+        if smuggle_data:
+            # Use smuggled data for tv show
+            series = smuggle_data.get('show_title')
+            video_data = smuggle_data.get('show_data')
+        else:
+            # Get metadata from page
+            video_data = self._download_json(f'https://tubitv.com/oz/videos/{video_id}/content', video_id, query={
+                'video_resources': ['dash', 'hlsv3', 'hlsv6', *self._UNPLAYABLE_FORMATS],
+            })
+            # webpage = self._download_webpage(f'https://tubitv.com/video/{video_id}/{video_id}', video_id)
+            # page_json = self._parse_page_data(webpage, video_id)
+            # video_data = traverse_obj(page_json, ('byId', video_id))
+            series_id = video_data.get('series_id')
+            if series_id:
+                series = self._get_show_title(page_json, series_id)
+
         title = video_data['title']
 
         formats = []
@@ -125,20 +225,19 @@ class TubiTvIE(InfoExtractor):
                 'url': self._proto_relative_url(sub_url),
             })
 
-        season_number, episode_number, episode_title = self._search_regex(
-            r'^S(\d+):E(\d+) - (.+)', title, 'episode info', fatal=False, group=(1, 2, 3), default=(None, None, None))
+        season_number = None
 
-        series = None
-        detailed_type = video_data.get('detailed_type')
-        series_id = video_data.get('series_id')
+        # Check if this is a special episode from a show not belonging to a season
+        episode_number, episode_title = self._search_regex(
+            r'^Specials E(\d+) - (.+)', title, 'episode info', fatal=False, group=(1, 2), default=(None, None))
 
-        if detailed_type == 'episode':
-            full_title = traverse_obj(smuggle_data, ('full_title'))
-            if full_title:
-                series = full_title
-            elif series_id:
-                show_webpage = self._download_webpage('https://tubitv.com/series/%s/%s?start=true' % (series_id, series_id), series_id)
-                series = self._og_search_title(show_webpage)
+        if episode_number or episode_title:
+            # Use season 0 for specials (common convention used by media servers)
+            season_number = 0
+        else:
+            # Try standard season/episode parsing
+            season_number, episode_number, episode_title = self._search_regex(
+                r'^S(\d+):E(\d+) - (.+)', title, 'episode info', fatal=False, group=(1, 2, 3), default=(None, None, None))
 
         return {
             'id': video_id,
@@ -153,37 +252,38 @@ class TubiTvIE(InfoExtractor):
             'season_number': int_or_none(season_number),
             'episode_number': int_or_none(episode_number),
             'series': series,
-            'episode': episode_title
+            'episode': episode_title,
         }
 
 
-class TubiTvShowIE(InfoExtractor):
+class TubiTvShowIE(TubiTvBaseIE):
 
-    _VALID_URL = r'https?://(?:www\.)?tubitv\.com/series/[0-9]+/(?P<show_name>[^/?#]+)'
+    # Show URL format: tubitv.com/series/<show_id>/<slug>
+
+    # Show ID is numeric and uniquely identifies show in Tubi API.
+    # Slug is text provided by Tubi in URL for readability/SEO. Slug can be arbitrarily
+    #    changed in URL and site will still load the correct video, so it is not necessarily
+    #    guaranteed to always be the same for the same show, unlike the ID.
+
+    _VALID_URL = r'https?://(?:www\.)?tubitv\.com/series/(?P<show_id>[0-9]+)/[^/?#]+'
     _TESTS = [{
         'url': 'https://tubitv.com/series/3936/the-joy-of-painting-with-bob-ross?start=true',
         'playlist_mincount': 389,
         'info_dict': {
-            'id': 'the-joy-of-painting-with-bob-ross',
+            'id': '3936',
+            'title': 'The Joy of Painting With Bob Ross',
         }
     }]
 
-    def _entries(self, show_url, show_name):
-        show_webpage = self._download_webpage(show_url, show_name)
-
-        full_title = self._og_search_title(show_webpage)
-
-        show_json = self._parse_json(self._search_regex(
-            r'window\.__data\s*=\s*({[^<]+});\s*</script>',
-            show_webpage, 'data'), show_name, transform_source=js_to_json)['video']
-
+    def _entries(self, show_json, show_title):
         for episode_id in show_json['fullContentById'].keys():
             if traverse_obj(show_json, ('byId', episode_id, 'type')) == 's':
                 continue
-            yield self.url_result(
-                smuggle_url('tubitv:%s' % episode_id, {'full_title': full_title}),
-                ie=TubiTvIE.ie_key(), video_id=episode_id)
+            yield self.url_result(smuggle_url(f'tubitv:{episode_id}', {'show_title': show_title, 'show_data': traverse_obj(show_json, ('byId', episode_id))}), ie=TubiTvIE.ie_key(), video_id=episode_id)
 
     def _real_extract(self, url):
-        show_name = self._match_valid_url(url).group('show_name')
-        return self.playlist_result(self._entries(url, show_name), playlist_id=show_name)
+        show_id = self._match_valid_url(url).group('show_id')
+        show_webpage = self._download_webpage(url, show_id)
+        show_json = self._parse_page_data(show_webpage, show_id)
+        show_title = self._get_show_title(show_json, show_id)
+        return self.playlist_result(self._entries(show_json, show_title), playlist_id=show_id, playlist_title=show_title)


### PR DESCRIPTION
- Adds correct series and episode names when downloading shows.
- Fixes series ID assignment.
- Reduces HTTP requests to a single call no matter what type of content is being downloaded.
  - A series/episode webpage contains JSON with information pertaining to every episode in the series, so the data is smuggled for individual episode downloads.



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
