### PR TITLE
[utils] `traverse_obj`: return `[]` if last path branches without default

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1890,6 +1890,7 @@ Line 1
                 {'index': 2},
                 {'index': 3},
             ),
+            'dict': {},
         }
 
         # Test base functionality
@@ -1933,7 +1934,7 @@ Line 1
                          msg='alternatives should return `default` if exhausted')
         self.assertEqual(traverse_obj(_TEST_DATA, (..., 'fail'), 100), 100,
                          msg='alternatives should track their own branching return')
-        self.assertEqual(traverse_obj({0: [], 1: ['res']}, (0, ...), (1, ...)), ['res'],
+        self.assertEqual(traverse_obj(_TEST_DATA, ('dict', ...), ('data', ...)), list(_TEST_DATA['data']),
                          msg='alternatives on empty objects should search further')
 
         # Test branch and path nesting
@@ -1967,14 +1968,16 @@ Line 1
         self.assertEqual(traverse_obj(_TEST_DATA, {0: ('urls', ((1, ('fail', 'url')), (0, 'url')))}),
                          {0: ['https://www.example.com/1', 'https://www.example.com/0']},
                          msg='tripple nesting in dict path should be treated as branches')
-        self.assertEqual(traverse_obj({}, {0: 1}), {},
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: 'fail'}), {},
                          msg='remove `None` values when dict key')
-        self.assertEqual(traverse_obj({}, {0: 1}, default=...), {0: ...},
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: 'fail'}, default=...), {0: ...},
                          msg='do not remove `None` values if `default`')
-        self.assertEqual(traverse_obj({0: [], 1: {}}, {0: 1}), {0: {}},
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: 'dict'}), {0: {}},
                          msg='do not remove empty values when dict key')
-        self.assertEqual(traverse_obj({0: [], 1: {}}, {0: 1}, default=...), {0: {}},
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: 'dict'}, default=...), {0: {}},
                          msg='do not remove empty values when dict key and a default')
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: ('dict', ...)}), {0: []},
+                         msg='if branch in dict key not successful, return `[]`')
 
         # Testing default parameter behavior
         _DEFAULT_DATA = {'None': None, 'int': 0, 'list': []}
@@ -1997,7 +2000,7 @@ Line 1
         self.assertEqual(traverse_obj(_DEFAULT_DATA, (..., 'fail')), [],
                          msg='if branched but not successful return `[]`, not `default`')
         self.assertEqual(traverse_obj(_DEFAULT_DATA, ('list', ...)), [],
-                         msg='branched but object is empty return `[]`, not `default`')
+                         msg='if branched but object is empty return `[]`, not `default`')
 
         # Testing expected_type behavior
         _EXPECTED_TYPE_DATA = {'str': 'str', 'int': 0}

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5428,16 +5428,18 @@ def traverse_obj(
 
         return has_branched, objs
 
-    def _traverse_obj(obj, path, last=True):
+    def _traverse_obj(obj, path, use_list=True):
         has_branched, results = apply_path(obj, path)
         results = LazyList(x for x in map(type_test, results) if x is not None)
-        if not results:
-            return [] if has_branched and last and default is NO_DEFAULT else None
 
-        return results.exhaust() if get_all and has_branched else results[0]
+        if get_all and has_branched:
+            return results.exhaust() if results or use_list else None
+
+        return results[0] if results else None
 
     for index, path in enumerate(paths, 1):
-        result = _traverse_obj(obj, path, index == len(paths))
+        use_list = default is NO_DEFAULT and index == len(paths)
+        result = _traverse_obj(obj, path, use_list)
         if result is not None:
             return result
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5305,7 +5305,6 @@ def traverse_obj(
 
     Each of the provided `paths` is tested and the first producing a valid result will be returned.
     The next path will also be tested if the path branched but no results could be found.
-    If the branching path is the last of `paths` always return a list.
     A value of None is treated as the absence of a value.
 
     The paths will be wrapped in `variadic`, so that `'key'` is conveniently the same as `('key', )`.
@@ -5344,6 +5343,7 @@ def traverse_obj(
     @returns                The result of the object traversal.
                             If successful, `get_all=True`, and the path branches at least once,
                             then a list of results is returned instead.
+                            A list is always returned if the last path branches.
     """
     is_sequence = lambda x: isinstance(x, collections.abc.Sequence) and not isinstance(x, (str, bytes))
     casefold = lambda k: k.casefold() if isinstance(k, str) else k

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5343,7 +5343,7 @@ def traverse_obj(
     @returns                The result of the object traversal.
                             If successful, `get_all=True`, and the path branches at least once,
                             then a list of results is returned instead.
-                            A list is always returned if the last path branches.
+                            A list is always returned if the last path branches and no `default` is given.
     """
     is_sequence = lambda x: isinstance(x, collections.abc.Sequence) and not isinstance(x, (str, bytes))
     casefold = lambda k: k.casefold() if isinstance(k, str) else k


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

It is common to see a pattern like `traverse_obj(obj, ...) or []` since the default is currently `None`.
This can cause developers to fall into the trap of doing `for item in traverse_obj(obj, ...)`.
This PR addresses this issue by defaulting to `[]` if the last path did not match and no default was provided.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

Closes #5162