### PR TITLE
Tnaflix 500 err

### DIFF
--- a/yt_dlp/extractor/tnaflix.py
+++ b/yt_dlp/extractor/tnaflix.py
@@ -19,15 +19,11 @@ class TNAFlixNetworkBaseIE(InfoExtractor):
         r'config\s*=\s*(["\'])(?P<url>(?:https?:)?//(?:(?!\1).)+)\1',
     ]
     _HOST = 'tna'
-    _VIDEO_XML_URL = "https://www.tnaflix.com/cdn/cdn.php?file={}.fid&key={}&VID={}&nomp4=1&catID=0&rollover=1&" \
-                     "startThumb=12&embed=0&utm_source=0&multiview=0&premium=1&country=0user=0&vip=1&cd=0&ref=0&alpha"
+    _VIDEO_XML_URL = 'https://www.tnaflix.com/cdn/cdn.php?file={}.fid&key={}&VID={}&nomp4=1&catID=0&rollover=1&startThumb=12&embed=0&utm_source=0&multiview=0&premium=1&country=0user=0&vip=1&cd=0&ref=0&alpha'
     _VKEY_SUFFIX = ''
     _TITLE_REGEX = r'<input[^>]+name="title" value="([^"]+)"'
     _DESCRIPTION_REGEX = r'<input[^>]+name="description" value="([^"]+)"'
     _UPLOADER_REGEX = r'<input[^>]+name="username" value="([^"]+)"'
-    _VKEY_REGEX = r'<input id="vkey" type="hidden" value="(?P<vkey>[^"]+)" />'
-    _NKEY_REGEX = r'<input id="nkey" type="hidden" value="(?P<nkey>[^"]+)" />'
-    _VID_REGEX = r'<input id="VID" type="hidden" value="(?P<VID>[^"]+)" />'
     _VIEW_COUNT_REGEX = None
     _COMMENT_COUNT_REGEX = None
     _AVERAGE_RATING_REGEX = None
@@ -95,9 +91,9 @@ class TNAFlixNetworkBaseIE(InfoExtractor):
             group='url'), 'http:')
 
         if not cfg_url:
-            vkey = extract_field(self._VKEY_REGEX, 'vkey')
-            nkey = extract_field(self._NKEY_REGEX, 'nkey')
-            vid = extract_field(self._VID_REGEX, 'vid')
+            vkey = extract_field(r'<input id="vkey" type="hidden" value="(?P<vkey>[^"]+)" />', 'vkey')
+            nkey = extract_field(r'<input id="nkey" type="hidden" value="(?P<nkey>[^"]+)" />', 'nkey')
+            vid = extract_field(r'<input id="VID" type="hidden" value="(?P<VID>[^"]+)" />', 'vid')
             if vkey and nkey and vid:
                 cfg_url = self._proto_relative_url(self._VIDEO_XML_URL.format(vkey, nkey, vid), 'http:')
 

--- a/yt_dlp/extractor/tnaflix.py
+++ b/yt_dlp/extractor/tnaflix.py
@@ -91,9 +91,9 @@ class TNAFlixNetworkBaseIE(InfoExtractor):
             group='url'), 'http:')
 
         if not cfg_url:
-            vkey = extract_field(r'<input id="vkey" type="hidden" value="(?P<vkey>[^"]+)" />', 'vkey')
-            nkey = extract_field(r'<input id="nkey" type="hidden" value="(?P<nkey>[^"]+)" />', 'nkey')
-            vid = extract_field(r'<input id="VID" type="hidden" value="(?P<VID>[^"]+)" />', 'vid')
+            vkey = extract_field(r'<input id="vkey" type="hidden" value="([^"]+)"', 'vkey')
+            nkey = extract_field(r'<input id="nkey" type="hidden" value="([^"]+)"', 'nkey')
+            vid = extract_field(r'<input id="VID" type="hidden" value="([^"]+)"', 'vid')
             if vkey and nkey and vid:
                 cfg_url = self._proto_relative_url(self._VIDEO_XML_URL.format(vkey, nkey, vid), 'http:')
 

--- a/yt_dlp/extractor/tnaflix.py
+++ b/yt_dlp/extractor/tnaflix.py
@@ -91,9 +91,9 @@ class TNAFlixNetworkBaseIE(InfoExtractor):
             group='url'), 'http:')
 
         if not cfg_url:
-            vkey = extract_field(r'<input id="vkey" type="hidden" value="([^"]+)"', 'vkey')
-            nkey = extract_field(r'<input id="nkey" type="hidden" value="([^"]+)"', 'nkey')
-            vid = extract_field(r'<input id="VID" type="hidden" value="([^"]+)"', 'vid')
+            vkey = extract_field(r'<input\b[^>]+\bid="vkey"\b[^>]+\bvalue="([^"]+)"', 'vkey')
+            nkey = extract_field(r'<input\b[^>]+\bid="nkey"\b[^>]+\bvalue="([^"]+)"', 'nkey')
+            vid = extract_field(r'<input\b[^>]+\bid="VID"\b[^>]+\bvalue="([^"]+)"', 'vid')
             if vkey and nkey and vid:
                 cfg_url = self._proto_relative_url(self._VIDEO_XML_URL.format(vkey, nkey, vid), 'http:')
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fix Tnaflix 500 error code for video download

this MR

```
yt-dlp is up to date (2022.10.04)
[debug] [TNAFlix] Extracting URL: https://www.tnaflix.com/hd-videos/Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang/video4651785
[TNAFlix] Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang: Downloading webpage
[TNAFlix] Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang: Downloading metadata
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: best/bestvideo+bestaudio
[info] 4651785: Downloading 1 format(s): 720p
[download] Pantat Bulat dan Montok Dedek Hijab bikin Tegang [4651785].mp4 has already been downloaded
[download] 100% of   25.23MiB
[debug] Invoking http downloader on "http://fck-ch28.tnaflix.com/dev28/0/030/216/0030216658/Pantat_Bulat_dan_Montok_Dedek_Hijab_bikin_Tegang-720p.mp4?speed=268&burst=1097707&rb=1097707&rs=268&se=1665016237&ss=c133cee0177f0eba15e5f54a81908e8a"
```

current branch

```
yt-dlp is up to date (2022.10.04)
[debug] [TNAFlix] Extracting URL: https://www.tnaflix.com/hd-videos/Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang/video4651785
[TNAFlix] Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang: Downloading webpage
[TNAFlix] Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang: Downloading metadata
ERROR: [TNAFlix] 4651785: Unable to download XML: HTTP Error 500: Internal Server Error (caused by <HTTPError 500: 'Internal Server Error'>); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 672, in extract
    ie_result = self._real_extract(url)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\tnaflix.py", line 95, in _real_extract
    transform_source=fix_xml_ampersands, headers={'Referer': url})
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 1032, in download_content
    res = getattr(self, download_handle.__name__)(url_or_request, video_id, **kwargs)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 998, in download_handle
    data=data, headers=headers, query=query, expected_status=expected_status)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 866, in _download_webpage_handle
    urlh = self._request_webpage(url_or_request, video_id, note, errnote, fatal, data=data, headers=headers, query=query, expected_status=expected_status)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 823, in _request_webpage
    raise ExtractorError(errmsg, cause=err)

  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 805, in _request_webpage
    return self._downloader.urlopen(self._create_request(url_or_request, data, headers, query))
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\YoutubeDL.py", line 3684, in urlopen
    return self._opener.open(req, timeout=self._socket_timeout)
  File "C:\Python37\lib\urllib\request.py", line 531, in open
    response = meth(req, response)
  File "C:\Python37\lib\urllib\request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "C:\Python37\lib\urllib\request.py", line 569, in error
    return self._call_chain(*args)
  File "C:\Python37\lib\urllib\request.py", line 503, in _call_chain
    result = func(*args)
  File "C:\Python37\lib\urllib\request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 500: Internal Server Error
```


Fixes #5107


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
