### PR TITLE
Tnaflix: remote extra chars from regex

### DIFF
--- a/yt_dlp/extractor/tnaflix.py
+++ b/yt_dlp/extractor/tnaflix.py
@@ -91,9 +91,9 @@ class TNAFlixNetworkBaseIE(InfoExtractor):
             group='url'), 'http:')
 
         if not cfg_url:
-            vkey = extract_field(r'<input\b[^>]+\bid="vkey"\b[^>]+\bvalue="([^"]+)"', 'vkey')
-            nkey = extract_field(r'<input\b[^>]+\bid="nkey"\b[^>]+\bvalue="([^"]+)"', 'nkey')
-            vid = extract_field(r'<input\b[^>]+\bid="VID"\b[^>]+\bvalue="([^"]+)"', 'vid')
+            vkey = extract_field(r'<input[^>]+id="vkey"[^>]+value="([^"]+)"', 'vkey')
+            nkey = extract_field(r'<input[^>]+id="nkey"[^>]+value="([^"]+)"', 'nkey')
+            vid = extract_field(r'<input[^>]+id="VID"[^>]+value="([^"]+)"', 'vid')
             if vkey and nkey and vid:
                 cfg_url = self._proto_relative_url(self._VIDEO_XML_URL.format(vkey, nkey, vid), 'http:')
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fix Tnaflix 500 error code for video download

this MR

```
Latest version: 2022.10.04, Current version: 2022.10.04
yt-dlp is up to date (2022.10.04)
[debug] [TNAFlix] Extracting URL: https://www.tnaflix.com/amateur-porn/Fiona-Lewis-Breasts-Scene-in-Tintorera/video4674185?isFeatured=1
[TNAFlix] Fiona-Lewis-Breasts-Scene-in-Tintorera: Downloading webpage
[TNAFlix] Fiona-Lewis-Breasts-Scene-in-Tintorera: Downloading metadata
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: best/bestvideo+bestaudio
[info] 4674185: Downloading 1 format(s): 360p
[download] Fiona Lewis Breasts Scene  in Tintorera [4674185].mp4 has already been downloaded
[download] 100% of    1.46MiB
[debug] Invoking http downloader on "http://fck-ch38.tnaflix.com/dev38/0/030/294/0030294007/Fiona_Lewis_Breasts_Scene_in_Tintorera-360p.mp4?speed=91&burst=294461&rb=294461&rs=91&se=1665344314&ss=a9f4c25f6e29d81838861838b984b45f"

Process finished with exit code 0
```

current branch

```
yt-dlp is up to date (2022.10.04)
[debug] [TNAFlix] Extracting URL: https://www.tnaflix.com/hd-videos/Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang/video4651785
[TNAFlix] Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang: Downloading webpage
[TNAFlix] Pantat-Bulat-dan-Montok-Dedek-Hijab-bikin-Tegang: Downloading metadata
ERROR: [TNAFlix] 4651785: Unable to download XML: HTTP Error 500: Internal Server Error (caused by <HTTPError 500: 'Internal Server Error'>); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 672, in extract
    ie_result = self._real_extract(url)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\tnaflix.py", line 95, in _real_extract
    transform_source=fix_xml_ampersands, headers={'Referer': url})
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 1032, in download_content
    res = getattr(self, download_handle.__name__)(url_or_request, video_id, **kwargs)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 998, in download_handle
    data=data, headers=headers, query=query, expected_status=expected_status)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 866, in _download_webpage_handle
    urlh = self._request_webpage(url_or_request, video_id, note, errnote, fatal, data=data, headers=headers, query=query, expected_status=expected_status)
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 823, in _request_webpage
    raise ExtractorError(errmsg, cause=err)

  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\extractor\common.py", line 805, in _request_webpage
    return self._downloader.urlopen(self._create_request(url_or_request, data, headers, query))
  File "C:\Users\admin\Documents\project\yt-dlp\yt_dlp\YoutubeDL.py", line 3684, in urlopen
    return self._opener.open(req, timeout=self._socket_timeout)
  File "C:\Python37\lib\urllib\request.py", line 531, in open
    response = meth(req, response)
  File "C:\Python37\lib\urllib\request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "C:\Python37\lib\urllib\request.py", line 569, in error
    return self._call_chain(*args)
  File "C:\Python37\lib\urllib\request.py", line 503, in _call_chain
    result = func(*args)
  File "C:\Python37\lib\urllib\request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 500: Internal Server Error
```


Fixes #5107


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
