### PR TITLE
Fix bug in recent commit

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -725,8 +725,6 @@ class YoutubeDL:
             archive = set()
             if fn is None:
                 return archive
-            elif not isinstance(fn, os.PathLike):
-                return fn
 
             self.write_debug(f'Loading archive file {fn!r}')
             try:


### PR DESCRIPTION
The introduction of that `elif` in `preload_download_archive()` resulted in `self.archive` being a string instead of a set, which causes an error in the last line of `in_downlod_archive()`.

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ae1035646a6be09c2aed3e22eb8910f341ddacfe introduced an error when using download archives.
```
ERROR: 'in <string>' requires string as left operand, not NoneType
Traceback (most recent call last):
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 1474, in wrapper
  return func(self, *args, **kwargs)
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 1571, in __extract_info
  return self.process_ie_result(ie_result, download, extra_info)
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 1699, in process_ie_result
  return self.__process_playlist(ie_result, download)
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 1759, in __process_playlist
  if self._match_entry(common_info, incomplete=True) is not None:
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 1401, in _match_entry
  if self.in_download_archive(info_dict):
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 3474, in in_download_archive
  return any(id_ in self.archive for id_ in vid_ids)
File "/home/christoph/Projects/yt-dlp/yt_dlp/YoutubeDL.py", line 3474, in <genexpr>
  return any(id_ in self.archive for id_ in vid_ids)
TypeError: 'in <string>' requires string as left operand, not NoneType
```
The introduction of [this elif](https://github.com/yt-dlp/yt-dlp/blob/c26f9b991a0681fd3ea548d535919cec1fbbd430/yt_dlp/YoutubeDL.py#L728-L729) results in `self.archive` being a string instead of a set, which leads to the error above.
I'm sure this has been added for a reason, and so simply removing it probably breaks something, but any tests I've run were fine (although I didn't notice any archive specific tests, so maybe add some?). 
Feel free to close this and fix it in some other way.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
