### PR TITLE
[extractor/youtube] Fix `duration` extraction for upcoming premieres

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3787,10 +3787,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 return self.playlist_result(
                     entries, video_id, video_title, video_description)
 
-        duration = int_or_none(
-            get_first(microformats, 'lengthSeconds')
-            or get_first(video_details, 'lengthSeconds')
-            or parse_duration(search_meta('duration'))) or None
+        duration = (int_or_none(get_first(video_details, 'lengthSeconds'))
+            or int_or_none(get_first(microformats, 'lengthSeconds'))
+            or parse_duration(search_meta('duration')) or None)
 
         live_broadcast_details, live_status, streaming_data, formats, automatic_captions = \
             self._list_formats(video_id, microformats, video_details, player_responses, player_url, duration)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3788,8 +3788,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     entries, video_id, video_title, video_description)
 
         duration = int_or_none(
-            get_first(video_details, 'lengthSeconds')
-            or get_first(microformats, 'lengthSeconds')
+            get_first(microformats, 'lengthSeconds')
+            or get_first(video_details, 'lengthSeconds')
             or parse_duration(search_meta('duration'))) or None
 
         live_broadcast_details, live_status, streaming_data, formats, automatic_captions = \

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3788,8 +3788,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     entries, video_id, video_title, video_description)
 
         duration = (int_or_none(get_first(video_details, 'lengthSeconds'))
-            or int_or_none(get_first(microformats, 'lengthSeconds'))
-            or parse_duration(search_meta('duration')) or None)
+                    or int_or_none(get_first(microformats, 'lengthSeconds'))
+                    or parse_duration(search_meta('duration')) or None)
 
         live_broadcast_details, live_status, streaming_data, formats, automatic_captions = \
             self._list_formats(video_id, microformats, video_details, player_responses, player_url, duration)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fixes #5378

Upcoming premieres on YouTube have the `lengthSeconds` field in `video_details` set to the string '0', making the call to `int_or_none` short-circuit and return `None`.

This PR switches around the order to look up the value in `microformats` first, which does return the video duration.

Output of command in listed issue (`-U` omitted):

```
[debug] Command-line config: ['-v', 'https://www.youtube.com/watch?v=AtwcZeFLvpI', '-s', '--ignore-no-f', '--print', '%(duration)s']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.10.04 [4e0511f27] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: ac3fff17b
[debug] Python 3.9.2 (CPython 64bit) - Windows-10-10.0.19041-SP0
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg 5.0.1-full_build-www.gyan.dev (setts), ffprobe 5.0.1-full_build-www.gyan.dev
[debug] Optional libraries: Cryptodome-3.15.0, brotli-1.0.9, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1702 extractors
[debug] [youtube] Extracting URL: https://www.youtube.com/watch?v=AtwcZeFLvpI
[youtube] AtwcZeFLvpI: Downloading webpage
[youtube] AtwcZeFLvpI: Downloading android player API JSON
WARNING: [youtube] Premieres in 11 hours
WARNING: No video formats found!
[debug] Default format spec: bestvideo*+bestaudio/best
WARNING: Requested format is not available
31
```

I'm not sure if changing the order causes any regressions; a quick check with a few URLs suggests that it doesn't.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
    - The code already existed as part of the repository; this PR only changes the order of operations.  I made this change, however.

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
