### PR TITLE
[extractor/malltv] Fix video_id extraction

### DIFF
--- a/yt_dlp/extractor/malltv.py
+++ b/yt_dlp/extractor/malltv.py
@@ -14,7 +14,7 @@ class MallTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:(?:www|sk)\.)?mall\.tv/(?:[^/]+/)*(?P<id>[^/?#&]+)'
     _TESTS = [{
         'url': 'https://www.mall.tv/18-miliard-pro-neziskovky-opravdu-jsou-sportovci-nebo-clovek-v-tisni-pijavice',
-        'md5': '1c4a37f080e1f3023103a7b43458e518',
+        'md5': 'cd69ce29176f6533b65bff69ed9a5f2a',
         'info_dict': {
             'id': 't0zzt0',
             'display_id': '18-miliard-pro-neziskovky-opravdu-jsou-sportovci-nebo-clovek-v-tisni-pijavice',
@@ -25,6 +25,11 @@ class MallTVIE(InfoExtractor):
             'timestamp': 1538870400,
             'upload_date': '20181007',
             'view_count': int,
+            'comment_count': int,
+            'thumbnail': 'https://cdn.vpplayer.tech/agmipnzv/encode/vjsnigfq/thumbnails/retina.jpg',
+            'average_rating': 9.060869565217391,
+            'dislike_count': int,
+            'like_count': int,
         }
     }, {
         'url': 'https://www.mall.tv/kdo-to-plati/18-miliard-pro-neziskovky-opravdu-jsou-sportovci-nebo-clovek-v-tisni-pijavice',
@@ -32,6 +37,24 @@ class MallTVIE(InfoExtractor):
     }, {
         'url': 'https://sk.mall.tv/gejmhaus/reklamacia-nehreje-vyrobnik-tepla-alebo-spekacka',
         'only_matching': True,
+    }, {
+        'url': 'https://www.mall.tv/zivoty-slavnych/nadeje-vychodu-i-zapadu-jak-michail-gorbacov-zmenil-politickou-mapu-sveta-a-ziskal-za-to-nobelovu-cenu-miru',
+        'info_dict': {
+            'id': 'yx010y',
+            'ext': 'mp4',
+            'dislike_count': int,
+            'description': 'md5:aee02bee5a8d072c6a8207b91d1905a9',
+            'thumbnail': 'https://cdn.vpplayer.tech/agmipnzv/encode/vjsnjdeu/thumbnails/retina.jpg',
+            'comment_count': int,
+            'display_id': 'md5:0ec2afa94d2e2b7091c019cef2a43a9b',
+            'like_count': int,
+            'duration': 752,
+            'timestamp': 1646956800,
+            'title': 'md5:fe79385daaf16d74c12c1ec4a26687af',
+            'view_count': int,
+            'upload_date': '20220311',
+            'average_rating': 9.685714285714285,
+        }
     }]
 
     def _real_extract(self, url):
@@ -43,12 +66,12 @@ class MallTVIE(InfoExtractor):
         video = self._parse_json(self._search_regex(
             r'videoObject\s*=\s*JSON\.parse\(JSON\.stringify\(({.+?})\)\);',
             webpage, 'video object'), display_id)
-        video_source = video['VideoSource']
+            
         video_id = self._search_regex(
-            r'/([\da-z]+)/index\b', video_source, 'video id')
+            r'<input\s*id\s*=\s*player-id-name\s*[^>]+value\s*=\s*(\w+)', webpage, 'video id')
 
         formats = self._extract_m3u8_formats(
-            video_source + '.m3u8', video_id, 'mp4', 'm3u8_native')
+            video['VideoSource'], video_id, 'mp4', 'm3u8_native')
         self._sort_formats(formats)
 
         subtitles = {}
@@ -69,7 +92,7 @@ class MallTVIE(InfoExtractor):
         info = self._search_json_ld(webpage, video_id, default={})
 
         return merge_dicts({
-            'id': video_id,
+            'id': str(video_id),
             'display_id': display_id,
             'title': video.get('Title'),
             'description': clean_html(video.get('Description')),

--- a/yt_dlp/extractor/malltv.py
+++ b/yt_dlp/extractor/malltv.py
@@ -66,7 +66,7 @@ class MallTVIE(InfoExtractor):
         video = self._parse_json(self._search_regex(
             r'videoObject\s*=\s*JSON\.parse\(JSON\.stringify\(({.+?})\)\);',
             webpage, 'video object'), display_id)
-            
+
         video_id = self._search_regex(
             r'<input\s*id\s*=\s*player-id-name\s*[^>]+value\s*=\s*(\w+)', webpage, 'video id')
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE
This PR fix the video_id in mall tv. The site seems change their layout a bit so the current extractor can't get the video_id. This PR use `player-id-name`  value as video_id to prevent archive broke because the value is identical to old video id. The 'real' video_id is located in `video['VideoId']`


Fixes #4870 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
