### PR TITLE
[extractor/youtube] Add fallback formats

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3680,6 +3680,19 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 stream_ids.append(stream_id)
             yield dct
 
+            # Fallback format url
+            # TODO: fix preference, and implement for DASH/HLS
+            mn = query.get('mn', [''])[0].split(',')
+            fvip = query.get('fvip', [''])[0]
+            if len(mn) > 1 and mn[1] and fvip:
+                fallback_dct = dct.copy()
+                fmt_url_parsed = urllib.parse.urlparse(fallback_dct['url'])
+                new_netloc = re.sub(r'\d+', fvip, fmt_url_parsed.netloc.split('---')[0]) + '---' + mn[1] + '.googlevideo.com'
+                fallback_dct['url'] = update_url_query(
+                    fmt_url_parsed._replace(netloc=new_netloc).geturl(), {'fallback_count': '1'})
+                fallback_dct['format_id'] += 'f'
+                yield fallback_dct
+
         needs_live_processing = self._needs_live_processing(live_status, duration)
         skip_bad_formats = not self._configuration_arg('include_incomplete_formats')
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3691,6 +3691,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 fallback_dct['url'] = update_url_query(
                     fmt_url_parsed._replace(netloc=new_netloc).geturl(), {'fallback_count': '1'})
                 fallback_dct['format_id'] += 'f'
+                fallback_dct['format_note'] += ' (fallback)'
                 yield fallback_dct
 
         needs_live_processing = self._needs_live_processing(live_status, duration)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3760,7 +3760,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         # Fallback format url
                         # Note: YouTube does not allow us changing the playback_host in the manifest_url.
                         # So this will not work for external downloaders such as ffmpeg.
-                        # XXX: if ?fallback_count=1 is sent in the request, the server will just redirect to the original..
                         fallback_url = self._build_fallback_playback_url(
                             f['fragment_base_url'],
                             mn=self._search_regex(r'/mn/([^/]+)', f['fragment_base_url'], 'mn param', default=None),
@@ -3770,7 +3769,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                             f_fallback['fragment_base_url'] = fallback_url
                             f_fallback['format_id'] += '-f'
                             f_fallback['format_note'] += ' (fallback)'
-                            print(f_fallback['fragment_base_url'])
                             yield f_fallback
 
         yield subtitles


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Potential workaround for #1986. This makes use of the `mn` and `fvip` parameters to change the host to the fallback server.

This adds fallback formats for each format generated from the url params of the format url. This is designed to be used with `--check-formats`.

It's not a perfect solution but should technically work.

I've implemented this for HTTP and DASH (probably can do HLS too). 


Issues to fix:
- [ ] - preference needs to be corrected (@pukkandan since it's your area)
- [ ] - Support HLS

Known issues/concerns/observations:
- The DASH downloader strips url parameters. This means the fallback_count parameter is not sent. This doesn't appear to be required for this but good to keep in mind.
- Format table is now much bigger as there are duplicated formats
- DASH fallback formats will not work correctly for external downloaders that use the manifest url/url instead of the fragment base url. Instead ffmpeg will download the non-fallback link under the fallback format. This is because YouTube does not appear to allow us to change the playback_host for the `manifest.googlevideo.com` url.
- YouTube may redirect to another server midway through a download. Meaning that for every request, there'll be a redirect and it'll slow the download down. Q: Does the YT clients take note of this redirected url and use the host for subsequent requests?
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
