### PR TITLE
[redgifs] Fix extractor

### DIFF
--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -49,7 +49,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         return {
             'id': video_id,
             'webpage_url': f'https://redgifs.com/watch/{video_id}',
-            'ie_key': RedGifsIE.ie_key(),
+            'extractor_key': RedGifsIE.ie_key(),
             'extractor': 'RedGifs',
             'title': ' '.join(gif_data.get('tags') or []) or 'RedGifs',
             'timestamp': int_or_none(gif_data.get('createDate')),
@@ -128,7 +128,6 @@ class RedGifsIE(RedGifsBaseInfoExtractor):
             'like_count': int,
             'categories': list,
             'age_limit': 18,
-            'ie_key': 'RedGifs',
             'tags': list,
         }
     }, {
@@ -145,6 +144,7 @@ class RedGifsIE(RedGifsBaseInfoExtractor):
             'like_count': int,
             'categories': list,
             'age_limit': 18,
+            'tags': list,
         }
     }]
 

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -18,9 +18,11 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         'hd': None,
     }
 
-    _API_HEADERS = {'referer': 'https://www.redgifs.com/',
-                    'origin': 'https://www.redgifs.com',
-                    'content-type': 'application/json'}
+    _API_HEADERS = {
+        'referer': 'https://www.redgifs.com/',
+        'origin': 'https://www.redgifs.com',
+        'content-type': 'application/json',
+    }
 
     def _parse_gif_data(self, gif_data):
         video_id = gif_data.get('id')

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -18,6 +18,10 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         'hd': None,
     }
 
+    _API_HEADERS = {'referer': 'https://www.redgifs.com/',
+                    'origin': 'https://www.redgifs.com',
+                    'content-type': 'application/json'}
+
     def _parse_gif_data(self, gif_data):
         video_id = gif_data.get('id')
         quality = qualities(tuple(self._FORMATS.keys()))
@@ -57,9 +61,32 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
             'formats': formats,
         }
 
+    def _fetch_oauth_token(self, video_id):
+        # These pages contain the OAuth token that is necessary to make API calls.
+        index_page = self._download_webpage(f'https://www.redgifs.com/watch/{video_id}', video_id)
+        index_js_uri = self._html_search_regex(r'href="?(/assets/js/index[.a-z0-9]*.js)"?\W',
+                                               index_page, 'index_js_uri')
+        index_js = self._download_webpage('https://www.redgifs.com/' + index_js_uri, video_id)
+
+        # It turns out that a { followed by any valid JSON punctuation will always result in the
+        # first two characters of the base64 encoding being "ey".
+        #
+        # Use this fact to find any such string constant of a reasonable length with the correct
+        # punctuation for an oauth token
+        oauth_token = self._html_search_regex(r'\w+[=:]"(ey[^"]+\.[^"]*\.[^"]{43,45})"',
+                                              index_js.replace(' ', ''),
+                                              'oauth_token')
+        self._API_HEADERS['authorization'] = "Bearer " + oauth_token
+
     def _call_api(self, ep, video_id, *args, **kwargs):
+        if 'authorization' not in self._API_HEADERS:
+            self._fetch_oauth_token(video_id)
+        assert 'authorization' in self._API_HEADERS
+
+        headers = dict(self._API_HEADERS)
+        headers['x-customheader'] = f'https://www.redgifs.com/watch/{video_id}'
         data = self._download_json(
-            f'https://api.redgifs.com/v2/{ep}', video_id, *args, **kwargs)
+            f'https://api.redgifs.com/v2/{ep}', video_id, headers=headers, *args, **kwargs)
         if 'error' in data:
             raise ExtractorError(f'RedGifs said: {data["error"]}', expected=True, video_id=video_id)
         return data
@@ -102,6 +129,8 @@ class RedGifsIE(RedGifsBaseInfoExtractor):
             'like_count': int,
             'categories': list,
             'age_limit': 18,
+            'ie_key': 'RedGifs',
+            'tags': list,
         }
     }, {
         'url': 'https://thumbs2.redgifs.com/SqueakyHelplessWisent-mobile.mp4#t=0',
@@ -123,7 +152,7 @@ class RedGifsIE(RedGifsBaseInfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url).lower()
         video_info = self._call_api(
-            f'gifs/{video_id}', video_id, note='Downloading video info')
+            f'gifs/{video_id}?views=yes', video_id, note='Downloading video info')
         return self._parse_gif_data(video_info['gif'])
 
 

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -66,19 +66,16 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
     def _fetch_oauth_token(self, video_id):
         # These pages contain the OAuth token that is necessary to make API calls.
         index_page = self._download_webpage(f'https://www.redgifs.com/watch/{video_id}', video_id)
-        index_js_uri = self._html_search_regex(r'href="(/assets/js/index[.a-z0-9]*.js)"\W',
-                                               index_page, 'index_js_uri')
-        index_js = self._download_webpage('https://www.redgifs.com/' + index_js_uri, video_id)
-
+        index_js_uri = self._html_search_regex(
+            r'href="?(/assets/js/index[.a-z0-9]*.js)"?\W', index_page, 'index_js_uri')
+        index_js = self._download_webpage(f'https://www.redgifs.com/{index_js_uri}', video_id)
         # It turns out that a { followed by any valid JSON punctuation will always result in the
         # first two characters of the base64 encoding being "ey".
-        #
         # Use this fact to find any such string constant of a reasonable length with the correct
         # punctuation for an oauth token
-        oauth_token = self._html_search_regex(r'\w+[=:]"(ey[^"]+\.[^"]*\.[^"]{43,45})"',
-                                              index_js.replace(' ', ''),
-                                              'oauth_token')
-        self._API_HEADERS['authorization'] = "Bearer " + oauth_token
+        oauth_token = self._html_search_regex(
+            r'\w+\s*[=:]\s*"(ey[^"]+\.[^"]*\.[^"]{43,45})"', index_js, 'oauth token')
+        self._API_HEADERS['authorization'] = f'Bearer {oauth_token}'
 
     def _call_api(self, ep, video_id, *args, **kwargs):
         if 'authorization' not in self._API_HEADERS:

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -66,7 +66,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
     def _fetch_oauth_token(self, video_id):
         # These pages contain the OAuth token that is necessary to make API calls.
         index_page = self._download_webpage(f'https://www.redgifs.com/watch/{video_id}', video_id)
-        index_js_uri = self._html_search_regex(r'href="?(/assets/js/index[.a-z0-9]*.js)"?\W',
+        index_js_uri = self._html_search_regex(r'href="(/assets/js/index[.a-z0-9]*.js)"\W',
                                                index_page, 'index_js_uri')
         index_js = self._download_webpage('https://www.redgifs.com/' + index_js_uri, video_id)
 


### PR DESCRIPTION
### Description of your *pull request* and other information


</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I figured out the backend OAuth token that is used by their website. Further testing identified this as to be a long-lived and static token. Other issues I encountered were specific to my setup, and this fix should be all that is needed.

In addition, the tests were not quite working because slightly different metadata is returned now. Fixed those while I was in there.

Fixes #4805 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
