### PR TITLE
[extractor/twitter] Base extractor api overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1763,7 +1763,7 @@ The following extractors use this feature:
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`
 
 #### twitter
-* `force_graphql`: Force usage of the GraphQL-API. By default it will only be used if login cookies are provided.
+* `force_graphql`: Force usage of the GraphQL API. By default it will only be used if login cookies are provided
 
 NOTE: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/README.md
+++ b/README.md
@@ -1762,6 +1762,8 @@ The following extractors use this feature:
 #### rokfinchannel
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`
 
+#### twitter
+* `force_graphql`: Force usage of the GraphQL-API. By default it will only be used if login cookies are provided.
 
 NOTE: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1940,6 +1940,7 @@ from .twitter import (
     TwitterIE,
     TwitterAmplifyIE,
     TwitterBroadcastIE,
+    TwitterSpacesIE,
     TwitterShortenerIE,
 )
 from .udemy import (

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -754,13 +754,13 @@ class TwitterSpacesIE(TwitterBaseIE):
         }
         live_status = SPACE_SATUS.get(metadata.get('state').lower())
 
-        # partecipants
-        partecipants = join_nonempty(*[p.get('display_name') for p in traverse_obj(data, ('participants', 'speakers'))], delim=', ') or 'nobody yet.'
+        # participants
+        participants = join_nonempty(*[p.get('display_name') for p in traverse_obj(data, ('participants', 'speakers'))], delim=', ') or 'nobody yet.'
 
         return {
             'id': space_id,
             'title': metadata.get('title'),
-            'description': f'Twitter Space partecipated by {partecipants}',
+            'description': f'Twitter Space partecipated by {participants}',
             'media_key': metadata.get('media_key'),
             'uploader': traverse_obj(
                 metadata, ('creator_results', 'result', 'legacy', 'name')),

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -762,7 +762,7 @@ class TwitterIE(TwitterBaseIE):
     def _real_extract(self, url):
         twid = self._match_id(url)
         if self.is_logged_in or self._configuration_arg('force_graphql'):
-            self.write_debug(f'Using GraphQL API (Auth = {self.logged_in}')
+            self.write_debug(f'Using GraphQL API (Auth = {self.is_logged_in}')
             result = self._call_graphql_api('zZXycP0V6H7m-2r0mOnFcA/TweetDetail', twid)
             status = self._graphql_to_legacy(result, twid)
 

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -19,7 +19,6 @@ from ..utils import (
     make_archive_id,
     str_or_none,
     strip_or_none,
-    join_nonempty,
     traverse_obj,
     try_call,
     try_get,
@@ -166,7 +165,7 @@ class TwitterCardIE(InfoExtractor):
             'url': 'https://twitter.com/i/cards/tfw/v1/560070183650213889',
             # MD5 checksums are different in different places
             'info_dict': {
-                'id': '560070183650213889',
+                'id': '560070131976392705',
                 'ext': 'mp4',
                 'title': "Twitter - You can now shoot, edit and share video on Twitter. Capture life's most moving moments from your perspective.",
                 'description': 'md5:18d3e24bb4f6e5007487dd546e53bd96',
@@ -176,6 +175,13 @@ class TwitterCardIE(InfoExtractor):
                 'duration': 30.033,
                 'timestamp': 1422366112,
                 'upload_date': '20150127',
+                'age_limit': 0,
+                'comment_count': int,
+                'tags': [],
+                'repost_count': int,
+                'like_count': int,
+                'display_id': '560070183650213889',
+                'uploader_url': 'https://twitter.com/Twitter',
             },
         },
         {
@@ -190,7 +196,14 @@ class TwitterCardIE(InfoExtractor):
                 'uploader_id': 'NASA',
                 'timestamp': 1437408129,
                 'upload_date': '20150720',
+                'uploader_url': 'https://twitter.com/NASA',
+                'age_limit': 0,
+                'comment_count': int,
+                'like_count': int,
+                'repost_count': int,
+                'tags': ['PlutoFlyby'],
             },
+            'params': {'format': '[protocol=https]'}
         },
         {
             'url': 'https://twitter.com/i/cards/tfw/v1/654001591733886977',
@@ -203,12 +216,27 @@ class TwitterCardIE(InfoExtractor):
                 'upload_date': '20111013',
                 'uploader': 'OMG! UBUNTU!',
                 'uploader_id': 'omgubuntu',
+                'channel_url': 'https://www.youtube.com/channel/UCIiSwcm9xiFb3Y4wjzR41eQ',
+                'channel_id': 'UCIiSwcm9xiFb3Y4wjzR41eQ',
+                'channel_follower_count': int,
+                'chapters': 'count:8',
+                'uploader_url': 'http://www.youtube.com/user/omgubuntu',
+                'duration': 138,
+                'categories': ['Film & Animation'],
+                'age_limit': 0,
+                'comment_count': int,
+                'availability': 'public',
+                'like_count': int,
+                'thumbnail': 'https://i.ytimg.com/vi/dq4Oj5quskI/maxresdefault.jpg',
+                'view_count': int,
+                'tags': 'count:12',
+                'channel': 'OMG! UBUNTU!',
+                'playable_in_embed': True,
             },
             'add_ie': ['Youtube'],
         },
         {
             'url': 'https://twitter.com/i/cards/tfw/v1/665289828897005568',
-            'md5': '6dabeaca9e68cbb71c99c322a4b42a11',
             'info_dict': {
                 'id': 'iBb2x00UVlv',
                 'ext': 'mp4',
@@ -217,9 +245,17 @@ class TwitterCardIE(InfoExtractor):
                 'uploader': 'ArsenalTerje',
                 'title': 'Vine by ArsenalTerje',
                 'timestamp': 1447451307,
+                'alt_title': 'Vine by ArsenalTerje',
+                'comment_count': int,
+                'like_count': int,
+                'thumbnail': r're:^https?://[^?#]+\.jpg',
+                'view_count': int,
+                'repost_count': int,
             },
             'add_ie': ['Vine'],
-        }, {
+            'params': {'skip_download': 'm3u8'},
+        },
+        {
             'url': 'https://twitter.com/i/videos/tweet/705235433198714880',
             'md5': '884812a2adc8aaf6fe52b15ccbfa3b88',
             'info_dict': {
@@ -233,7 +269,8 @@ class TwitterCardIE(InfoExtractor):
                 'upload_date': '20160303',
             },
             'skip': 'This content is no longer available.',
-        }, {
+        },
+        {
             'url': 'https://twitter.com/i/videos/752274308186120192',
             'only_matching': True,
         },
@@ -291,10 +328,10 @@ class TwitterIE(TwitterBaseIE):
             'id': '665052190608723968',
             'display_id': '665052190608723968',
             'ext': 'mp4',
-            'title': 'Star Wars - A new beginning is coming December 18. Watch the official 60 second #TV spot for #StarWars: #TheForceAwakens.',
+            'title': 'md5:3f57ab5d35116537a2ae7345cd0060d8',
             'description': 'A new beginning is coming December 18. Watch the official 60 second #TV spot for #StarWars: #TheForceAwakens. https://t.co/OkSqT2fjWJ',
             'uploader_id': 'starwars',
-            'uploader': 'Star Wars',
+            'uploader': r're:Star Wars.*',
             'timestamp': 1447395772,
             'upload_date': '20151113',
             'uploader_url': 'https://twitter.com/starwars',
@@ -501,23 +538,6 @@ class TwitterIE(TwitterBaseIE):
         },
         'add_ie': ['TwitterBroadcast'],
     }, {
-        # Twitter Spaces
-        'url': 'https://twitter.com/MoniqueCamarra/status/1550101959377551360',
-        'info_dict': {
-            'id': '1lPJqmBeeNAJb',
-            'ext': 'm4a',
-            'title': 'EuroFile@6 Ukraine Up-date-Draghi Defenestration-the West',
-            'uploader': r're:Monique Camarra.+?',
-            'uploader_id': 'MoniqueCamarra',
-            'live_status': 'was_live',
-            'description': 'md5:c62fc4c35ce2e0e977d5a72fc3418594',
-            'timestamp': 1658407771464,
-        },
-        'add_ie': ['TwitterSpaces'],
-        'params': {
-            'skip_download': True,  # requires ffmpeg
-        },
-    }, {
         # unified card
         'url': 'https://twitter.com/BrooklynNets/status/1349794411333394432?s=20',
         'info_dict': {
@@ -624,7 +644,7 @@ class TwitterIE(TwitterBaseIE):
             'tags': [],
             'age_limit': 18,
         },
-        'expected_warnings': ['404'],
+        'skip': '404',
     }, {
         'url': 'https://twitter.com/Srirachachau/status/1395079556562706435',
         'playlist_mincount': 2,
@@ -679,6 +699,21 @@ class TwitterIE(TwitterBaseIE):
             'like_count': int,
             'tags': ['TheRingsOfPower'],
         },
+    }, {
+        # Twitter Spaces
+        'url': 'https://twitter.com/MoniqueCamarra/status/1550101959377551360',
+        'info_dict': {
+            'id': '1lPJqmBeeNAJb',
+            'ext': 'm4a',
+            'title': 'EuroFile@6 Ukraine Up-date-Draghi Defenestration-the West',
+            'uploader': r're:Monique Camarra.+?',
+            'uploader_id': 'MoniqueCamarra',
+            'live_status': 'was_live',
+            'description': 'md5:acce559345fd49f129c20dbcda3f1201',
+            'timestamp': 1658407771464,
+        },
+        'add_ie': ['TwitterSpaces'],
+        'params': {'skip_download': 'm3u8'},
     }, {
         # onion route
         'url': 'https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/TwitterBlue/status/1484226494708662273',
@@ -965,13 +1000,14 @@ class TwitterAmplifyIE(TwitterBaseIE):
 
     _TEST = {
         'url': 'https://amp.twimg.com/v/0ba0c3c7-0af3-4c0a-bed5-7efd1ffa2951',
-        'md5': '7df102d0b9fd7066b86f3159f8e81bf6',
+        'md5': 'fec25801d18a4557c5c9f33d2c379ffa',
         'info_dict': {
             'id': '0ba0c3c7-0af3-4c0a-bed5-7efd1ffa2951',
             'ext': 'mp4',
             'title': 'Twitter Video',
             'thumbnail': 're:^https?://.*',
         },
+        'params': {'format': '[protocol=https]'},
     }
 
     def _real_extract(self, url):
@@ -980,7 +1016,7 @@ class TwitterAmplifyIE(TwitterBaseIE):
 
         vmap_url = self._html_search_meta(
             'twitter:amplify:vmap', webpage, 'vmap url')
-        formats = self._extract_formats_from_vmap_url(vmap_url, video_id)
+        formats, _ = self._extract_formats_from_vmap_url(vmap_url, video_id)
 
         thumbnails = []
         thumbnail = self._html_search_meta(
@@ -1028,6 +1064,8 @@ class TwitterBroadcastIE(TwitterBaseIE, PeriscopeBaseIE):
             'title': 'Andrea May Sahouri - Periscope Broadcast',
             'uploader': 'Andrea May Sahouri',
             'uploader_id': '1PXEdBZWpGwKe',
+            'thumbnail': r're:^https?://[^?#]+\.jpg\?token=',
+            'view_count': int,
         },
     }
 
@@ -1062,22 +1100,20 @@ class TwitterSpacesIE(TwitterBaseIE):
             'id': '1RDxlgyvNXzJL',
             'ext': 'm4a',
             'title': 'King Carlo e la mossa Kansas City per fare il Grande Centro',
-            'description': 'Twitter Space partecipated by annarita digiorgio, Signor Ernesto, Raffaello Colosimo, Simone M. Sepe',
+            'description': 'Twitter Space participated by annarita digiorgio, Signor Ernesto, Raffaello Colosimo, Simone M. Sepe',
             'uploader': r're:Lucio Di Gaetano.*?',
             'uploader_id': 'luciodigaetano',
             'live_status': 'was_live',
             'timestamp': 1659877956397,
         },
-        'params': {
-            'skip_download': True,  # requires ffmpeg
-        },
+        'params': {'skip_download': 'm3u8'},
     }, {
         # Twitter Space not started yet
         'url': 'https://twitter.com/i/spaces/1mnGeRyljQPJX',
         'info_dict': {
             'id': '1mnGeRyljQPJX',
             'title': '@staderlabs x Hedera AMA w/ @defigirlxoxo, @bmgentile, & @thehbarbull',
-            'description': 'Twitter Space partecipated by nobody yet.',
+            'description': 'Twitter Space participated by nobody yet',
             'uploader': 'Hedera',
             'uploader_id': 'hedera',
             'live_status': 'is_upcoming',
@@ -1085,7 +1121,7 @@ class TwitterSpacesIE(TwitterBaseIE):
         },
         'params': {
             'ignore_no_formats_error': True,
-            'skip_download': True,  # requires ffmpeg
+            'skip_download': True,
         },
         'expected_warnings': ['Twitter Space not started yet', 'No video formats found', 'Requested format is not available'],
     }]

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -752,12 +752,12 @@ class TwitterSpacesIE(TwitterBaseIE):
             live_status = 'post_live'
 
         # partecipants
-        partecipants = join_nonempty(*[p.get('display_name') for p in traverse_obj(data, ('participants', 'speakers'))], delim=', ')
+        partecipants = join_nonempty(*[p.get('display_name') for p in traverse_obj(data, ('participants', 'speakers'))], delim=', ') or 'nobody yet.'
 
         return {
             'id': space_id,
             'title': metadata.get('title'),
-            'description': f"Twitter Space partecipated by {partecipants or 'nobody yet.'}",
+            'description': f'Twitter Space partecipated by {partecipants}',
             'media_key': metadata.get('media_key'),
             'uploader': traverse_obj(
                 metadata, ('creator_results', 'result', 'legacy', 'name')),

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -397,7 +397,7 @@ class TwitterIE(TwitterBaseIE):
             'live_status': 'was_live',
             'description': 'md5:c62fc4c35ce2e0e977d5a72fc3418594',
         },
-        'add_ie': ['TwitterSpaces'], 
+        'add_ie': ['TwitterSpaces'],
     }, {
         # unified card
         'url': 'https://twitter.com/BrooklynNets/status/1349794411333394432?s=20',
@@ -468,7 +468,6 @@ class TwitterIE(TwitterBaseIE):
         uploader = user.get('name')
         if uploader:
             title = '%s - %s' % (uploader, title)
-
         uploader_id = user.get('screen_name')
 
         tags = []

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -625,27 +625,30 @@ class TwitterIE(TwitterBaseIE):
             'age_limit': 0,
         },
     }, {
-        'url': 'https://twitter.com/i/web/status/1579846363218870272',
+        # Adult content, uses old token
+        # Fails if not logged in (GraphQL)
+        'url': 'https://twitter.com/Rizdraws/status/1575199173472927762',
         'info_dict': {
-            'id': '1579846355576659970',
-            'display_id': '1579846363218870272',
+            'id': '1575199163847000068',
+            'display_id': '1575199173472927762',
             'ext': 'mp4',
-            'title': 'PokiLewd \U0001f51e - @Rizdraws',
-            'thumbnail': r're:^https?://.*\.jpg',
-            'description': '@Rizdraws https://t.co/oSl56cgKKD',
-            'uploader': 'PokiLewd \U0001f51e',
-            'uploader_id': 'pokilewd',
-            'uploader_url': 'https://twitter.com/pokilewd',
-            'timestamp': 1665499699,
-            'upload_date': '20221011',
-            'comment_count': int,
-            'repost_count': int,
+            'title': str,
+            'description': str,
+            'uploader': str,
+            'uploader_id': 'Rizdraws',
+            'uploader_url': 'https://twitter.com/Rizdraws',
+            'upload_date': '20220928',
+            'timestamp': 1664391723,
+            'thumbnail': 're:^https?://.*\\.jpg',
             'like_count': int,
-            'tags': [],
+            'repost_count': int,
+            'comment_count': int,
             'age_limit': 18,
+            'tags': []
         },
-        'skip': '404',
+        'expected_warnings': ['404'],
     }, {
+        # Description is missing one https://t.co url (GraphQL)
         'url': 'https://twitter.com/Srirachachau/status/1395079556562706435',
         'playlist_mincount': 2,
         'info_dict': {
@@ -664,6 +667,7 @@ class TwitterIE(TwitterBaseIE):
             'timestamp': 1621447860,
         },
     }, {
+        # Description is missing one https://t.co url (GraphQL)
         'url': 'https://twitter.com/DavidToons_/status/1578353380363501568',
         'playlist_mincount': 2,
         'info_dict': {

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -799,11 +799,17 @@ class TwitterSpacesIE(TwitterBaseIE):
             m3u8_url = source.get('noRedirectPlaybackUrl') or source['location']
             m3u8_id = 'live' if info['is_live'] else 'replay'
 
+            # force entry_protocol to m3u8 because m3u8_native is broken
             formats = self._extract_m3u8_formats(
-                m3u8_url, media_key, 'mp4', m3u8_id=m3u8_id)
+                m3u8_url, media_key, 'm4a',
+                m3u8_id=m3u8_id, entry_protocol='m3u8',
+                live=info['is_live'])
             # force audio-only
             for i in range(len(formats)):
-                formats[i].update({'vcodec': 'none'})
+                formats[i].update({
+                    'vcodec': 'none',
+                    'acodec': 'aac',
+                })
 
         return {
             **info,

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -766,7 +766,7 @@ class TwitterIE(TwitterBaseIE):
 
     def _real_extract(self, url):
         twid = self._match_id(url)
-        use_graphql = self.is_logged_in() or True
+        use_graphql = self.is_logged_in()
 
         force_graphql = bool(self._configuration_arg('force_graphql'))
         if force_graphql and not use_graphql:

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -143,8 +143,11 @@ class TwitterBaseIE(InfoExtractor):
                     'Twitter API gave 404 response, retrying with deprecated token. '
                     'This means only one media item can be extracted.')
 
-        error_message = ' '.join(traverse_obj(result, ('errors', ..., 'message')))
-        if error_message:
+        errors = traverse_obj(result, 'errors')
+        if errors:
+            error_message = ', '.join(set(traverse_obj(errors, (..., 'message'), expected_type=str)))
+            if not error_message:
+                error_message = 'Unknown error.'
             raise ExtractorError(f'Error(s) while querying api: {error_message}', expected=True)
 
         assert result is not None

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1115,23 +1115,40 @@ class TwitterSpacesIE(TwitterBaseIE):
             'timestamp': metadata.get('created_at'),
         }
 
+    def _build_graphql_query(self, space_id):
+        return {
+            'variables': {
+                'id': space_id,
+                'isMetatagsQuery': True,
+                'withDownvotePerspective': False,
+                'withReactionsMetadata': False,
+                'withReactionsPerspective': False,
+                'withReplays': True,
+                'withSuperFollowsUserFields': True,
+                'withSuperFollowsTweetFields': True,
+            },
+            'features': {
+                'dont_mention_me_view_api_enabled': True,
+                'interactive_text_enabled': True,
+                'responsive_web_edit_tweet_api_enabled': True,
+                'responsive_web_enhance_cards_enabled': True,
+                'responsive_web_uc_gql_enabled': True,
+                'spaces_2022_h2_clipping': True,
+                'spaces_2022_h2_spaces_communities': False,
+                'standardized_nudges_misinfo': True,
+                'tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled': False,
+                'vibe_api_enabled': True,
+            },
+        }
+
     def _real_extract(self, url):
         space_id = self._match_id(url)
-
-        space_data = self._call_api(
-            'AudioSpaceById',
-            space_id,
-            query={
-                'variables': f'{{"id":"{space_id}","isMetatagsQuery":true,"withSuperFollowsUserFields":true,"withDownvotePerspective":false,"withReactionsMetadata":false,"withReactionsPerspective":false,"withSuperFollowsTweetFields":true,"withReplays":true}}',
-                'features': '{"spaces_2022_h2_clipping":true,"spaces_2022_h2_spaces_communities":false,"dont_mention_me_view_api_enabled":true,"interactive_text_enabled":true,"responsive_web_uc_gql_enabled":true,"vibe_api_enabled":true,"responsive_web_edit_tweet_api_enabled":true,"standardized_nudges_misinfo":true,"tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled":false,"responsive_web_enhance_cards_enabled":true}'
-            },
-            api_base_url=self._TWITTER_GRAPHQL
-        )['data']['audioSpace']
+        space_data = self._call_graphql_api('HPEisOmj1epUNLCWTYhUWw/AudioSpaceById', space_id)
 
         if not space_data:
             self.raise_no_formats('Twitter Space not found', expected=True)
 
-        info = self._parse_spaces_data(space_data, space_id)
+        info = self._parse_spaces_data(space_data.get('audioSpace'), space_id)
 
         formats = []
         media_key = info.pop('media_key')

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1111,23 +1111,6 @@ class TwitterSpacesIE(TwitterBaseIE):
             'timestamp': 1659877956397,
         },
         'params': {'skip_download': 'm3u8'},
-    }, {
-        # Twitter Space not started yet
-        'url': 'https://twitter.com/i/spaces/1mnGeRyljQPJX',
-        'info_dict': {
-            'id': '1mnGeRyljQPJX',
-            'title': '@staderlabs x Hedera AMA w/ @defigirlxoxo, @bmgentile, & @thehbarbull',
-            'description': 'Twitter Space participated by nobody yet',
-            'uploader': 'Hedera',
-            'uploader_id': 'hedera',
-            'live_status': 'is_upcoming',
-            'timestamp': 1662394668924,
-        },
-        'params': {
-            'ignore_no_formats_error': True,
-            'skip_download': True,
-        },
-        'expected_warnings': ['Twitter Space not started yet', 'No video formats found', 'Requested format is not available'],
     }]
 
     SPACE_STATUS = {
@@ -1165,11 +1148,11 @@ class TwitterSpacesIE(TwitterBaseIE):
 
     def _real_extract(self, url):
         space_id = self._match_id(url)
-        space_data = self._call_graphql_api('HPEisOmj1epUNLCWTYhUWw/AudioSpaceById', space_id)
+        space_data = self._call_graphql_api('HPEisOmj1epUNLCWTYhUWw/AudioSpaceById', space_id)['audioSpace']
         if not space_data:
             raise ExtractorError('Twitter Space not found', expected=True)
 
-        metadata = space_data['audioSpace']['metadata']
+        metadata = space_data['metadata']
         live_status = try_call(lambda: self.SPACE_STATUS[metadata['state'].lower()])
 
         formats = []
@@ -1189,7 +1172,7 @@ class TwitterSpacesIE(TwitterBaseIE):
                 fmt.update({'vcodec': 'none', 'acodec': 'aac'})
 
         participants = ', '.join(traverse_obj(
-            space_data, ('audioSpace', 'participants', 'speakers', ..., 'display_name'))) or 'nobody yet'
+            space_data, ('participants', 'speakers', ..., 'display_name'))) or 'nobody yet'
         return {
             'id': space_id,
             'title': metadata.get('title'),


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The PR introduces the following changes:
- Provide GraphQL API for future usage (this + #4864).
    - GraphQL errors are handled gracefully, extracting the error from the returned data.
- Allow usage of GraphQL for `TwitterIE` which transforms the GraphQL result into a v1.1 result.
    - In this transformation, Tombstones are filtered and returned as an `ExtractorError` with explicit message.
- Allow the use of cookies for requests (Fixes #1605), using GraphQL.
    - This also enables extraction for NSFW tweets with multiple media.
- Fallback to the old token if the new token gives a 404 (Fixes #5233).
- Stabilize multiple media support for cards (e.g. in [this](https://twitter.com/primevideouk/status/1578401165338976258) Tweet).
- Add an extractor arg (`force_graphql`) to force the usage of GraphQL on unauthenticated api requests.

All tests working with the v1.1 API work with GraphQL as well. Exceptions are:
- 17: NSFW fallback is not implemented for GraphQL, so it will issue an error if login cookies are not passed.
- 18 and 19: While GraphQL returns mostly the same data there are instances it does not.
    For these the returned url entities do not match, resulting in the description lacking some `https://t.co` urls.

Massive thanks to @bashonly for helping with this PR.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))