### PR TITLE
[rumble] add HLS formats

### DIFF
--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -2400,42 +2400,6 @@ class GenericIE(InfoExtractor):
             }
         },
         {
-            'note': 'Rumble embed',
-            'url': 'https://rumble.com/vdmum1-moose-the-dog-helps-girls-dig-a-snow-fort.html',
-            'md5': '53af34098a7f92c4e51cf0bd1c33f009',
-            'info_dict': {
-                'id': 'vb0ofn',
-                'ext': 'mp4',
-                'timestamp': 1612662578,
-                'uploader': 'LovingMontana',
-                'channel': 'LovingMontana',
-                'upload_date': '20210207',
-                'title': 'Winter-loving dog helps girls dig a snow fort ',
-                'channel_url': 'https://rumble.com/c/c-546523',
-                'thumbnail': 'https://sp.rmbl.ws/s8/1/5/f/x/x/5fxxb.OvCc.1-small-Moose-The-Dog-Helps-Girls-D.jpg',
-                'duration': 103,
-                'live_status': 'not_live',
-            }
-        },
-        {
-            'note': 'Rumble JS embed',
-            'url': 'https://therightscoop.com/what-does-9-plus-1-plus-1-equal-listen-to-this-audio-of-attempted-kavanaugh-assassins-call-and-youll-get-it',
-            'md5': '4701209ac99095592e73dbba21889690',
-            'info_dict': {
-                'id': 'v15eqxl',
-                'ext': 'mp4',
-                'channel': 'Mr Producer Media',
-                'duration': 92,
-                'title': '911 Audio From The Man Who Wanted To Kill Supreme Court Justice Kavanaugh',
-                'channel_url': 'https://rumble.com/c/RichSementa',
-                'thumbnail': 'https://sp.rmbl.ws/s8/1/P/j/f/A/PjfAe.OvCc-small-911-Audio-From-The-Man-Who-.jpg',
-                'timestamp': 1654892716,
-                'uploader': 'Mr Producer Media',
-                'upload_date': '20220610',
-                'live_status': 'not_live',
-            }
-        },
-        {
             'note': 'JSON LD with multiple @type',
             'url': 'https://www.nu.nl/280161/video/hoe-een-bladvlo-dit-verwoestende-japanse-onkruid-moet-vernietigen.html',
             'md5': 'c7949f34f57273013fb7ccb1156393db',

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -2414,6 +2414,7 @@ class GenericIE(InfoExtractor):
                 'channel_url': 'https://rumble.com/c/c-546523',
                 'thumbnail': 'https://sp.rmbl.ws/s8/1/5/f/x/x/5fxxb.OvCc.1-small-Moose-The-Dog-Helps-Girls-D.jpg',
                 'duration': 103,
+                'live_status': 'not_live',
             }
         },
         {
@@ -2431,6 +2432,7 @@ class GenericIE(InfoExtractor):
                 'timestamp': 1654892716,
                 'uploader': 'Mr Producer Media',
                 'upload_date': '20220610',
+                'live_status': 'not_live',
             }
         },
         {

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -6,6 +6,7 @@ from ..compat import compat_HTTPError
 from ..utils import (
     int_or_none,
     parse_iso8601,
+    traverse_obj,
     unescapeHTML,
     ExtractorError,
 )
@@ -107,6 +108,10 @@ class RumbleEmbedIE(InfoExtractor):
         video = self._download_json(
             'https://rumble.com/embedJS/u3/', video_id,
             query={'request': 'video', 'ver': 2, 'v': video_id})
+
+        sys_msg = traverse_obj(video, ('sys', 'msg'), default=None)
+        if sys_msg:
+            self.report_warning(sys_msg, video_id=video_id)
 
         if not video.get('livestream_has_dvr'):
             live_status = 'not_live'

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -144,10 +144,11 @@ class RumbleEmbedIE(InfoExtractor):
                 if not video_info.get('url'):
                     continue
                 if ext == 'hls':
-                    formats.extend(self._extract_m3u8_formats(
-                        video_info['url'], video_id, ext='mp4', m3u8_id='hls', fatal=False))
                     if meta.get('live') is True and video.get('live') == 1:
                         live_status = 'post_live'
+                    formats.extend(self._extract_m3u8_formats(
+                        video_info['url'], video_id,
+                        ext='mp4', m3u8_id='hls', fatal=False, live=live_status == 'is_live'))
                     continue
                 formats.append({
                     'ext': ext,

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -28,6 +28,7 @@ class RumbleEmbedIE(InfoExtractor):
             'thumbnail': 'https://sp.rmbl.ws/s8/1/5/M/z/1/5Mz1a.OvCc-small-WMAR-2-News-Latest-Headline.jpg',
             'duration': 234,
             'uploader': 'WMAR',
+            'live_status': 'not_live',
         }
     }, {
         'url': 'https://rumble.com/embed/vslb7v',
@@ -43,7 +44,49 @@ class RumbleEmbedIE(InfoExtractor):
             'thumbnail': 'https://sp.rmbl.ws/s8/6/7/i/9/h/7i9hd.OvCc.jpg',
             'duration': 901,
             'uploader': 'CTNews',
+            'live_status': 'not_live',
         }
+    }, {
+        'url': 'https://rumble.com/embed/vunh1h',
+        'info_dict': {
+            'id': 'vunh1h',
+            'ext': 'mp4',
+            'title': '‘Gideon, op zoek naar de waarheid’ including ENG SUBS',
+            'timestamp': 1647197663,
+            'upload_date': '20220313',
+            'channel_url': 'https://rumble.com/user/BLCKBX',
+            'channel': 'BLCKBX',
+            'thumbnail': r're:https://.+\.jpg',
+            'duration': 5069,
+            'uploader': 'BLCKBX',
+            'live_status': 'not_live',
+            'subtitles': {
+                'en': [
+                    {
+                        'url': r're:https://.+\.vtt',
+                        'name': 'English',
+                        'ext': 'vtt'
+                    }
+                ]
+            },
+        },
+        'params': {'skip_download': True}
+    }, {
+        'url': 'https://rumble.com/embed/v1essrt',
+        'info_dict': {
+            'id': 'v1essrt',
+            'ext': 'mp4',
+            'title': 'startswith:lofi hip hop radio - beats to relax/study',
+            'timestamp': 1661519399,
+            'upload_date': '20220826',
+            'channel_url': 'https://rumble.com/c/LofiGirl',
+            'channel': 'Lofi Girl',
+            'thumbnail': r're:https://.+\.jpg',
+            'duration': None,
+            'uploader': 'Lofi Girl',
+            'live_status': 'is_live',
+        },
+        'params': {'skip_download': True}
     }, {
         'url': 'https://rumble.com/embed/ufe9n.v5pv5f',
         'only_matching': True,

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -64,7 +64,6 @@ class RumbleEmbedIE(InfoExtractor):
         video = self._download_json(
             'https://rumble.com/embedJS/', video_id,
             query={'request': 'video', 'v': video_id})
-        title = unescapeHTML(video['title'])
 
         formats = []
         for height, ua in (video.get('ua') or {}).items():
@@ -95,7 +94,7 @@ class RumbleEmbedIE(InfoExtractor):
 
         return {
             'id': video_id,
-            'title': title,
+            'title': unescapeHTML(video['title']),
             'formats': formats,
             'subtitles': subtitles,
             'thumbnail': video.get('i'),

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -110,6 +110,45 @@ class RumbleEmbedIE(InfoExtractor):
         'only_matching': True,
     }]
 
+    _WEBPAGE_TESTS = [
+        {
+            'note': 'Rumble embed',
+            'url': 'https://rumble.com/vdmum1-moose-the-dog-helps-girls-dig-a-snow-fort.html',
+            'md5': '53af34098a7f92c4e51cf0bd1c33f009',
+            'info_dict': {
+                'id': 'vb0ofn',
+                'ext': 'mp4',
+                'timestamp': 1612662578,
+                'uploader': 'LovingMontana',
+                'channel': 'LovingMontana',
+                'upload_date': '20210207',
+                'title': 'Winter-loving dog helps girls dig a snow fort ',
+                'channel_url': 'https://rumble.com/c/c-546523',
+                'thumbnail': 'https://sp.rmbl.ws/s8/1/5/f/x/x/5fxxb.OvCc.1-small-Moose-The-Dog-Helps-Girls-D.jpg',
+                'duration': 103,
+                'live_status': 'not_live',
+            }
+        },
+        {
+            'note': 'Rumble JS embed',
+            'url': 'https://therightscoop.com/what-does-9-plus-1-plus-1-equal-listen-to-this-audio-of-attempted-kavanaugh-assassins-call-and-youll-get-it',
+            'md5': '4701209ac99095592e73dbba21889690',
+            'info_dict': {
+                'id': 'v15eqxl',
+                'ext': 'mp4',
+                'channel': 'Mr Producer Media',
+                'duration': 92,
+                'title': '911 Audio From The Man Who Wanted To Kill Supreme Court Justice Kavanaugh',
+                'channel_url': 'https://rumble.com/c/RichSementa',
+                'thumbnail': 'https://sp.rmbl.ws/s8/1/P/j/f/A/PjfAe.OvCc-small-911-Audio-From-The-Man-Who-.jpg',
+                'timestamp': 1654892716,
+                'uploader': 'Mr Producer Media',
+                'upload_date': '20220610',
+                'live_status': 'not_live',
+            }
+        },
+    ]
+
     @classmethod
     def _extract_embed_urls(cls, url, webpage):
         embeds = tuple(super()._extract_embed_urls(url, webpage))

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -138,7 +138,8 @@ class RumbleEmbedIE(InfoExtractor):
                     'ext': ext,
                     'url': video_info['url'],
                     'format_id': '%s-%sp' % (ext, height),
-                    'height': int_or_none(height)
+                    'height': int_or_none(height),
+                    'fps': video.get('fps'),
                 }
                 fmt.update(
                     {key: meta[meta_key] for meta_key, key in self.FORMAT_MAPPING.items()

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -89,6 +89,23 @@ class RumbleEmbedIE(InfoExtractor):
         },
         'params': {'skip_download': True}
     }, {
+        'url': 'https://rumble.com/embed/v1amumr',
+        'info_dict': {
+            'id': 'v1amumr',
+            'ext': 'webm',
+            'fps': 60,
+            'title': 'Turning Point USA 2022 Student Action Summit DAY 1  - Rumble Exclusive Live',
+            'timestamp': 1658518457,
+            'upload_date': '20220722',
+            'channel_url': 'https://rumble.com/c/RumbleEvents',
+            'channel': 'Rumble Events',
+            'thumbnail': r're:https://.+\.jpg',
+            'duration': 16427,
+            'uploader': 'Rumble Events',
+            'live_status': 'was_live',
+        },
+        'params': {'skip_download': True}
+    }, {
         'url': 'https://rumble.com/embed/ufe9n.v5pv5f',
         'only_matching': True,
     }]

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -118,7 +118,7 @@ class RumbleChannelIE(InfoExtractor):
         },
     }, {
         'url': 'https://rumble.com/user/goldenpoodleharleyeuna',
-        'playlist_count': 4,
+        'playlist_mincount': 4,
         'info_dict': {
             'id': 'goldenpoodleharleyeuna',
         },


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Rumble provides additional m3u8 formats. This PR supports them and sets the appropriate live status.
The JSON provides a 'live' code which reads as follows:
* 0 - not live
* 1 - was live / dvr
* 2 - currently live

Upcoming videos have live status code 1 but the HLS formats are not downloadable (HTTP 404)
The other mp4 files provide a preview/announcement of about 6 seconds.

Fixes #5277 
Fixes #5177


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
