### PR TITLE
Hls extract channels

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2274,6 +2274,9 @@ class InfoExtractor:
                 subtitles.setdefault(lang, []).append(sub_info)
             if media_type not in ('VIDEO', 'AUDIO'):
                 return
+            channels = media.get('CHANNELS')
+            if not channels is None and channels.isDigit():
+                channels = int(channels)
             media_url = media.get('URI')
             if media_url:
                 manifest_url = format_url(media_url)
@@ -2284,6 +2287,7 @@ class InfoExtractor:
                     'url': manifest_url,
                     'manifest_url': m3u8_url,
                     'language': media.get('LANGUAGE'),
+                    'audio_channels': channels,
                     'ext': ext,
                     'protocol': entry_protocol,
                     'preference': preference,

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2275,7 +2275,7 @@ class InfoExtractor:
             if media_type not in ('VIDEO', 'AUDIO'):
                 return
             channels = media.get('CHANNELS')
-            if not channels is None and channels.isDigit():
+            if not channels is None and str(channels).isdigit():
                 channels = int(channels)
             media_url = media.get('URI')
             if media_url:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I came across some m3u8/hls streams that have multiple audio tracks available, different number of channels and different codecs. Ordinarily, yt-dlp would choose the best track - i.e., 5.1 over 2.0. Unfortunately, this doesn't work for m3u8 streams, because yt-dlp doesn't extract the `CHANNELS` parameter yet. As a consequence, a stereo track can be chosen over 5.1 if the codec is preferred.


Fixes #

The PR extracts the `CHANNELS` parameter if available and stores it as `audio_channels`. Track selection works as expected now and 5.1 is preferred over 2.0.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
