### PR TITLE
[extractor/plutotv] Fix extraction for videos with non-zero ts start

### DIFF
--- a/yt_dlp/extractor/plutotv.py
+++ b/yt_dlp/extractor/plutotv.py
@@ -103,7 +103,7 @@ class PlutoTVIE(InfoExtractor):
                     compat_urlparse.urljoin(first_segment_url.group(1), '0-end/master.m3u8'))
                 continue
             first_segment_url = re.search(
-                r'^(https?://.*/).+\-0+\.ts$', res,
+                r'^(https?://.*/).+\-0+[0-1]0\.ts$', res,
                 re.MULTILINE)
             if first_segment_url:
                 m3u8_urls.add(

--- a/yt_dlp/extractor/plutotv.py
+++ b/yt_dlp/extractor/plutotv.py
@@ -84,6 +84,17 @@ class PlutoTVIE(InfoExtractor):
         }, {
             'url': 'https://pluto.tv/it/on-demand/series/csi-vegas/episode/legacy-2021-1-1',
             'only_matching': True,
+        },
+        {
+            'url': 'https://pluto.tv/en/on-demand/movies/attack-of-the-killer-tomatoes-1977-1-1-ptv1',
+            'md5': '7db56369c0da626a32d505ec6eb3f89f',
+            'info_dict': {
+                'id': '5b190c7bb0875c36c90c29c4',
+                'ext': 'mp4',
+                'title': 'Attack of the Killer Tomatoes',
+                'description': 'A group of scientists band together to save the world from mutated tomatoes that KILL! (1978)',
+                'duration': 5700,
+            }
         }
     ]
 


### PR DESCRIPTION
This pull request fixes several cases when the Pluto TV extractor would appear to download the content successfully. However, the resulting file would be very small and upon play would be
just the station ident / logo bumper. This did not occur in all cases so it was initially unclear why this occurred for certain videos.

Examples which exhibited this issue include:
https://pluto.tv/en/on-demand/movies/attack-of-the-killer-tomatoes-1977-1-1-ptv1
https://pluto.tv/en/on-demand/movies/pandorum-2009-1-1

This occurred when the content does not match the first regular expression case and when matching the second case, it starts from a URL which does NOT end with 000000.ts.

The second regexp then errorneously matches the bumper URL instead.

This change fixes this to work with both 000000.ts and 000010.ts which covers the cases
identified so far.

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
