### PR TITLE
[extractor/bilibili] Skip FLV+HEVC format sources

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -1074,6 +1074,8 @@ class BiliLiveIE(InfoExtractor):
         for codec in fmt.get('codec') or []:
             if codec.get('current_qn') != qn:
                 continue
+            if fmt.get('format_name') == "flv" and codec.get('codec_name') in ["hevc", "h265"]:
+                continue
             for url_info in codec['url_info']:
                 yield {
                     'url': f'{url_info["host"]}{codec["base_url"]}{url_info["extra"]}',


### PR DESCRIPTION
### Skip FLV+HEVC format sources on bilibili live

HEVC over FLV (and thus RTMP) is not defined nor supported.

These sources cannot be played, so skip these.

Ref: https://trac.ffmpeg.org/ticket/6389

Current version (and yt-dlp select source-7 by default):

``` 
yt-dlp -F https://live.bilibili.com/7777
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[BiliLive] 7777: Downloading JSON metadata
[info] Available formats for 7777:
ID               EXT  RESOLUTION │ PROTO │ VCODEC ACODEC  MORE INFO
───────────────────────────────────────────────────────────────────
high_res-0       fmp4 unknown    │ m3u8  │ avc    unknown 高清
high_res-1       fmp4 unknown    │ m3u8  │ avc    unknown 高清
high_res-2       flv  unknown    │ https │ avc    unknown 高清
high_res-3       flv  unknown    │ https │ avc    unknown 高清
ultra_high_res-0 fmp4 unknown    │ m3u8  │ avc    unknown 超清
ultra_high_res-1 fmp4 unknown    │ m3u8  │ avc    unknown 超清
ultra_high_res-2 flv  unknown    │ https │ avc    unknown 超清
ultra_high_res-3 flv  unknown    │ https │ avc    unknown 超清
ultra_high_res-4 fmp4 unknown    │ m3u8  │ hevc   unknown 超清
ultra_high_res-5 fmp4 unknown    │ m3u8  │ hevc   unknown 超清
ultra_high_res-6 flv  unknown    │ https │ hevc   unknown 超清
ultra_high_res-7 flv  unknown    │ https │ hevc   unknown 超清
blue_ray-0       fmp4 unknown    │ m3u8  │ avc    unknown 蓝光
blue_ray-1       fmp4 unknown    │ m3u8  │ avc    unknown 蓝光
blue_ray-2       flv  unknown    │ https │ avc    unknown 蓝光
blue_ray-3       flv  unknown    │ https │ avc    unknown 蓝光
source-0         fmp4 unknown    │ m3u8  │ avc    unknown 原画
source-1         fmp4 unknown    │ m3u8  │ avc    unknown 原画
source-2         flv  unknown    │ https │ avc    unknown 原画
source-3         flv  unknown    │ https │ avc    unknown 原画
source-4         fmp4 unknown    │ m3u8  │ hevc   unknown 原画
source-5         fmp4 unknown    │ m3u8  │ hevc   unknown 原画
source-6         flv  unknown    │ https │ hevc   unknown 原画
source-7         flv  unknown    │ https │ hevc   unknown 原画
```
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
