### PR TITLE
[extractor/generic] Separate embed extractor into own function

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -66,6 +66,7 @@ from ..utils import (
     sanitize_filename,
     sanitize_url,
     sanitized_Request,
+    smuggle_url,
     str_or_none,
     str_to_int,
     strip_or_none,
@@ -3874,10 +3875,11 @@ class InfoExtractor:
     def RetryManager(self, **kwargs):
         return RetryManager(self.get_param('extractor_retries', 3), self._error_or_warning, **kwargs)
 
-    def _extract_generic_embeds(self, *args, info_dict={}, note='Extracting generic embeds', **kwargs):
+    def _extract_generic_embeds(self, url, *args, info_dict={}, note='Extracting generic embeds', **kwargs):
         display_id = traverse_obj(info_dict, 'display_id', 'id')
         self.to_screen(f'{format_field(display_id, None, "%s: ")}{note}')
-        return self._downloader.get_info_extractor('Generic')._extract_embeds(*args, **kwargs)
+        return self._downloader.get_info_extractor('Generic')._extract_embeds(
+            smuggle_url(url, {'block_ies': [self.ie_key()]}), *args, **kwargs)
 
     @classmethod
     def extract_from_webpage(cls, ydl, url, webpage):

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -3874,6 +3874,9 @@ class InfoExtractor:
     def RetryManager(self, **kwargs):
         return RetryManager(self.get_param('extractor_retries', 3), self._error_or_warning, **kwargs)
 
+    def _extract_generic_embeds(self, *args, **kwargs):
+        return self._downloader.get_info_extractor('Generic')._extract_embeds(*args, **kwargs)
+
     @classmethod
     def extract_from_webpage(cls, ydl, url, webpage):
         ie = (cls if isinstance(cls._extract_from_webpage, types.MethodType)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -3874,7 +3874,9 @@ class InfoExtractor:
     def RetryManager(self, **kwargs):
         return RetryManager(self.get_param('extractor_retries', 3), self._error_or_warning, **kwargs)
 
-    def _extract_generic_embeds(self, *args, **kwargs):
+    def _extract_generic_embeds(self, *args, info_dict={}, note='Extracting generic embeds', **kwargs):
+        display_id = traverse_obj(info_dict, 'display_id', 'id')
+        self.to_screen(f'{format_field(display_id, None, "%s: ")}{note}')
         return self._downloader.get_info_extractor('Generic')._extract_embeds(*args, **kwargs)
 
     @classmethod

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -2786,8 +2786,6 @@ class GenericIE(InfoExtractor):
         self._downloader.write_debug('Looking for embeds')
         embeds = []
         for ie in self._downloader._ies.values():
-            if ie == type(self):  # Prevent recursion
-                continue
             gen = ie.extract_from_webpage(self._downloader, url, webpage)
             current_embeds = []
             try:


### PR DESCRIPTION
@coletdjnz Check that this works well enough your requirement. Will merge after you have confirmed

* I have tried to make minimal changes. But there is still changes to some of the extraction. But these only ever add more metadata, so it should be fine. Besides, there are changes that would eventually be needed for #4517 anyway

* It's not viable to make `_extract_embeds` a `classmethod`. But we still need to access it from other extractors. One option would be to move it into `common.py`, but then any related functions will also have to be moved there. Instead, Ive opted to create the `_extract_generic_embeds` wrapper. After #4517, if this function ends up being simple enough, we could still move it into common, replacing the current wrapper

* ~~I added a check to prevent accidental recursion of `extract_from_webpage`. Idk if it will ever actually be useful though. More importantly, do you think there is any use-case where it's harmful?~~
