### PR TITLE
[extractor/americastestkitchen] Fix `_VALID_URL` and season extraction

### DIFF
--- a/yt_dlp/extractor/americastestkitchen.py
+++ b/yt_dlp/extractor/americastestkitchen.py
@@ -124,7 +124,6 @@ class AmericasTestKitchenSeasonIE(InfoExtractor):
         season_number = int(season_number)
 
         slug = 'cco' if show_path == '/cookscountry' else 'atk'
-        show_path = '' if not show_path else show_path
 
         season = 'Season %d' % season_number
 
@@ -152,7 +151,7 @@ class AmericasTestKitchenSeasonIE(InfoExtractor):
                     continue
                 yield {
                     '_type': 'url',
-                    'url': f'https://www.americastestkitchen.com{show_path}{search_url}',
+                    'url': f'https://www.americastestkitchen.com{show_path or ""}{search_url}',
                     'id': try_get(episode, lambda e: e['objectID'].split('_')[-1]),
                     'title': episode.get('title'),
                     'description': episode.get('description'),

--- a/yt_dlp/extractor/americastestkitchen.py
+++ b/yt_dlp/extractor/americastestkitchen.py
@@ -11,7 +11,7 @@ from ..utils import (
 
 
 class AmericasTestKitchenIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?:americastestkitchen|cooks(?:country|illustrated))\.com/(?P<resource_type>episode|videos)/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?americastestkitchen\.com/(?:cooks(?:country|illustrated)/)?(?P<resource_type>episode|videos)/(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.americastestkitchen.com/episode/582-weeknight-japanese-suppers',
         'md5': 'b861c3e365ac38ad319cfd509c30577f',
@@ -19,15 +19,20 @@ class AmericasTestKitchenIE(InfoExtractor):
             'id': '5b400b9ee338f922cb06450c',
             'title': 'Japanese Suppers',
             'ext': 'mp4',
+            'display_id': 'weeknight-japanese-suppers',
             'description': 'md5:64e606bfee910627efc4b5f050de92b3',
-            'thumbnail': r're:^https?://',
-            'timestamp': 1523318400,
-            'upload_date': '20180410',
-            'release_date': '20180410',
-            'series': "America's Test Kitchen",
-            'season_number': 18,
+            'timestamp': 1523304000,
+            'upload_date': '20180409',
+            'release_date': '20180409',
+            'series': 'America\'s Test Kitchen',
+            'season': 'Season 18',
             'episode': 'Japanese Suppers',
+            'season_number': 18,
             'episode_number': 15,
+            'duration': 1376,
+            'thumbnail': r're:^https?://',
+            'average_rating': 0,
+            'view_count': int,
         },
         'params': {
             'skip_download': True,
@@ -40,15 +45,20 @@ class AmericasTestKitchenIE(InfoExtractor):
             'id': '5fbe8c61bda2010001c6763b',
             'title': 'Simple Chicken Dinner',
             'ext': 'mp4',
+            'display_id': 'atktv_2103_simple-chicken-dinner_full-episode_web-mp4',
             'description': 'md5:eb68737cc2fd4c26ca7db30139d109e7',
-            'thumbnail': r're:^https?://',
-            'timestamp': 1610755200,
-            'upload_date': '20210116',
-            'release_date': '20210116',
-            'series': "America's Test Kitchen",
-            'season_number': 21,
+            'timestamp': 1610737200,
+            'upload_date': '20210115',
+            'release_date': '20210115',
+            'series': 'America\'s Test Kitchen',
+            'season': 'Season 21',
             'episode': 'Simple Chicken Dinner',
+            'season_number': 21,
             'episode_number': 3,
+            'duration': 1397,
+            'thumbnail': r're:^https?://',
+            'view_count': int,
+            'average_rating': 0,
         },
         'params': {
             'skip_download': True,
@@ -57,10 +67,10 @@ class AmericasTestKitchenIE(InfoExtractor):
         'url': 'https://www.americastestkitchen.com/videos/3420-pan-seared-salmon',
         'only_matching': True,
     }, {
-        'url': 'https://www.cookscountry.com/episode/564-when-only-chocolate-will-do',
+        'url': 'https://www.americastestkitchen.com/cookscountry/episode/564-when-only-chocolate-will-do',
         'only_matching': True,
     }, {
-        'url': 'https://www.cooksillustrated.com/videos/4478-beef-wellington',
+        'url': 'https://www.americastestkitchen.com/cooksillustrated/videos/4478-beef-wellington',
         'only_matching': True,
     }]
 
@@ -90,7 +100,7 @@ class AmericasTestKitchenIE(InfoExtractor):
 
 
 class AmericasTestKitchenSeasonIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?P<show>americastestkitchen|cookscountry)\.com/episodes/browse/season_(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?americastestkitchen\.com(?P<show>/cookscountry)?/episodes/browse/season_(?P<id>\d+)'
     _TESTS = [{
         # ATK Season
         'url': 'https://www.americastestkitchen.com/episodes/browse/season_1',
@@ -101,7 +111,7 @@ class AmericasTestKitchenSeasonIE(InfoExtractor):
         'playlist_count': 13,
     }, {
         # Cooks Country Season
-        'url': 'https://www.cookscountry.com/episodes/browse/season_12',
+        'url': 'https://www.americastestkitchen.com/cookscountry/episodes/browse/season_12',
         'info_dict': {
             'id': 'season_12',
             'title': 'Season 12',
@@ -110,17 +120,18 @@ class AmericasTestKitchenSeasonIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        show_name, season_number = self._match_valid_url(url).groups()
+        show_path, season_number = self._match_valid_url(url).group('show', 'id')
         season_number = int(season_number)
 
-        slug = 'atk' if show_name == 'americastestkitchen' else 'cco'
+        slug = 'cco' if show_path == '/cookscountry' else 'atk'
+        show_path = '' if not show_path else show_path
 
         season = 'Season %d' % season_number
 
         season_search = self._download_json(
             'https://y1fnzxui30-dsn.algolia.net/1/indexes/everest_search_%s_season_desc_production' % slug,
             season, headers={
-                'Origin': 'https://www.%s.com' % show_name,
+                'Origin': 'https://www.americastestkitchen.com',
                 'X-Algolia-API-Key': '8d504d0099ed27c1b73708d22871d805',
                 'X-Algolia-Application-Id': 'Y1FNZXUI30',
             }, query={
@@ -136,12 +147,12 @@ class AmericasTestKitchenSeasonIE(InfoExtractor):
 
         def entries():
             for episode in (season_search.get('hits') or []):
-                search_url = episode.get('search_url')
+                search_url = episode.get('search_url')  # always formatted like '/episode/123-title-of-episode'
                 if not search_url:
                     continue
                 yield {
                     '_type': 'url',
-                    'url': 'https://www.%s.com%s' % (show_name, search_url),
+                    'url': f'https://www.americastestkitchen.com{show_path}{search_url}',
                     'id': try_get(episode, lambda e: e['objectID'].split('_')[-1]),
                     'title': episode.get('title'),
                     'description': episode.get('description'),


### PR DESCRIPTION
`cookscountry.com` and `cooksillustrated.com` now redirect to `americastestkitchen.com/cookscountry` and `americastestkitchen.com/cooksillustrated`, respectively.

This PR fixes the `_VALID_URL` for both extractors and adjusts the `AmericasTestKitchenSeasonIE` logic to account for the new URL format.

Fixes #5337 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
