### PR TITLE
Deprioritize HEVC-over-FLV formats

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -1074,18 +1074,12 @@ class BiliLiveIE(InfoExtractor):
         for codec in fmt.get('codec') or []:
             if codec.get('current_qn') != qn:
                 continue
-            preference = -1
-            if fmt.get('format_name') == 'flv' and codec.get('codec_name') in ('hevc', 'h265'):
-                # HEVC-over-FLV is out-of-spec from FLV's original spec
-                # ref. https://trac.ffmpeg.org/ticket/6389
-                preference = -10
             for url_info in codec['url_info']:
                 yield {
                     'url': f'{url_info["host"]}{codec["base_url"]}{url_info["extra"]}',
                     'ext': fmt.get('format_name'),
                     'vcodec': codec.get('codec_name'),
                     'quality': self._quality(qn),
-                    'preference': preference,
                     **self._FORMATS[qn],
                 }
 

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -1085,7 +1085,7 @@ class BiliLiveIE(InfoExtractor):
                     'ext': fmt.get('format_name'),
                     'vcodec': codec.get('codec_name'),
                     'quality': self._quality(qn),
-                    'source_preference': preference,
+                    'preference': preference,
                     **self._FORMATS[qn],
                 }
 
@@ -1117,7 +1117,6 @@ class BiliLiveIE(InfoExtractor):
             'thumbnail': room_data.get('user_cover'),
             'timestamp': stream_data.get('live_time'),
             'formats': formats,
-            '_format_sort_fields': ['source'],
             'http_headers': {
                 'Referer': url,
             },

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -6307,6 +6307,12 @@ class FormatSorter:
         # if format.get('preference') is None and format.get('ext') in ('f4f', 'f4m'):  # Not supported?
         #    format['preference'] = -1000
 
+        if format.get('preference') is None and format.get('ext') == 'flv' and format.get('vcodec') in ('hevc', 'h265'):
+            # HEVC-over-FLV is out-of-spec by FLV's original spec
+            # ref. https://trac.ffmpeg.org/ticket/6389
+            # ref. https://github.com/yt-dlp/yt-dlp/pull/5821
+            format['preference'] = -1000
+
         # Determine missing bitrates
         if format.get('tbr') is None:
             if format.get('vbr') is not None and format.get('abr') is not None:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -6307,7 +6307,7 @@ class FormatSorter:
         # if format.get('preference') is None and format.get('ext') in ('f4f', 'f4m'):  # Not supported?
         #    format['preference'] = -1000
 
-        if format.get('preference') is None and format.get('ext') == 'flv' and format.get('vcodec') in ('hevc', 'h265'):
+        if format.get('preference') is None and format.get('ext') == 'flv' and re.match('[hx]265|he?vc?', format.get('vcodec') or ''):
             # HEVC-over-FLV is out-of-spec by FLV's original spec
             # ref. https://trac.ffmpeg.org/ticket/6389
             # ref. https://github.com/yt-dlp/yt-dlp/pull/5821

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -6311,7 +6311,7 @@ class FormatSorter:
             # HEVC-over-FLV is out-of-spec by FLV's original spec
             # ref. https://trac.ffmpeg.org/ticket/6389
             # ref. https://github.com/yt-dlp/yt-dlp/pull/5821
-            format['preference'] = -1000
+            format['preference'] = -100
 
         # Determine missing bitrates
         if format.get('tbr') is None:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Looks like BiliBili is offering HEVC-over-FLV formats, which isn't in standards and even not supported by ffmpeg. ([How do browsers play? There's a library to demux for them](https://github.com/xqq/mpegts.js/blob/6bf10e8a5be96543aaf3fb4bb7dcfcf8e7a21f02/src/demux/flv-demuxer.js#L843))

Although they could have been skipped, I think they should be available for download for anyone interested in.

ref. https://trac.ffmpeg.org/ticket/6389
ref. #5821

... wait, should we implement some scheme to deprioritize such formats (i.e. impossible or out-of-spec combination of container/codecs) globally? @pukkandan 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

#5821

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
