### PR TITLE
Fixing [Errno 18] Invalid cross-device-link appearing on 'python3 devscripts/make_lazy_extractors.py' execution

### DIFF
--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -51,13 +51,12 @@ def get_all_ies():
     PLUGINS_DIRNAME = 'ytdlp_plugins'
     BLOCKED_DIRNAME = f'{PLUGINS_DIRNAME}_blocked'
     if os.path.exists(PLUGINS_DIRNAME):
-        # This fix [Errno 18] Invalid cross-device-link
+        # os.rename cannot be used, e.g. in Docker. See https://github.com/yt-dlp/yt-dlp/pull/4958
         shutil.move(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
     try:
         from yt_dlp.extractor.extractors import _ALL_CLASSES
     finally:
         if os.path.exists(BLOCKED_DIRNAME):
-            # This fix [Errno 18] Invalid cross-device-link
             shutil.move(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
     return _ALL_CLASSES
 

--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -51,11 +51,13 @@ def get_all_ies():
     PLUGINS_DIRNAME = 'ytdlp_plugins'
     BLOCKED_DIRNAME = f'{PLUGINS_DIRNAME}_blocked'
     if os.path.exists(PLUGINS_DIRNAME):
+        # This fix [Errno 18] Invalid cross-device-link
         shutil.move(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
     try:
         from yt_dlp.extractor.extractors import _ALL_CLASSES
     finally:
         if os.path.exists(BLOCKED_DIRNAME):
+            # This fix [Errno 18] Invalid cross-device-link
             shutil.move(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
     return _ALL_CLASSES
 

--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -51,13 +51,11 @@ def get_all_ies():
     PLUGINS_DIRNAME = 'ytdlp_plugins'
     BLOCKED_DIRNAME = f'{PLUGINS_DIRNAME}_blocked'
     if os.path.exists(PLUGINS_DIRNAME):
-        #os.rename(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
         shutil.move(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
     try:
         from yt_dlp.extractor.extractors import _ALL_CLASSES
     finally:
         if os.path.exists(BLOCKED_DIRNAME):
-            #os.rename(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
             shutil.move(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
     return _ALL_CLASSES
 

--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -3,6 +3,7 @@
 # Allow direct execution
 import os
 import sys
+import shutil
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -50,12 +51,14 @@ def get_all_ies():
     PLUGINS_DIRNAME = 'ytdlp_plugins'
     BLOCKED_DIRNAME = f'{PLUGINS_DIRNAME}_blocked'
     if os.path.exists(PLUGINS_DIRNAME):
-        os.rename(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
+        #os.rename(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
+        shutil.move(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
     try:
         from yt_dlp.extractor.extractors import _ALL_CLASSES
     finally:
         if os.path.exists(BLOCKED_DIRNAME):
-            os.rename(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
+            #os.rename(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
+            shutil.move(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
     return _ALL_CLASSES
 
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Fixing `OSError: [Errno 18] Invalid cross-device link` when a Docker image is created during the compilation process of the `yt-dlp` binary. In particular, this error raises when the `python3 devscripts/make_lazy_extractors.py` step is executed.

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I am interested to create a Docker image having the `yt-dlp` command. My (preliminary) `Dockerfile` looks as follows:
```
FROM ubuntu
ARG CONTAINER_USER="yt-dlp"
ARG WORKDIR="/workdir"
ENV CONTAINER_USER=${CONTAINER_USER}
ENV WORKDIR=${WORKDIR}
RUN useradd ${CONTAINER_USER}
RUN apt update && apt install -y python3 python3-pip git ffmpeg
WORKDIR ${WORKDIR}
RUN git clone https://github.com/yt-dlp/yt-dlp.git
WORKDIR ${WORKDIR}/yt-dlp
RUN python3 -m pip install -U pyinstaller -r requirements.txt && python3 devscripts/make_lazy_extractors.py && python3 pyinst.py
WORKDIR /workdir
RUN rm -rf yt-dlp/*
RUN rm -rf /var/lib/apt/lists/*
USER ${CONTAINER_USER}
``` 
In order to create this image I use the `docker-compose` command. My  `docker-compose.yml` looks as follows:
```
version: "3.6"

services:
        yt-dlp:
                build: 
                        context: image
                container_name: yt-dlp
                hostname: yt-dlp
                stdin_open: true
                tty: true
                volumes:
                        - ./:/workdir
```

The `Dockerfile` is in a directory named `image`. 

On running the `docker-compose build` command the following error appears:
```
Traceback (most recent call last):
  File "/workdir/yt-dlp/devscripts/make_lazy_extractors.py", line 119, in <module>
    main()                                 
  File "/workdir/yt-dlp/devscripts/make_lazy_extractors.py", line 33, in main
    _ALL_CLASSES = get_all_ies()  # Must be before import              
  File "/workdir/yt-dlp/devscripts/make_lazy_extractors.py", line 53, in get_all_ies
    os.rename(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
OSError: [Errno 18] Invalid cross-device link: 'ytdlp_plugins' -> 'ytdlp_plugins_block
ed'            
ERROR: Service 'yt-dlp' failed to build: The command '/bin/sh -c python3 -m pip instal
l -U pyinstaller -r requirements.txt && python3 devscripts/make_lazy_extractors.py && 
python3 pyinst.py' returned a non-zero code: 1
```
 
Fixes #

The problem is fixed when the `os.rename()` instruction on line 53 in the `devscripts/make_lazy_extractors.py` file is changed by the `shutil.move()` function.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
