### PR TITLE
[utils] `traverse_obj`: Add `set` transformations/filters and `re.Match` group names

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2015,6 +2015,11 @@ Line 1
                          msg='function as query key should perform a filter based on (key, value)')
         self.assertCountEqual(traverse_obj(_TEST_DATA, lambda _, x: isinstance(x[0], str)), {'str'},
                               msg='exceptions in the query function should be catched')
+        if __debug__:
+            with self.assertRaises(Exception, msg='Unassignable parameters should raise in debug'):
+                traverse_obj(_TEST_DATA, lambda a: ...)
+            with self.assertRaises(Exception, msg='Unassignable parameters should raise in debug'):
+                traverse_obj(_TEST_DATA, lambda a, b, c: ...)
 
         # Test set as key (transformation)
         self.assertEqual(traverse_obj('str', ({str.upper}, )), 'STR',

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1985,6 +1985,9 @@ Line 1
             'dict': {},
         }
 
+        self.assertCountEqual(traverse_obj(_TEST_DATA, ('urls', 0, ...)), _TEST_DATA['urls'][0].values(),
+                        msg='`...` selection for dicts should select all values')
+
         # Test base functionality
         self.assertEqual(traverse_obj(_TEST_DATA, ('str',)), 'str',
                          msg='allow tuple path')
@@ -2130,6 +2133,20 @@ Line 1
                          msg='wrap expected_type fuction in try_call')
         self.assertEqual(traverse_obj(_EXPECTED_TYPE_DATA, ..., expected_type=str), ['str'],
                          msg='eliminate items that expected_type fails on')
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: 100, 1: 1.2}, expected_type=int), {0: 100},
+                         msg='type as expected_type should filter dict values')
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: 100, 1: 1.2, 2: 'None'}, expected_type=str_or_none), {0: '100', 1: '1.2'},
+                         msg='function as expected_type should transform dict values')
+        self.assertEqual(traverse_obj(_TEST_DATA, ({0: 1.2}, 0, {int_or_none}), expected_type=int), 1,
+                         msg='expected_type should not filter non final dict values')
+        self.assertEqual(traverse_obj(_TEST_DATA, {0: {0: 100, 1: 'str'}}, expected_type=int), {0: {0: 100}},
+                         msg='expected_type should transform deep dict values')
+        self.assertEqual(traverse_obj(_TEST_DATA, [({0: '...'}, {0: '...'})], expected_type=type(...)), [{0: ...}, {0: ...}],
+                         msg='expected_type should transform branched dict values')
+        self.assertEqual(traverse_obj({1: {3: 4}}, [(1, 2), 3], expected_type=int), [4],
+                         msg='expected_type regression for type matching in tuple branching')
+        self.assertEqual(traverse_obj(_TEST_DATA, ['data', ...], expected_type=int), [],
+                         msg='expected_type regression for type matching in dict result')
 
         # Test get_all behavior
         _GET_ALL_DATA = {'key': [0, 1, 2]}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2016,6 +2016,22 @@ Line 1
         self.assertCountEqual(traverse_obj(_TEST_DATA, lambda _, x: isinstance(x[0], str)), {'str'},
                               msg='exceptions in the query function should be catched')
 
+        # Test set as key (transformation)
+        self.assertEqual(traverse_obj('str', ({str.upper}, )), 'STR',
+                         msg='Set should function as a transformation')
+        self.assertEqual(traverse_obj(_TEST_DATA, {dict}), _TEST_DATA,
+                         msg='A single set should be treated as a path')
+        self.assertEqual(traverse_obj(_TEST_DATA, (..., {str.upper})), ['STR'],
+                         msg='Transformation function should not raise')
+        self.assertEqual(traverse_obj(_TEST_DATA, (..., {str}, {str.upper})),
+                         [str(item).upper() for item in _TEST_DATA.values() if item is not None],
+                         msg='Any callable in the set should be treated as a transformation function')
+        if __debug__:
+            with self.assertRaises(Exception, msg='Sets with length != 1 should raise in debug'):
+                traverse_obj(_TEST_DATA, set())
+            with self.assertRaises(Exception, msg='Sets with length != 1 should raise in debug'):
+                traverse_obj(_TEST_DATA, {str.upper, str})
+
         # Test alternative paths
         self.assertEqual(traverse_obj(_TEST_DATA, 'fail', 'str'), 'str',
                          msg='multiple `paths` should be treated as alternative paths')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2016,9 +2016,9 @@ Line 1
         self.assertCountEqual(traverse_obj(_TEST_DATA, lambda _, x: isinstance(x[0], str)), {'str'},
                               msg='exceptions in the query function should be catched')
         if __debug__:
-            with self.assertRaises(Exception, msg='Unassignable parameters should raise in debug'):
+            with self.assertRaises(Exception, msg='Wrong function signature should raise in debug'):
                 traverse_obj(_TEST_DATA, lambda a: ...)
-            with self.assertRaises(Exception, msg='Unassignable parameters should raise in debug'):
+            with self.assertRaises(Exception, msg='Wrong function signature should raise in debug'):
                 traverse_obj(_TEST_DATA, lambda a, b, c: ...)
 
         # Test set as key (transformation)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2210,6 +2210,8 @@ Line 1
                          msg='failing str key on a `re.Match` should return `default`')
         self.assertEqual(traverse_obj(mobj, 8), None,
                          msg='failing int key on a `re.Match` should return `default`')
+        self.assertEqual(traverse_obj(mobj, lambda k, _: k in (0, 'group')), ['0123', '3'],
+                         msg='function on a `re.Match` should give group name as well')
 
 
 if __name__ == '__main__':

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -105,6 +105,7 @@ from yt_dlp.utils import (
     sanitized_Request,
     shell_quote,
     smuggle_url,
+    str_or_none,
     str_to_int,
     strip_jsonp,
     strip_or_none,
@@ -2021,16 +2022,18 @@ Line 1
             with self.assertRaises(Exception, msg='Wrong function signature should raise in debug'):
                 traverse_obj(_TEST_DATA, lambda a, b, c: ...)
 
-        # Test set as key (transformation)
-        self.assertEqual(traverse_obj('str', ({str.upper}, )), 'STR',
-                         msg='Set should function as a transformation')
+        # Test set as key (transformation/type, like `expected_type`)
+        self.assertEqual(traverse_obj(_TEST_DATA, (..., {str.upper}, )), ['STR'],
+                         msg='Function in set should be a transformation')
+        self.assertEqual(traverse_obj(_TEST_DATA, (..., {str})), ['str'],
+                         msg='Type in set should be a type filter')
         self.assertEqual(traverse_obj(_TEST_DATA, {dict}), _TEST_DATA,
-                         msg='A single set should be treated as a path')
+                         msg='A single set should be wrapped into a path')
         self.assertEqual(traverse_obj(_TEST_DATA, (..., {str.upper})), ['STR'],
                          msg='Transformation function should not raise')
-        self.assertEqual(traverse_obj(_TEST_DATA, (..., {str}, {str.upper})),
-                         [str(item).upper() for item in _TEST_DATA.values() if item is not None],
-                         msg='Any callable in the set should be treated as a transformation function')
+        self.assertEqual(traverse_obj(_TEST_DATA, (..., {str_or_none})),
+                         [item for item in map(str_or_none, _TEST_DATA.values()) if item is not None],
+                         msg='Function in set should be a transformation')
         if __debug__:
             with self.assertRaises(Exception, msg='Sets with length != 1 should raise in debug'):
                 traverse_obj(_TEST_DATA, set())

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1985,9 +1985,6 @@ Line 1
             'dict': {},
         }
 
-        self.assertCountEqual(traverse_obj(_TEST_DATA, ('urls', 0, ...)), _TEST_DATA['urls'][0].values(),
-                        msg='`...` selection for dicts should select all values')
-
         # Test base functionality
         self.assertEqual(traverse_obj(_TEST_DATA, ('str',)), 'str',
                          msg='allow tuple path')

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5478,7 +5478,7 @@ def traverse_obj(
             yield obj
 
         elif isinstance(key, set):
-            assert len(key) == 1
+            assert len(key) == 1, 'Set should only be used to wrap a single transformation'
             yield try_call(next(iter(key)), args=(obj,))
 
         elif isinstance(key, (list, tuple)):
@@ -5562,6 +5562,7 @@ def traverse_obj(
                 has_branched = True
 
             if __debug__ and callable(key):
+                # Verify function signature
                 inspect.signature(key).bind(None, None)
 
             key_func = functools.partial(apply_key, key)

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5557,6 +5557,9 @@ def traverse_obj(
             if key is ... or isinstance(key, (list, tuple)) or callable(key):
                 has_branched = True
 
+            if __debug__ and callable(key):
+                inspect.signature(key).bind(None, None)
+
             key_func = functools.partial(apply_key, key)
             objs = itertools.chain.from_iterable(map(key_func, objs))
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5424,6 +5424,8 @@ def traverse_obj(
 
     The keys in the path can be one of:
         - `None`:           Return the current object.
+        - `set`:            Requires the only item in the set to be a function,
+                            like `{func}`. Returns `func(obj)`.
         - `str`/`int`:      Return `obj[key]`. For `re.Match`, return `obj.group(key)`.
         - `slice`:          Branch out and return all values in `obj[key]`.
         - `Ellipsis`:       Branch out and return a list of all values.
@@ -5472,6 +5474,10 @@ def traverse_obj(
 
         elif key is None:
             yield obj
+
+        elif isinstance(key, set):
+            assert len(key) == 1
+            yield try_call(next(iter(key)), args=(obj,))
 
         elif isinstance(key, (list, tuple)):
             for branch in key:
@@ -5541,7 +5547,7 @@ def traverse_obj(
         objs = (start_obj,)
         has_branched = False
 
-        for key in variadic(path):
+        for key in variadic(path, (str, bytes, dict, set)):
             if is_user_input and key == ':':
                 key = ...
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -5434,6 +5434,8 @@ def traverse_obj(
         - `function`:       Branch out and return values filtered by the function.
                             Read as: `[value for key, value in obj if function(key, value)]`.
                             For `Sequence`s, `key` is the index of the value.
+                            For `re.Match`es, `key` is the group number (0 = full match)
+                            as well as additionally any group names, if given.
         - `dict`            Transform the current object and return a matching dict.
                             Read as: `{key: traverse_obj(obj, path) for key, path in dct.items()}`.
 
@@ -5500,7 +5502,9 @@ def traverse_obj(
             elif isinstance(obj, collections.abc.Mapping):
                 iter_obj = obj.items()
             elif isinstance(obj, re.Match):
-                iter_obj = enumerate((obj.group(), *obj.groups()))
+                iter_obj = itertools.chain(
+                    enumerate((obj.group(), *obj.groups())),
+                    obj.groupdict().items())
             elif traverse_string:
                 iter_obj = enumerate(str(obj))
             else:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Add transformation functions and type filters (through wrapping them into a `set`) and named groups for `re.Match` in filter functions to `traverse_obj`. It also adds a sanity check for filter functions in debug mode to require 2 parameters.
```py
traverse_obj(obj, ("some", "path", {int_or_none}))  # Convert to int
traverse_obj(obj, ("some", "path", {int}))  # Filter non int values
traverse_obj(re.findall("...", "..."), (..., lambda k, _: k.startswith("name")))
traverse_obj(..., lambda x: ...)  # Error in debug mode
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
