### PR TITLE
[extractor/RUTV] Fix warnings for livestreams

### DIFF
--- a/yt_dlp/extractor/rutv.py
+++ b/yt_dlp/extractor/rutv.py
@@ -141,7 +141,7 @@ class RUTVIE(InfoExtractor):
         if media['errors']:
             raise ExtractorError('%s said: %s' % (self.IE_NAME, media['errors']), expected=True)
 
-        view_count = playlist.get('count_views')
+        view_count = int_or_none(playlist.get('count_views'))
         priority_transport = playlist['priority_transport']
 
         thumbnail = media['picture']
@@ -152,6 +152,7 @@ class RUTVIE(InfoExtractor):
         duration = int_or_none(media.get('duration'))
 
         formats = []
+        subtitles = {}
 
         for transport, links in media['sources'].items():
             for quality, url in links.items():
@@ -171,8 +172,10 @@ class RUTVIE(InfoExtractor):
                         'vbr': str_to_int(quality),
                     }
                 elif transport == 'm3u8':
-                    formats.extend(self._extract_m3u8_formats(
-                        url, video_id, 'mp4', quality=preference, m3u8_id='hls'))
+                    fmt, subs = self._extract_m3u8_formats_and_subtitles(
+                        url, video_id, 'mp4', quality=preference, m3u8_id='hls')
+                    formats.extend(fmt)
+                    self._merge_subtitles(subs, target=subtitles)
                     continue
                 else:
                     fmt = {
@@ -186,7 +189,7 @@ class RUTVIE(InfoExtractor):
                 })
                 formats.append(fmt)
 
-        self._sort_formats(formats)
+        self._sort_formats(formats, ('source', ))
 
         return {
             'id': video_id,
@@ -196,5 +199,6 @@ class RUTVIE(InfoExtractor):
             'view_count': view_count,
             'duration': duration,
             'formats': formats,
+            'subtitles': subtitles,
             'is_live': is_live,
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This fixes the following warnings:

```
$ ./yt-dlp.sh -s https://player.vgtrk.com/iframe/live/id/19201 
[RUTV] 19201: Downloading JSON
[RUTV] 19201: Downloading m3u8 information
WARNING: [RUTV] Ignoring subtitle tracks found in the HLS manifest; if any subtitle tracks are missing, please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: "view_count" field is not numeric - forcing int conversion, there is an error in extractor
[info] 19201: Downloading 1 format(s): rtmp-1600
```

And format sorting bug caused by absence of `('source', )`

`--list-subs` shows:
```
$ ./yt-dlp.sh -s https://player.vgtrk.com/iframe/live/id/19201 --list-subs
[RUTV] 19201: Downloading JSON
[RUTV] 19201: Downloading m3u8 information
[info] Available subtitles for 19201:
Language Formats
rus      vtt
[info] 19201: Downloading 1 format(s): hls-2156
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
