### PR TITLE
[youtube] Fix premiere trailer detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,7 +1724,7 @@ The following extractors use this feature:
 * `include_incomplete_formats`: Extract formats that cannot be downloaded completely (live dash and post-live m3u8)
 * `innertube_host`: Innertube API host to use for all API requests; e.g. `studio.youtube.com`, `youtubei.googleapis.com`. Note that cookies exported from one subdomain will not work on others
 * `innertube_key`: Innertube API key to use for all API requests
-
+* `download_trailers`: Download trailers for upcoming premieres, if available
 #### youtubetab (YouTube playlists, channels, feeds, etc.)
 * `skip`: One or more of `webpage` (skip initial webpage download), `authcheck` (allow the download of playlists requiring authentication when no initial webpage is downloaded. This may cause unwanted behavior, see [#1122](https://github.com/yt-dlp/yt-dlp/pull/1122) for more details)
 * `approximate_date`: Extract approximate `upload_date` and `timestamp` in flat-playlist. This may cause date-based filters to be slightly off

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2448,6 +2448,31 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'note': '6 channel audio',
             'url': 'https://www.youtube.com/watch?v=zgdo7-RRjgo',
             'only_matching': True,
+        }, {
+            'url': 'https://www.youtube.com/watch?v=wCslYcJhHDw',
+            'info_dict': {
+                'id': 'OG_wJZ-8l90',
+                'ext': 'mp4',
+                'title': 'trailer',
+                'channel_url': 'https://www.youtube.com/channel/UCiu-3thuViMebBjw_5nWYrA',
+                'uploader_id': 'UCiu-3thuViMebBjw_5nWYrA',
+                'uploader_url': 'http://www.youtube.com/channel/UCiu-3thuViMebBjw_5nWYrA',
+                'thumbnail': 'https://i.ytimg.com/vi_webp/OG_wJZ-8l90/maxresdefault.webp',
+                'like_count': int,
+                'description': '',
+                'uploader': 'cole-dlp-test-acc',
+                'availability': 'unlisted',
+                'age_limit': 0,
+                'upload_date': '20221024',
+                'categories': ['People & Blogs'],
+                'playable_in_embed': True,
+                'view_count': int,
+                'live_status': 'not_live',
+                'channel_id': 'UCiu-3thuViMebBjw_5nWYrA',
+                'tags': [],
+                'channel': 'cole-dlp-test-acc',
+                'duration': 29,
+            },
         }
     ]
 
@@ -3715,11 +3740,16 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         trailer_video_id = get_first(
             playability_statuses,
-            ('errorScreen', 'playerLegacyDesktopYpcTrailerRenderer', 'trailerVideoId'),
+            ('errorScreen', 'ypcTrailerRenderer', 'unserializedPlayerResponse', 'videoDetails', 'videoId'),
             expected_type=str)
         if trailer_video_id:
-            return self.url_result(
-                trailer_video_id, self.ie_key(), trailer_video_id)
+            if not self._configuration_arg('ignore_trailers'):
+                self.to_screen(
+                    f'Downloading trailer {trailer_video_id} - pass --extractor-args youtube:ignore-trailers to skip')
+                return self.url_result(
+                    trailer_video_id, self.ie_key(), trailer_video_id)
+            else:
+                self.to_screen(f'Ignoring trailer {trailer_video_id}')
 
         search_meta = ((lambda x: self._html_search_meta(x, webpage, default=None))
                        if webpage else (lambda x: None))

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2449,6 +2449,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'url': 'https://www.youtube.com/watch?v=zgdo7-RRjgo',
             'only_matching': True,
         }, {
+            # Download trailers if extractor argument is set
             'url': 'https://www.youtube.com/watch?v=wCslYcJhHDw',
             'info_dict': {
                 'id': 'OG_wJZ-8l90',
@@ -2473,6 +2474,37 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 'channel': 'cole-dlp-test-acc',
                 'duration': 29,
             },
+            'params': {'extractor_args': {'youtube': {'download_trailers': 'True'}}, 'skip_download': True},
+        }, {
+            # Do not download trailers if extractor argument is not set
+            'url': 'https://www.youtube.com/watch?v=wCslYcJhHDw',
+            'info_dict': {
+                'id': 'wCslYcJhHDw',
+                'ext': None,
+                'title': 'Test Premiere With Trailer',
+                'live_status': 'is_upcoming',
+                'concurrent_view_count': int,
+                'categories': ['People & Blogs'],
+                'thumbnail': 'https://i.ytimg.com/vi_webp/wCslYcJhHDw/maxresdefault.webp',
+                'channel': 'cole-dlp-test-acc',
+                'release_timestamp': 1720569600,
+                'view_count': int,
+                'channel_url': 'https://www.youtube.com/channel/UCiu-3thuViMebBjw_5nWYrA',
+                'uploader': 'cole-dlp-test-acc',
+                'upload_date': '20221023',
+                'release_date': '20240710',
+                'description': 'fgg',
+                'uploader_url': 'http://www.youtube.com/channel/UCiu-3thuViMebBjw_5nWYrA',
+                'channel_id': 'UCiu-3thuViMebBjw_5nWYrA',
+                'uploader_id': 'UCiu-3thuViMebBjw_5nWYrA',
+                'age_limit': 0,
+                'tags': [],
+                'like_count': int,
+                'playable_in_embed': True,
+                'availability': 'public',
+            },
+            'params': {'ignore_no_formats_error': True, 'skip_download': True},
+            'expected_warnings': [r'Premieres in \d+ days', 'No video formats found', 'Requested format is not available'],
         }
     ]
 
@@ -3743,13 +3775,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             ('errorScreen', 'ypcTrailerRenderer', 'unserializedPlayerResponse', 'videoDetails', 'videoId'),
             expected_type=str)
         if trailer_video_id:
-            if not self._configuration_arg('ignore_trailers'):
+            if self._configuration_arg('download_trailers'):
                 self.to_screen(
-                    f'Downloading trailer {trailer_video_id} - pass --extractor-args youtube:ignore-trailers to skip')
+                    f'Downloading trailer {trailer_video_id} due to download-trailers extractor argument')
                 return self.url_result(
                     trailer_video_id, self.ie_key(), trailer_video_id)
             else:
-                self.to_screen(f'Ignoring trailer {trailer_video_id}')
+                self.to_screen(f'Ignoring trailer {trailer_video_id}; pass --extractor-args youtube:download_trailers to download')
 
         search_meta = ((lambda x: self._html_search_meta(x, webpage, default=None))
                        if webpage else (lambda x: None))


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes https://github.com/yt-dlp/yt-dlp/issues/5291

Trailers used to be downloaded for premieres if they were available, but YouTube has changed the method in how they are extracted.

I have made a slight change to behaviour and put this behind an extractor arg rather than downloading the trailers by default, as this behaviour may not be wanted and to keep compatibility.

TODO:
- Fix for iOS clients (these return a base64 encoded player response)
- ~~Research the possibility of there being multiple trailers on a video~~ edit: the backend appears to support this but yt hasn't implemented this *yet*

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
