### PR TITLE
Support for flat --extract-single-video that allows single video download

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ You can also fork the project on GitHub and run your fork's [build workflow](.gi
     --flat-playlist                 Do not extract the videos of a playlist,
                                     only list them
     --no-flat-playlist              Extract the videos of a playlist
+    --extract-single-video          Extract single video from a playlist
     --live-from-start               Download livestreams from the start.
                                     Currently only supported for YouTube
                                     (Experimental)

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -405,6 +405,10 @@ def create_parser():
         action='store_false', dest='extract_flat',
         help='Extract the videos of a playlist')
     general.add_option(
+        '--extract-single-video',
+        action='store_true', dest='extract_flat',
+        help='Extract single video from a playlist')
+    general.add_option(
         '--live-from-start',
         action='store_true', dest='live_from_start',
         help='Download livestreams from the start. Currently only supported for YouTube (Experimental)')


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I have been running into problems when yt-dlp follows links on the youtube page, twitter post or facebook posts and tries to download videos from pages post links to. This is great but I want to have the option to download ONLY the specified URL and do not follow any links. 

I found in yt_dlp/YoutubeDL.py line 1615
```
 if ((extract_flat == 'in_playlist' and 'playlist' in extra_info)
                    or extract_flat is True):
```
but here is not way to extract_flat to True.
I added the option to set extract_flat to True and avoid following links.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
