### PR TITLE
[extractor/artetv] Remove duplicate stream urls

### DIFF
--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -135,7 +135,7 @@ class ArteTVIE(ArteTVBaseIE):
                 'Video is not available in this language edition of Arte or broadcast rights expired', expected=True)
 
         formats, subtitles = [], {}
-        potential_duplicates = []
+        secondary_formats = []
         for stream in config['data']['attributes']['streams']:
             # official player contains code like `e.get("versions")[0].eStat.ml5`
             stream_version = stream['versions'][0]
@@ -153,7 +153,7 @@ class ArteTVIE(ArteTVBaseIE):
                     not m.group('sdh_sub'),                 # and we prefer not the hard-of-hearing subtitles if there are subtitles
                 )))
 
-            short_label = traverse_obj(stream_version, "shortLabel", expected_type=str, default='?')
+            short_label = traverse_obj(stream_version, 'shortLabel', expected_type=str, default='?')
             if stream['protocol'].startswith('HLS'):
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
                     stream['url'], video_id=video_id, ext='mp4', m3u8_id=stream_version_code, fatal=False)
@@ -163,7 +163,7 @@ class ArteTVIE(ArteTVBaseIE):
                         'language_preference': lang_pref,
                     })
                 if any(map(short_label.startswith, ('cc', 'OGsub'))):
-                    potential_duplicates.extend(fmts)
+                    secondary_formats.extend(fmts)
                 else:
                     formats.extend(fmts)
                 self._merge_subtitles(subs, target=subtitles)
@@ -184,7 +184,7 @@ class ArteTVIE(ArteTVBaseIE):
             # The JS also looks for chapters in config['data']['attributes']['chapters'],
             # but I am yet to find a video having those
 
-        formats.extend(potential_duplicates)
+        formats.extend(secondary_formats)
         self._remove_duplicate_formats(formats)
         self._sort_formats(formats)
 

--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -184,12 +184,8 @@ class ArteTVIE(ArteTVBaseIE):
             # The JS also looks for chapters in config['data']['attributes']['chapters'],
             # but I am yet to find a video having those
 
-        stream_urls = set(traverse_obj(formats, (..., 'url')))
-        for potential_duplicate in potential_duplicates:
-            if potential_duplicate['url'] in stream_urls:
-                self.write_debug(f'Ignoring duplicate format: {traverse_obj(potential_duplicate, "format_note")}')
-            else:
-                formats.append(potential_duplicate)
+        formats.extend(potential_duplicates)
+        self._remove_duplicate_formats(formats)
         self._sort_formats(formats)
 
         metadata = config['data']['attributes']['metadata']


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Remove duplicate streams if it is a subtitle only stream (`cc` or `OGsub`).

Fixes #4510

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
