### PR TITLE
[extractor/sovietscloset] Fix __NUXT_JSONP__ extraction

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -955,14 +955,8 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(escape_url('http://vimeo.com/56015672#at=0'), 'http://vimeo.com/56015672#at=0')
 
     def test_js_to_json_vars_strings(self):
-        def parse_js_to_json(js, vars):
-            try:
-                return json.loads(js_to_json(js, vars))
-            except json.JSONDecodeError as e:
-                raise ValueError(f'JSON: {e.msg}: line {e.lineno} column {e.colno} "{e.doc}"')
-
         self.assertDictEqual(
-            parse_js_to_json(
+            json.loads(js_to_json(
                 '''{
                     'null': a,
                     'nullStr': b,
@@ -981,7 +975,7 @@ class TestUtil(unittest.TestCase):
                     'f': '"false"',
                     'g': 'var',
                 }
-            ),
+            )),
             {
                 'null': None,
                 'nullStr': 'null',
@@ -994,7 +988,7 @@ class TestUtil(unittest.TestCase):
         )
 
         self.assertDictEqual(
-            parse_js_to_json(
+            json.loads(js_to_json(
                 '''{
                     'int': a,
                     'intStr': b,
@@ -1007,7 +1001,7 @@ class TestUtil(unittest.TestCase):
                     'c': '1.23',
                     'd': '"1.23"',
                 }
-            ),
+            )),
             {
                 'int': 123,
                 'intStr': '123',
@@ -1017,7 +1011,7 @@ class TestUtil(unittest.TestCase):
         )
 
         self.assertDictEqual(
-            parse_js_to_json(
+            json.loads(js_to_json(
                 '''{
                     'object': a,
                     'objectStr': b,
@@ -1030,7 +1024,7 @@ class TestUtil(unittest.TestCase):
                     'c': '[]',
                     'd': '"[]"',
                 }
-            ),
+            )),
             {
                 'object': {},
                 'objectStr': '{}',

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -970,6 +970,7 @@ class TestUtil(unittest.TestCase):
                     'trueStr': d,
                     'false': e,
                     'falseStr': f,
+                    'unresolvedVar': g,
                 }''',
                 {
                     'a': 'null',
@@ -978,6 +979,7 @@ class TestUtil(unittest.TestCase):
                     'd': '"true"',
                     'e': 'false',
                     'f': '"false"',
+                    'g': 'var',
                 }
             ),
             {
@@ -987,6 +989,7 @@ class TestUtil(unittest.TestCase):
                 'trueStr': 'true',
                 'false': False,
                 'falseStr': 'false',
+                'unresolvedVar': 'var'
             }
         )
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -954,6 +954,88 @@ class TestUtil(unittest.TestCase):
         )
         self.assertEqual(escape_url('http://vimeo.com/56015672#at=0'), 'http://vimeo.com/56015672#at=0')
 
+    def test_js_to_json_vars_strings(self):
+        def parse_js_to_json(js, vars):
+            try:
+                return json.loads(js_to_json(js, vars))
+            except json.JSONDecodeError as e:
+                raise ValueError(f'JSON: {e.msg}: line {e.lineno} column {e.colno} "{e.doc}"')
+
+        self.assertDictEqual(
+            parse_js_to_json(
+                '''{
+                    'null': a,
+                    'nullStr': b,
+                    'true': c,
+                    'trueStr': d,
+                    'false': e,
+                    'falseStr': f,
+                }''',
+                {
+                    'a': 'null',
+                    'b': '"null"',
+                    'c': 'true',
+                    'd': '"true"',
+                    'e': 'false',
+                    'f': '"false"',
+                }
+            ),
+            {
+                'null': None,
+                'nullStr': 'null',
+                'true': True,
+                'trueStr': 'true',
+                'false': False,
+                'falseStr': 'false',
+            }
+        )
+
+        self.assertDictEqual(
+            parse_js_to_json(
+                '''{
+                    'int': a,
+                    'intStr': b,
+                    'float': c,
+                    'floatStr': d,
+                }''',
+                {
+                    'a': '123',
+                    'b': '"123"',
+                    'c': '1.23',
+                    'd': '"1.23"',
+                }
+            ),
+            {
+                'int': 123,
+                'intStr': '123',
+                'float': 1.23,
+                'floatStr': '1.23',
+            }
+        )
+
+        self.assertDictEqual(
+            parse_js_to_json(
+                '''{
+                    'object': a,
+                    'objectStr': b,
+                    'array': c,
+                    'arrayStr': d,
+                }''',
+                {
+                    'a': '{}',
+                    'b': '"{}"',
+                    'c': '[]',
+                    'd': '"[]"',
+                }
+            ),
+            {
+                'object': {},
+                'objectStr': '{}',
+                'array': [],
+                'arrayStr': '[]',
+            }
+        )
+
     def test_js_to_json_realworld(self):
         inp = '''{
             'clip':{'provider':'pseudo'}

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3360,7 +3360,11 @@ def js_to_json(code, vars={}, *, strict=False):
                 return f'"{i}":' if v.endswith(':') else str(i)
 
         if v in vars:
-            return vars[v]
+            try:
+                json.loads(vars[v])
+                return vars[v]
+            except:
+                return json.dumps(vars[v])
 
         if not strict:
             return f'"{v}"'

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3360,11 +3360,14 @@ def js_to_json(code, vars={}, *, strict=False):
                 return f'"{i}":' if v.endswith(':') else str(i)
 
         if v in vars:
-            try:
-                json.loads(vars[v])
+            if strict:
                 return vars[v]
-            except Exception:
-                return json.dumps(vars[v])
+            else:
+                try:
+                    json.loads(vars[v])
+                    return vars[v]
+                except json.decoder.JSONDecodeError:
+                    return f'"{vars[v]}"'
 
         if not strict:
             return f'"{v}"'

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3363,7 +3363,7 @@ def js_to_json(code, vars={}, *, strict=False):
             try:
                 json.loads(vars[v])
                 return vars[v]
-            except:
+            except Exception:
                 return json.dumps(vars[v])
 
         if not strict:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3360,7 +3360,7 @@ def js_to_json(code, vars={}, *, strict=False):
                 return f'"{i}":' if v.endswith(':') else str(i)
 
         if v in vars:
-            return json.dumps(vars[v])
+            return vars[v]
 
         if not strict:
             return f'"{v}"'

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -3360,14 +3360,13 @@ def js_to_json(code, vars={}, *, strict=False):
                 return f'"{i}":' if v.endswith(':') else str(i)
 
         if v in vars:
-            if strict:
-                return vars[v]
-            else:
-                try:
+            try:
+                if not strict:
                     json.loads(vars[v])
-                    return vars[v]
-                except json.decoder.JSONDecodeError:
-                    return f'"{vars[v]}"'
+            except json.decoder.JSONDecodeError:
+                return json.dumps(vars[v])
+            else:
+                return vars[v]
 
         if not strict:
             return f'"{v}"'


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This partially reverts https://github.com/yt-dlp/yt-dlp/commit/f55523cfdd18dcd578f5d96cbb06266663169d35 which JSON encoded all `js_to_json` vars. This broke \_\_NUXT_JSONP\_\_ parsing because JS numbers turned into strings (`123` to `"123"`) and JS strings turned into quoted strings (`"abc"` to `"\"abc\""`).


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
