### PR TITLE
[extractor/paramountplus] Update API token

### DIFF
--- a/yt_dlp/extractor/paramountplus.py
+++ b/yt_dlp/extractor/paramountplus.py
@@ -40,7 +40,6 @@ class ParamountPlusIE(CBSBaseIE):
         'params': {
             'skip_download': 'm3u8',
         },
-        'expected_warnings': ['Ignoring subtitle tracks'],  # TODO: Investigate this
     }, {
         'url': 'https://www.paramountplus.com/shows/video/6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd/',
         'info_dict': {
@@ -63,7 +62,6 @@ class ParamountPlusIE(CBSBaseIE):
         'params': {
             'skip_download': 'm3u8',
         },
-        'expected_warnings': ['Ignoring subtitle tracks'],
     }, {
         'url': 'https://www.paramountplus.com/movies/video/vM2vm0kE6vsS2U41VhMRKTOVHyQAr6pC/',
         'info_dict': {
@@ -118,8 +116,11 @@ class ParamountPlusIE(CBSBaseIE):
 
     def _extract_video_info(self, content_id, mpx_acc=2198311517):
         items_data = self._download_json(
-            'https://www.paramountplus.com/apps-api/v2.0/androidtv/video/cid/%s.json' % content_id,
-            content_id, query={'locale': 'en-us', 'at': 'ABCqWNNSwhIqINWIIAG+DFzcFUvF8/vcN6cNyXFFfNzWAIvXuoVgX+fK4naOC7V8MLI='}, headers=self.geo_verification_headers())
+            f'https://www.paramountplus.com/apps-api/v2.0/androidtv/video/cid/{content_id}.json',
+            content_id, query={
+                'locale': 'en-us',
+                'at': 'ABCXgPuoStiPipsK0OHVXIVh68zNys+G4f7nW9R6qH68GDOcneW6Kg89cJXGfiQCsj0=',
+            }, headers=self.geo_verification_headers())
 
         asset_types = {
             item.get('assetType'): {


### PR DESCRIPTION
Fixes broken API requests by updating the token.

Closes #5273 

```shellsession
$ yt_dlp -v -F https://www.paramountplus.com/shows/video/kGirBXHpqTs8cDR1lLP2JPUTsw414PIv/
[debug] Command-line config: ['-v', '-F', 'https://www.paramountplus.com/shows/video/kGirBXHpqTs8cDR1lLP2JPUTsw414PIv/']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.10.04 [4e0511f27]
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Python 3.10.8 (CPython 64bit) - Linux-6.0.2-arch1-1-x86_64-with-glibc2.36 (glibc 2.36)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 5.1.2 (setts), ffprobe 5.1.2
[debug] Optional libraries: Cryptodome-3.12.0, brotlicffi-1.0.9.2, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1698 extractors
[debug] [ParamountPlus] Extracting URL: https://www.paramountplus.com/shows/video/kGirBXHpqTs8cDR1lLP2JPUTsw414PIv/
[ParamountPlus] kGirBXHpqTs8cDR1lLP2JPUTsw414PIv: Downloading JSON metadata
[ParamountPlus] kGirBXHpqTs8cDR1lLP2JPUTsw414PIv: Downloading JSON metadata
[ParamountPlus] kGirBXHpqTs8cDR1lLP2JPUTsw414PIv: Downloading DASH_CENC_PRECON SMIL data
[ParamountPlus] kGirBXHpqTs8cDR1lLP2JPUTsw414PIv: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for kGirBXHpqTs8cDR1lLP2JPUTsw414PIv:
ID       EXT RESOLUTION │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────
hls-96   mp4 audio only │ ~ 30.52MiB   96k m3u8  │ audio only        mp4a.40.2 96k
hls-499  mp4 640x360    │ ~158.62MiB  499k m3u8  │ avc1.640028  499k mp4a.40.2  0k
hls-840  mp4 768x432    │ ~267.01MiB  840k m3u8  │ avc1.640028  840k mp4a.40.2  0k
hls-1614 mp4 960x540    │ ~513.04MiB 1614k m3u8  │ avc1.640028 1614k mp4a.40.2  0k
hls-2207 mp4 1024x576   │ ~701.54MiB 2207k m3u8  │ avc1.640028 2207k mp4a.40.2  0k
hls-3091 mp4 1280x720   │ ~982.54MiB 3091k m3u8  │ avc1.640028 3091k mp4a.40.2  0k
hls-4570 mp4 1920x1080  │ ~  1.42GiB 4570k m3u8  │ avc1.640028 4570k mp4a.40.2  0k
```

```shellsession
$ python test/test_download.py TestDownload.test_ParamountPlus
[debug] Loaded 1698 extractors
[debug] [ParamountPlus] Extracting URL: https://www.paramountplus.com/shows/video/Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k/
[ParamountPlus] Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k: Downloading JSON metadata
[ParamountPlus] Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k: Downloading JSON metadata
[ParamountPlus] Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k: Downloading DASH_CENC_PRECON SMIL data
[ParamountPlus] Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k: Downloading 1 format(s): hls-3113
[info] Writing video metadata as JSON to: test_ParamountPlus_Oe44g5_NrlgiZE3aQVONleD6vXc8kP0k.info.json
.
----------------------------------------------------------------------
Ran 1 test in 1.635s

OK
```

```shellsession
$ python test/test_download.py TestDownload.test_ParamountPlus_1
[debug] Loaded 1698 extractors
[debug] [ParamountPlus] Extracting URL: https://www.paramountplus.com/shows/video/6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd/
[ParamountPlus] 6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd: Downloading JSON metadata
[ParamountPlus] 6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd: Downloading JSON metadata
[ParamountPlus] 6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd: Downloading DASH_CENC_PRECON SMIL data
[ParamountPlus] 6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] 6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd: Downloading 1 format(s): hls-4507
[info] Writing video metadata as JSON to: test_ParamountPlus_1_6hSWYWRrR9EUTz7IEe5fJKBhYvSUfexd.info.json
.
----------------------------------------------------------------------
Ran 1 test in 1.798s

OK
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
