### PR TITLE
Fix headers for ffmpeg and video+audio formats

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3171,6 +3171,8 @@ class YoutubeDL:
                                 'f%s' % f['format_id'], info_dict['ext'])
                             downloaded.append(fname)
                         info_dict['url'] = '\n'.join(f['url'] for f in requested_formats)
+                        info_dict['http_headers'] = traverse_obj(
+                            info_dict, 'http_headers', ('requested_formats', ..., 'http_headers'), get_all=False)
                         success, real_download = self.dl(temp_filename, info_dict)
                         info_dict['__real_download'] = real_download
                     else:

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3171,8 +3171,6 @@ class YoutubeDL:
                                 'f%s' % f['format_id'], info_dict['ext'])
                             downloaded.append(fname)
                         info_dict['url'] = '\n'.join(f['url'] for f in requested_formats)
-                        info_dict['http_headers'] = traverse_obj(
-                            info_dict, 'http_headers', ('requested_formats', ..., 'http_headers'), get_all=False)
                         success, real_download = self.dl(temp_filename, info_dict)
                         info_dict['__real_download'] = real_download
                     else:

--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -342,7 +342,6 @@ class FFmpegFD(ExternalFD):
             and cls.can_download(info_dict))
 
     def _call_downloader(self, tmpfilename, info_dict):
-        urls = [f['url'] for f in info_dict.get('requested_formats', [])] or [info_dict['url']]
         ffpp = FFmpegPostProcessor(downloader=self)
         if not ffpp.available:
             self.report_error('m3u8 download detected but ffmpeg could not be found. Please install')
@@ -371,16 +370,6 @@ class FFmpegFD(ExternalFD):
             # https://github.com/ytdl-org/youtube-dl/issues/11800#issuecomment-275037127
             # http://trac.ffmpeg.org/ticket/6125#comment:10
             args += ['-seekable', '1' if seekable else '0']
-
-        http_headers = None
-        if info_dict.get('http_headers'):
-            youtubedl_headers = handle_youtubedl_headers(info_dict['http_headers'])
-            http_headers = [
-                # Trailing \r\n after each HTTP header is important to prevent warning from ffmpeg/avconv:
-                # [http @ 00000000003d2fa0] No trailing CRLF found in HTTP header.
-                '-headers',
-                ''.join(f'{key}: {val}\r\n' for key, val in youtubedl_headers.items())
-            ]
 
         env = None
         proxy = self.params.get('proxy')
@@ -434,21 +423,30 @@ class FFmpegFD(ExternalFD):
 
         start_time, end_time = info_dict.get('section_start') or 0, info_dict.get('section_end')
 
-        for i, url in enumerate(urls):
-            if http_headers is not None and re.match(r'^https?://', url):
-                args += http_headers
+        selected_formats = info_dict.get('requested_formats') or [info_dict]
+        for i, fmt in enumerate(selected_formats):
+            if fmt.get('http_headers') is not None:
+                headers_dict = handle_youtubedl_headers(fmt['http_headers'])
+                # Trailing \r\n after each HTTP header is important to prevent warning from ffmpeg/avconv:
+                # [http @ 00000000003d2fa0] No trailing CRLF found in HTTP header.
+                http_headers = [
+                    '-headers', ''.join(f'{key}: {val}\r\n' for key, val in headers_dict.items())
+                ]
+                if re.match(r'^https?://', fmt['url']):
+                    args += http_headers
+
             if start_time:
                 args += ['-ss', str(start_time)]
             if end_time:
                 args += ['-t', str(end_time - start_time)]
 
-            args += self._configuration_args((f'_i{i + 1}', '_i')) + ['-i', url]
+            args += self._configuration_args((f'_i{i + 1}', '_i')) + ['-i', fmt['url']]
 
         if not (start_time or end_time) or not self.params.get('force_keyframes_at_cuts'):
             args += ['-c', 'copy']
 
         if info_dict.get('requested_formats') or protocol == 'http_dash_segments':
-            for (i, fmt) in enumerate(info_dict.get('requested_formats') or [info_dict]):
+            for i, fmt in enumerate(selected_formats):
                 stream_number = fmt.get('manifest_stream_number', 0)
                 args.extend(['-map', f'{i}:{stream_number}'])
 
@@ -488,8 +486,9 @@ class FFmpegFD(ExternalFD):
         args.append(encodeFilename(ffpp._ffmpeg_filename_argument(tmpfilename), True))
         self._debug_cmd(args)
 
+        piped = any(fmt['url'] in ('-', 'pipe:') for fmt in selected_formats)
         with Popen(args, stdin=subprocess.PIPE, env=env) as proc:
-            if url in ('-', 'pipe:'):
+            if piped:
                 self.on_process_started(proc, proc.stdin)
             try:
                 retval = proc.wait()
@@ -499,7 +498,7 @@ class FFmpegFD(ExternalFD):
                 # produces a file that is playable (this is mostly useful for live
                 # streams). Note that Windows is not affected and produces playable
                 # files (see https://github.com/ytdl-org/youtube-dl/issues/8300).
-                if isinstance(e, KeyboardInterrupt) and sys.platform != 'win32' and url not in ('-', 'pipe:'):
+                if isinstance(e, KeyboardInterrupt) and sys.platform != 'win32' and not piped:
                     proc.communicate_or_kill(b'q')
                 else:
                     proc.kill(timeout=None)

--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -425,15 +425,11 @@ class FFmpegFD(ExternalFD):
 
         selected_formats = info_dict.get('requested_formats') or [info_dict]
         for i, fmt in enumerate(selected_formats):
-            if fmt.get('http_headers') is not None:
+            if fmt.get('http_headers') and re.match(r'^https?://', fmt['url']):
                 headers_dict = handle_youtubedl_headers(fmt['http_headers'])
                 # Trailing \r\n after each HTTP header is important to prevent warning from ffmpeg/avconv:
                 # [http @ 00000000003d2fa0] No trailing CRLF found in HTTP header.
-                http_headers = [
-                    '-headers', ''.join(f'{key}: {val}\r\n' for key, val in headers_dict.items())
-                ]
-                if re.match(r'^https?://', fmt['url']):
-                    args += http_headers
+                args.extend(['-headers', ''.join(f'{key}: {val}\r\n' for key, val in headers_dict.items())])
 
             if start_time:
                 args += ['-ss', str(start_time)]

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -2374,7 +2374,7 @@ class GenericIE(InfoExtractor):
             info_dict.update({
                 'formats': formats,
                 'subtitles': subtitles,
-                'http_headers': headers,
+                'http_headers': headers or None,
             })
             return info_dict
 


### PR DESCRIPTION
This PR aims to fix HTTP headers not being passed to ffmpeg for formats that need to be merged.

For example, if you try to use ffmpeg to download an HLS stream that has separate media playlists for video and for audio, yt-dlp (latest release+master) will not pass any http headers to ffmpeg (see last line of log):
```shellsession
$ yt-dlp --downloader ffmpeg -v 'https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8'
[debug] Command-line config: ['--downloader', 'ffmpeg', '-v', 'https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.11.11 [8b644025b]
...
[debug] [generic] Extracting URL: https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8
[generic] hlsv4_master: Downloading webpage
[debug] Identified a direct video link
[generic] hlsv4_master: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] hlsv4_master: Downloading 1 format(s): 5783+audio-1-English
[debug] Invoking ffmpeg downloader on "https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_1920x1080-5400-v4.m3u8", "https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_audio-160-v4.m3u8"
[download] Destination: 20221127_Sun_23_58_11_NA_hlsv4_master_hlsv4_master.mp4
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -i https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_1920x1080-5400-v4.m3u8 -i https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_audio-160-v4.m3u8 -c copy -map 0:0 -map 1:0 -f mp4 file:20221127_Sun_23_58_11_NA_hlsv4_master_hlsv4_master.mp4.part
```
yt-dlp should be passing standard headers as well as any headers added via CLI args / params. But it doesn't even pass manually added headers to ffmpeg:
```shellsession
$ yt-dlp --add-header "User-Agent:testing" --downloader ffmpeg -v 'https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8'
[debug] Command-line config: ['--add-header', 'User-Agent:testing', '--downloader', 'ffmpeg', '-v', 'https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8']
...
[info] hlsv4_master: Downloading 1 format(s): 5783+audio-1-English
[debug] Invoking ffmpeg downloader on "https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_1920x1080-5400-v4.m3u8", "https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_audio-160-v4.m3u8"
[download] Destination: 20221127_Sun_23_58_11_NA_hlsv4_master_hlsv4_master.mp4
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -i https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_1920x1080-5400-v4.m3u8 -i https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_audio-160-v4.m3u8 -c copy -map 0:0 -map 1:0 -f mp4 file:20221127_Sun_23_58_11_NA_hlsv4_master_hlsv4_master.mp4.part
```
This was brought to my attention by #5658 (which this PR addresses but may not necessarily resolve). After some investigation I found a couple problems that need fixing:

 - A regression in [3166e68](https://github.com/yt-dlp/yt-dlp/commit/3166e6840c7f7b1ea3984f0e40a892d87e690480#diff-28ac72db5ec9cbb295cfe1f162c6947893d6f348cb3ce76b90a6459194770892R2683) where the generic extractor returns its info_dict's `http_headers` as an empty dict (if there aren't any headers in the `smuggled_data`)
 
If we trace the path of `http_headers` through ydl we can see why this is a problem:

`process_video_result` - here the std/params headers are merged with `info_dict['http_headers']`, but they are bound to the `formats`:
https://github.com/yt-dlp/yt-dlp/blob/48652590ec401f4e747a5e51552cdcac20744aa1/yt_dlp/YoutubeDL.py#L2652-L2656

further down in `process_video_result` - here the info_dict is updated with `fmt`, but if this is a merged format then the value of `fmt` is actually a list of `requested_formats`, so the headers still do not get directly bound to `info_dict['http_headers']`:
https://github.com/yt-dlp/yt-dlp/blob/48652590ec401f4e747a5e51552cdcac20744aa1/yt_dlp/YoutubeDL.py#L2751-L2753

`process_info` - here is where the info_dict is updated with each of the `requested_formats` and the headers are bound to `info_dict['http_headers']` - BUT this is ONLY reached `if not fd`, so this code will not run if ffmpeg is the downloader:
https://github.com/yt-dlp/yt-dlp/blob/48652590ec401f4e747a5e51552cdcac20744aa1/yt_dlp/YoutubeDL.py#L3197-L3200

if we look right above in the `elif fd:` block, we see nothing happens with the info_dict/formats/http_headers:
https://github.com/yt-dlp/yt-dlp/blob/48652590ec401f4e747a5e51552cdcac20744aa1/yt_dlp/YoutubeDL.py#L3167-L3176
 
and then finally, the `dl` function checks if the info_dict's `http_headers` are `None`, and if so calculates headers:
https://github.com/yt-dlp/yt-dlp/blob/48652590ec401f4e747a5e51552cdcac20744aa1/yt_dlp/YoutubeDL.py#L2950-L2953
 but there are two problems with that. First is the regression mentioned above where the generic extractor's `info_dict['http_headers'] == {}`, so it remains as an empty dict.
 
 And then the second problem this PR is trying to fix:
 - Merged formats being downloaded with an external downloader will have their `http_headers` re-calculated in `dl` since their original value from the `ie_result` is never actually bound to `info_dict['http_headers']`. 
 
 That's my rationale for these changes. Credit to @Grub4K for helping with the FFmpegFD refactor.
 Here is a log of the problematic HLS stream w/patch applied:
```shellsession
$ yt-dlp --downloader ffmpeg -v 'https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8'
[debug] Command-line config: ['--downloader', 'ffmpeg', '-v', 'https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2022.11.11 [8b644025b]
...
[debug] [generic] Extracting URL: https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master.m3u8
[generic] hlsv4_master: Downloading webpage
[debug] Identified a direct video link
[generic] hlsv4_master: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] hlsv4_master: Downloading 1 format(s): 5783+audio-1-English
[debug] Invoking ffmpeg downloader on "https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_1920x1080-5400-v4.m3u8", "https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_audio-160-v4.m3u8"
[download] Destination: 20221127_Sun_23_58_11_NA_hlsv4_master_hlsv4_master.mp4
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.50 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -i https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_1920x1080-5400-v4.m3u8 -headers 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.50 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
' -i https://d1akq03u1jevln.cloudfront.net/wp-gmg/20221127/6383f78294dbac7cdab246cb/t_66e94b28caed4cafb71caa599f58eb5a_name_video/hlsv4_master_audio-160-v4.m3u8 -c copy -map 0:0 -map 1:0 -f mp4 file:20221127_Sun_23_58_11_NA_hlsv4_master_hlsv4_master.mp4.part
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
