### PR TITLE
Fix bug with `simulate` param and `list_only` options

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -649,6 +649,13 @@ class YoutubeDL:
         else:
             self.params['nooverwrites'] = not self.params['overwrites']
 
+        if self.params.get('simulate') is None and any([
+            self.params.get('list_thumbnails'),
+            self.params.get('listformats'),
+            self.params.get('listsubtitles'),
+        ]):
+            self.params['simulate'] = True
+
         self.params.setdefault('forceprint', {})
         self.params.setdefault('print_to_file', {})
 
@@ -2642,7 +2649,7 @@ class YoutubeDL:
         # The pre-processors may have modified the formats
         formats = self._get_formats(info_dict)
 
-        list_only = self.params.get('simulate') is None and (
+        list_only = self.params.get('simulate') and (
             self.params.get('list_thumbnails') or self.params.get('listformats') or self.params.get('listsubtitles'))
         interactive_format_selection = not list_only and self.format_selector == '-'
         if self.params.get('list_thumbnails'):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -649,12 +649,12 @@ class YoutubeDL:
         else:
             self.params['nooverwrites'] = not self.params['overwrites']
 
-        if self.params.get('simulate') is None and any([
+        if self.params.get('simulate') is None and any((
             self.params.get('list_thumbnails'),
             self.params.get('listformats'),
             self.params.get('listsubtitles'),
-        ]):
-            self.params['simulate'] = True
+        )):
+            self.params['simulate'] = 'list_only'
 
         self.params.setdefault('forceprint', {})
         self.params.setdefault('print_to_file', {})
@@ -2649,8 +2649,7 @@ class YoutubeDL:
         # The pre-processors may have modified the formats
         formats = self._get_formats(info_dict)
 
-        list_only = self.params.get('simulate') and (
-            self.params.get('list_thumbnails') or self.params.get('listformats') or self.params.get('listsubtitles'))
+        list_only = self.params.get('simulate') == 'list_only'
         interactive_format_selection = not list_only and self.format_selector == '-'
         if self.params.get('list_thumbnails'):
             self.list_thumbnails(info_dict)


### PR DESCRIPTION
(this code was co-authored by @Grub4K and @pukkandan)

The purpose of this patch is so that `_downloader.params.get('simulate')` will return a truthy value if any of the `list_only` options have been passed:
 - `--list-formats` / `-F` / `listformats`
 - `--list-subs` / `listsubtitles`
 - `--list-thumbnails` / `list_thumbnails`
 
Per the documentation, any of these options should imply `--simulate` unless the `--no-simulate` option is also passed.

Here is one specific issue that this will fix:

Listing formats for a URL that returns a `multi_video` playlist causes yt-dlp to raise an error, because it still tries to run postprocessing (ffmpeg concatenation) after the playlist extraction finishes, even though no downloading occurred.

If we look at the postprocessor code for `FFmpegConcatPP`, we can see that the `simulated` param of the decorator `@PostProcessor._restrict_to` is set to `False` (from `postprocessor/ffmpeg.py`):
```py
class FFmpegConcatPP(FFmpegPostProcessor):
    # ...
    @PostProcessor._restrict_to(images=False, simulated=False)
    def run(self, info):
```

Then we can see what the meaning of `simulated=False` is in `postprocessor/common.py`:
```py
    @staticmethod
    def _restrict_to(*, video=True, audio=True, images=True, simulated=True):
        allowed = {'video': video, 'audio': audio, 'images': images}

        def decorator(func):
            @functools.wraps(func)
            def wrapper(self, info):
                if not simulated and (self.get_param('simulate') or self.get_param('skip_download')):
                    return [], info
                # ...
```

So, in the current code, because `self.get_param('simulate')` doesn't return a truthy value when only `--list-formats` is passed (`simulate` is `None`), the postprocessing tries to run anyways, causing the error. 

A concrete example:

I am currently working on the `MTVServicesInfoExtractor` and its derived extractors, and I have changed it so that it returns a `multi_video` playlist. Here is a log of what happens without this PR's patch:

```shellsession
$ yt_dlp -v -F https://southpark.cc.com/episodes/fi4nmu/south-park-mexican-joker-season-23-ep-1
[debug] Command-line config: ['-v', '-F', 'https://southpark.cc.com/episodes/fi4nmu/south-park-mexican-joker-season-23-ep-1']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.10.04 [4e0511f27]
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Python 3.10.8 (CPython 64bit) - Linux-6.0.2-arch1-1-x86_64-with-glibc2.36 (glibc 2.36)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 5.1.2 (setts), ffprobe 5.1.2
[debug] Optional libraries: Cryptodome-3.12.0, brotlicffi-1.0.9.2, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1699 extractors
[debug] [southpark.cc.com] Extracting URL: https://southpark.cc.com/episodes/fi4nmu/south-park-mexican-joker-season-23-ep-1
[southpark.cc.com] south-park-mexican-joker-season-23-ep-1: Downloading webpage
[southpark.cc.com] ac8de693-b355-11e9-9fb2-70df2f866ace: Downloading info
[southpark.cc.com] 34fe92fa-efd4-4556-ab6f-2769380e883a: Extracting information
[southpark.cc.com] 34fe92fa-efd4-4556-ab6f-2769380e883a: Downloading video urls
[southpark.cc.com] 34fe92fa-efd4-4556-ab6f-2769380e883a: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 17b24f9e-9abf-4261-8244-8d3a1fcc8f10: Extracting information
[southpark.cc.com] 17b24f9e-9abf-4261-8244-8d3a1fcc8f10: Downloading video urls
[southpark.cc.com] 17b24f9e-9abf-4261-8244-8d3a1fcc8f10: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 052090fc-b049-454e-b8d2-e1c0dd5ccdfc: Extracting information
[southpark.cc.com] 052090fc-b049-454e-b8d2-e1c0dd5ccdfc: Downloading video urls
[southpark.cc.com] 052090fc-b049-454e-b8d2-e1c0dd5ccdfc: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 82671fe3-b44d-4e7e-b084-f5c3c11697e2: Extracting information
[southpark.cc.com] 82671fe3-b44d-4e7e-b084-f5c3c11697e2: Downloading video urls
[southpark.cc.com] 82671fe3-b44d-4e7e-b084-f5c3c11697e2: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 51ba788d-38f1-42e6-8648-27945f5249b5: Extracting information
[southpark.cc.com] 51ba788d-38f1-42e6-8648-27945f5249b5: Downloading video urls
[southpark.cc.com] 51ba788d-38f1-42e6-8648-27945f5249b5: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[download] Downloading multi_video: Mexican Joker
[southpark.cc.com] Playlist Mexican Joker: Downloading 5 videos of 5
[debug] The information of all playlist entries will be held in memory
[download] Downloading video 1 of 5
[info] Available formats for 34fe92fa-efd4-4556-ab6f-2769380e883a:
ID       EXT RESOLUTION FPS │  FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
─────────────────────────────────────────────────────────────────────────────────────
hls-345  mp4 384x216     24 │ ~ 1.35MiB  345k m3u8  │ avc1.4D401E  345k mp4a.40.2  0k
hls-527  mp4 512x288     24 │ ~ 2.06MiB  528k m3u8  │ avc1.4D401F  528k mp4a.40.2  0k
hls-918  mp4 640x360     24 │ ~ 3.59MiB  919k m3u8  │ avc1.4D401F  919k mp4a.40.2  0k
hls-1157 mp4 768x432     24 │ ~ 4.52MiB 1158k m3u8  │ avc1.4D401F 1158k mp4a.40.2  0k
hls-1646 mp4 960x540     24 │ ~ 6.43MiB 1647k m3u8  │ avc1.4D401F 1647k mp4a.40.2  0k
hls-2443 mp4 1280x720    24 │ ~ 9.54MiB 2443k m3u8  │ avc1.640028 2443k mp4a.40.2  0k
hls-4356 mp4 1920x1080   24 │ ~17.02MiB 4356k m3u8  │ avc1.640028 4356k mp4a.40.2  0k
[download] Downloading video 2 of 5
[info] Available formats for 17b24f9e-9abf-4261-8244-8d3a1fcc8f10:
ID       EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────────
hls-324  mp4 384x216     24 │ ~ 21.28MiB  325k m3u8  │ avc1.4D401E  325k mp4a.40.2  0k
hls-416  mp4 512x288     24 │ ~ 27.27MiB  416k m3u8  │ avc1.4D401F  416k mp4a.40.2  0k
hls-644  mp4 640x360     24 │ ~ 42.24MiB  644k m3u8  │ avc1.4D401F  644k mp4a.40.2  0k
hls-776  mp4 768x432     24 │ ~ 50.93MiB  777k m3u8  │ avc1.4D401F  777k mp4a.40.2  0k
hls-1090 mp4 960x540     24 │ ~ 71.47MiB 1090k m3u8  │ avc1.4D401F 1090k mp4a.40.2  0k
hls-1604 mp4 1280x720    24 │ ~105.21MiB 1605k m3u8  │ avc1.640028 1605k mp4a.40.2  0k
hls-3274 mp4 1920x1080   24 │ ~214.65MiB 3275k m3u8  │ avc1.640028 3275k mp4a.40.2  0k
[download] Downloading video 3 of 5
[info] Available formats for 052090fc-b049-454e-b8d2-e1c0dd5ccdfc:
ID       EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────────
hls-315  mp4 384x216     24 │ ~ 14.00MiB  315k m3u8  │ avc1.4D401E  315k mp4a.40.2  0k
hls-381  mp4 512x288     24 │ ~ 16.96MiB  382k m3u8  │ avc1.4D401F  382k mp4a.40.2  0k
hls-569  mp4 640x360     24 │ ~ 25.28MiB  569k m3u8  │ avc1.4D401F  569k mp4a.40.2  0k
hls-676  mp4 768x432     24 │ ~ 30.08MiB  677k m3u8  │ avc1.4D401F  677k mp4a.40.2  0k
hls-951  mp4 960x540     24 │ ~ 42.26MiB  951k m3u8  │ avc1.4D401F  951k mp4a.40.2  0k
hls-1395 mp4 1280x720    24 │ ~ 62.01MiB 1396k m3u8  │ avc1.640028 1396k mp4a.40.2  0k
hls-2880 mp4 1920x1080   24 │ ~127.97MiB 2880k m3u8  │ avc1.640028 2880k mp4a.40.2  0k
[download] Downloading video 4 of 5
[info] Available formats for 82671fe3-b44d-4e7e-b084-f5c3c11697e2:
ID       EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────────
hls-317  mp4 384x216     24 │ ~ 14.39MiB  318k m3u8  │ avc1.4D401E  318k mp4a.40.2  0k
hls-409  mp4 512x288     24 │ ~ 18.54MiB  409k m3u8  │ avc1.4D401F  409k mp4a.40.2  0k
hls-623  mp4 640x360     24 │ ~ 28.25MiB  624k m3u8  │ avc1.4D401F  624k mp4a.40.2  0k
hls-742  mp4 768x432     24 │ ~ 33.61MiB  742k m3u8  │ avc1.4D401F  742k mp4a.40.2  0k
hls-1041 mp4 960x540     24 │ ~ 47.16MiB 1041k m3u8  │ avc1.4D401F 1041k mp4a.40.2  0k
hls-1524 mp4 1280x720    24 │ ~ 69.05MiB 1525k m3u8  │ avc1.640028 1525k mp4a.40.2  0k
hls-3060 mp4 1920x1080   24 │ ~138.62MiB 3061k m3u8  │ avc1.640028 3061k mp4a.40.2  0k
[download] Downloading video 5 of 5
[info] Available formats for 51ba788d-38f1-42e6-8648-27945f5249b5:
ID      EXT RESOLUTION FPS │   FILESIZE  TBR PROTO │ VCODEC       VBR ACODEC    ABR
───────────────────────────────────────────────────────────────────────────────────
hls-265 mp4 384x216     24 │ ~994.96KiB 265k m3u8  │ avc1.4D401E 265k mp4a.40.2  0k
hls-294 mp4 512x288     24 │ ~  1.08MiB 294k m3u8  │ avc1.4D401F 294k mp4a.40.2  0k
hls-356 mp4 640x360     24 │ ~  1.31MiB 357k m3u8  │ avc1.4D401F 357k mp4a.40.2  0k
hls-393 mp4 768x432     24 │ ~  1.44MiB 393k m3u8  │ avc1.4D401F 393k mp4a.40.2  0k
hls-472 mp4 960x540     24 │ ~  1.73MiB 472k m3u8  │ avc1.4D401F 472k mp4a.40.2  0k
hls-567 mp4 1280x720    24 │ ~  2.08MiB 567k m3u8  │ avc1.640028 567k mp4a.40.2  0k
hls-769 mp4 1920x1080   24 │ ~  2.82MiB 769k m3u8  │ avc1.640028 769k mp4a.40.2  0k
ERROR: Aborting concatenation because some downloads failed
Traceback (most recent call last):
  File "/home/user/git/yt-dlp/yt_dlp/YoutubeDL.py", line 1477, in wrapper
    return func(self, *args, **kwargs)
  File "/home/user/git/yt-dlp/yt_dlp/YoutubeDL.py", line 1574, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/user/git/yt-dlp/yt_dlp/YoutubeDL.py", line 1703, in process_ie_result
    return self.__process_playlist(ie_result, download)
  File "/home/user/git/yt-dlp/yt_dlp/YoutubeDL.py", line 1871, in __process_playlist
    ie_result = self.run_all_pps('playlist', ie_result)
  File "/home/user/git/yt-dlp/yt_dlp/YoutubeDL.py", line 3428, in run_all_pps
    info = self.run_pp(pp, info)
  File "/home/user/git/yt-dlp/yt_dlp/YoutubeDL.py", line 3407, in run_pp
    files_to_delete, infodict = pp.run(infodict)
  File "/home/user/git/yt-dlp/yt_dlp/postprocessor/common.py", line 24, in run
    ret = func(self, info, *args, **kwargs)
  File "/home/user/git/yt-dlp/yt_dlp/postprocessor/common.py", line 129, in wrapper
    return func(self, info)
  File "/home/user/git/yt-dlp/yt_dlp/postprocessor/ffmpeg.py", line 1164, in run
    raise PostProcessingError('Aborting concatenation because some downloads failed')
yt_dlp.utils.PostProcessingError: Aborting concatenation because some downloads failed
```

And what happens with this patch:

```shellsession
$ yt_dlp -v -F https://southpark.cc.com/episodes/fi4nmu/south-park-mexican-joker-season-23-ep-1
[debug] Command-line config: ['-v', '-F', 'https://southpark.cc.com/episodes/fi4nmu/south-park-mexican-joker-season-23-ep-1']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.10.04 [4e0511f27]
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Python 3.10.8 (CPython 64bit) - Linux-6.0.2-arch1-1-x86_64-with-glibc2.36 (glibc 2.36)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 5.1.2 (setts), ffprobe 5.1.2
[debug] Optional libraries: Cryptodome-3.12.0, brotlicffi-1.0.9.2, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.3
[debug] Proxy map: {}
[debug] Loaded 1699 extractors
[debug] [southpark.cc.com] Extracting URL: https://southpark.cc.com/episodes/fi4nmu/south-park-mexican-joker-season-23-ep-1
[southpark.cc.com] south-park-mexican-joker-season-23-ep-1: Downloading webpage
[southpark.cc.com] ac8de693-b355-11e9-9fb2-70df2f866ace: Downloading info
[southpark.cc.com] 34fe92fa-efd4-4556-ab6f-2769380e883a: Extracting information
[southpark.cc.com] 34fe92fa-efd4-4556-ab6f-2769380e883a: Downloading video urls
[southpark.cc.com] 34fe92fa-efd4-4556-ab6f-2769380e883a: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 17b24f9e-9abf-4261-8244-8d3a1fcc8f10: Extracting information
[southpark.cc.com] 17b24f9e-9abf-4261-8244-8d3a1fcc8f10: Downloading video urls
[southpark.cc.com] 17b24f9e-9abf-4261-8244-8d3a1fcc8f10: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 052090fc-b049-454e-b8d2-e1c0dd5ccdfc: Extracting information
[southpark.cc.com] 052090fc-b049-454e-b8d2-e1c0dd5ccdfc: Downloading video urls
[southpark.cc.com] 052090fc-b049-454e-b8d2-e1c0dd5ccdfc: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 82671fe3-b44d-4e7e-b084-f5c3c11697e2: Extracting information
[southpark.cc.com] 82671fe3-b44d-4e7e-b084-f5c3c11697e2: Downloading video urls
[southpark.cc.com] 82671fe3-b44d-4e7e-b084-f5c3c11697e2: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[southpark.cc.com] 51ba788d-38f1-42e6-8648-27945f5249b5: Extracting information
[southpark.cc.com] 51ba788d-38f1-42e6-8648-27945f5249b5: Downloading video urls
[southpark.cc.com] 51ba788d-38f1-42e6-8648-27945f5249b5: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[download] Downloading multi_video: Mexican Joker
[southpark.cc.com] Playlist Mexican Joker: Downloading 5 videos of 5
[debug] The information of all playlist entries will be held in memory
[download] Downloading video 1 of 5
[info] Available formats for 34fe92fa-efd4-4556-ab6f-2769380e883a:
ID       EXT RESOLUTION FPS │  FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
─────────────────────────────────────────────────────────────────────────────────────
hls-345  mp4 384x216     24 │ ~ 1.35MiB  345k m3u8  │ avc1.4D401E  345k mp4a.40.2  0k
hls-527  mp4 512x288     24 │ ~ 2.06MiB  528k m3u8  │ avc1.4D401F  528k mp4a.40.2  0k
hls-918  mp4 640x360     24 │ ~ 3.59MiB  919k m3u8  │ avc1.4D401F  919k mp4a.40.2  0k
hls-1157 mp4 768x432     24 │ ~ 4.52MiB 1158k m3u8  │ avc1.4D401F 1158k mp4a.40.2  0k
hls-1646 mp4 960x540     24 │ ~ 6.43MiB 1647k m3u8  │ avc1.4D401F 1647k mp4a.40.2  0k
hls-2443 mp4 1280x720    24 │ ~ 9.54MiB 2443k m3u8  │ avc1.640028 2443k mp4a.40.2  0k
hls-4356 mp4 1920x1080   24 │ ~17.02MiB 4356k m3u8  │ avc1.640028 4356k mp4a.40.2  0k
[download] Downloading video 2 of 5
[info] Available formats for 17b24f9e-9abf-4261-8244-8d3a1fcc8f10:
ID       EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────────
hls-324  mp4 384x216     24 │ ~ 21.28MiB  325k m3u8  │ avc1.4D401E  325k mp4a.40.2  0k
hls-416  mp4 512x288     24 │ ~ 27.27MiB  416k m3u8  │ avc1.4D401F  416k mp4a.40.2  0k
hls-644  mp4 640x360     24 │ ~ 42.24MiB  644k m3u8  │ avc1.4D401F  644k mp4a.40.2  0k
hls-776  mp4 768x432     24 │ ~ 50.93MiB  777k m3u8  │ avc1.4D401F  777k mp4a.40.2  0k
hls-1090 mp4 960x540     24 │ ~ 71.47MiB 1090k m3u8  │ avc1.4D401F 1090k mp4a.40.2  0k
hls-1604 mp4 1280x720    24 │ ~105.21MiB 1605k m3u8  │ avc1.640028 1605k mp4a.40.2  0k
hls-3274 mp4 1920x1080   24 │ ~214.65MiB 3275k m3u8  │ avc1.640028 3275k mp4a.40.2  0k
[download] Downloading video 3 of 5
[info] Available formats for 052090fc-b049-454e-b8d2-e1c0dd5ccdfc:
ID       EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────────
hls-315  mp4 384x216     24 │ ~ 14.00MiB  315k m3u8  │ avc1.4D401E  315k mp4a.40.2  0k
hls-381  mp4 512x288     24 │ ~ 16.96MiB  382k m3u8  │ avc1.4D401F  382k mp4a.40.2  0k
hls-569  mp4 640x360     24 │ ~ 25.28MiB  569k m3u8  │ avc1.4D401F  569k mp4a.40.2  0k
hls-676  mp4 768x432     24 │ ~ 30.08MiB  677k m3u8  │ avc1.4D401F  677k mp4a.40.2  0k
hls-951  mp4 960x540     24 │ ~ 42.26MiB  951k m3u8  │ avc1.4D401F  951k mp4a.40.2  0k
hls-1395 mp4 1280x720    24 │ ~ 62.01MiB 1396k m3u8  │ avc1.640028 1396k mp4a.40.2  0k
hls-2880 mp4 1920x1080   24 │ ~127.97MiB 2880k m3u8  │ avc1.640028 2880k mp4a.40.2  0k
[download] Downloading video 4 of 5
[info] Available formats for 82671fe3-b44d-4e7e-b084-f5c3c11697e2:
ID       EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC    ABR
──────────────────────────────────────────────────────────────────────────────────────
hls-317  mp4 384x216     24 │ ~ 14.39MiB  318k m3u8  │ avc1.4D401E  318k mp4a.40.2  0k
hls-409  mp4 512x288     24 │ ~ 18.54MiB  409k m3u8  │ avc1.4D401F  409k mp4a.40.2  0k
hls-623  mp4 640x360     24 │ ~ 28.25MiB  624k m3u8  │ avc1.4D401F  624k mp4a.40.2  0k
hls-742  mp4 768x432     24 │ ~ 33.61MiB  742k m3u8  │ avc1.4D401F  742k mp4a.40.2  0k
hls-1041 mp4 960x540     24 │ ~ 47.16MiB 1041k m3u8  │ avc1.4D401F 1041k mp4a.40.2  0k
hls-1524 mp4 1280x720    24 │ ~ 69.05MiB 1525k m3u8  │ avc1.640028 1525k mp4a.40.2  0k
hls-3060 mp4 1920x1080   24 │ ~138.62MiB 3061k m3u8  │ avc1.640028 3061k mp4a.40.2  0k
[download] Downloading video 5 of 5
[info] Available formats for 51ba788d-38f1-42e6-8648-27945f5249b5:
ID      EXT RESOLUTION FPS │   FILESIZE  TBR PROTO │ VCODEC       VBR ACODEC    ABR
───────────────────────────────────────────────────────────────────────────────────
hls-265 mp4 384x216     24 │ ~994.96KiB 265k m3u8  │ avc1.4D401E 265k mp4a.40.2  0k
hls-294 mp4 512x288     24 │ ~  1.08MiB 294k m3u8  │ avc1.4D401F 294k mp4a.40.2  0k
hls-356 mp4 640x360     24 │ ~  1.31MiB 357k m3u8  │ avc1.4D401F 357k mp4a.40.2  0k
hls-393 mp4 768x432     24 │ ~  1.44MiB 393k m3u8  │ avc1.4D401F 393k mp4a.40.2  0k
hls-472 mp4 960x540     24 │ ~  1.73MiB 472k m3u8  │ avc1.4D401F 472k mp4a.40.2  0k
hls-567 mp4 1280x720    24 │ ~  2.08MiB 567k m3u8  │ avc1.640028 567k mp4a.40.2  0k
hls-769 mp4 1920x1080   24 │ ~  2.82MiB 769k m3u8  │ avc1.640028 769k mp4a.40.2  0k
[download] Finished downloading playlist: Mexican Joker
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
