### PR TITLE
[extractor/prankcast] Fix fatal error if guests_json is empty

### DIFF
--- a/yt_dlp/extractor/prankcast.py
+++ b/yt_dlp/extractor/prankcast.py
@@ -62,7 +62,7 @@ class PrankCastIE(InfoExtractor):
             'uploader': uploader,
             'channel_id': json_info.get('user_id'),
             'duration': try_call(lambda: parse_iso8601(json_info['end_date']) - start_date),
-            'cast': list(filter(None, [uploader] + (try_call(lambda: traverse_obj(guests_json, (..., 'name'))) or []))),
+            'cast': list(filter(None, [uploader] + traverse_obj(guests_json, (..., 'name'), default=[]))),
             'description': json_info.get('broadcast_description'),
             'categories': [json_info.get('broadcast_category')],
             'tags': self._parse_json(json_info.get('broadcast_tags') or '{}', video_id)

--- a/yt_dlp/extractor/prankcast.py
+++ b/yt_dlp/extractor/prankcast.py
@@ -4,24 +4,44 @@ from ..utils import parse_iso8601, traverse_obj, try_call
 
 class PrankCastIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?prankcast\.com/[^/?#]+/showreel/(?P<id>\d+)-(?P<display_id>[^/?#]+)'
-    _TESTS = [{
-        'url': 'https://prankcast.com/Devonanustart/showreel/1561-Beverly-is-back-like-a-heart-attack-',
-        'info_dict': {
-            'id': '1561',
-            'ext': 'mp3',
-            'title': 'Beverly is back like a heart attack!',
-            'display_id': 'Beverly-is-back-like-a-heart-attack-',
-            'timestamp': 1661391575,
-            'uploader': 'Devonanustart',
-            'channel_id': 4,
-            'duration': 7918,
-            'cast': ['Devonanustart', 'Phonelosers'],
-            'description': '',
-            'categories': ['prank'],
-            'tags': ['prank call', 'prank'],
-            'upload_date': '20220825'
+    _TESTS = [
+        {
+            'url': 'https://prankcast.com/Devonanustart/showreel/1561-Beverly-is-back-like-a-heart-attack-',
+            'info_dict': {
+                'id': '1561',
+                'ext': 'mp3',
+                'title': 'Beverly is back like a heart attack!',
+                'display_id': 'Beverly-is-back-like-a-heart-attack-',
+                'timestamp': 1661391575,
+                'uploader': 'Devonanustart',
+                'channel_id': 4,
+                'duration': 7918,
+                'cast': ['Devonanustart', 'Phonelosers'],
+                'description': '',
+                'categories': ['prank'],
+                'tags': ['prank call', 'prank'],
+                'upload_date': '20220825'
+            }
+        },
+        {
+            'url': 'https://prankcast.com/phonelosers/showreel/2048-NOT-COOL',
+            'info_dict': {
+                'id': '2048',
+                'ext': 'mp3',
+                'title': 'NOT COOL',
+                'display_id': 'NOT-COOL',
+                'timestamp': 1665028364,
+                'uploader': 'phonelosers',
+                'channel_id': 6,
+                'duration': 4044,
+                'cast': ['phonelosers'],
+                'description': '',
+                'categories': ['prank'],
+                'tags': ['prank call', 'prank'],
+                'upload_date': '20221006'
+            }
         }
-    }]
+    ]
 
     def _real_extract(self, url):
         video_id, display_id = self._match_valid_url(url).group('id', 'display_id')
@@ -42,7 +62,7 @@ class PrankCastIE(InfoExtractor):
             'uploader': uploader,
             'channel_id': json_info.get('user_id'),
             'duration': try_call(lambda: parse_iso8601(json_info['end_date']) - start_date),
-            'cast': list(filter(None, [uploader] + traverse_obj(guests_json, (..., 'name')))),
+            'cast': list(filter(None, [uploader] + (try_call(lambda: traverse_obj(guests_json, (..., 'name'))) or []))),
             'description': json_info.get('broadcast_description'),
             'categories': [json_info.get('broadcast_category')],
             'tags': self._parse_json(json_info.get('broadcast_tags') or '{}', video_id)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Currently if the guests_json is empty we get a "can only concatenate list" error. This wraps the traverse_obj in a try_call and returns an empty list if it fails. I've added a second test to check this.

```
[~] yt-dlp "https://prankcast.com/phonelosers/showreel/2048-NOT-COOL"
[PrankCast] 2048: Downloading webpage
ERROR: can only concatenate list (not "NoneType") to list
```

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
