### PR TITLE
[extractor/tencent] Fix geo-restricted video extraction

### DIFF
--- a/yt_dlp/extractor/tencent.py
+++ b/yt_dlp/extractor/tencent.py
@@ -67,9 +67,11 @@ class TencentBaseIE(InfoExtractor):
 
         formats, subtitles = [], {}
         for video_format in video_response['ul']['ui']:
-            if video_format.get('hls'):
+            url_is_m3u8 = determine_ext(video_format['url']) == 'm3u8'
+            if video_format.get('hls') or url_is_m3u8:
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                    video_format['url'] + video_format['hls']['pt'], video_id, 'mp4', fatal=False)
+                    video_format['url'] if url_is_m3u8 else video_format['url'] + video_format['hls']['pt'],
+                    video_id, 'mp4', fatal=False)
                 for f in fmts:
                     f.update({'width': video_width, 'height': video_height})
 
@@ -187,6 +189,10 @@ class VQQVideoIE(VQQBaseIE):
             'thumbnail': r're:^https?://[^?#]+s0043cwsgj0',
             'series': '青年理工工作者生活研究所',
         },
+    }, {
+        # Geo-restricted to China
+        'url': 'https://v.qq.com/x/cover/mcv8hkc8zk8lnov/x0036x5qqsr.html',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/tencent.py
+++ b/yt_dlp/extractor/tencent.py
@@ -67,10 +67,9 @@ class TencentBaseIE(InfoExtractor):
 
         formats, subtitles = [], {}
         for video_format in video_response['ul']['ui']:
-            url_is_m3u8 = determine_ext(video_format['url']) == 'm3u8'
-            if video_format.get('hls') or url_is_m3u8:
+            if video_format.get('hls') or determine_ext(video_format['url']) == 'm3u8':
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                    video_format['url'] if url_is_m3u8 else video_format['url'] + video_format['hls']['pt'],
+                    video_format['url'] + traverse_obj(video_format, ('hls', 'pt'), default=''),
                     video_id, 'mp4', fatal=False)
                 for f in fmts:
                     f.update({'width': video_width, 'height': video_height})


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

For some China-only videos, the api returns a direct m3u8 link that the extractor didn't handle before and therefore failed.

### Verbose log with this fix

The warnings seem to be network/proxy related, but the OP confirmed that it works without errors on its side
```bash
[debug] Command-line config: ['https://v.qq.com/x/cover/mcv8hkc8zk8lnov/x0036x5qqsr.html', '--verbose', '--proxy', 'private-proxy', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.10.04 [4e0511f27] (source)
[debug] Lazy loading extractors is disabled
[debug] Plugins: ['SamplePluginIE', 'SamplePluginPP']
[debug] Git HEAD: 62fd10172
[debug] Python 3.10.7 (CPython 64bit) - Linux-5.19.0-23-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] Checking exe version: ffmpeg -bsfs
[debug] Checking exe version: ffprobe -bsfs
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {'http': 'private-proxy', 'https': 'private-proxy'}
[debug] Loaded 1722 extractors
[debug] [vqq:video] Extracting URL: https://v.qq.com/x/cover/mcv8hkc8zk8lnov/x0036x5qqsr.html
[vqq:video] x0036x5qqsr: Downloading webpage
[vqq:video] x0036x5qqsr: Downloading webpage
[vqq:video] x0036x5qqsr: Downloading webpage
[vqq:video] x0036x5qqsr: Downloading m3u8 information
WARNING: [vqq:video] Failed to download m3u8 information: <urlopen error [Errno 104] Connection reset by peer>
[vqq:video] x0036x5qqsr: Downloading m3u8 information
WARNING: [vqq:video] Failed to download m3u8 information: <urlopen error _ssl.c:980: The handshake operation timed out>
[vqq:video] x0036x5qqsr: Downloading m3u8 information
WARNING: [vqq:video] Failed to download m3u8 information: <urlopen error [Errno 104] Connection reset by peer>
[vqq:video] x0036x5qqsr: Downloading m3u8 information
[vqq:video] x0036x5qqsr: Downloading webpage
[vqq:video] x0036x5qqsr: Downloading m3u8 information
WARNING: [vqq:video] Failed to download m3u8 information: <urlopen error _ssl.c:980: The handshake operation timed out>
[vqq:video] x0036x5qqsr: Downloading m3u8 information
WARNING: [vqq:video] Failed to download m3u8 information: <urlopen error [Errno 104] Connection reset by peer>
[vqq:video] x0036x5qqsr: Downloading m3u8 information
WARNING: [vqq:video] Failed to download m3u8 information: <urlopen error [Errno 104] Connection reset by peer>
[vqq:video] x0036x5qqsr: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for x0036x5qqsr:
ID EXT RESOLUTION │ PROTO │ VCODEC  ACODEC
───────────────────────────────────────────
0  mp4 864x368    │ https │ unknown unknown
1  mp4 864x368    │ https │ unknown unknown
2  mp4 864x368    │ https │ unknown unknown
3  mp4 864x368    │ https │ unknown unknown
4  mp4 1280x544   │ m3u8  │ unknown unknown
5  mp4 1280x544   │ m3u8  │ unknown unknown
```

Fixes #5230 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
