### PR TITLE
[RedGifs] Refresh auth token when API returns HTTP 401

### DIFF
--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -83,9 +83,9 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
                     f'https://api.redgifs.com/v2/{ep}', video_id, headers=headers, *args, **kwargs)
                 break
             except ExtractorError as e:
-                if attempt or not isinstance(e.cause, urllib.error.HTTPError) or e.cause.code != 401:
-                    raise
-                del self._API_HEADERS['authorization']  # refresh the token
+                if not attempt and isinstance(e.cause, urllib.error.HTTPError) and e.cause.code == 401:
+                    del self._API_HEADERS['authorization']  # refresh the token
+                raise
 
         if 'error' in data:
             raise ExtractorError(f'RedGifs said: {data["error"]}', expected=True, video_id=video_id)

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -14,6 +14,7 @@ from ..utils import (
 # The temporary token may expire. Make only one attempt to refresh it.
 MAX_TOKEN_REFRESH_ATTEMPTS = 1
 
+
 class RedGifsBaseInfoExtractor(InfoExtractor):
     _FORMATS = {
         'gif': 250,

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -1,4 +1,5 @@
 import functools
+import urllib
 
 from .common import InfoExtractor
 from ..compat import compat_parse_qs
@@ -10,6 +11,8 @@ from ..utils import (
     OnDemandPagedList,
 )
 
+# The temporary token may expire. Make only one attempt to refresh it.
+MAX_TOKEN_REFRESH_ATTEMPTS = 1
 
 class RedGifsBaseInfoExtractor(InfoExtractor):
     _FORMATS = {
@@ -76,10 +79,22 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
             self._fetch_oauth_token(video_id)
         assert 'authorization' in self._API_HEADERS
 
-        headers = dict(self._API_HEADERS)
-        headers['x-customheader'] = f'https://www.redgifs.com/watch/{video_id}'
-        data = self._download_json(
-            f'https://api.redgifs.com/v2/{ep}', video_id, headers=headers, *args, **kwargs)
+        for _ in range(MAX_TOKEN_REFRESH_ATTEMPTS + 1):
+            try:
+                headers = dict(self._API_HEADERS)
+                headers['x-customheader'] = f'https://www.redgifs.com/watch/{video_id}'
+
+                data = self._download_json(
+                    f'https://api.redgifs.com/v2/{ep}', video_id, headers=headers, *args, **kwargs)
+                break
+            except ExtractorError as e:
+                if not isinstance(e.cause, urllib.error.HTTPError) or e.cause.code != 401:
+                    raise
+
+                # Likely the temporary token has expired
+                del self._API_HEADERS['authorization']
+                self._fetch_oauth_token(video_id)
+
         if 'error' in data:
             raise ExtractorError(f'RedGifs said: {data["error"]}', expected=True, video_id=video_id)
         return data

--- a/yt_dlp/extractor/redgifs.py
+++ b/yt_dlp/extractor/redgifs.py
@@ -11,6 +11,7 @@ from ..utils import (
     OnDemandPagedList,
 )
 
+
 class RedGifsBaseInfoExtractor(InfoExtractor):
     _FORMATS = {
         'gif': 250,
@@ -77,7 +78,7 @@ class RedGifsBaseInfoExtractor(InfoExtractor):
         while True:
             if 'authorization' not in self._API_HEADERS:
                 self._fetch_oauth_token(video_id)
-                
+
             try:
                 headers = dict(self._API_HEADERS)
                 headers['x-customheader'] = f'https://www.redgifs.com/watch/{video_id}'


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

RedGifs provides a temporary auth token which eventually expires. It gets stuck in the saved headers, so a mechanism to refresh the token is needed.

Fixes #5351


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
