### PR TITLE
Update py refactoring

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -42,8 +42,8 @@ def _get_variant_and_executable_path():
     path = os.path.dirname(__file__)
     if isinstance(__loader__, zipimporter):
         return 'zip', os.path.join(path, '..')
-    elif (os.path.basename(sys.argv[0]) in ('__main__.py', '-m')
-          and os.path.exists(os.path.join(path, '../.git/HEAD'))):
+    if (os.path.basename(sys.argv[0]) in ('__main__.py', '-m')
+            and os.path.exists(os.path.join(path, '../.git/HEAD'))):
         return 'source', path
     return 'unknown', path
 

--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -281,7 +281,7 @@ class Updater:
         # There is no sys.orig_argv in py < 3.10. Also, it can be [] when frozen
         if getattr(sys, 'orig_argv', None):
             return sys.orig_argv
-        elif hasattr(sys, 'frozen'):
+        if getattr(sys, 'frozen', False):
             return sys.argv
 
     def restart(self):

--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -29,7 +29,7 @@ API_URL = f'https://api.github.com/repos/{REPOSITORY}/releases'
 @functools.cache
 def _get_variant_and_executable_path():
     """@returns (variant, executable_path)"""
-    if hasattr(sys, 'frozen'):
+    if getattr(sys, 'frozen', False):
         path = sys.executable
         if not hasattr(sys, '_MEIPASS'):
             return 'py2exe', path

--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -33,17 +33,17 @@ def _get_variant_and_executable_path():
         path = sys.executable
         if not hasattr(sys, '_MEIPASS'):
             return 'py2exe', path
-        if sys._MEIPASS == os.path.dirname(path):
+        elif sys._MEIPASS == os.path.dirname(path):
             return f'{sys.platform}_dir', path
-        if sys.platform == 'darwin' and version_tuple(platform.mac_ver()[0]) < (10, 15):
+        elif sys.platform == 'darwin' and version_tuple(platform.mac_ver()[0]) < (10, 15):
             return 'darwin_legacy_exe', path
         return f'{sys.platform}_exe', path
 
     path = os.path.dirname(__file__)
     if isinstance(__loader__, zipimporter):
         return 'zip', os.path.join(path, '..')
-    if (os.path.basename(sys.argv[0]) in ('__main__.py', '-m')
-            and os.path.exists(os.path.join(path, '../.git/HEAD'))):
+    elif (os.path.basename(sys.argv[0]) in ('__main__.py', '-m')
+          and os.path.exists(os.path.join(path, '../.git/HEAD'))):
         return 'source', path
     return 'unknown', path
 
@@ -281,7 +281,7 @@ class Updater:
         # There is no sys.orig_argv in py < 3.10. Also, it can be [] when frozen
         if getattr(sys, 'orig_argv', None):
             return sys.orig_argv
-        if getattr(sys, 'frozen', False):
+        elif getattr(sys, 'frozen', False):
             return sys.argv
 
     def restart(self):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
Small refactoring of `_get_variant_and_executable_path` method.

The method `hasattr` checks if `sys` has the attribute `frozen` but doesn't check the value. If `frozen = False` the original code returns True. The use of `getattr` is also proposed by the PyInstaller [documentation](https://pyinstaller.org/en/stable/runtime-information.html#run-time-information).

The change from `elif` to `if` in Line 45 is to make the usage of `if` consistent (in this method).

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
