### PR TITLE
[extractor/slideslive] Fix thumbnails and chapters/duration

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2185,6 +2185,16 @@ class InfoExtractor:
             float(line[len('#EXTINF:'):].split(',')[0])
             for line in m3u8_vod.splitlines() if line.startswith('#EXTINF:'))) or None
 
+    def _extract_mpd_vod_duration(
+            self, mpd_url, video_id, note=None, errnote=None, data=None, headers={}, query={}):
+
+        mpd_doc = self._download_xml(
+            mpd_url, video_id,
+            note='Downloading MPD VOD manifest' if note is None else note,
+            errnote='Failed to download VOD manifest' if errnote is None else errnote,
+            fatal=False, data=data, headers=headers, query=query) or {}
+        return int_or_none(parse_duration(mpd_doc.get('mediaPresentationDuration')))
+
     @staticmethod
     def _xpath_ns(path, namespace=None):
         if not namespace:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2178,7 +2178,7 @@ class InfoExtractor:
         return self._parse_m3u8_vod_duration(m3u8_vod or '', video_id)
 
     def _parse_m3u8_vod_duration(self, m3u8_vod, video_id):
-        if '#EXT-X-PLAYLIST-TYPE:VOD' not in m3u8_vod:
+        if '#EXT-X-ENDLIST' not in m3u8_vod:
             return None
 
         return int(sum(

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -5,7 +5,6 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     int_or_none,
-    parse_duration,
     parse_qs,
     smuggle_url,
     traverse_obj,

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -537,8 +537,9 @@ class SlidesLiveIE(InfoExtractor):
             if not duration:
                 last_start_time = traverse_obj(
                     info, ('chapters', -1, 'start_time'), expected_type=int_or_none)
+                # if chapters, prevent core code from setting the last chapter's end_time as None
                 if last_start_time:
-                    info['chapters'][-1]['end_time'] = last_start_time + 1
+                    info['chapters'][-1]['end_time'] = last_start_time
             info.update({
                 'duration': duration,
                 'formats': formats,

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -30,6 +30,7 @@ class SlidesLiveIE(InfoExtractor):
             'thumbnail': r're:^https?://.*\.jpg',
             'thumbnails': 'count:42',
             'chapters': 'count:41',
+            'duration': 1638,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -46,6 +47,7 @@ class SlidesLiveIE(InfoExtractor):
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',
             'thumbnails': 'count:640',
             'chapters': 'count:639',
+            'duration': 9832,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -62,6 +64,7 @@ class SlidesLiveIE(InfoExtractor):
             'timestamp': 1643728135,
             'thumbnails': 'count:3',
             'chapters': 'count:2',
+            'duration': 5889,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -111,6 +114,7 @@ class SlidesLiveIE(InfoExtractor):
             'timestamp': 1629671508,
             'upload_date': '20210822',
             'chapters': 'count:7',
+            'duration': 326,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -127,6 +131,7 @@ class SlidesLiveIE(InfoExtractor):
             'timestamp': 1654714970,
             'upload_date': '20220608',
             'chapters': 'count:6',
+            'duration': 171,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -143,6 +148,7 @@ class SlidesLiveIE(InfoExtractor):
             'timestamp': 1622806321,
             'upload_date': '20210604',
             'chapters': 'count:15',
+            'duration': 306,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -159,6 +165,7 @@ class SlidesLiveIE(InfoExtractor):
             'timestamp': 1654714896,
             'upload_date': '20220608',
             'chapters': 'count:8',
+            'duration': 295,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -175,6 +182,7 @@ class SlidesLiveIE(InfoExtractor):
             'thumbnails': 'count:22',
             'upload_date': '20220608',
             'chapters': 'count:21',
+            'duration': 294,
         },
         'params': {
             'skip_download': 'm3u8',
@@ -197,6 +205,7 @@ class SlidesLiveIE(InfoExtractor):
                 'thumbnails': 'count:30',
                 'upload_date': '20220608',
                 'chapters': 'count:31',
+                'duration': 272,
             },
         }, {
             'info_dict': {
@@ -238,6 +247,7 @@ class SlidesLiveIE(InfoExtractor):
                 'thumbnails': 'count:43',
                 'upload_date': '20220608',
                 'chapters': 'count:43',
+                'duration': 315,
             },
         }, {
             'info_dict': {
@@ -287,6 +297,23 @@ class SlidesLiveIE(InfoExtractor):
             'skip_download': 'm3u8',
         },
     }, {
+        # /v3/ slides, .png only, service_name = yoda
+        'url': 'https://slideslive.com/38983994',
+        'info_dict': {
+            'id': '38983994',
+            'ext': 'mp4',
+            'title': 'Zero-Shot AutoML with Pretrained Models',
+            'timestamp': 1662384834,
+            'upload_date': '20220905',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'thumbnails': 'count:23',
+            'chapters': 'count:22',
+            'duration': 295,
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }, {
         # service_name = yoda
         'url': 'https://slideslive.com/38903721/magic-a-scientific-resurrection-of-an-esoteric-legend',
         'only_matching': True,
@@ -312,6 +339,7 @@ class SlidesLiveIE(InfoExtractor):
             'timestamp': 1629671508,
             'upload_date': '20210822',
             'chapters': 'count:7',
+            'duration': 326,
         },
         'params': {
             'skip_download': 'm3u8',

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -398,15 +398,6 @@ class SlidesLiveIE(InfoExtractor):
 
         return m3u8_dict
 
-    def _parse_m3u8_vod_duration(self, m3u8_vod, video_id):
-        # SlidesLive VOD m3u8 does not contain '#EXT-X-PLAYLIST-TYPE:VOD'
-        if '#EXT-X-ENDLIST' not in m3u8_vod:
-            return None
-
-        return int(sum(
-            float(line[len('#EXTINF:'):].split(',')[0])
-            for line in m3u8_vod.splitlines() if line.startswith('#EXTINF:'))) or None
-
     def _extract_formats_and_duration(self, cdn_hostname, path, video_id, skip_duration=False):
         formats, duration = [], None
 

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -407,16 +407,6 @@ class SlidesLiveIE(InfoExtractor):
             float(line[len('#EXTINF:'):].split(',')[0])
             for line in m3u8_vod.splitlines() if line.startswith('#EXTINF:'))) or None
 
-    def _extract_mpd_vod_duration(
-            self, mpd_url, video_id, note=None, errnote=None, data=None, headers={}, query={}):
-
-        mpd_doc = self._download_xml(
-            mpd_url, video_id,
-            note='Downloading MPD VOD manifest' if note is None else note,
-            errnote='Failed to download VOD manifest' if errnote is None else errnote,
-            fatal=False, data=data, headers=headers, query=query) or {}
-        return int_or_none(parse_duration(mpd_doc.get('mediaPresentationDuration')))
-
     def _extract_formats_and_duration(self, cdn_hostname, path, video_id, skip_duration=False):
         formats, duration = [], None
 

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -515,12 +515,6 @@ class SlidesLiveIE(InfoExtractor):
         elif service_name == 'yoda':
             formats, duration = self._extract_formats_and_duration(
                 player_info['video_servers'][0], service_id, video_id)
-            if not duration:
-                last_start_time = traverse_obj(
-                    info, ('chapters', -1, 'start_time'), expected_type=int_or_none)
-                # if chapters, prevent core code from setting the last chapter's end_time as None
-                if last_start_time:
-                    info['chapters'][-1]['end_time'] = last_start_time
             info.update({
                 'duration': duration,
                 'formats': formats,

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -431,7 +431,7 @@ class SlidesLiveIE(InfoExtractor):
         slides_version = int(self._search_regex(
             r'https?://slides\.slideslive\.com/\d+/v(\d+)/\w+\.(?:json|xml)',
             slides_info_url, 'slides version', default=0))
-        if slides_version < 4:
+        if slides_version < 3:
             slide_url_template = 'https://cdn.slideslive.com/data/presentations/%s/slides/big/%s.jpg'
         else:
             slide_url_template = 'https://slides.slideslive.com/%s/slides/original/%s.png'


### PR DESCRIPTION
### Chapters/duration:
* I had previously written the extractor so that core code would take care of setting chapter end times, but the video's duration was not being extracted, so the final chapter's end time was being set as `None`. [This causes problems with postprocessing.](https://github.com/yt-dlp/yt-dlp/issues/5818#issuecomment-1380926974) With this PR, the extractor tries to extract duration from the m3u8 media playlist and falls back to extracting from the MPD manifest. (This was not an issue with the youtube embeds.)

### Thumbnails:
* ~~SlidesLive serves several different "versions" of slides, and I had previously assumed that "v3" slides were available as both .jpg and .png based off of the only v3 example URL I was able to find, so I had written the extractor to use .jpg URLs for the thumbnails. [This assumption was wrong](https://github.com/yt-dlp/yt-dlp/issues/5818#issuecomment-1380827150), so this PR uses .png URLs instead, which seem to be the safer option.~~

* I found a much more robust approach to extracting slides:
   - if there is only slides XML available, the slides always use .jpg extension and the URL template:
     `https://cdn.slideslive.com/data/presentations/{video_id}/slides/big/{slide_path}.{ext}`
     
   - some, but not all, videos' slides JSON has a `slide_qualities` array. if this exists, the slides use .jpg extension and the URL template:
     `https://cdn.slideslive.com/data/presentations/{video_id}/slides/{slide_quality}/{slide_path}.{ext}`
     
   - if `slide_qualities` does not exist in the slides JSON, then the slide objects in the JSON array have an `extname` key with a value of .jpg or .png and the slides use the URL template:
     `https://slides.slideslive.com/{video_id}/slides/original/{slide_path}.{ext}`
     
     (to be clear: `extname` keys *only* exist in JSON where there is no `slide_qualities` array) 

After commit 05682e3110d06c044a8b2764e995cdfde812d51b, I ran all of the test URLs with `--write-all-thumbnails` and `-O chapters` and everything looked good.

Addresses https://github.com/yt-dlp/yt-dlp/issues/5818#issuecomment-1380827150 and https://github.com/yt-dlp/yt-dlp/issues/5818#issuecomment-1380926974


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
