### PR TITLE
fix permission error when starting yt-dlp in celery

### DIFF
--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -58,7 +58,10 @@ class PluginFinder(importlib.abc.MetaPathFinder):
         def _get_package_paths(*root_paths, containing_folder='plugins'):
             for config_dir in orderedSet(map(Path, root_paths), lazy=True):
                 plugin_dir = config_dir / containing_folder
-                if not plugin_dir.is_dir():
+                try:
+                    if not plugin_dir.is_dir():
+                        continue
+                except PermissionError:
                     continue
                 yield from plugin_dir.iterdir()
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Hi,
we encountered an error when running yt-dlp from a celery worker. Since celery is starting being root it changes the user to the worker which then obviously is not root. In this case yt-dlp tries to look up if a path in /root/ is a directory and expects to have permission, which it has not.

Since ~ is always added to the paths it will check /root/ in this case, because Python resolves this to $HOME.

```python
Traceback (most recent call last):
File "/opt/venv/bin/celery", line 8, in <module>
  sys.exit(main())
File "/opt/venv/lib/python3.8/site-packages/celery/__main__.py", line 15, in main
  sys.exit(_main())
File "/opt/venv/lib/python3.8/site-packages/celery/bin/celery.py", line 217, in main
  return celery(auto_envvar_prefix="CELERY")
File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
  return self.main(*args, **kwargs)
File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 1055, in main
  rv = self.invoke(ctx)
File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
  return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
  return ctx.invoke(self.callback, **ctx.params)
File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 760, in invoke
  return __callback(*args, **kwargs)
File "/opt/venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
  return f(get_current_context(), *args, **kwargs)
File "/opt/venv/lib/python3.8/site-packages/celery/bin/base.py", line 134, in caller
  return f(ctx, *args, **kwargs)
File "/opt/venv/lib/python3.8/site-packages/celery/bin/worker.py", line 343, in worker
  worker = app.Worker(
File "/opt/venv/lib/python3.8/site-packages/celery/worker/worker.py", line 94, in __init__
  self.app.loader.init_worker()
File "/opt/venv/lib/python3.8/site-packages/celery/loaders/base.py", line 111, in init_worker
  self.import_default_modules()
File "/opt/venv/lib/python3.8/site-packages/celery/loaders/base.py", line 105, in import_default_modules
  raise response
File "/opt/venv/lib/python3.8/site-packages/celery/utils/dispatch/signal.py", line 276, in send
  response = receiver(signal=self, sender=sender, **named)
File "/opt/venv/lib/python3.8/site-packages/vine/promises.py", line 160, in __call__
  return self.throw()
File "/opt/venv/lib/python3.8/site-packages/vine/promises.py", line 157, in __call__
  retval = fun(*final_args, **final_kwargs)
File "/opt/venv/lib/python3.8/site-packages/celery/app/base.py", line 688, in _autodiscover_tasks
  return self._autodiscover_tasks_from_names(packages, related_name)
File "/opt/venv/lib/python3.8/site-packages/celery/app/base.py", line 693, in _autodiscover_tasks_from_names
  return self.loader.autodiscover_tasks(
File "/opt/venv/lib/python3.8/site-packages/celery/loaders/base.py", line 221, in autodiscover_tasks
  mod.__name__ for mod in autodiscover_tasks(packages or (),
File "/opt/venv/lib/python3.8/site-packages/celery/loaders/base.py", line 247, in autodiscover_tasks
  return [find_related_module(pkg, related_name) for pkg in packages]
File "/opt/venv/lib/python3.8/site-packages/celery/loaders/base.py", line 247, in <listcomp>
  return [find_related_module(pkg, related_name) for pkg in packages]
File "/opt/venv/lib/python3.8/site-packages/celery/loaders/base.py", line 268, in find_related_module
  return importlib.import_module(module_name)
File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
  return _bootstrap._gcd_import(name[level:], package, level)
File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
File "<frozen importlib._bootstrap>", line 991, in _find_and_load
File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
File "<frozen importlib._bootstrap_external>", line 843, in exec_module
File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
File "/home/workeruser/project/worker/basic_worker/tasks.py", line 5, in <module>
  from yt_dlp.version import __version__ as version
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/__init__.py", line 19, in <module>
  from .downloader.external import get_external_downloader
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/downloader/__init__.py", line 26, in <module>
  from .external import FFmpegFD, get_external_downloader
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/downloader/external.py", line 12, in <module>
  from ..postprocessor.ffmpeg import EXT_TO_OUT_FORMATS, FFmpegPostProcessor
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/postprocessor/__init__.py", line 38, in <module>
  _PLUGIN_CLASSES = load_plugins('postprocessor', 'PP')
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/plugins.py", line 135, in load_plugins
  for finder, module_name, _ in iter_modules(name):
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/plugins.py", line 119, in iter_modules
  pkg = importlib.import_module(fullname)
File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
  return _bootstrap._gcd_import(name[level:], package, level)
File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
File "<frozen importlib._bootstrap>", line 991, in _find_and_load
File "<frozen importlib._bootstrap>", line 971, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 914, in _find_spec
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/plugins.py", line 96, in find_spec
  search_locations = self.search_locations(fullname)
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/plugins.py", line 66, in search_locations
  candidate_locations.extend(_get_package_paths(
File "/opt/venv/lib/python3.8/site-packages/yt_dlp/plugins.py", line 61, in _get_package_paths
  if not plugin_dir.is_dir():
File "/usr/local/lib/python3.8/pathlib.py", line 1422, in is_dir
  return S_ISDIR(self.stat().st_mode)
File "/usr/local/lib/python3.8/pathlib.py", line 1198, in stat
  return self._accessor.stat(self)
PermissionError: [Errno 13] Permission denied: '/root/.config/yt-dlp/plugins'

```
I put our whole exception message i think that explains it quite well. The provided try, catch would not add paths with no permission.

I also tried this version in our code and it works. No other errors appeared after that.

I would be happy to know what you think and hope we can fix this soon.

Greetings

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
