### PR TITLE
[extractor/epoch] Support videos without data-trailer

### DIFF
--- a/yt_dlp/extractor/epoch.py
+++ b/yt_dlp/extractor/epoch.py
@@ -1,4 +1,5 @@
 from .common import InfoExtractor
+from ..utils import extract_attributes, get_element_html_by_id
 
 
 class EpochIE(InfoExtractor):
@@ -42,12 +43,7 @@ class EpochIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        html_ws = r'\t\n\f\r\x20'
-        html_attr_val = r'(?:"[^"]*"|\'[^\']*\'|[{html_ws}]*[^"\'{html_ws}>][^{html_ws}>]*)'
-        youmaker_video_id = next(id for id in self._search_regex(
-            fr'[{html_ws}]data-trailer={html_attr_val}[{html_ws}]+data-id=(?:(["\'])(?P<id_quoted>[\w-]+)\1|(?P<id_unquoted>[\w-]+))',
-            webpage, 'url', group=('id_quoted', 'id_unquoted'))
-            if id is not None)
+        youmaker_video_id = extract_attributes(get_element_html_by_id('videobox', webpage))['data-id']
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
             f'http://vs1.youmaker.com/assets/{youmaker_video_id}/playlist.m3u8', video_id, 'mp4', m3u8_id='hls')
 

--- a/yt_dlp/extractor/epoch.py
+++ b/yt_dlp/extractor/epoch.py
@@ -28,13 +28,26 @@ class EpochIE(InfoExtractor):
                 'title': 'Kash Patel: A ‘6-Year-Saga’ of Government Corruption, From Russiagate to Mar-a-Lago',
             }
         },
+        {
+            'url': 'https://www.theepochtimes.com/dick-morris-discusses-his-book-the-return-trumps-big-2024-comeback_4819205.html',
+            'info_dict': {
+                'id': '9489f994-2a20-4812-b233-ac0e5c345632',
+                'ext': 'mp4',
+                'title': 'Dick Morris Discusses His Book ‘The Return: Trump’s Big 2024 Comeback’',
+            }
+        },
     ]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        youmaker_video_id = self._search_regex(r'data-trailer="[\w-]+" data-id="([\w-]+)"', webpage, 'url')
+        html_ws = r'\t\n\f\r\x20'
+        html_attr_val = r'(?:"[^"]*"|\'[^\']*\'|[{html_ws}]*[^"\'{html_ws}>][^{html_ws}>]*)'
+        youmaker_video_id = next(id for id in self._search_regex(
+            fr'[{html_ws}]data-trailer={html_attr_val}[{html_ws}]+data-id=(?:(["\'])(?P<id_quoted>[\w-]+)\1|(?P<id_unquoted>[\w-]+))',
+            webpage, 'url', group=('id_quoted', 'id_unquoted'))
+            if id is not None)
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
             f'http://vs1.youmaker.com/assets/{youmaker_video_id}/playlist.m3u8', video_id, 'mp4', m3u8_id='hls')
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -519,6 +519,7 @@ class HTMLAttributeParser(html.parser.HTMLParser):
 
     def handle_starttag(self, tag, attrs):
         self.attrs = dict(attrs)
+        raise compat_HTMLParseError('done')
 
 
 class HTMLListAttrsParser(html.parser.HTMLParser):


### PR DESCRIPTION
### Description of your *pull request* and other information

Updates the Epoch Times video id regular expression to tolerate empty `data-trailer` attributes.

Fixes #5359


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
