### PR TITLE
[extractor/screencastify] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1603,6 +1603,7 @@ from .savefrom import SaveFromIE
 from .sbs import SBSIE
 from .screen9 import Screen9IE
 from .screencast import ScreencastIE
+from .screencastify import ScreencastifyIE
 from .screencastomatic import ScreencastOMaticIE
 from .scrippsnetworks import (
     ScrippsNetworksWatchIE,

--- a/yt_dlp/extractor/screencastify.py
+++ b/yt_dlp/extractor/screencastify.py
@@ -1,0 +1,49 @@
+import urllib.parse
+
+from .common import InfoExtractor
+from ..utils import traverse_obj, update_url_query
+
+
+class ScreencastifyIE(InfoExtractor):
+    _VALID_URL = r'https?://watch\.screencastify\.com/v/(?P<id>[^/?#]+)'
+    _TESTS = [{
+        'url': 'https://watch.screencastify.com/v/sYVkZip3quLKhHw4Ybk8',
+        'info_dict': {
+            'id': 'sYVkZip3quLKhHw4Ybk8',
+            'ext': 'mp4',
+            'title': 'Inserting and Aligning the Case Top and Bottom',
+            'description': '',
+            'uploader': 'Paul Gunn',
+            'extra_param_to_segment_url': str,
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        info = self._download_json(
+            f'https://umbrella.svc.screencastify.com/api/umbrellaService/watch/{video_id}', video_id)
+
+        query_string = traverse_obj(info, ('manifest', 'auth', 'query'))
+        query = urllib.parse.parse_qs(query_string)
+        formats = []
+        hls_manifest_url = traverse_obj(info, ('manifest', 'hlsUrl'))
+        if hls_manifest_url:
+            formats.extend(
+                self._extract_m3u8_formats(
+                    hls_manifest_url, video_id, ext='mp4', m3u8_id='hls', query=query))
+        # DASH formats also need query to be appended to segment URLs but downloader is unable to
+        # dash_manifest_url = traverse_obj(info, ('manifest', 'url'))
+        for f in formats:
+            f['url'] = update_url_query(f['url'], query)
+
+        return {
+            'id': video_id,
+            'title': info.get('title'),
+            'description': info.get('description'),
+            'uploader': info.get('userName'),
+            'formats': formats,
+            'extra_param_to_segment_url': query_string,
+        }

--- a/yt_dlp/extractor/screencastify.py
+++ b/yt_dlp/extractor/screencastify.py
@@ -29,13 +29,16 @@ class ScreencastifyIE(InfoExtractor):
         query_string = traverse_obj(info, ('manifest', 'auth', 'query'))
         query = urllib.parse.parse_qs(query_string)
         formats = []
+        dash_manifest_url = traverse_obj(info, ('manifest', 'url'))
+        if dash_manifest_url:
+            formats.extend(
+                self._extract_mpd_formats(
+                    dash_manifest_url, video_id, mpd_id='dash', query=query, fatal=False))
         hls_manifest_url = traverse_obj(info, ('manifest', 'hlsUrl'))
         if hls_manifest_url:
             formats.extend(
                 self._extract_m3u8_formats(
-                    hls_manifest_url, video_id, ext='mp4', m3u8_id='hls', query=query))
-        # DASH formats also need query to be appended to segment URLs but downloader is unable to
-        # dash_manifest_url = traverse_obj(info, ('manifest', 'url'))
+                    hls_manifest_url, video_id, ext='mp4', m3u8_id='hls', query=query, fatal=False))
         for f in formats:
             f['url'] = update_url_query(f['url'], query)
 

--- a/yt_dlp/extractor/screencastify.py
+++ b/yt_dlp/extractor/screencastify.py
@@ -17,7 +17,7 @@ class ScreencastifyIE(InfoExtractor):
             'extra_param_to_segment_url': str,
         },
         'params': {
-            'skip_download': True,
+            'skip_download': 'm3u8',
         },
     }]
 


### PR DESCRIPTION
Adds support for screencastify.com

Closes #5603


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
