### PR TITLE
[extractor/foxsports] Fix extractor

### DIFF
--- a/yt_dlp/extractor/foxsports.py
+++ b/yt_dlp/extractor/foxsports.py
@@ -1,31 +1,56 @@
 from .common import InfoExtractor
 
+from ..utils import (
+    HEADRequest,
+    float_or_none,
+    make_archive_id,
+    smuggle_url,
+)
+
 
 class FoxSportsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?foxsports\.com/(?:[^/]+/)*video/(?P<id>\d+)'
-
-    _TEST = {
-        'url': 'http://www.foxsports.com/tennessee/video/432609859715',
-        'md5': 'b49050e955bebe32c301972e4012ac17',
+    _VALID_URL = r'https?://(?:www\.)?foxsports\.com/watch/(?P<id>[\w-]+)'
+    _TESTS = [{
+        'url': 'https://www.foxsports.com/watch/play-612168c6700004b',
         'info_dict': {
-            'id': '432609859715',
+            'id': 'b72f5bd8658140baa5791bb676433733',
             'ext': 'mp4',
-            'title': 'Courtney Lee on going up 2-0 in series vs. Blazers',
-            'description': 'Courtney Lee talks about Memphis being focused.',
-            # TODO: fix timestamp
-            'upload_date': '19700101',  # '20150423',
-            # 'timestamp': 1429761109,
-            'uploader': 'NEWA-FNG-FOXSPORTS',
+            'display_id': 'play-612168c6700004b',
+            'title': 'md5:e0c4ecac3a1f25295b4fae22fb5c126a',
+            'description': 'md5:371bc43609708ae2b9e1a939229762af',
+            'uploader_id': '06b4a36349624051a9ba52ac3a91d268',
+            'upload_date': '20221205',
+            'timestamp': 1670262586,
+            'duration': 31.7317,
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'extra_param_to_segment_url': str,
         },
         'params': {
-            # m3u8 download
-            'skip_download': True,
+            'skip_download': 'm3u8',
         },
-        'add_ie': ['ThePlatform'],
-    }
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        json_ld = self._search_json_ld(webpage, video_id, expected_type='VideoObject', default={})
+        data = self._download_json(
+            f'https://api3.fox.com/v2.0/vodplayer/sportsclip/{video_id}',
+            video_id, note='Downloading API JSON', headers={
+                'x-api-key': 'cf289e299efdfa39fb6316f259d1de93',
+            })
+        preplay_url = self._request_webpage(
+            HEADRequest(data['url']), video_id, 'Fetching preplay URL').geturl()
 
-        return self.url_result(
-            'https://feed.theplatform.com/f/BKQ29B/foxsports-all?byId=' + video_id, 'ThePlatformFeed')
+        return {
+            '_type': 'url_transparent',
+            'ie_key': 'UplynkPreplay',
+            'url': smuggle_url(preplay_url, {'Origin': 'https://www.foxsports.com'}),
+            'display_id': video_id,
+            'title': data.get('name') or json_ld.get('title'),
+            'description': data.get('description') or json_ld.get('description'),
+            'duration': float_or_none(data.get('durationInSeconds')),
+            'timestamp': json_ld.get('timestamp'),
+            'thumbnails': json_ld.get('thumbnails'),
+            '_old_archive_ids': [make_archive_id(self, video_id)],
+        }

--- a/yt_dlp/extractor/foxsports.py
+++ b/yt_dlp/extractor/foxsports.py
@@ -1,11 +1,6 @@
 from .common import InfoExtractor
-
-from ..utils import (
-    HEADRequest,
-    float_or_none,
-    make_archive_id,
-    smuggle_url,
-)
+from .uplynk import UplynkPreplayIE
+from ..utils import HEADRequest, float_or_none, make_archive_id, smuggle_url
 
 
 class FoxSportsIE(InfoExtractor):
@@ -44,7 +39,7 @@ class FoxSportsIE(InfoExtractor):
 
         return {
             '_type': 'url_transparent',
-            'ie_key': 'UplynkPreplay',
+            'ie_key': UplynkPreplayIE.ie_key(),
             'url': smuggle_url(preplay_url, {'Origin': 'https://www.foxsports.com'}),
             'display_id': video_id,
             'title': data.get('name') or json_ld.get('title'),

--- a/yt_dlp/extractor/uplynk.py
+++ b/yt_dlp/extractor/uplynk.py
@@ -4,38 +4,48 @@ from .common import InfoExtractor
 from ..utils import (
     float_or_none,
     ExtractorError,
+    smuggle_url,
+    unsmuggle_url,
+    traverse_obj,
+    update_url_query,
 )
 
 
-class UplynkIE(InfoExtractor):
-    IE_NAME = 'uplynk'
-    _VALID_URL = r'https?://.*?\.uplynk\.com/(?P<path>ext/[0-9a-f]{32}/(?P<external_id>[^/?&]+)|(?P<id>[0-9a-f]{32}))\.(?:m3u8|json)(?:.*?\bpbs=(?P<session_id>[^&]+))?'
-    _TEST = {
-        'url': 'http://content.uplynk.com/e89eaf2ce9054aa89d92ddb2d817a52e.m3u8',
-        'info_dict': {
-            'id': 'e89eaf2ce9054aa89d92ddb2d817a52e',
-            'ext': 'mp4',
-            'title': '030816-kgo-530pm-solar-eclipse-vid_web.mp4',
-            'uploader_id': '4413701bf5a1488db55b767f8ae9d4fa',
-        },
-        'params': {
-            # m3u8 download
-            'skip_download': True,
-        },
-    }
+class UplynkBaseIE(InfoExtractor):
+    _UPLYNK_URL_RE = r'''(?x)
+                        https?://
+                            .*?\.uplynk\.com/
+                            (?P<path>
+                                ext/[0-9a-f]{32}/
+                                (?P<external_id>[^/?&]+)|
+                                (?P<id>[0-9a-f]{32})
+                            )
+                            \.(?:m3u8|json)
+                            (?:
+                                .*?\b
+                                pbs=(?P<session_id>[^&]+)
+                            )?
+                    '''
 
-    def _extract_uplynk_info(self, uplynk_content_url):
-        path, external_id, video_id, session_id = re.match(UplynkIE._VALID_URL, uplynk_content_url).groups()
+    def _extract_uplynk_info(self, url):
+        uplynk_content_url, smuggled_data = unsmuggle_url(url, {})
+        mobj = re.match(self._UPLYNK_URL_RE, uplynk_content_url)
+        if not mobj:
+            raise ExtractorError('Necessary parameters not found in Uplynk URL')
+        path, external_id, video_id, session_id = mobj.group('path', 'external_id', 'id', 'session_id')
         display_id = video_id or external_id
+        headers = traverse_obj(
+            smuggled_data, {'Referer': 'Referer', 'Origin': 'Origin'}, casesense=False)
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            'http://content.uplynk.com/%s.m3u8' % path,
-            display_id, 'mp4', 'm3u8_native')
+            f'http://content.uplynk.com/{path}.m3u8', display_id, 'mp4', headers=headers)
         if session_id:
             for f in formats:
-                f['extra_param_to_segment_url'] = 'pbs=' + session_id
-        asset = self._download_json('http://content.uplynk.com/player/assetinfo/%s.json' % path, display_id)
+                f['extra_param_to_segment_url'] = f'pbs={session_id}'
+        asset = self._download_json(
+            f'http://content.uplynk.com/player/assetinfo/{path}.json', display_id)
         if asset.get('error') == 1:
-            raise ExtractorError('% said: %s' % (self.IE_NAME, asset['msg']), expected=True)
+            msg = asset.get('msg') or 'unknown error'
+            raise ExtractorError(f'{self.IE_NAME} said: {msg}', expected=True)
 
         return {
             'id': asset['asset'],
@@ -47,20 +57,38 @@ class UplynkIE(InfoExtractor):
             'subtitles': subtitles,
         }
 
+
+class UplynkIE(UplynkBaseIE):
+    IE_NAME = 'uplynk'
+    _VALID_URL = UplynkBaseIE._UPLYNK_URL_RE
+    _TEST = {
+        'url': 'http://content.uplynk.com/e89eaf2ce9054aa89d92ddb2d817a52e.m3u8',
+        'info_dict': {
+            'id': 'e89eaf2ce9054aa89d92ddb2d817a52e',
+            'ext': 'mp4',
+            'title': '030816-kgo-530pm-solar-eclipse-vid_web.mp4',
+            'uploader_id': '4413701bf5a1488db55b767f8ae9d4fa',
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }
+
     def _real_extract(self, url):
         return self._extract_uplynk_info(url)
 
 
-class UplynkPreplayIE(UplynkIE):  # XXX: Do not subclass from concrete IE
+class UplynkPreplayIE(UplynkBaseIE):
     IE_NAME = 'uplynk:preplay'
     _VALID_URL = r'https?://.*?\.uplynk\.com/preplay2?/(?P<path>ext/[0-9a-f]{32}/(?P<external_id>[^/?&]+)|(?P<id>[0-9a-f]{32}))\.json'
 
     def _real_extract(self, url):
+        url, smuggled_data = unsmuggle_url(url, {})
         path, external_id, video_id = self._match_valid_url(url).groups()
         display_id = video_id or external_id
         preplay = self._download_json(url, display_id)
-        content_url = 'http://content.uplynk.com/%s.m3u8' % path
+        content_url = f'http://content.uplynk.com/{path}.m3u8'
         session_id = preplay.get('sid')
         if session_id:
-            content_url += '?pbs=' + session_id
-        return self._extract_uplynk_info(content_url)
+            content_url = update_url_query(content_url, {'pbs': session_id})
+        return self._extract_uplynk_info(smuggle_url(content_url, smuggled_data))

--- a/yt_dlp/extractor/uplynk.py
+++ b/yt_dlp/extractor/uplynk.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 class UplynkBaseIE(InfoExtractor):
     _UPLYNK_URL_RE = r'''(?x)
-        https?://\w+\.uplynk\.com/(?P<path>
+        https?://[\w-]+\.uplynk\.com/(?P<path>
             ext/[0-9a-f]{32}/(?P<external_id>[^/?&]+)|
             (?P<id>[0-9a-f]{32})
         )\.(?:m3u8|json)
@@ -74,7 +74,7 @@ class UplynkIE(UplynkBaseIE):
 
 class UplynkPreplayIE(UplynkBaseIE):
     IE_NAME = 'uplynk:preplay'
-    _VALID_URL = r'https?://.*?\.uplynk\.com/preplay2?/(?P<path>ext/[0-9a-f]{32}/(?P<external_id>[^/?&]+)|(?P<id>[0-9a-f]{32}))\.json'
+    _VALID_URL = r'https?://[\w-]+\.uplynk\.com/preplay2?/(?P<path>ext/[0-9a-f]{32}/(?P<external_id>[^/?&]+)|(?P<id>[0-9a-f]{32}))\.json'
 
     def _real_extract(self, url):
         url, smuggled_data = unsmuggle_url(url, {})

--- a/yt_dlp/extractor/uplynk.py
+++ b/yt_dlp/extractor/uplynk.py
@@ -68,6 +68,8 @@ class UplynkIE(UplynkBaseIE):
             'ext': 'mp4',
             'title': '030816-kgo-530pm-solar-eclipse-vid_web.mp4',
             'uploader_id': '4413701bf5a1488db55b767f8ae9d4fa',
+            'duration': 530.2739166666679,
+            'thumbnail': r're:^https?://.*\.jpg$',
         },
         'params': {
             'skip_download': 'm3u8',

--- a/yt_dlp/extractor/uplynk.py
+++ b/yt_dlp/extractor/uplynk.py
@@ -2,30 +2,22 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
-    float_or_none,
     ExtractorError,
+    float_or_none,
     smuggle_url,
-    unsmuggle_url,
     traverse_obj,
+    unsmuggle_url,
     update_url_query,
 )
 
 
 class UplynkBaseIE(InfoExtractor):
     _UPLYNK_URL_RE = r'''(?x)
-                        https?://
-                            .*?\.uplynk\.com/
-                            (?P<path>
-                                ext/[0-9a-f]{32}/
-                                (?P<external_id>[^/?&]+)|
-                                (?P<id>[0-9a-f]{32})
-                            )
-                            \.(?:m3u8|json)
-                            (?:
-                                .*?\b
-                                pbs=(?P<session_id>[^&]+)
-                            )?
-                    '''
+        https?://\w+\.uplynk\.com/(?P<path>
+            ext/[0-9a-f]{32}/(?P<external_id>[^/?&]+)|
+            (?P<id>[0-9a-f]{32})
+        )\.(?:m3u8|json)
+        (?:.*?\bpbs=(?P<session_id>[^&]+))?'''
 
     def _extract_uplynk_info(self, url):
         uplynk_content_url, smuggled_data = unsmuggle_url(url, {})


### PR DESCRIPTION
### FoxSports

The FoxSports website has been revamped since the last time this extractor was touched, and has a new URL format and a new API. The VOD content now only uses ThePlatform as a redirection service, and the VOD now seems to be entirely Uplynk Preplay HLS. (ThePlatform is not able to find any content for the old extractor test case, and I can't get it to play in my browser, either.)

This PR only focuses on fixing VOD extraction. The site also has provider-locked livestreams (via AdobePass); these are not currently supported.

### Uplynk

The Uplynk manifest URLs yielded from the FoxSports extractor will return a 403 error unless the request has a foxsports.com `Origin` header. This necessitated header smuggling into the Uplynk and UplynkPreplay extractors. `UplynkPreplayIE` was improperly subclassed from `UplynkIE`, so a base IE class was added. Also tried to clean up and modernize the code somewhat.
  
Closes #5714

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
