### PR TITLE
[couriositystream] Fix passing auth.

### DIFF
--- a/yt_dlp/extractor/curiositystream.py
+++ b/yt_dlp/extractor/curiositystream.py
@@ -1,8 +1,9 @@
 import re
 
 from .common import InfoExtractor
-from ..compat import compat_str, compat_urllib_parse_unquote
+from ..compat import compat_str
 from ..utils import ExtractorError, int_or_none, urlencode_postdata
+import urllib.parse
 
 
 class CuriosityStreamBaseIE(InfoExtractor):
@@ -23,7 +24,7 @@ class CuriosityStreamBaseIE(InfoExtractor):
             auth_cookie = self._get_cookies('https://curiositystream.com').get('auth_token')
             if auth_cookie:
                 self.write_debug('Obtained auth_token cookie')
-                self._auth_token = compat_urllib_parse_unquote(auth_cookie.value)
+                self._auth_token = urllib.parse.unquote(auth_cookie.value)
         if self._auth_token:
             headers['X-Auth-Token'] = self._auth_token
         result = self._download_json(

--- a/yt_dlp/extractor/curiositystream.py
+++ b/yt_dlp/extractor/curiositystream.py
@@ -1,9 +1,9 @@
 import re
+import urllib.parse
 
 from .common import InfoExtractor
 from ..compat import compat_str
 from ..utils import ExtractorError, int_or_none, urlencode_postdata
-import urllib.parse
 
 
 class CuriosityStreamBaseIE(InfoExtractor):

--- a/yt_dlp/extractor/curiositystream.py
+++ b/yt_dlp/extractor/curiositystream.py
@@ -25,7 +25,7 @@ class CuriosityStreamBaseIE(InfoExtractor):
                 self.write_debug('Obtained auth_token cookie')
                 self._auth_token = compat_urllib_parse_unquote(auth_cookie.value)
         if self._auth_token:
-            headers['x-auth-token'] = self._auth_token
+            headers['X-Auth-Token'] = self._auth_token
         result = self._download_json(
             self._API_BASE_URL + path, video_id, headers=headers, query=query)
         self._handle_errors(result)

--- a/yt_dlp/extractor/curiositystream.py
+++ b/yt_dlp/extractor/curiositystream.py
@@ -1,7 +1,7 @@
 import re
 
 from .common import InfoExtractor
-from ..compat import compat_str
+from ..compat import compat_str, compat_urllib_parse_unquote
 from ..utils import ExtractorError, int_or_none, urlencode_postdata
 
 
@@ -23,9 +23,11 @@ class CuriosityStreamBaseIE(InfoExtractor):
             auth_cookie = self._get_cookies('https://curiositystream.com').get('auth_token')
             if auth_cookie:
                 self.write_debug('Obtained auth_token cookie')
-                self._auth_token = auth_cookie.value
+                self._auth_token = compat_urllib_parse_unquote(auth_cookie.value)
+            else:
+                self.write_debug('Auth cookie NOT found')
         if self._auth_token:
-            headers['X-Auth-Token'] = self._auth_token
+            headers['x-auth-token'] = self._auth_token
         result = self._download_json(
             self._API_BASE_URL + path, video_id, headers=headers, query=query)
         self._handle_errors(result)

--- a/yt_dlp/extractor/curiositystream.py
+++ b/yt_dlp/extractor/curiositystream.py
@@ -24,8 +24,6 @@ class CuriosityStreamBaseIE(InfoExtractor):
             if auth_cookie:
                 self.write_debug('Obtained auth_token cookie')
                 self._auth_token = compat_urllib_parse_unquote(auth_cookie.value)
-            else:
-                self.write_debug('Auth cookie NOT found')
         if self._auth_token:
             headers['x-auth-token'] = self._auth_token
         result = self._download_json(
@@ -56,8 +54,11 @@ class CuriosityStreamIE(CuriosityStreamBaseIE):
             'description': 'Vint Cerf, Google\'s Chief Internet Evangelist, describes how he and Bob Kahn created the internet.',
             'channel': 'Curiosity Stream',
             'categories': ['Technology', 'Interview'],
-            'average_rating': 96.79,
+            'average_rating': 96.71,
             'series_id': '2',
+            'thumbnail': 'https://img.curiositystream.com/w:1255/cHJvZHVjdGlvbi9zb3VyY2VzL3RpdGxlcy8yL2hvcml6b250YWxfaW1hZ2VfMTZfOS9lbi1VUy83YjA2MWZjYS0yZDQyLTRiNGEtYTNkMy0zYmYzOGU0MGQzNzgvbWVkaWFfaG9yaXpvbnRhbF9pbWFnZV8xNl85XzJfMzg0MHgyMTYwXzAwMDEuanBn.jpg',
+            'tags': [],
+            'duration': 158
         },
         'params': {
             # m3u8 download

--- a/yt_dlp/extractor/curiositystream.py
+++ b/yt_dlp/extractor/curiositystream.py
@@ -54,9 +54,9 @@ class CuriosityStreamIE(CuriosityStreamBaseIE):
             'description': 'Vint Cerf, Google\'s Chief Internet Evangelist, describes how he and Bob Kahn created the internet.',
             'channel': 'Curiosity Stream',
             'categories': ['Technology', 'Interview'],
-            'average_rating': 96.71,
+            'average_rating': float,
             'series_id': '2',
-            'thumbnail': 'https://img.curiositystream.com/w:1255/cHJvZHVjdGlvbi9zb3VyY2VzL3RpdGxlcy8yL2hvcml6b250YWxfaW1hZ2VfMTZfOS9lbi1VUy83YjA2MWZjYS0yZDQyLTRiNGEtYTNkMy0zYmYzOGU0MGQzNzgvbWVkaWFfaG9yaXpvbnRhbF9pbWFnZV8xNl85XzJfMzg0MHgyMTYwXzAwMDEuanBn.jpg',
+            'thumbnail': r're:https://img.curiositystream.com/.+\.jpg',
             'tags': [],
             'duration': 158
         },


### PR DESCRIPTION
### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Probably a week or two ago yt-dlp stopped downloading full videos, only downloaded "trial" ones (first 2 minutes). This happened also when I tried fresh master (commit 935bac1e).

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

`flake8` passes, but I am not sure how to run specific tests. When running all tests it seemed there is a lot of missing videos from other extractors.

I have tested it on `https://curiositystream.com/video/5893`. Before the downloaded file was cut at 2 minutes (42MB), after this fix it has full duration of 11 minutes (229MB). Used command:

```
python -m yt_dlp --no-playlist --no-check-certificate --force-ipv4 --no-call-home -f 'bv+ba[language=en]' -v --cookies-from-browser vivaldi https://curiositystream.com/video/5893
```

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
