### PR TITLE
[livestreamfails] Support alternative URLs

### DIFF
--- a/yt_dlp/extractor/livestreamfails.py
+++ b/yt_dlp/extractor/livestreamfails.py
@@ -3,21 +3,27 @@ from ..utils import format_field, traverse_obj, unified_timestamp
 
 
 class LivestreamfailsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?livestreamfails\.com/clip/(?P<id>[0-9]+)'
-    _TESTS = [{
-        'url': 'https://livestreamfails.com/clip/139200',
-        'md5': '8a03aea1a46e94a05af6410337463102',
-        'info_dict': {
-            'id': '139200',
-            'ext': 'mp4',
-            'display_id': 'ConcernedLitigiousSalmonPeteZaroll-O8yo9W2L8OZEKhV2',
-            'title': 'Streamer jumps off a trampoline at full speed',
-            'creator': 'paradeev1ch',
-            'thumbnail': r're:^https?://.+',
-            'timestamp': 1656271785,
-            'upload_date': '20220626',
+    _VALID_URL = r'https?://(?:www\.)?livestreamfails\.com/(clip|post)/(?P<id>[0-9]+)'
+    _TESTS = [
+        {
+            'url': 'https://livestreamfails.com/clip/139200',
+            'md5': '8a03aea1a46e94a05af6410337463102',
+            'info_dict': {
+                'id': '139200',
+                'ext': 'mp4',
+                'display_id': 'ConcernedLitigiousSalmonPeteZaroll-O8yo9W2L8OZEKhV2',
+                'title': 'Streamer jumps off a trampoline at full speed',
+                'creator': 'paradeev1ch',
+                'thumbnail': r're:^https?://.+',
+                'timestamp': 1656271785,
+                'upload_date': '20220626',
+            }
+        },
+        {
+            'url': 'https://livestreamfails.com/post/139200',
+            'only_matching': True,
         }
-    }]
+    ]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/yt_dlp/extractor/livestreamfails.py
+++ b/yt_dlp/extractor/livestreamfails.py
@@ -3,27 +3,24 @@ from ..utils import format_field, traverse_obj, unified_timestamp
 
 
 class LivestreamfailsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?livestreamfails\.com/(clip|post)/(?P<id>[0-9]+)'
-    _TESTS = [
-        {
-            'url': 'https://livestreamfails.com/clip/139200',
-            'md5': '8a03aea1a46e94a05af6410337463102',
-            'info_dict': {
-                'id': '139200',
-                'ext': 'mp4',
-                'display_id': 'ConcernedLitigiousSalmonPeteZaroll-O8yo9W2L8OZEKhV2',
-                'title': 'Streamer jumps off a trampoline at full speed',
-                'creator': 'paradeev1ch',
-                'thumbnail': r're:^https?://.+',
-                'timestamp': 1656271785,
-                'upload_date': '20220626',
-            }
-        },
-        {
-            'url': 'https://livestreamfails.com/post/139200',
-            'only_matching': True,
+    _VALID_URL = r'https?://(?:www\.)?livestreamfails\.com/(?:clip|post)/(?P<id>[0-9]+)'
+    _TESTS = [{
+        'url': 'https://livestreamfails.com/clip/139200',
+        'md5': '8a03aea1a46e94a05af6410337463102',
+        'info_dict': {
+            'id': '139200',
+            'ext': 'mp4',
+            'display_id': 'ConcernedLitigiousSalmonPeteZaroll-O8yo9W2L8OZEKhV2',
+            'title': 'Streamer jumps off a trampoline at full speed',
+            'creator': 'paradeev1ch',
+            'thumbnail': r're:^https?://.+',
+            'timestamp': 1656271785,
+            'upload_date': '20220626',
         }
-    ]
+    }, {
+        'url': 'https://livestreamfails.com/post/139200',
+        'only_matching': True,
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Support  alternatives URLs that contain /post instead of /clip (e.g. https://livestreamfails.com/post/139200 instead of https://livestreamfails.com/clip/139200).


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
