### PR TITLE
[extractor/biliIntl] Temporary workaround for failed `video_data` extraction

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -16,6 +16,7 @@ from ..utils import (
     format_field,
     int_or_none,
     make_archive_id,
+    merge_dicts,
     mimetype2ext,
     parse_count,
     parse_qs,
@@ -934,6 +935,10 @@ class BiliIntlIE(BiliIntlBaseIE):
             'title': 'E2 - The First Night',
             'thumbnail': r're:^https://pic\.bstarstatic\.com/ogv/.+\.png$',
             'episode_number': 2,
+            'upload_date': '20201009',
+            'episode': 'Episode 2',
+            'timestamp': 1602259500,
+            'description': 'md5:297b5a17155eb645e14a14b385ab547e',
         }
     }, {
         # Non-Bstation page
@@ -944,6 +949,10 @@ class BiliIntlIE(BiliIntlBaseIE):
             'title': 'E3 - Who?',
             'thumbnail': r're:^https://pic\.bstarstatic\.com/ogv/.+\.png$',
             'episode_number': 3,
+            'description': 'md5:e1a775e71a35c43f141484715470ad09',
+            'episode': 'Episode 3',
+            'upload_date': '20211219',
+            'timestamp': 1639928700,
         }
     }, {
         # Subtitle with empty content
@@ -956,6 +965,17 @@ class BiliIntlIE(BiliIntlBaseIE):
             'episode_number': 140,
         },
         'skip': 'According to the copyright owner\'s request, you may only watch the video after you log in.'
+    }, {
+        'url': 'https://www.bilibili.tv/en/video/2041863208',
+        'info_dict': {
+            'id': '2041863208',
+            'ext': 'mp4',
+            'timestamp': 1670874843,
+            'description': 'Scheduled for April 2023.\nStudio: ufotable',
+            'thumbnail': r're:https?://pic[-\.]bstarstatic.+/ugc/.+\.jpg$',
+            'upload_date': '20221212',
+            'title': 'Kimetsu no Yaiba Season 3 Official Trailer - Bstation',
+        }
     }, {
         'url': 'https://www.biliintl.com/en/play/34613/341736',
         'only_matching': True,
@@ -998,7 +1018,12 @@ class BiliIntlIE(BiliIntlBaseIE):
                 'sections', ..., 'episodes', lambda _, v: str(v['episode_id']) == video_id
             ), expected_type=dict, get_all=False)
 
-        return self._parse_video_metadata(video_data)
+        # XXX: webpage metadata may not accurate, it just used to not crash when video_data not found
+        return merge_dicts(
+            self._parse_video_metadata(video_data), self._search_json_ld(webpage, video_id), {
+                'title': self._html_search_meta('og:title', webpage),
+                'description': self._html_search_meta('og:description', webpage)
+            })
 
     def _real_extract(self, url):
         season_id, ep_id, aid = self._match_valid_url(url).group('season_id', 'ep_id', 'aid')

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -989,7 +989,7 @@ class BiliIntlIE(BiliIntlBaseIE):
             self._search_json(r'window\.__INITIAL_(?:DATA|STATE)__\s*=', webpage, 'preload state', video_id, default={})
             or self._search_nuxt_data(webpage, video_id, '__initialState', fatal=False, traverse=None))
         video_data = traverse_obj(
-            initial_data, ('OgvVideo', 'epDetail'), ('UgcVideo', 'videoData'), ('ugc', 'archive'), expected_type=dict)
+            initial_data, ('OgvVideo', 'epDetail'), ('UgcVideo', 'videoData'), ('ugc', 'archive'), expected_type=dict) or {}
 
         if season_id and not video_data:
             # Non-Bstation layout, read through episode list


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fix error that caused because the `video_data` failed to extract, this error seems only applied to user-generated content. Here's the relevant code line:
https://github.com/yt-dlp/yt-dlp/blob/933ed882e94ebfacc5e407dbd74fa25e672092c4/yt_dlp/extractor/bilibili.py#L991-L992

If the `video_data` failed and not a get season id, the code will execute this line
https://github.com/yt-dlp/yt-dlp/blob/933ed882e94ebfacc5e407dbd74fa25e672092c4/yt_dlp/extractor/bilibili.py#L1001

in this state, `video_data` get value as `None` and then getting error on `_parse_video_metadata`:
https://github.com/yt-dlp/yt-dlp/blob/933ed882e94ebfacc5e407dbd74fa25e672092c4/yt_dlp/extractor/bilibili.py#L886-L892

Before this PR:
```shell
C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp>python -m yt_dlp -vg "https://www.bilibili.tv/em/video/2041863208?bstar_from=bstar-web.homepage.recommend.all"
[debug] Command-line config: ['-vg', 'https://www.bilibili.tv/en/video/2041863208?bstar_from=bstar-web.homepage.recommend.all']
[debug] User config: []
[debug] System config: []
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2023.01.02 [d83b0ad80] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 933ed882e
[debug] Python 3.11.1 (CPython AMD64 64bit) - Windows-10-10.0.22000-SP0 (OpenSSL 1.1.1q  5 Jul 2022)
[debug] exe versions: none
[debug] Optional libraries: sqlite3-2.6.0
[debug] Proxy map: {}
[debug] Loaded 1757 extractors
[BiliIntl] Extracting URL: https://www.bilibili.tv/en/video/2041863208?bstar_from=bstar-web.homepage.recommend.all
[BiliIntl] 2041863208: Downloading webpage
ERROR: 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp\yt_dlp\YoutubeDL.py", line 1502, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp\yt_dlp\YoutubeDL.py", line 1578, in __extract_info
    ie_result = ie.extract(url)
                ^^^^^^^^^^^^^^^
  File "C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp\yt_dlp\extractor\common.py", line 680, in extract
    ie_result = self._real_extract(url)
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp\yt_dlp\extractor\bilibili.py", line 1009, in _real_extract
    **self._extract_video_metadata(url, video_id, season_id),
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp\yt_dlp\extractor\bilibili.py", line 1001, in _extract_video_metadata
    return self._parse_video_metadata(video_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp\yt_dlp\extractor\bilibili.py", line 888, in _parse_video_metadata
    'title': video_data.get('title_display') or video_data.get('title'),
             ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

After applied PR:
```shell
C:\Users\HobbyistDev\Documents\Program\python_proj\yt-dlp>python -m yt_dlp -vF "https://www.bilibili.tv/en/video/2041863208?bstar_from=bstar-web.homepage.recommend.all"
[debug] Command-line config: ['-vF', 'https://www.bilibili.tv/en/video/2041863208?bstar_from=bstar-web.homepage.recommend.all']
[debug] User config: []
[debug] System config: []
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2023.01.02 [d83b0ad80] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: a7019cf2d
[debug] Python 3.11.1 (CPython AMD64 64bit) - Windows-10-10.0.22000-SP0 (OpenSSL 1.1.1q  5 Jul 2022)
[debug] exe versions: none
[debug] Optional libraries: sqlite3-2.6.0
[debug] Proxy map: {}
[debug] Loaded 1757 extractors
[BiliIntl] Extracting URL: https://www.bilibili.tv/en/video/2041863208?bstar_from=bstar-web.homepage.recommend.all
[BiliIntl] 2041863208: Downloading webpage
[BiliIntl] 2041863208: Downloading video formats
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 2041863208:
ID EXT RESOLUTION │   FILESIZE PROTO │ VCODEC          VBR ACODEC        ABR MORE INFO
──────────────────────────────────────────────────────────────────────────────────────
0  mp4 audio only │  206.72KiB https │ audio only          mp4a.40.5  33484k
1  mp4 audio only │  484.68KiB https │ audio only          mp4a.40.2  78655k
2  mp4 audio only │  484.68KiB https │ audio only          mp4a.40.2  78655k
3  mp4 256x144    │  506.98KiB https │ avc1.64001E  82432k video only        144P
4  mp4 426x240    │    1.02MiB https │ avc1.64001E 170534k video only        240P
5  mp4 640x360    │    1.82MiB https │ avc1.64001E 303403k video only        360P
6  mp4 852x480    │    2.69MiB https │ avc1.64001E 448176k video only        480P
7  mp4 1280x720   │    4.69MiB https │ avc1.64001F 780166k video only        720P
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
