### PR TITLE
[movefiles] Add workaround option `--no-copystat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,14 @@ You can also fork the project on GitHub and run your fork's [build workflow](.gi
 
 ## Workarounds:
     --encoding ENCODING             Force the specified encoding (experimental)
+    --no-copystat                   Do not copy file metadata (mode, timestamps,
+                                    etc.) when moving between volumes
+                                    This option has no effect if the original
+                                    file and the target location are on the same
+                                    volume.
+                                    Note: This option will override some other
+                                    features such as "--mtime" and "--xattrs".
+                                    Use with caution.
     --legacy-server-connect         Explicitly allow HTTPS connection to servers
                                     that do not support RFC 5746 secure
                                     renegotiation

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3070,7 +3070,8 @@ class YoutubeDL:
             info_dict['filepath'] = temp_filename
             info_dict['__finaldir'] = os.path.dirname(os.path.abspath(encodeFilename(full_filename)))
             info_dict['__files_to_move'] = files_to_move
-            replace_info_dict(self.run_pp(MoveFilesAfterDownloadPP(self, False), info_dict))
+            move_files = MoveFilesAfterDownloadPP(self, False, self.params.get('no_copystat', False))
+            replace_info_dict(self.run_pp(move_files, info_dict))
             info_dict['__write_download_archive'] = self.params.get('force_write_download_archive')
         else:
             # Download
@@ -3444,7 +3445,7 @@ class YoutubeDL:
         info['filepath'] = filename
         info['__files_to_move'] = files_to_move or {}
         info = self.run_all_pps('post_process', info, additional_pps=info.get('__postprocessors'))
-        info = self.run_pp(MoveFilesAfterDownloadPP(self), info)
+        info = self.run_pp(MoveFilesAfterDownloadPP(self, True, self.params.get('no_copystat', False)), info)
         del info['__files_to_move']
         return self.run_all_pps('after_move', info)
 

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -853,6 +853,7 @@ def parse_options(argv=None):
         'cookiesfrombrowser': opts.cookiesfrombrowser,
         'legacyserverconnect': opts.legacy_server_connect,
         'nocheckcertificate': opts.no_check_certificate,
+        'no_copystat': opts.no_copystat,
         'prefer_insecure': opts.prefer_insecure,
         'http_headers': opts.headers,
         'proxy': opts.proxy,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1002,6 +1002,13 @@ def create_parser():
         dest='encoding', metavar='ENCODING',
         help='Force the specified encoding (experimental)')
     workarounds.add_option(
+        '--no-copystat',
+        action='store_true', dest='no_copystat', default=False,
+        help=(
+            'Do not copy file metadata (mode, timestamps, etc.) when moving between volumes'
+            'This option has no effect if the original file and the target location are on the same volume.'
+            'Note: This option will override some other features such as "--mtime" and "--xattrs". Use with caution.'))
+    workarounds.add_option(
         '--legacy-server-connect',
         action='store_true', dest='legacy_server_connect', default=False,
         help='Explicitly allow HTTPS connection to servers that do not support RFC 5746 secure renegotiation')

--- a/yt_dlp/postprocessor/movefilesafterdownload.py
+++ b/yt_dlp/postprocessor/movefilesafterdownload.py
@@ -10,11 +10,22 @@ from ..utils import (
 )
 
 
+def copy2_no_copystat(src, dst, *, follow_symlinks=True):
+    """'shutil.copy2' without 'shutil.copystat'"""
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+    shutil.copyfile(src, dst, follow_symlinks=follow_symlinks)
+    # on FreeBSD when the dest dir is constrained by ACLs, shutil.copystat will
+    # raise a PermissionError (Operation not permitted) which is not handled by shutil
+    return dst
+
+
 class MoveFilesAfterDownloadPP(PostProcessor):
 
-    def __init__(self, downloader=None, downloaded=True):
+    def __init__(self, downloader=None, downloaded=True, no_copystat=False):
         PostProcessor.__init__(self, downloader)
         self._downloaded = downloaded
+        self._no_copystat = no_copystat
 
     @classmethod
     def pp_key(cls):
@@ -27,6 +38,8 @@ class MoveFilesAfterDownloadPP(PostProcessor):
         if self._downloaded:
             info['__files_to_move'][info['filepath']] = decodeFilename(finalpath)
 
+        # when no_copystat is true, don't copy any metadata at all
+        copy_func = copy2_no_copystat if self._no_copystat else shutil.copy2
         make_newfilename = lambda old: decodeFilename(os.path.join(finaldir, os.path.basename(encodeFilename(old))))
         for oldfile, newfile in info['__files_to_move'].items():
             if not newfile:
@@ -47,7 +60,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
                     continue
             make_dir(newfile, PostProcessingError)
             self.to_screen(f'Moving file "{oldfile}" to "{newfile}"')
-            shutil.move(oldfile, newfile)  # os.rename cannot move between volumes
+            shutil.move(oldfile, newfile, copy_func)  # os.rename cannot move between volumes
 
         info['filepath'] = finalpath
         return [], info

--- a/yt_dlp/postprocessor/movefilesafterdownload.py
+++ b/yt_dlp/postprocessor/movefilesafterdownload.py
@@ -40,6 +40,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
 
         # when no_copystat is true, don't copy any metadata at all
         copy_func = copy2_no_copystat if self._no_copystat else shutil.copy2
+        extra = ' without copying metadata' if self._no_copystat else ''
         make_newfilename = lambda old: decodeFilename(os.path.join(finaldir, os.path.basename(encodeFilename(old))))
         for oldfile, newfile in info['__files_to_move'].items():
             if not newfile:
@@ -59,7 +60,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
                         % (oldfile, newfile))
                     continue
             make_dir(newfile, PostProcessingError)
-            self.to_screen(f'Moving file "{oldfile}" to "{newfile}"')
+            self.to_screen(f'Moving file "{oldfile}" to "{newfile}"{extra}')
             shutil.move(oldfile, newfile, copy_func)  # os.rename cannot move between volumes
 
         info['filepath'] = finalpath


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds an option to prevent `shutil.move` from copying file metedata when moving across volumes.
#### Motivation
I use yt-dlp in a FreeBSD jail. The target directory (on ZFS) is mounted inside the jail, and the ACL mode is set to `restricted`, so normal `chmod` operations will fail. Unfortunately, `shutil.copystat` only handles `NotImplementedError`, but not `PermissionError`:
```
[MoveFiles] Moving file "/tmp/yt-dlp/35a8ffec-downloading/video.en.vtt" to "35a8ffec-downloading/video.en.vtt"
ERROR: [Errno 1] Operation not permitted: '35a8ffec-downloading/video.en.vtt'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/shutil.py", line 825, in move
    os.rename(src, real_dst)
OSError: [Errno 18] Cross-device link: '/tmp/yt-dlp/35a8ffec-downloading/video.en.vtt' -> '35a8ffec-downloading/video.en.vtt'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 1477, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 1574, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 1633, in process_ie_result
    ie_result = self.process_video_result(ie_result, download=download)
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 2730, in process_video_result
    self.process_info(new_info)
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 3270, in process_info
    replace_info_dict(self.post_process(dl_filename, info_dict, files_to_move))
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 3448, in post_process
    info = self.run_pp(MoveFilesAfterDownloadPP(self), info)
  File "/usr/local/bin/python/yt_dlp/YoutubeDL.py", line 3408, in run_pp
    files_to_delete, infodict = pp.run(infodict)
  File "/usr/local/bin/python/yt_dlp/postprocessor/common.py", line 24, in run
    ret = func(self, info, *args, **kwargs)
  File "/usr/local/bin/python/yt_dlp/postprocessor/movefilesafterdownload.py", line 63, in run
    shutil.move(oldfile, newfile)  # os.rename cannot move between volumes
  File "/usr/local/lib/python3.9/shutil.py", line 845, in move
    copy_function(src, real_dst)
  File "/usr/local/lib/python3.9/shutil.py", line 445, in copy2
    copystat(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/local/lib/python3.9/shutil.py", line 390, in copystat
    lookup("chmod")(dst, mode, follow_symlinks=follow)
PermissionError: [Errno 1] Operation not permitted: '35a8ffec-downloading/video.en.vtt'
```
This is the most straightforward workaround I could think of. I don't think it will cause too much trouble since it's entirely up to the user to enable it.

I'm new to Python so any advice or feedback is appreciated :)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
