### PR TITLE
[utils] Support `--convert-subs srt` for MP4 container

### DIFF
--- a/yt_dlp/mp4parser.py
+++ b/yt_dlp/mp4parser.py
@@ -1,0 +1,113 @@
+import enum
+import io
+import re
+from .downloader.ism import extract_box_data
+
+
+GF_ISOM_TRUN_DATA_OFFSET    = 0x01
+GF_ISOM_TRUN_FIRST_FLAG     = 0x04
+GF_ISOM_TRUN_DURATION       = 0x100
+GF_ISOM_TRUN_SIZE           = 0x200
+GF_ISOM_TRUN_FLAGS          = 0x400
+GF_ISOM_TRUN_CTS_OFFSET     = 0x800
+
+
+class SubtitleType(enum.Enum):
+    SUBS_XML = enum.auto()
+    WEBVTT = enum.auto()
+    SIMPLE_TEXT = enum.auto()
+    SUBS_TEXT = enum.auto()
+    TX3G = enum.auto()
+    SUBPIC = enum.auto()
+
+
+def prepare(mp4_data):
+    stype, mdat, trun = None, [], []
+    selection = {b'moov', b'moof', b'mdat'}
+    for box_type, box_data in extract_box_data(mp4_data, selection):
+        if box_type == b'moov':
+            if re.search(b'stbl.+stsd.+stpp', box_data):
+                stype = SubtitleType.SUBS_XML
+            if re.search(b'stbl.+stsd.+wvtt', box_data):
+                stype = SubtitleType.WEBVTT
+            # TODO stxt:SIMPLE_TEXT, sbtt:SUBS_TEXT, tx3g:TX3G, SUBPIC
+            continue
+        if box_type == b'mdat':
+            mdat.append(box_data)
+        if stype == SubtitleType.WEBVTT:
+            if box_type == b'moof':
+                pos = box_data.find(b'trun')
+                tail = box_data[pos + 4:]
+                trun.append(tail)
+
+    if stype == SubtitleType.SUBS_XML:
+        return stype, mdat
+    elif stype == SubtitleType.WEBVTT:
+        return stype, zip(trun, mdat)
+
+
+def read_trun(trun):
+    # https://github.com/gpac/gpac/blob/62a4ad6b5cd088834a2f1853db227397edda8cbe/src/isomedia/box_code_base.c#L7562-L7648
+    data_reader = io.BytesIO(trun)
+    def read32():
+        b = data_reader.read(4)
+        return int.from_bytes(b)
+
+    flags, sample_count = read32(), read32()
+
+    if flags & GF_ISOM_TRUN_FIRST_FLAG and flags & GF_ISOM_TRUN_FLAGS:
+        raise ValueError("INVALID_FILE")
+
+    if flags & GF_ISOM_TRUN_DATA_OFFSET:
+        data_offset = read32()
+
+    if flags & GF_ISOM_TRUN_FIRST_FLAG:
+        first_sample_flags = read32()
+
+    if flags & 0xF00:
+
+        samples = [{"id": x} for x in range(sample_count)]
+
+        for p in samples:
+
+            if flags & GF_ISOM_TRUN_DURATION:
+                p["Duration"] = read32()
+
+            if flags & GF_ISOM_TRUN_SIZE:
+                p["size"] = read32()
+
+            if flags & GF_ISOM_TRUN_FLAGS:
+                p["flags"] = read32()
+
+            if flags & GF_ISOM_TRUN_CTS_OFFSET:
+                p["CTS_Offset"] = read32()
+
+    else:
+        raise ValueError("UNSUPPORTED_FILE")
+
+    return samples
+
+
+def _time2txt(t):
+    # https://github.com/gpac/gpac/blob/2ce645d23c88a3f776d92783549085380903608c/src/media_tools/webvtt.c#L1368-L1395
+    sec_, msec = divmod(t, 1000)
+    min_, sec_ = divmod(sec_, 60)
+    hour, min_ = divmod(min_, 60)
+    return f"{hour:02}:{min_:02}:{sec_:02},{msec:03}"
+
+
+def webvtt2srt(info, data, ts):
+    # https://github.com/gpac/gpac/blob/2ce645d23c88a3f776d92783549085380903608c/src/media_tools/webvtt.c#L1197-L1246
+    size = info["size"]
+    start_ts = ts
+    end_ts = start_ts + info["Duration"]
+    head, tail = data[:size], data[size:]
+    if b"payl" not in head:
+        return None, tail, end_ts
+
+    pos = head.find(b"payl")
+    txt = head[pos+4:].decode("utf-8")
+
+    start_end = f'{_time2txt(start_ts)} --> {_time2txt(end_ts)}'
+    lines = f"{start_end}\n{txt}\n"
+    return lines, tail, end_ts

--- a/yt_dlp/mp4parser.py
+++ b/yt_dlp/mp4parser.py
@@ -1,15 +1,15 @@
 import enum
 import io
 import re
+
 from .downloader.ism import extract_box_data
 
-
-GF_ISOM_TRUN_DATA_OFFSET    = 0x01
-GF_ISOM_TRUN_FIRST_FLAG     = 0x04
-GF_ISOM_TRUN_DURATION       = 0x100
-GF_ISOM_TRUN_SIZE           = 0x200
-GF_ISOM_TRUN_FLAGS          = 0x400
-GF_ISOM_TRUN_CTS_OFFSET     = 0x800
+GF_ISOM_TRUN_DATA_OFFSET = 0x01
+GF_ISOM_TRUN_FIRST_FLAG = 0x04
+GF_ISOM_TRUN_DURATION = 0x100
+GF_ISOM_TRUN_SIZE = 0x200
+GF_ISOM_TRUN_FLAGS = 0x400
+GF_ISOM_TRUN_CTS_OFFSET = 0x800
 
 
 class SubtitleType(enum.Enum):
@@ -49,6 +49,7 @@ def prepare(mp4_data):
 def read_trun(trun):
     # https://github.com/gpac/gpac/blob/62a4ad6b5cd088834a2f1853db227397edda8cbe/src/isomedia/box_code_base.c#L7562-L7648
     data_reader = io.BytesIO(trun)
+
     def read32():
         b = data_reader.read(4)
         return int.from_bytes(b)
@@ -56,34 +57,34 @@ def read_trun(trun):
     flags, sample_count = read32(), read32()
 
     if flags & GF_ISOM_TRUN_FIRST_FLAG and flags & GF_ISOM_TRUN_FLAGS:
-        raise ValueError("INVALID_FILE")
+        raise ValueError('INVALID_FILE')
 
     if flags & GF_ISOM_TRUN_DATA_OFFSET:
-        data_offset = read32()
+        _ = read32()
 
     if flags & GF_ISOM_TRUN_FIRST_FLAG:
-        first_sample_flags = read32()
+        _ = read32()
 
     if flags & 0xF00:
 
-        samples = [{"id": x} for x in range(sample_count)]
+        samples = [{'id': x} for x in range(sample_count)]
 
         for p in samples:
 
             if flags & GF_ISOM_TRUN_DURATION:
-                p["Duration"] = read32()
+                p['Duration'] = read32()
 
             if flags & GF_ISOM_TRUN_SIZE:
-                p["size"] = read32()
+                p['size'] = read32()
 
             if flags & GF_ISOM_TRUN_FLAGS:
-                p["flags"] = read32()
+                p['flags'] = read32()
 
             if flags & GF_ISOM_TRUN_CTS_OFFSET:
-                p["CTS_Offset"] = read32()
+                p['CTS_Offset'] = read32()
 
     else:
-        raise ValueError("UNSUPPORTED_FILE")
+        raise ValueError('UNSUPPORTED_FILE')
 
     return samples
 
@@ -93,21 +94,21 @@ def _time2txt(t):
     sec_, msec = divmod(t, 1000)
     min_, sec_ = divmod(sec_, 60)
     hour, min_ = divmod(min_, 60)
-    return f"{hour:02}:{min_:02}:{sec_:02},{msec:03}"
+    return f'{hour:02}:{min_:02}:{sec_:02},{msec:03}'
 
 
 def webvtt2srt(info, data, ts):
     # https://github.com/gpac/gpac/blob/2ce645d23c88a3f776d92783549085380903608c/src/media_tools/webvtt.c#L1197-L1246
-    size = info["size"]
+    size = info['size']
     start_ts = ts
-    end_ts = start_ts + info["Duration"]
+    end_ts = start_ts + info['Duration']
     head, tail = data[:size], data[size:]
-    if b"payl" not in head:
+    if b'payl' not in head:
         return None, tail, end_ts
 
-    pos = head.find(b"payl")
-    txt = head[pos+4:].decode("utf-8")
+    pos = head.find(b'payl')
+    txt = head[pos + 4:].decode('utf-8')
 
     start_end = f'{_time2txt(start_ts)} --> {_time2txt(end_ts)}'
-    lines = f"{start_end}\n{txt}\n"
+    lines = f'{start_end}\n{txt}\n'
     return lines, tail, end_ts

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -24,6 +24,7 @@ from ..utils import (
     filter_dict,
     float_or_none,
     is_outdated_version,
+    mp42srt,
     orderedSet,
     prepend_extension,
     replace_extension,
@@ -967,7 +968,7 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
             sub_filenames.append(old_file)
             new_file = replace_extension(old_file, new_ext)
 
-            if ext in ('dfxp', 'ttml', 'tt'):
+            if ext in ('dfxp', 'ttml', 'tt', 'mp4'):
                 self.report_warning(
                     'You have requested to convert dfxp (TTML) subtitles into another format, '
                     'which results in style information loss')
@@ -976,7 +977,10 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
                 srt_file = replace_extension(old_file, 'srt')
 
                 with open(dfxp_file, 'rb') as f:
-                    srt_data = dfxp2srt(f.read())
+                    if ext == 'mp4':
+                        srt_data = mp42srt(f.read())
+                    else:
+                        srt_data = dfxp2srt(f.read())
 
                 with open(srt_file, 'wt', encoding='utf-8') as f:
                     f.write(srt_data)

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4105,7 +4105,7 @@ def mp42srt(mp4_data):
         out.append(f'{num + 1}\n{txt}\n')
 
     return ''.join(out)
-    
+
 
 def cli_option(params, command_option, param, separator=None):
     param = params.get(param)

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4062,6 +4062,51 @@ def dfxp2srt(dfxp_data):
     return ''.join(out)
 
 
+def mp42srt(mp4_data):
+    from .mp4parser import (
+        SubtitleType,
+        prepare,
+        read_trun,
+        webvtt2srt,
+    )
+
+    stype, boxes = prepare(mp4_data)
+    items = []
+
+    if stype == SubtitleType.SUBS_XML:
+
+        def parse(box):
+            srt = dfxp2srt(box)
+            items = re.split('\n[0-9]+\n', srt[2:-1])
+            return items
+
+        items = [parse(box) for box in boxes
+                 if b"body" in box]
+
+    elif stype == SubtitleType.WEBVTT:
+
+        def parse(box, ts):
+            trun, samples = box
+            items = []
+            durations = read_trun(trun)
+            for info in durations:
+                item, samples, ts = webvtt2srt(info, samples, ts)
+                if item:
+                    items.append(item)
+            return ts, items
+
+        ts = 0
+        for box in boxes:
+            ts, item = parse(box, ts)
+            items.append(item)
+
+    out = []
+    for num, txt in enumerate(itertools.chain.from_iterable(items)):
+        out.append(f'{num + 1}\n{txt}\n')
+
+    return ''.join(out)
+    
+
 def cli_option(params, command_option, param, separator=None):
     param = params.get(param)
     return ([] if param is None


### PR DESCRIPTION
This PR aims to fix `Preprocessing: Output file #0 does not contain any stream` when `--convert-subs srt` is used but subtitles are
 * webvtt in mp4
 * ttml in mp4

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [X] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
