### PR TITLE
[utils] optionally right align strings created by format_bytes()

### DIFF
--- a/yt_dlp/downloader/common.py
+++ b/yt_dlp/downloader/common.py
@@ -339,7 +339,7 @@ class FileDownloader:
             s.update({
                 'speed': speed,
                 '_speed_str': self.format_speed(speed).strip(),
-                '_total_bytes_str': format_bytes(s.get('total_bytes')),
+                '_total_bytes_str': format_bytes(s.get('total_bytes'), align=True),
                 '_elapsed_str': self.format_seconds(s.get('elapsed')),
                 '_percent_str': self.format_percent(100),
             })
@@ -360,9 +360,9 @@ class FileDownloader:
                 lambda: 100 * s['downloaded_bytes'] / s['total_bytes'],
                 lambda: 100 * s['downloaded_bytes'] / s['total_bytes_estimate'],
                 lambda: s['downloaded_bytes'] == 0 and 0)),
-            '_total_bytes_str': format_bytes(s.get('total_bytes')),
-            '_total_bytes_estimate_str': format_bytes(s.get('total_bytes_estimate')),
-            '_downloaded_bytes_str': format_bytes(s.get('downloaded_bytes')),
+            '_total_bytes_str': format_bytes(s.get('total_bytes'), align=True),
+            '_total_bytes_estimate_str': format_bytes(s.get('total_bytes_estimate'), align=True),
+            '_downloaded_bytes_str': format_bytes(s.get('downloaded_bytes'), align=True),
             '_elapsed_str': self.format_seconds(s.get('elapsed')),
         })
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2247,8 +2247,9 @@ def format_decimal_suffix(num, fmt='%d%s', *, factor=1000):
     return fmt % (converted, suffix)
 
 
-def format_bytes(bytes):
-    return format_decimal_suffix(bytes, '%.2f%sB', factor=1024) or 'N/A'
+def format_bytes(bytes, *, align=False):
+    format_string = '%6.2f%sB' if align else '%.2f%sB'
+    return format_decimal_suffix(bytes, format_string, factor=1024) or 'N/A'
 
 
 def lookup_unit_table(unit_table, s):


### PR DESCRIPTION
optionally right align strings created by `utils.format_bytes()` to avoid progress flicker

### explanation
Most progress formatting functions like `format_speed()` or `format_percent()` use fixed width alignment for the output string. `format_bytes()` seems to be a different beast since it resides in utils module and is also used in other context.

This PR proposes an optional `align` parameter to avoid incompatibilities. 
`downloader.common` can then use the function with `align=True` which allows for right aligned formatting of bytes with a minimum width of 9 characters, hence reducing progress output flicker.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
