### PR TITLE
[youtube] Fixes for redesign Part 2

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -5981,8 +5981,10 @@ class YoutubeTabIE(YoutubeTabBaseInfoExtractor):
                 'extractor': YoutubeTabIE.IE_NAME,
                 'webpage_url': url,
             })
-        # Users expect to get all `video_id`s with `--flat-playlist`. So don't return `url_result`
-        entries.extend(map(self._real_extract, extra_tabs))
+        if self.get_param('playlist_items') == '0':
+            entries.extend(self.url_result(u, YoutubeTabIE) for u in extra_tabs)
+        else:  # Users expect to get all `video_id`s even with `--flat-playlist`. So don't return `url_result`
+            entries.extend(map(self._real_extract, extra_tabs))
 
         if len(entries) == 1:
             return entries[0]

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -5849,7 +5849,9 @@ class YoutubeTabIE(YoutubeTabBaseInfoExtractor):
         tab_id = (traverse_obj(tab, 'tabIdentifier', expected_type=str)
                   or tab_url and self._get_url_mobj(tab_url)['tab'][1:])
         if tab_id:
-            return tab_id, tab_name
+            return {
+                'TAB_ID_SPONSORSHIPS': 'membership',
+            }.get(tab_id, tab_id), tab_name
 
         # Fallback to tab name if we cannot get the tab id.
         # XXX: should we strip non-ascii letters? e.g. in case of 'let's play' tab example on special gaming channel

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4627,7 +4627,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
             if info['uploader_id']:
                 info['id'] = info['uploader_id']
         else:
-            metadata_renderer = traverse_obj(data, ('metadata', 'playlistMetadataRenderer'), expected_type=dict) or {}
+            metadata_renderer = traverse_obj(data, ('metadata', 'playlistMetadataRenderer'), expected_type=dict)
 
         # We can get the uncropped banner/avatar by replacing the crop params with '=s0'
         # See: https://github.com/yt-dlp/yt-dlp/issues/2237#issuecomment-1013694714
@@ -4668,13 +4668,13 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
             playlist_header_renderer, ('playlistHeaderBanner', 'heroPlaylistThumbnailRenderer', 'thumbnail'))
 
         info.update({
-            'title': (metadata_renderer.get('title')
+            'title': (traverse_obj(metadata_renderer, 'title')
                       or self._get_text(data, ('header', 'hashtagHeaderRenderer', 'hashtag'))
                       or info['id']),
             'availability': self._extract_availability(data),
             'channel_follower_count': self._get_count(data, ('header', ..., 'subscriberCountText')),
-            'description': metadata_renderer.get('description'),
-            'tags': try_get(metadata_renderer, lambda x: x['keywords'].split()),
+            'description': try_get(metadata_renderer, lambda x: x.get('description', '')),
+            'tags': try_get(metadata_renderer or {}, lambda x: x.get('keywords', '').split()),
             'thumbnails': (primary_thumbnails or playlist_thumbnails) + avatar_thumbnails + channel_banners,
         })
 
@@ -5737,7 +5737,16 @@ class YoutubeTabIE(YoutubeTabBaseInfoExtractor):
         'url': 'https://www.youtube.com/channel/UCK9V2B22uJYu3N7eR_BT9QA',
         'info_dict': {
             'id': 'UCK9V2B22uJYu3N7eR_BT9QA',
-            'title': 'Uploads for UCK9V2B22uJYu3N7eR_BT9QA'
+            'title': 'Polka Ch. 尾丸ポルカ',
+            'channel_follower_count': int,
+            'channel_id': 'UCK9V2B22uJYu3N7eR_BT9QA',
+            'channel_url': 'https://www.youtube.com/channel/UCK9V2B22uJYu3N7eR_BT9QA',
+            'uploader': 'Polka Ch. 尾丸ポルカ',
+            'description': 'md5:3b8df1ac5af337aa206e37ee3d181ec9',
+            'channel': 'Polka Ch. 尾丸ポルカ',
+            'tags': 'count:35',
+            'uploader_url': 'https://www.youtube.com/channel/UCK9V2B22uJYu3N7eR_BT9QA',
+            'uploader_id': 'UCK9V2B22uJYu3N7eR_BT9QA',
         },
         'playlist_count': 3,
     }, {

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -5846,8 +5846,8 @@ class YoutubeTabIE(YoutubeTabBaseInfoExtractor):
         tab_url = urljoin(base_url, traverse_obj(
             tab, ('endpoint', 'commandMetadata', 'webCommandMetadata', 'url')))
 
-        tab_id = (traverse_obj(tab, 'tabIdentifier', expected_type=str)
-                  or tab_url and self._get_url_mobj(tab_url)['tab'][1:])
+        tab_id = (tab_url and self._get_url_mobj(tab_url)['tab'][1:]
+                  or traverse_obj(tab, 'tabIdentifier', expected_type=str))
         if tab_id:
             return {
                 'TAB_ID_SPONSORSHIPS': 'membership',


### PR DESCRIPTION
* Fixes https://github.com/yt-dlp/yt-dlp/issues/5486
* Tries to make similar issues less likely in future
* Add metadata for the wrapping playlist
* Improves [`--flat-playlist --get-id`](https://github.com/yt-dlp/yt-dlp/pull/5439#issuecomment-1309054679) using [method 3](https://github.com/yt-dlp/yt-dlp/pull/5439#issuecomment-1309322019) (still not sure whether this is the best approach)

@coletdjnz Pls review, especially https://github.com/yt-dlp/yt-dlp/commit/905956cb63356f3d7316d20c5a5ec1e204b72c44 - is there some other metadata that should not be copied into parent?