### PR TITLE
Add flag --breaking-match-filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,8 @@ You can also fork the project on GitHub and run your fork's [build workflow](.gi
                                     dogs" (caseless). Use "--match-filter -" to
                                     interactively ask whether to download each
                                     video
+    --breaking-match-filters FILTER Same as "--match-filters" but breaks when
+                                    a filter rejects a video.
     --no-match-filter               Do not use generic video filter (default)
     --no-playlist                   Download only the video, if the URL refers
                                     to a video and a playlist

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -408,6 +408,7 @@ def validate_options(opts):
             raise ValueError('unsupported geo-bypass country or ip-block')
 
     opts.match_filter = match_filter_func(opts.match_filter)
+    opts.breaking_match_filter = match_filter_func(opts.breaking_match_filter)
 
     if opts.download_archive is not None:
         opts.download_archive = expand_path(opts.download_archive)
@@ -890,6 +891,7 @@ def parse_options(argv=None):
         'playlist_items': opts.playlist_items,
         'xattr_set_filesize': opts.xattr_set_filesize,
         'match_filter': opts.match_filter,
+        'breaking_match_filter': opts.breaking_match_filter,
         'no_color': opts.no_color,
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -626,6 +626,10 @@ def create_parser():
             'that contains the phrase "cats & dogs" (caseless). '
             'Use "--match-filter -" to interactively ask whether to download each video'))
     selection.add_option(
+        '--breaking-match-filters',
+        metavar='FILTER', dest='breaking_match_filter', action='append',
+        help=('Same as "--match-filters" but breaks when a filter rejects a video.'))
+    selection.add_option(
         '--no-match-filter',
         metavar='FILTER', dest='match_filter', action='store_const', const=None,
         help='Do not use generic video filter (default)')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1211,6 +1211,11 @@ class RejectedVideoReached(DownloadCancelled):
     msg = 'Encountered a video that did not match filter, stopping due to --break-on-reject'
 
 
+class BreakingMatchFilterReach(DownloadCancelled):
+    """ --breaking-match-filters triggered """
+    msg = 'Encountered a video that did not match a filter defined by --breaking-match-filters'
+
+
 class MaxDownloadsReached(DownloadCancelled):
     """ --max-downloads limit has been reached. """
     msg = 'Maximum number of downloads reached, stopping due to --max-downloads'
@@ -3024,7 +3029,7 @@ class PlaylistEntries:
                 try:
                     # TODO: Add auto-generated fields
                     self.ydl._match_entry(entry, incomplete=True, silent=True)
-                except (ExistingVideoReached, RejectedVideoReached):
+                except (ExistingVideoReached, RejectedVideoReached, BreakingMatchFilterReach):
                     return
 
     def get_full_count(self):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Implement the `--break-on-reject-date` flag.

When downloading all videos a channel/playlist after some date  it can save a lot of time to use `--break-on-reject --lazy-playlist`.
This works fine, until you also want to use some `--match-filters`. Then you have to drop  `--break-on-reject` or the download will not work. The new flag solves this by only breaking, when a date filter (`--date`, `--datebefore`, `--dateafter`) is hit.

Example:
 
List:  https://www.youtube.com/playlist?list=UUYO_jab_esuFRV4b17AJtAw

Videos in date range:

* But what is a convolution?
* Researchers thought this was a bug (Borwein integrals)

Broken call using `--break-on-reject`

	python3 -m yt_dlp --break-on-reject --lazy-playlist --dateafter 20221101 --match-filters 'fulltitle!*="convolution"' 'https://www.youtube.com/playlist?list=UUYO_jab_esuFRV4b17AJtAw'

	[youtube:tab] Extracting URL: https://www.youtube.com/playlist?list=UUYO_jab_esuFRV4b17AJtAw
	[youtube:tab] UUYO_jab_esuFRV4b17AJtAw: Downloading webpage
	[youtube:tab] UUYO_jab_esuFRV4b17AJtAw: Redownloading playlist API JSON with unavailable videos
	[download] Downloading playlist: Uploads from 3Blue1Brown
	[youtube:tab] Playlist Uploads from 3Blue1Brown: Downloading N/A items of 127
	[download] Downloading item 1 of N/A
	[youtube] Extracting URL: https://www.youtube.com/watch?v=KuXjwB4LzSA
	[youtube] KuXjwB4LzSA: Downloading webpage
	[youtube] KuXjwB4LzSA: Downloading android player API JSON
	[download] But what is a convolution? does not pass filter (fulltitle!*="convolution"), skipping ..
	[info] Encountered a video that did not match filter, stopping due to --break-on-reject
	Aborting remaining downloads

-> no video was downloaded, since the first was filtered out

Call using `--break-on-reject-date`

	python3 -m yt_dlp --break-on-reject-date --lazy-playlist --dateafter 20221101 --match-filters 'fulltitle!*="convolution"' 'https://www.youtube.com/playlist?list=UUYO_jab_esuFRV4b17AJtAw'

	[youtube:tab] Extracting URL: https://www.youtube.com/playlist?list=UUYO_jab_esuFRV4b17AJtAw
	[youtube:tab] UUYO_jab_esuFRV4b17AJtAw: Downloading webpage
	[youtube:tab] UUYO_jab_esuFRV4b17AJtAw: Redownloading playlist API JSON with unavailable videos
	[download] Downloading playlist: Uploads from 3Blue1Brown
	[youtube:tab] Playlist Uploads from 3Blue1Brown: Downloading N/A items of 127
	[download] Downloading item 1 of N/A
	[youtube] Extracting URL: https://www.youtube.com/watch?v=KuXjwB4LzSA
	[youtube] KuXjwB4LzSA: Downloading webpage
	[youtube] KuXjwB4LzSA: Downloading android player API JSON
	[download] But what is a convolution? does not pass filter (fulltitle!*="convolution"), skipping ..
	[download] Downloading item 2 of N/A
	[youtube] Extracting URL: https://www.youtube.com/watch?v=851U557j6HE
	[youtube] 851U557j6HE: Downloading webpage
	[youtube] 851U557j6HE: Downloading android player API JSON
	[info] 851U557j6HE: Downloading 1 format(s): 313+251
	[download] Destination: Researchers thought this was a bug (Borwein integrals) [851U557j6HE].f313.webm
	[download] 100% of  334.38MiB in 00:00:17 at 19.42MiB/s
	[download] Destination: Researchers thought this was a bug (Borwein integrals) [851U557j6HE].f251.webm
	[download] 100% of   17.00MiB in 00:00:00 at 21.37MiB/s
	[Merger] Merging formats into "Researchers thought this was a bug (Borwein integrals) [851U557j6HE].webm"
	Deleting original file Researchers thought this was a bug (Borwein integrals) [851U557j6HE].f251.webm (pass -k to keep)
	Deleting original file Researchers thought this was a bug (Borwein integrals) [851U557j6HE].f313.webm (pass -k to keep)
	[download] Downloading item 3 of N/A
	[youtube] Extracting URL: https://www.youtube.com/watch?v=cDofhN-RJqg
	[youtube] cDofhN-RJqg: Downloading webpage
	[youtube] cDofhN-RJqg: Downloading android player API JSON
	[download] 2022-10-01 upload date is not in range 2022-11-01 - 9999-12-31
	[info] Encountered a video that did not match the allowed range of dates, stopping due to --break-on-reject-date
	Aborting remaining downloads

-> downloading the second video and stopping due to dateafter.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
