### PR TITLE
[redgifs], handle /users/ links

### DIFF
--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -23,6 +23,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         'origin': 'https://www.redgifs.com',
         'content-type': 'application/json',
     }
+    _TOKEN_BASE_URL = "https://www.redgifs.com/watch/"
 
     def _parse_gif_data(self, gif_data):
         video_id = gif_data.get('id')
@@ -65,7 +66,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
 
     def _fetch_oauth_token(self, video_id):
         # These pages contain the OAuth token that is necessary to make API calls.
-        index_page = self._download_webpage(f'https://www.redgifs.com/watch/{video_id}', video_id)
+        index_page = self._download_webpage(f'{self._TOKEN_BASE_URL}{video_id}', video_id)
         index_js_uri = self._html_search_regex(
             r'href="?(/assets/js/index[.a-z0-9]*.js)"?\W', index_page, 'index_js_uri')
         index_js = self._download_webpage(f'https://www.redgifs.com/{index_js_uri}', video_id)
@@ -242,6 +243,7 @@ class RedGifsUserIE(RedGifsBaseInfoExtractor):
             'playlist_mincount': 100,
         }
     ]
+    _TOKEN_BASE_URL = "https://www.redgifs.com/users/"
 
     def _real_extract(self, url):
         username, query_str = self._match_valid_url(url).group('username', 'query')

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -23,7 +23,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         'origin': 'https://www.redgifs.com',
         'content-type': 'application/json',
     }
-    _TOKEN_BASE_URL = "https://www.redgifs.com/watch/"
+    _TOKEN_BASE_URL = ""
 
     def _parse_gif_data(self, gif_data):
         video_id = gif_data.get('id')
@@ -65,8 +65,8 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         }
 
     def _fetch_oauth_token(self, video_id):
-        if not hasattr(self, "_TOKEN_BASE_URL"):
-            raise ExtractorError("Can't get OAUTH token, _TOKEN_BASE_URL doesn't exist", expected=True, video_id=video_id)
+        if self._TOKEN_BASE_URL == "":
+            raise ExtractorError("Can't get OAUTH token, _TOKEN_BASE_URL is empty", expected=True, video_id=video_id)
         # These pages contain the OAuth token that is necessary to make API calls.
         index_page = self._download_webpage(f'{self._TOKEN_BASE_URL}{video_id}', video_id)
         index_js_uri = self._html_search_regex(

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -65,6 +65,8 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         }
 
     def _fetch_oauth_token(self, video_id):
+        if not hasattr(self, "_TOKEN_BASE_URL"):
+            raise ExtractorError(f"Can't get OAUTH token, _TOKEN_BASE_URL doesn't exist", expected=True, video_id=video_id)
         # These pages contain the OAuth token that is necessary to make API calls.
         index_page = self._download_webpage(f'{self._TOKEN_BASE_URL}{video_id}', video_id)
         index_js_uri = self._html_search_regex(
@@ -148,6 +150,7 @@ class RedGifsIE(RedGifsBaseInfoExtractor):
             'tags': list,
         }
     }]
+    _TOKEN_BASE_URL = "https://www.redgifs.com/watch/"
 
     def _real_extract(self, url):
         video_id = self._match_id(url).lower()
@@ -189,6 +192,7 @@ class RedGifsSearchIE(RedGifsBaseInfoExtractor):
             'playlist_count': 80,
         }
     ]
+    _TOKEN_BASE_URL = "https://www.redgifs.com/browse?"
 
     def _real_extract(self, url):
         query_str = self._match_valid_url(url).group('query')

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -66,7 +66,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
 
     def _fetch_oauth_token(self, video_id):
         if not hasattr(self, "_TOKEN_BASE_URL"):
-            raise ExtractorError(f"Can't get OAUTH token, _TOKEN_BASE_URL doesn't exist", expected=True, video_id=video_id)
+            raise ExtractorError("Can't get OAUTH token, _TOKEN_BASE_URL doesn't exist", expected=True, video_id=video_id)
         # These pages contain the OAuth token that is necessary to make API calls.
         index_page = self._download_webpage(f'{self._TOKEN_BASE_URL}{video_id}', video_id)
         index_js_uri = self._html_search_regex(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
`yt-dlp` supports for redgifs.com next types of links:

https://www.redgifs.com/watch/*
https://www.redgifs.com/users/*
https://www.redgifs.com/browse?tags=*

Current implementation of function `_fetch_oauth_token` works only with first link, all other links are raise 404 error

Current `master` branch fails `test_RedGifsSearch` and `test_RedGifsUser` cases

```
    raise DownloadError(message, exc_info)
yt_dlp.utils.DownloadError: ERROR: Unable to download webpage: HTTP Error 404: Not Found (caused by <HTTPError 404: 'Not Found'>); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U

----------------------------------------------------------------------
Ran 1 test in 1.074s

FAILED (errors=1)
```

New changes pass these tests
```
[info] minordependentwisent: Downloading 1 format(s): hd
[info] Writing video metadata as JSON to: test_RedGifsSearch_minordependentwisent.info.json
[info] Writing updated playlist metadata as JSON to: test_RedGifsSearch_tags=Lesbian.info.json
[download] Finished downloading playlist: Lesbian
.
----------------------------------------------------------------------
Ran 1 test in 2.708s

OK
```

```
[info] kosherstarchygallowaycow: Downloading 1 format(s): hd
[info] Writing video metadata as JSON to: test_RedGifsUser_kosherstarchygallowaycow.info.json
[info] Writing updated playlist metadata as JSON to: test_RedGifsUser_lamsinka89.info.json
[download] Finished downloading playlist: lamsinka89
.
----------------------------------------------------------------------
Ran 1 test in 2.470s

OK
```

Fixes #5202


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
