### PR TITLE
Extractor for Microsoft embedded videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ ytdlp_plugins/extractor/*
 ytdlp_plugins/postprocessor/*
 !ytdlp_plugins/postprocessor/__init__.py
 !ytdlp_plugins/postprocessor/sample.py
+*.dfxp
+*.tt

--- a/.gitignore
+++ b/.gitignore
@@ -122,5 +122,3 @@ ytdlp_plugins/extractor/*
 ytdlp_plugins/postprocessor/*
 !ytdlp_plugins/postprocessor/__init__.py
 !ytdlp_plugins/postprocessor/sample.py
-*.dfxp
-*.tt

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3640,7 +3640,7 @@ class YoutubeDL:
             return None
         return render_table(
             self._list_format_headers('ID', 'Width', 'Height', 'URL'),
-            [[t.get('id'), t.get('width', 'unknown'), t.get('height', 'unknown'), t['url']] for t in thumbnails])
+            [[t.get('id'), t.get('width') or 'unknown', t.get('height') or 'unknown', t['url']] for t in thumbnails])
 
     def render_subtitles_table(self, video_id, subtitles):
         def _row(lang, formats):

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -958,6 +958,7 @@ from .microsoftvirtualacademy import (
     MicrosoftVirtualAcademyIE,
     MicrosoftVirtualAcademyCourseIE,
 )
+from .microsoftembed import MicrosoftEmbedIE
 from .mildom import (
     MildomIE,
     MildomVodIE,

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -6,8 +6,10 @@ from ..utils import (
 )
 from collections import OrderedDict
 
+
 class MicrosoftEmbedIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?microsoft\.com/en-us/videoplayer/embed/(?P<id>[a-z0-9A-Z]+)'
+
     _TESTS = [{
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
         'info_dict': {
@@ -34,7 +36,7 @@ class MicrosoftEmbedIE(InfoExtractor):
                 formats.extend(self._extract_m3u8_formats(stream_url, video_id))
             elif source_type == 'mPEG_DASH':
                 formats.extend(self._extract_mpd_formats(stream_url, video_id))
-            else: 
+            else:
                 formats.append({
                     'format_id': source_type,
                     'url': stream_url,

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -1,0 +1,38 @@
+from .common import InfoExtractor
+
+
+class MicrosoftEmbedIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?microsoft\.com/en-us/videoplayer/embed/[a-z0-9A-Z]+'
+    _TESTS = [{
+        'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
+        'only_matching': True
+    }]
+    _WEBPAGE_URL = 'https://prod-video-cms-rt-microsoft-com.akamaized.net/vhs/api/videos/'
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        metadata = self._download_json(
+            self.WEBPAGE_URL + video_id,
+            video_id)
+
+        formats = []
+        streams = metadata['streams']
+
+        for key, value in streams:
+            stream_url = value['url']
+
+            if key in ('smoothStreaming', 'apple_HTTP_Live_Streaming', 'mPEG_DASH'):
+                formats.extend(self._extract_ism_formats((stream_url, video_id)))
+
+            # else:
+            #     formats[key] = value
+
+        output = {
+            'id': video_id,
+            'title': metadata['snippet']['title'],
+            'thumbnails': metadata['snippet']['thumbnails'],
+            'timestamp': metadata['snippet']['activeStartDate'],
+            'formats': formats
+        }
+        return output

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -29,26 +29,36 @@ class MicrosoftEmbedIE(InfoExtractor):
 
             if source_type == 'smoothStreaming':
                 formats.extend(self._extract_ism_formats(stream_url, video_id, 'mss'))
-            elif source_type in ('apple_HTTP_Live_Streaming', 'mPEG_DASH'):
+            elif source_type == 'apple_HTTP_Live_Streaming':
                 formats.extend(self._extract_m3u8_formats(stream_url, video_id))
+            elif source_type == 'mPEG_DASH':
+                formats.extend(self._extract_mpd_formats(stream_url, video_id))
             else: 
                 formats.append({
                     'format_id': source_type,
-                    'url': stream_url
-                    # height...
-                    #width ...
+                    'url': stream_url,
+                    'height': source.get('heightPixels'),
+                    'width': source.get('widthPixels')
                 })
-            # else:
-            #     formats[key] = value
+
+        self._sort_formats(formats)
+        
+        timestamp = traverse_obj(
+            metadata, ('snippet', 'activeStartDate'))
+
+        age_limit = int_or_none(
+            traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0
+
         # TODO:
         # - extract subtitles (see expected return format in common.py)
         # - extract thumbnails (see expected return format in common.py)
         output = {
             'id': video_id,
-            'title': traverse_obj('snippet', 'title'),
+            'title': traverse_obj(metadata, ('snippet', 'title')),
             #'thumbnails': metadata['snippet']['thumbnails'],  # will need to extract into thumbnail list ofrmat
-            'timestamp': metadata['snippet']['activeStartDate'],  # use unified_timestamp from utils
+            'timestamp': unified_timestamp(timestamp),  # use unified_timestamp from utils
             'formats': formats,
-            'age_limit': int_or_none(traverse_obj('snippet', 'minimumAge')) or 0
+            'age_limit': age_limit,
+            'subtitles': ''
         }
         return output

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -50,7 +50,7 @@ class MicrosoftEmbedIE(InfoExtractor):
         age_limit = int_or_none(
             traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0
 
-        subtitles = {}
+        subtitles = OrderedDict()
 
         for lang, data in (traverse_obj(metadata, 'captions') or {}).items():
             subtitles[lang] = [{
@@ -58,15 +58,13 @@ class MicrosoftEmbedIE(InfoExtractor):
                 'ext': 'ttml'
             }]
 
-        thumbnails = {}
+        thumbnails = []
 
         for thumbnailSize, data in (traverse_obj(metadata, ('snippet', 'thumbnails')) or {}).items():
-            thumbnails[thumbnailSize] = [
-                OrderedDict({
-                    'url': data.get('url'),
-                    'http_headers': data.get('link')
-                })
-            ]
+            thumbnails.append({
+                'url': data.get('url'),
+                'http_headers': data.get('link')
+            })
 
         output = {
             'id': video_id,

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -21,9 +21,7 @@ class MicrosoftEmbedIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        metadata = self._download_json(
-            self._API_URL + video_id,
-            video_id)
+        metadata = self._download_json(self._API_URL + video_id, video_id)
 
         formats = []
         for source_type, source in metadata['streams'].items():

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -11,9 +11,12 @@ class MicrosoftEmbedIE(InfoExtractor):
 
     _TESTS = [{
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
+        'md5': '69a3bff81349094e91b303ff51393de2  Microsoft for Public Health and Social Services [RWL07e].mp4',
         'info_dict': {
-            'id': 'RWL07e',
-            'title': '...'
+            'id': r'?P<id>[a-z0-9A-Z]+',
+            'title': '...',
+            'ext': 'mp4',
+            'thumbnail': r're:^https?://.*\.jpg$'
         }
     }]
     _API_URL = 'https://prod-video-cms-rt-microsoft-com.akamaized.net/vhs/api/videos/'

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -56,7 +56,9 @@ class MicrosoftEmbedIE(InfoExtractor):
         }
 
         thumbnails = traverse_obj(metadata, ('snippet', 'thumbnails', ..., {
-            'url': 'url'
+            'url': 'url',
+            'width': 'width',
+            'height': 'height'
         }))
 
         return {

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -55,10 +55,10 @@ class MicrosoftEmbedIE(InfoExtractor):
             }] for lang, data in traverse_obj(metadata, 'captions', default={}).items()
         }
 
-        thumbnails = [{
-            'url': data.get('url'),
-            'http_headers': data.get('link')
-        } for thumbnail_size, data in traverse_obj(metadata, ('snippet', 'thumbnails'), default={}).items()]
+        thumbnails = traverse_obj(metadata, ('snippet', 'thumbnails', ..., {
+            'url': 'url',
+            'http_headers': 'link'
+        }))
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -48,9 +48,6 @@ class MicrosoftEmbedIE(InfoExtractor):
 
         self._sort_formats(formats)
 
-        timestamp = traverse_obj(
-            metadata, ('snippet', 'activeStartDate'))
-
         subtitles = {
             lang: [{
                 'url': data.get('url'),
@@ -66,7 +63,7 @@ class MicrosoftEmbedIE(InfoExtractor):
             'id': video_id,
             'title': traverse_obj(metadata, ('snippet', 'title')),
             'thumbnails': thumbnails,
-            'timestamp': unified_timestamp(timestamp),
+            'timestamp': unified_timestamp(traverse_obj(metadata, ('snippet', 'activeStartDate'))),
             'formats': formats,
             'age_limit': int_or_none(traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0,
             'subtitles': subtitles

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -45,21 +45,17 @@ class MicrosoftEmbedIE(InfoExtractor):
         timestamp = traverse_obj(
             metadata, ('snippet', 'activeStartDate'))
 
-        subtitles = {}
-
-        for lang, data in (traverse_obj(metadata, 'captions') or {}).items():
-            subtitles[lang] = [{
+        subtitles = {
+            lang: [{
                 'url': data.get('url'),
                 'ext': 'vtt'
-            }]
+            }] for lang, data in traverse_obj(metadata, 'captions', default={}).items()
+        }
 
-        thumbnails = []
-
-        for thumbnail_size, data in (traverse_obj(metadata, ('snippet', 'thumbnails')) or {}).items():
-            thumbnails.append({
-                'url': data.get('url'),
-                'http_headers': data.get('link')
-            })
+        thumbnails = [{
+            'url': data.get('url'),
+            'http_headers': data.get('link')
+        } for thumbnail_size, data in traverse_obj(metadata, ('snippet', 'thumbnails'), default={}).items()]
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -4,7 +4,6 @@ from ..utils import (
     unified_timestamp,
     int_or_none,
 )
-from collections import OrderedDict
 
 
 class MicrosoftEmbedIE(InfoExtractor):
@@ -52,7 +51,7 @@ class MicrosoftEmbedIE(InfoExtractor):
         age_limit = int_or_none(
             traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0
 
-        subtitles = OrderedDict()
+        subtitles = {}
 
         for lang, data in (traverse_obj(metadata, 'captions') or {}).items():
             subtitles[lang] = [{

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -2,18 +2,18 @@ from .common import InfoExtractor
 
 
 class MicrosoftEmbedIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?microsoft\.com/en-us/videoplayer/embed/[a-z0-9A-Z]+'
+    _VALID_URL = r'https?://(?:www\.)?microsoft\.com/en-us/videoplayer/embed/(?P<id>[a-z0-9A-Z]+)'
     _TESTS = [{
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
         'only_matching': True
     }]
-    _WEBPAGE_URL = 'https://prod-video-cms-rt-microsoft-com.akamaized.net/vhs/api/videos/'
+    _API_URL = 'https://prod-video-cms-rt-microsoft-com.akamaized.net/vhs/api/videos/'
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
         metadata = self._download_json(
-            self.WEBPAGE_URL + video_id,
+            self._API_URL + video_id,
             video_id)
 
         formats = []

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -42,12 +42,26 @@ class MicrosoftEmbedIE(InfoExtractor):
                 })
 
         self._sort_formats(formats)
-        
+
         timestamp = traverse_obj(
             metadata, ('snippet', 'activeStartDate'))
 
         age_limit = int_or_none(
             traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0
+
+        # subtitles = {}
+        #     'en-US': [
+        #         {
+        #             'url': '<subtitle url>'
+        #         }
+        #     ]
+        # }
+        subtitles = {}
+
+        for lang, data in (traverse_obj(metadata, 'captions') or {}).items():
+            subtitles[lang] = [{
+                'url': data.get('url')
+            }]
 
         # TODO:
         # - extract subtitles (see expected return format in common.py)
@@ -59,6 +73,6 @@ class MicrosoftEmbedIE(InfoExtractor):
             'timestamp': unified_timestamp(timestamp),  # use unified_timestamp from utils
             'formats': formats,
             'age_limit': age_limit,
-            'subtitles': ''
+            'subtitles': subtitles
         }
         return output

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -7,7 +7,7 @@ from ..utils import (
 
 
 class MicrosoftEmbedIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?microsoft\.com/en-us/videoplayer/embed/(?P<id>[a-z0-9A-Z]+)'
+    _VALID_URL = r'https?://(?:www\.)?microsoft\.com/(?:[^/]+/)?videoplayer/embed/(?P<id>[a-z0-9A-Z]+)'
 
     _TESTS = [{
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -20,10 +20,9 @@ class MicrosoftEmbedIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         metadata = self._download_json(self._API_URL + video_id, video_id)
-
         formats = []
+
         for source_type, source in metadata['streams'].items():
             stream_url = source['url']
 
@@ -45,9 +44,6 @@ class MicrosoftEmbedIE(InfoExtractor):
 
         timestamp = traverse_obj(
             metadata, ('snippet', 'activeStartDate'))
-
-        age_limit = int_or_none(
-            traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0
 
         subtitles = {}
 
@@ -71,6 +67,6 @@ class MicrosoftEmbedIE(InfoExtractor):
             'thumbnails': thumbnails,
             'timestamp': unified_timestamp(timestamp),
             'formats': formats,
-            'age_limit': age_limit,
+            'age_limit': int_or_none(traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0,
             'subtitles': subtitles
         }

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -1,11 +1,18 @@
 from .common import InfoExtractor
-
+from ..utils import (
+    traverse_obj,
+    unified_timestamp,
+    int_or_none,
+)
 
 class MicrosoftEmbedIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?microsoft\.com/en-us/videoplayer/embed/(?P<id>[a-z0-9A-Z]+)'
     _TESTS = [{
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
-        'only_matching': True
+        'info_dict': {
+            'id': 'RWL07e',
+            'title': '...'
+        }
     }]
     _API_URL = 'https://prod-video-cms-rt-microsoft-com.akamaized.net/vhs/api/videos/'
 
@@ -17,22 +24,31 @@ class MicrosoftEmbedIE(InfoExtractor):
             video_id)
 
         formats = []
-        streams = metadata['streams']
+        for source_type, source in metadata['streams'].items():
+            stream_url = source['url']
 
-        for key, value in streams.items():
-            stream_url = value['url']
-
-            if key in ('smoothStreaming', 'apple_HTTP_Live_Streaming', 'mPEG_DASH'):
-                formats.extend(self._extract_ism_formats(stream_url, video_id))
-
+            if source_type == 'smoothStreaming':
+                formats.extend(self._extract_ism_formats(stream_url, video_id, 'mss'))
+            elif source_type in ('apple_HTTP_Live_Streaming', 'mPEG_DASH'):
+                formats.extend(self._extract_m3u8_formats(stream_url, video_id))
+            else: 
+                formats.append({
+                    'format_id': source_type,
+                    'url': stream_url
+                    # height...
+                    #width ...
+                })
             # else:
             #     formats[key] = value
-
+        # TODO:
+        # - extract subtitles (see expected return format in common.py)
+        # - extract thumbnails (see expected return format in common.py)
         output = {
             'id': video_id,
-            'title': metadata['snippet']['title'],
-            'thumbnails': metadata['snippet']['thumbnails'],
-            'timestamp': metadata['snippet']['activeStartDate'],
-            'formats': formats
+            'title': traverse_obj('snippet', 'title'),
+            #'thumbnails': metadata['snippet']['thumbnails'],  # will need to extract into thumbnail list ofrmat
+            'timestamp': metadata['snippet']['activeStartDate'],  # use unified_timestamp from utils
+            'formats': formats,
+            'age_limit': int_or_none(traverse_obj('snippet', 'minimumAge')) or 0
         }
         return output

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -1,8 +1,8 @@
 from .common import InfoExtractor
 from ..utils import (
+    int_or_none,
     traverse_obj,
     unified_timestamp,
-    int_or_none,
 )
 
 
@@ -27,46 +27,44 @@ class MicrosoftEmbedIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         metadata = self._download_json(self._API_URL + video_id, video_id)
+
         formats = []
-
         for source_type, source in metadata['streams'].items():
-            stream_url = source['url']
-
-            if source_type == 'smoothStreaming':
-                formats.extend(self._extract_ism_formats(stream_url, video_id, 'mss'))
+            if source_type == 'smooth_Streaming':
+                formats.extend(self._extract_ism_formats(source['url'], video_id, 'mss'))
             elif source_type == 'apple_HTTP_Live_Streaming':
-                formats.extend(self._extract_m3u8_formats(stream_url, video_id))
+                formats.extend(self._extract_m3u8_formats(source['url'], video_id, 'mp4'))
             elif source_type == 'mPEG_DASH':
-                formats.extend(self._extract_mpd_formats(stream_url, video_id))
+                formats.extend(self._extract_mpd_formats(source['url'], video_id))
             else:
                 formats.append({
                     'format_id': source_type,
-                    'url': stream_url,
+                    'url': source['url'],
                     'height': source.get('heightPixels'),
-                    'width': source.get('widthPixels')
+                    'width': source.get('widthPixels'),
                 })
-
         self._sort_formats(formats)
 
         subtitles = {
             lang: [{
                 'url': data.get('url'),
-                'ext': 'vtt'
+                'ext': 'vtt',
             }] for lang, data in traverse_obj(metadata, 'captions', default={}).items()
         }
 
-        thumbnails = traverse_obj(metadata, ('snippet', 'thumbnails', ..., {
-            'url': 'url',
-            'width': 'width',
-            'height': 'height'
-        }))
+        thumbnails = [{
+            'url': thumb.get('url'),
+            'width': thumb.get('width') or None,
+            'height': thumb.get('height') or None,
+        } for thumb in traverse_obj(metadata, ('snippet', 'thumbnails', ...))]
+        self._remove_duplicate_formats(thumbnails)
 
         return {
             'id': video_id,
             'title': traverse_obj(metadata, ('snippet', 'title')),
-            'thumbnails': thumbnails,
             'timestamp': unified_timestamp(traverse_obj(metadata, ('snippet', 'activeStartDate'))),
-            'formats': formats,
             'age_limit': int_or_none(traverse_obj(metadata, ('snippet', 'minimumAge'))) or 0,
-            'subtitles': subtitles
+            'formats': formats,
+            'subtitles': subtitles,
+            'thumbnails': thumbnails,
         }

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -13,7 +13,7 @@ class MicrosoftEmbedIE(InfoExtractor):
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
         'md5': '69a3bff81349094e91b303ff51393de2  Microsoft for Public Health and Social Services [RWL07e].mp4',
         'info_dict': {
-            'id': r'?P<id>[a-z0-9A-Z]+',
+            'id': 'RWL07e',
             'title': '...',
             'ext': 'mp4',
             'thumbnail': r're:^https?://.*\.jpg$'

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -19,11 +19,11 @@ class MicrosoftEmbedIE(InfoExtractor):
         formats = []
         streams = metadata['streams']
 
-        for key, value in streams:
+        for key, value in streams.items():
             stream_url = value['url']
 
             if key in ('smoothStreaming', 'apple_HTTP_Live_Streaming', 'mPEG_DASH'):
-                formats.extend(self._extract_ism_formats((stream_url, video_id)))
+                formats.extend(self._extract_ism_formats(stream_url, video_id))
 
             # else:
             #     formats[key] = value

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -11,12 +11,15 @@ class MicrosoftEmbedIE(InfoExtractor):
 
     _TESTS = [{
         'url': 'https://www.microsoft.com/en-us/videoplayer/embed/RWL07e',
-        'md5': '69a3bff81349094e91b303ff51393de2  Microsoft for Public Health and Social Services [RWL07e].mp4',
+        'md5': 'eb0ae9007f9b305f9acd0a03e74cb1a9',
         'info_dict': {
             'id': 'RWL07e',
-            'title': '...',
+            'title': 'Microsoft for Public Health and Social Services',
             'ext': 'mp4',
-            'thumbnail': r're:^https?://.*\.jpg$'
+            'thumbnail': 'http://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RWL7Ju?ver=cae5',
+            'age_limit': 0,
+            'timestamp': 1631658316,
+            'upload_date': '20210914'
         }
     }]
     _API_URL = 'https://prod-video-cms-rt-microsoft-com.akamaized.net/vhs/api/videos/'

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -60,7 +60,7 @@ class MicrosoftEmbedIE(InfoExtractor):
 
         thumbnails = []
 
-        for thumbnailSize, data in (traverse_obj(metadata, ('snippet', 'thumbnails')) or {}).items():
+        for thumbnail_size, data in (traverse_obj(metadata, ('snippet', 'thumbnails')) or {}).items():
             thumbnails.append({
                 'url': data.get('url'),
                 'http_headers': data.get('link')

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -56,8 +56,7 @@ class MicrosoftEmbedIE(InfoExtractor):
         }
 
         thumbnails = traverse_obj(metadata, ('snippet', 'thumbnails', ..., {
-            'url': 'url',
-            'http_headers': 'link'
+            'url': 'url'
         }))
 
         return {

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -68,7 +68,7 @@ class MicrosoftEmbedIE(InfoExtractor):
                 'http_headers': data.get('link')
             })
 
-        output = {
+        return {
             'id': video_id,
             'title': traverse_obj(metadata, ('snippet', 'title')),
             'thumbnails': thumbnails,
@@ -77,4 +77,3 @@ class MicrosoftEmbedIE(InfoExtractor):
             'age_limit': age_limit,
             'subtitles': subtitles
         }
-        return output

--- a/yt_dlp/extractor/microsoftembed.py
+++ b/yt_dlp/extractor/microsoftembed.py
@@ -55,7 +55,7 @@ class MicrosoftEmbedIE(InfoExtractor):
         for lang, data in (traverse_obj(metadata, 'captions') or {}).items():
             subtitles[lang] = [{
                 'url': data.get('url'),
-                'ext': 'ttml'
+                'ext': 'vtt'
             }]
 
         thumbnails = []


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

An Extractor for Microsoft.com embedded videos. 

This feature proposal was created in support of the yt-dlp project during Hacktoberfest. It allows a user to scrape videos, metadata, thumbnails and subtitles. More information about this extractor can be found in issue #2638.

All lint errors have been resolved using `flake8` and a test has succeeded using CPython 3.10. The test used the `__main__.py` file as the entrypoint of a command line invocation.

This is a typical printout from a linux desktop's test:

    sushimint@sushimint:~/Desktop/Workshop/yt-dlp-fork$ cd yt_dlp
	sushimint@sushimint:~/Desktop/Workshop/yt-dlp-fork/yt_dlp$ python3 __main__.py https://www.microsoft.com/en-us/videoplayer/embed/RWL07e -v --write-subs
	[debug] Command-line config: ['https://www.microsoft.com/en-us/videoplayer/embed/RWL07e', '-v', '--write-subs']
	[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
	[debug] yt-dlp version 2022.09.01 [5d7c7d656] (source)
	[debug] Lazy loading extractors is disabled
	[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
	[debug] Git HEAD: a7cdda41f
	[debug] Python 3.8.10 (CPython 64bit) - Linux-5.4.0-126-generic-x86_64-with-glibc2.29 (glibc 2.31)
	[debug] Checking exe version: ffmpeg -bsfs
	[debug] Checking exe version: ffprobe -bsfs
	[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7, rtmpdump 2.4
	[debug] Optional libraries: Cryptodome-3.6.1, brotli-1.0.7, certifi-2019.11.28, mutagen-1.44.0, pyxattr-0.6.1, secretstorage-2.3.1, sqlite3-2.6.0, websockets-8.1
	[debug] Proxy map: {}
	[debug] Loaded 1678 extractors
	[debug] [MicrosoftEmbed] Extracting URL: https://www.microsoft.com/en-us/videoplayer/embed/RWL07e
	[MicrosoftEmbed] RWL07e: Downloading JSON metadata
	[MicrosoftEmbed] RWL07e: Downloading m3u8 information
	[MicrosoftEmbed] RWL07e: Downloading MPD manifest
	[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
	[info] RWL07e: Downloading subtitles: en-us
	[debug] Default format spec: bestvideo*+bestaudio/best
	[info] RWL07e: Downloading 1 format(s): 6722+106
	[info] Writing video subtitles to: Microsoft for Public Health and Social Services [RWL07e].en-us.vtt
	[debug] Invoking http downloader on "https://prod-video-cms-rt-microsoft-com.akamaized.net/cms/api/am/videofiledata/RWL07e-enus?ver=032b"
	[download] Destination: Microsoft for Public Health and Social Services [RWL07e].en-us.vtt
	[download] 100% of 5.03KiB in    00:00 at 231.32KiB/s
	[debug] Invoking hlsnative downloader on "https://wus-streaming-video-rt-microsoft-com.akamaized.net/064e1812-e02f-4fea-aff8-af73e11b3661/b6d9ea70-00f6-4786-be08-4fc9d1bf.ism/QualityLevels(6465762)/Manifest(video,format=m3u8-aapl)"
	[hlsnative] Downloading m3u8 manifest
	[hlsnative] Total fragments: 10
	[download] Destination: Microsoft for Public Health and Social Services [RWL07e].f6722.mp4
	[download] 100% of 79.19MiB in    00:02 at 29.51MiB/s
	[debug] Invoking hlsnative downloader on "https://wus-streaming-video-rt-microsoft-com.akamaized.net/064e1812-e02f-4fea-aff8-af73e11b3661/b6d9ea70-00f6-4786-be08-4fc9d1bf.ism/QualityLevels(96020)/Manifest(aac_UND_2_97,format=m3u8-aapl)"
	[hlsnative] Downloading m3u8 manifest
	[hlsnative] Total fragments: 10
	[download] Destination: Microsoft for Public Health and Social Services [RWL07e].f106.m4a
	[download] 100% of 1.24MiB in    00:00 at 3.72MiB/s
	[debug] ffmpeg command line: ffprobe -show_streams 'file:Microsoft for Public Health and Social Services [RWL07e].f106.m4a'
	[Merger] Merging formats into "Microsoft for Public Health and Social Services [RWL07e].mp4"
	[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:Microsoft for Public Health and Social Services [RWL07e].f6722.mp4' -i 'file:Microsoft for Public Health and Social Services [RWL07e].f106.m4a' -c copy -map 0:v:0 -map 1:a:0 -bsf:a:0 aac_adtstoasc -movflags +faststart 'file:Microsoft for Public Health and Social Services [RWL07e].temp.mp4'
	Deleting original file Microsoft for Public Health and Social Services [RWL07e].f6722.mp4 (pass -k to keep)
	Deleting original file Microsoft for Public Health and Social Services [RWL07e].f106.m4a (pass -k to keep)
	sushimint@sushimint:~/Desktop/Workshop/yt-dlp-fork/yt_dlp$  

The test took the following URL as input: [link](https://www.microsoft.com/en-us/videoplayer/embed/RWL07e)
The test resulted in two files being generated: 
    `Microsoft for Public Health and Social Services [RWL07e].mp4` 
    `Microsoft for Public Health and Social Services [RWL07e].en-us.vtt`

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [X] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
