### PR TITLE
[rumble] add dedicated RumbleIE extractor class

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1561,6 +1561,7 @@ from .ruhd import RUHDIE
 from .rule34video import Rule34VideoIE
 from .rumble import (
     RumbleEmbedIE,
+    RumbleIE,
     RumbleChannelIE,
 )
 from .rutube import (

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -4,11 +4,15 @@ import re
 from .common import InfoExtractor
 from ..compat import compat_HTTPError
 from ..utils import (
+    ExtractorError,
+    UnsupportedError,
+    clean_html,
+    get_element_by_class,
     int_or_none,
+    parse_count,
     parse_iso8601,
     traverse_obj,
     unescapeHTML,
-    ExtractorError,
 )
 
 
@@ -111,24 +115,6 @@ class RumbleEmbedIE(InfoExtractor):
     }]
 
     _WEBPAGE_TESTS = [
-        {
-            'note': 'Rumble embed',
-            'url': 'https://rumble.com/vdmum1-moose-the-dog-helps-girls-dig-a-snow-fort.html',
-            'md5': '53af34098a7f92c4e51cf0bd1c33f009',
-            'info_dict': {
-                'id': 'vb0ofn',
-                'ext': 'mp4',
-                'timestamp': 1612662578,
-                'uploader': 'LovingMontana',
-                'channel': 'LovingMontana',
-                'upload_date': '20210207',
-                'title': 'Winter-loving dog helps girls dig a snow fort ',
-                'channel_url': 'https://rumble.com/c/c-546523',
-                'thumbnail': 'https://sp.rmbl.ws/s8/1/5/f/x/x/5fxxb.OvCc.1-small-Moose-The-Dog-Helps-Girls-D.jpg',
-                'duration': 103,
-                'live_status': 'not_live',
-            }
-        },
         {
             'note': 'Rumble JS embed',
             'url': 'https://therightscoop.com/what-does-9-plus-1-plus-1-equal-listen-to-this-audio-of-attempted-kavanaugh-assassins-call-and-youll-get-it',
@@ -234,6 +220,96 @@ class RumbleEmbedIE(InfoExtractor):
             'uploader': author.get('name'),
             'live_status': live_status,
         }
+
+
+class RumbleIE(InfoExtractor):
+    _VALID_URL = r'''(?x)
+        https?://(?:www\.)?rumble\.com/
+        (?P<id>v            # ids start with v
+            (?!ideos)       # exclude https://rumble.com/videos
+            [0-9a-zA-Z]{4,} # video page identifier (case insensitive)
+            (?:-[^&?#$/]*)? # usually followed by -<title>.html otherwise redirected
+        )
+        [^/]*$              # queries are allowed, but no slashes
+    '''
+    _EMBED_REGEX = [r'<a class=video-item--a href=(?P<url>/v[0-9a-z.-]+\.html)>']
+    _TESTS = [{
+        'add_ie': ['RumbleEmbed'],
+        'url': 'https://rumble.com/vdmum1-moose-the-dog-helps-girls-dig-a-snow-fort.html',
+        'md5': '53af34098a7f92c4e51cf0bd1c33f009',
+        'info_dict': {
+            'id': 'vb0ofn',
+            'ext': 'mp4',
+            'timestamp': 1612662578,
+            'uploader': 'LovingMontana',
+            'channel': 'LovingMontana',
+            'upload_date': '20210207',
+            'title': 'Winter-loving dog helps girls dig a snow fort ',
+            'description': 'Moose the dog is more than happy to help '
+                           'with digging out this epic snow fort. Great job, Moose!',
+            'channel_url': 'https://rumble.com/c/c-546523',
+            'thumbnail': r're:https://.+\.jpg',
+            'duration': 103,
+            'like_count': int,
+            'view_count': int,
+            'live_status': 'not_live',
+        }
+    }, {
+        'url': 'http://www.rumble.com/vDMUM1?key=value',
+        'only_matching': True,
+    }]
+
+    _WEBPAGE_TESTS = [{
+        'url': 'https://rumble.com/videos?page=2',
+        'playlist_count': 25,
+        'info_dict': {
+            'id': 'videos?page=2',
+            'title': 'All videos',
+            'description': 'Browse videos uploaded to Rumble.com',
+            'age_limit': 0,
+        },
+    }, {
+        'url': 'https://rumble.com/live-videos',
+        'playlist_mincount': 19,
+        'info_dict': {
+            'id': 'live-videos',
+            'title': 'Live Videos',
+            'description': 'Live videos on Rumble.com',
+            'age_limit': 0,
+        },
+    }, {
+        'url': 'https://rumble.com/search/video?q=rumble&sort=views',
+        'playlist_count': 24,
+        'info_dict': {
+            'id': 'video?q=rumble&sort=views',
+            'title': 'Search results for: rumble',
+            'age_limit': 0,
+        },
+    }]
+
+    def _real_extract(self, url):
+        page_id = self._match_id(url)
+        webpage = self._download_webpage(url, page_id)
+
+        rumble_embed = self._downloader.get_info_extractor(RumbleEmbedIE.ie_key())
+        try:
+            url_info = next(rumble_embed.extract_from_webpage(self._downloader, url, webpage))
+        except StopIteration:
+            raise UnsupportedError(url)
+        info = rumble_embed.extract(url_info['url'])
+        release_ts_str = self._search_regex(
+            r'(?:Livestream begins|Streamed on):\s+<time datetime="([^"]+)',
+            webpage, 'release date', fatal=False, default=None)
+        view_count_str = self._search_regex(r'<span class="media-heading-info">([\d,]+) Views',
+                                            webpage, 'view count', fatal=False, default=None)
+        info.update({
+            'release_timestamp': parse_iso8601(release_ts_str),
+            'view_count': parse_count(view_count_str),
+            'like_count': parse_count(get_element_by_class('rumbles-count', webpage)),
+            'description': clean_html(get_element_by_class('media-description', webpage)),
+        })
+
+        return info
 
 
 class RumbleChannelIE(InfoExtractor):

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -281,10 +281,8 @@ class RumbleIE(InfoExtractor):
     def _real_extract(self, url):
         page_id = self._match_id(url)
         webpage = self._download_webpage(url, page_id)
-
-        try:
-            url_info = next(RumbleEmbedIE.extract_from_webpage(self._downloader, url, webpage))
-        except StopIteration:
+        url_info = next(RumbleEmbedIE.extract_from_webpage(self._downloader, url, webpage), None)
+        if not url_info:
             raise UnsupportedError(url)
 
         release_ts_str = self._search_regex(


### PR DESCRIPTION

### Description
Currently rumble URLs are supported via embedded links found by Generic extractor.
The native webpages on rumble.com contain some additional metadata which can be extracted (description, view_count, like_count, release_timestamp)

There were other attempts (#3031) but they required an additional web request, which is time consuming.

This PR adds a dedicated extractor for rumble.com URLs which uses the info from RumbleEmbedIE and updates it with the metadata from the webpage, hence using the same number of web requests as before.

Via `_EMBED_REGEX` it automatically supports some special playlist pages like:
* https://rumble.com/videos
* https://rumble.com/live-videos
* https://rumble.com/editor-picks
* https://rumble.com/license-videos

Fixes #2846


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
