### PR TITLE
[downloader/hls] Decouple Hls Media Manifest parsing

### DIFF
--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -11,6 +11,148 @@ from ..dependencies import Cryptodome_AES
 from ..utils import bug_reports_message, parse_m3u8_attributes, update_url_query
 
 
+class HlsMediaManifest:
+
+    @staticmethod
+    def is_ad_fragment_start(line):
+        return (line.startswith('#ANVATO-SEGMENT-INFO') and 'type=ad' in line
+                or line.startswith('#UPLYNK-SEGMENT') and line.endswith(',ad'))
+
+    @staticmethod
+    def is_ad_fragment_end(line):
+        return (line.startswith('#ANVATO-SEGMENT-INFO') and 'type=master' in line
+                or line.startswith('#UPLYNK-SEGMENT') and line.endswith(',segment'))
+
+    @staticmethod
+    def get_stats(manifest):
+        media_frags = 0
+        ad_frags = 0
+        ad_frag_next = False
+        for line in manifest.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith('#'):
+                if HlsMediaManifest.is_ad_fragment_start(line):
+                    ad_frag_next = True
+                elif HlsMediaManifest.is_ad_fragment_end(line):
+                    ad_frag_next = False
+                continue
+            if ad_frag_next:
+                ad_frags += 1
+                continue
+            media_frags += 1
+
+        return {
+            'media_frags': media_frags,
+            'ad_frags': ad_frags,
+        }
+
+    @staticmethod
+    def get_fragments(manifest, manifest_url, format_index=None, fragment_index=None, extra_query=None):
+        fragments = []
+
+        i = 0
+        media_sequence = 0
+        decrypt_info = {'METHOD': 'NONE'}
+        byte_range = {}
+        discontinuity_count = 0
+        frag_index = 0
+        ad_frag_next = False
+        for line in manifest.splitlines():
+            line = line.strip()
+            if line:
+                if not line.startswith('#'):
+                    if format_index and discontinuity_count != format_index:
+                        continue
+                    if ad_frag_next:
+                        continue
+                    frag_index += 1
+                    if fragment_index is not None and frag_index <= fragment_index:
+                        continue
+                    frag_url = (
+                        line
+                        if re.match(r'^https?://', line)
+                        else urllib.parse.urljoin(manifest_url, line))
+                    if extra_query:
+                        frag_url = update_url_query(frag_url, extra_query)
+
+                    fragments.append({
+                        'frag_index': frag_index,
+                        'url': frag_url,
+                        'decrypt_info': decrypt_info,
+                        'byte_range': byte_range,
+                        'media_sequence': media_sequence,
+                    })
+                    media_sequence += 1
+
+                elif line.startswith('#EXT-X-MAP'):
+                    if format_index and discontinuity_count != format_index:
+                        continue
+                    if frag_index > 0:
+                        # self.report_error(
+                        #    'Initialization fragment found after media fragments, unable to download')
+                        return False
+                    frag_index += 1
+                    map_info = parse_m3u8_attributes(line[11:])
+                    frag_url = (
+                        map_info.get('URI')
+                        if re.match(r'^https?://', map_info.get('URI'))
+                        else urllib.parse.urljoin(manifest_url, map_info.get('URI')))
+                    if extra_query:
+                        frag_url = update_url_query(frag_url, extra_query)
+
+                    if map_info.get('BYTERANGE'):
+                        splitted_byte_range = map_info.get('BYTERANGE').split('@')
+                        sub_range_start = int(splitted_byte_range[1]) if len(splitted_byte_range) == 2 else byte_range['end']
+                        byte_range = {
+                            'start': sub_range_start,
+                            'end': sub_range_start + int(splitted_byte_range[0]),
+                        }
+
+                    fragments.append({
+                        'frag_index': frag_index,
+                        'url': frag_url,
+                        'decrypt_info': decrypt_info,
+                        'byte_range': byte_range,
+                        'media_sequence': media_sequence
+                    })
+                    media_sequence += 1
+
+                elif line.startswith('#EXT-X-KEY'):
+                    decrypt_url = decrypt_info.get('URI')
+                    decrypt_info = parse_m3u8_attributes(line[11:])
+                    if decrypt_info['METHOD'] == 'AES-128':
+                        if 'IV' in decrypt_info:
+                            decrypt_info['IV'] = binascii.unhexlify(decrypt_info['IV'][2:].zfill(32))
+                        if not re.match(r'^https?://', decrypt_info['URI']):
+                            decrypt_info['URI'] = urllib.parse.urljoin(
+                                manifest_url, decrypt_info['URI'])
+                        if extra_query:
+                            decrypt_info['URI'] = update_url_query(decrypt_info['URI'], extra_query)
+                        if decrypt_url != decrypt_info['URI']:
+                            decrypt_info['KEY'] = None
+
+                elif line.startswith('#EXT-X-MEDIA-SEQUENCE'):
+                    media_sequence = int(line[22:])
+                elif line.startswith('#EXT-X-BYTERANGE'):
+                    splitted_byte_range = line[17:].split('@')
+                    sub_range_start = int(splitted_byte_range[1]) if len(splitted_byte_range) == 2 else byte_range['end']
+                    byte_range = {
+                        'start': sub_range_start,
+                        'end': sub_range_start + int(splitted_byte_range[0]),
+                    }
+                elif HlsMediaManifest.is_ad_fragment_start(line):
+                    ad_frag_next = True
+                elif HlsMediaManifest.is_ad_fragment_end(line):
+                    ad_frag_next = False
+                elif line.startswith('#EXT-X-DISCONTINUITY'):
+                    discontinuity_count += 1
+                i += 1
+
+        return fragments
+
+
 class HlsFD(FragmentFD):
     """
     Download segments in a m3u8 manifest. External downloaders can take over
@@ -101,38 +243,11 @@ class HlsFD(FragmentFD):
         if real_downloader:
             self.to_screen(f'[{self.FD_NAME}] Fragment downloads will be delegated to {real_downloader.get_basename()}')
 
-        def is_ad_fragment_start(s):
-            return (s.startswith('#ANVATO-SEGMENT-INFO') and 'type=ad' in s
-                    or s.startswith('#UPLYNK-SEGMENT') and s.endswith(',ad'))
-
-        def is_ad_fragment_end(s):
-            return (s.startswith('#ANVATO-SEGMENT-INFO') and 'type=master' in s
-                    or s.startswith('#UPLYNK-SEGMENT') and s.endswith(',segment'))
-
-        fragments = []
-
-        media_frags = 0
-        ad_frags = 0
-        ad_frag_next = False
-        for line in s.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            if line.startswith('#'):
-                if is_ad_fragment_start(line):
-                    ad_frag_next = True
-                elif is_ad_fragment_end(line):
-                    ad_frag_next = False
-                continue
-            if ad_frag_next:
-                ad_frags += 1
-                continue
-            media_frags += 1
-
+        manifest_stats = HlsMediaManifest.get_stats(s)
         ctx = {
             'filename': filename,
-            'total_frags': media_frags,
-            'ad_frags': ad_frags,
+            'total_frags': manifest_stats['media_frags'],
+            'ad_frags': manifest_stats['ad_frags'],
         }
 
         if real_downloader:
@@ -147,103 +262,8 @@ class HlsFD(FragmentFD):
         extra_param_to_segment_url = info_dict.get('extra_param_to_segment_url')
         if extra_param_to_segment_url:
             extra_query = urllib.parse.parse_qs(extra_param_to_segment_url)
-        i = 0
-        media_sequence = 0
-        decrypt_info = {'METHOD': 'NONE'}
-        byte_range = {}
-        discontinuity_count = 0
-        frag_index = 0
-        ad_frag_next = False
-        for line in s.splitlines():
-            line = line.strip()
-            if line:
-                if not line.startswith('#'):
-                    if format_index and discontinuity_count != format_index:
-                        continue
-                    if ad_frag_next:
-                        continue
-                    frag_index += 1
-                    if frag_index <= ctx['fragment_index']:
-                        continue
-                    frag_url = (
-                        line
-                        if re.match(r'^https?://', line)
-                        else urllib.parse.urljoin(man_url, line))
-                    if extra_query:
-                        frag_url = update_url_query(frag_url, extra_query)
 
-                    fragments.append({
-                        'frag_index': frag_index,
-                        'url': frag_url,
-                        'decrypt_info': decrypt_info,
-                        'byte_range': byte_range,
-                        'media_sequence': media_sequence,
-                    })
-                    media_sequence += 1
-
-                elif line.startswith('#EXT-X-MAP'):
-                    if format_index and discontinuity_count != format_index:
-                        continue
-                    if frag_index > 0:
-                        self.report_error(
-                            'Initialization fragment found after media fragments, unable to download')
-                        return False
-                    frag_index += 1
-                    map_info = parse_m3u8_attributes(line[11:])
-                    frag_url = (
-                        map_info.get('URI')
-                        if re.match(r'^https?://', map_info.get('URI'))
-                        else urllib.parse.urljoin(man_url, map_info.get('URI')))
-                    if extra_query:
-                        frag_url = update_url_query(frag_url, extra_query)
-
-                    if map_info.get('BYTERANGE'):
-                        splitted_byte_range = map_info.get('BYTERANGE').split('@')
-                        sub_range_start = int(splitted_byte_range[1]) if len(splitted_byte_range) == 2 else byte_range['end']
-                        byte_range = {
-                            'start': sub_range_start,
-                            'end': sub_range_start + int(splitted_byte_range[0]),
-                        }
-
-                    fragments.append({
-                        'frag_index': frag_index,
-                        'url': frag_url,
-                        'decrypt_info': decrypt_info,
-                        'byte_range': byte_range,
-                        'media_sequence': media_sequence
-                    })
-                    media_sequence += 1
-
-                elif line.startswith('#EXT-X-KEY'):
-                    decrypt_url = decrypt_info.get('URI')
-                    decrypt_info = parse_m3u8_attributes(line[11:])
-                    if decrypt_info['METHOD'] == 'AES-128':
-                        if 'IV' in decrypt_info:
-                            decrypt_info['IV'] = binascii.unhexlify(decrypt_info['IV'][2:].zfill(32))
-                        if not re.match(r'^https?://', decrypt_info['URI']):
-                            decrypt_info['URI'] = urllib.parse.urljoin(
-                                man_url, decrypt_info['URI'])
-                        if extra_query:
-                            decrypt_info['URI'] = update_url_query(decrypt_info['URI'], extra_query)
-                        if decrypt_url != decrypt_info['URI']:
-                            decrypt_info['KEY'] = None
-
-                elif line.startswith('#EXT-X-MEDIA-SEQUENCE'):
-                    media_sequence = int(line[22:])
-                elif line.startswith('#EXT-X-BYTERANGE'):
-                    splitted_byte_range = line[17:].split('@')
-                    sub_range_start = int(splitted_byte_range[1]) if len(splitted_byte_range) == 2 else byte_range['end']
-                    byte_range = {
-                        'start': sub_range_start,
-                        'end': sub_range_start + int(splitted_byte_range[0]),
-                    }
-                elif is_ad_fragment_start(line):
-                    ad_frag_next = True
-                elif is_ad_fragment_end(line):
-                    ad_frag_next = False
-                elif line.startswith('#EXT-X-DISCONTINUITY'):
-                    discontinuity_count += 1
-                i += 1
+        fragments = HlsMediaManifest.get_fragments(s, man_url, format_index, ctx['fragment_index'], extra_query)
 
         # We only download the first fragment during the test
         if self.params.get('test', False):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Progress towards #262

In order to download Hls livestreams natively, we need to be able to download and parse our manifests every X seconds. To avoid duplicating code I moved the parsing code to a new class called HlsMediaManifest and use it inside HlsFD.

I have some time looking into this and I have a WIP branch that shows that this will allow us to download Twitch livestreams:  https://github.com/elyse0/yt-dlp/tree/decouple-m3u8-manifest

An example that native hls downloader still works:

```bash
[debug] Command-line config: ['https://www.arte.tv/es/videos/108210-070-A/el-reves-de-los-mapas/', '--verbose']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 887ce212c
[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-126-generic-x86_64-with-glibc2.29 (glibc 2.31)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg n5.1.1-20220901 (setts), ffprobe n5.0.1-8-g11eff7739a-20220712, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.14.1, brotli-1.0.9, certifi-2021.10.08, mutagen-1.45.1, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1675 extractors
[debug] [ArteTV] Extracting URL: https://www.arte.tv/es/videos/108210-070-A/el-reves-de-los-mapas/
[ArteTV] 108210-070-A: Downloading JSON metadata
[ArteTV] 108210-070-A: Downloading m3u8 information
[ArteTV] 108210-070-A: Downloading m3u8 information
[ArteTV] 108210-070-A: Downloading m3u8 information
[ArteTV] 108210-070-A: Downloading m3u8 information
[ArteTV] 108210-070-A: Downloading m3u8 information
[ArteTV] 108210-070-A: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 108210-070-A: Downloading 1 format(s): VOF-STE_ESP_-2156+VOF-STE_ESP_-program_audio_0-VOF
[debug] Invoking hlsnative downloader on "https://arte-cmafhls.akamaized.net/am/cmaf/108000/108200/108210-070-A/220912130140/medias/108210-070-A_v720.m3u8"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 26
[download] Destination: El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-2156.mp4
[download] 100% of 36.45MiB in    00:22 at 1.62MiB/s
[debug] Invoking hlsnative downloader on "https://arte-cmafhls.akamaized.net/am/cmaf/108000/108200/108210-070-A/220912130140/medias/108210-070-A_aud_VOF.m3u8"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 26
[download] Destination: El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-program_audio_0-VOF.mp4
[download] 100% of 2.32MiB in    00:27 at 87.31KiB/s
[debug] ffmpeg command line: ffprobe -show_streams 'file:El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-program_audio_0-VOF.mp4'
[Merger] Merging formats into "El Reino Unido según Liz Truss [108210-070-A].mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-2156.mp4' -i 'file:El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-program_audio_0-VOF.mp4' -c copy -map 0:v:0 -map 1:a:0 -bsf:a:0 aac_adtstoasc -movflags +faststart 'file:El Reino Unido según Liz Truss [108210-070-A].temp.mp4'
Deleting original file El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-program_audio_0-VOF.mp4 (pass -k to keep)
Deleting original file El Reino Unido según Liz Truss [108210-070-A].fVOF-STE_ESP_-2156.mp4 (pass -k to keep)
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
