### PR TITLE
[daftsex] fix: update domain and embed player url

### DIFF
--- a/yt_dlp/extractor/daftsex.py
+++ b/yt_dlp/extractor/daftsex.py
@@ -12,9 +12,9 @@ from ..utils import (
 
 
 class DaftsexIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?daftsex\.com/watch/(?P<id>-?\d+_\d+)'
+    _VALID_URL = r'https?://(?:www\.)?daft\.sex/watch/(?P<id>-?\d+_\d+)'
     _TESTS = [{
-        'url': 'https://daftsex.com/watch/-35370899_456246186',
+        'url': 'https://daft.sex/watch/-35370899_456246186',
         'md5': 'd95135e6cea2d905bea20dbe82cda64a',
         'info_dict': {
             'id': '-35370899_456246186',
@@ -26,7 +26,7 @@ class DaftsexIE(InfoExtractor):
             'thumbnail': r're:https://[^/]+/impf/-43BuMDIawmBGr3GLcZ93CYwWf2PBv_tVWoS1A/dnu41DnARU4\.jpg\?size=800x450&quality=96&keep_aspect_ratio=1&background=000000&sign=6af2c26ff4a45e55334189301c867384&type=video_thumb',
         },
     }, {
-        'url': 'https://daftsex.com/watch/-156601359_456242791',
+        'url': 'https://daft.sex/watch/-156601359_456242791',
         'info_dict': {
             'id': '-156601359_456242791',
             'ext': 'mp4',
@@ -60,7 +60,7 @@ class DaftsexIE(InfoExtractor):
             webpage, 'player color', fatal=False) or ''
 
         embed_page = self._download_webpage(
-            'https://daxab.com/player/%s?color=%s' % (player_hash, player_color),
+            'https://dxb.to/player/%s?color=%s' % (player_hash, player_color),
             video_id, headers={'Referer': url})
         video_params = self._parse_json(
             self._search_regex(

--- a/yt_dlp/extractor/daftsex.py
+++ b/yt_dlp/extractor/daftsex.py
@@ -29,9 +29,18 @@ class DaftsexIE(InfoExtractor):
             'duration': 15.0,
             'view_count': int
         },
-    }, {  # deleted / private video
+    }, {
         'url': 'https://daft.sex/watch/-156601359_456242791',
-        'only_matching': True,
+        'info_dict': {
+            'id': '-156601359_456242791',
+            'ext': 'mp4',
+            'title': 'Skye Blue - Dinner And A Show',
+            'description': 'Skye Blue - Dinner And A Show - Watch video Watch video in high quality',
+            'upload_date': '20200916',
+            'timestamp': 1600250735,
+            'thumbnail': 'https://psv153-1.crazycloud.ru/videos/-156601359/456242791/thumb.jpg?extra=i3D32KaBbBFf9TqDRMAVmQ',
+        },
+        'skip': 'deleted / private'
     }]
 
     def _real_extract(self, url):
@@ -99,8 +108,8 @@ class DaftsexIE(InfoExtractor):
                 'credentials': video_params['video']['credentials'],
             })['response']['items']
 
-        if not isinstance(items, list) or len(items) < 1:
-            raise ExtractorError('Video %s is not available' % video_id, expected=True)
+        if not items:
+            raise ExtractorError('Video is not available', video_id=video_id, expected=True)
 
         item = items[0]
         formats = []


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR implements the fix, provided by @NiklasFarber1024, for #5881 by updating the VALID_URL regex with the new domain as well as updating the url for the embed player where the video parameters are parsed. 

Fixes #5881


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
