### PR TITLE
Hotfix for radiko.jp

### DIFF
--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -16,21 +16,21 @@ from ..utils import (
 class RadikoBaseIE(InfoExtractor):
     _FULL_KEY = None
     _HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED = (
-        "https://c-rpaa.smartstream.ne.jp",
-        "https://si-c-radiko.smartstream.ne.jp",
-        "https://tf-f-rpaa-radiko.smartstream.ne.jp",
-        "https://tf-c-rpaa-radiko.smartstream.ne.jp",
-        "https://si-f-radiko.smartstream.ne.jp",
-        "https://rpaa.smartstream.ne.jp",
+        'https://c-rpaa.smartstream.ne.jp',
+        'https://si-c-radiko.smartstream.ne.jp',
+        'https://tf-f-rpaa-radiko.smartstream.ne.jp',
+        'https://tf-c-rpaa-radiko.smartstream.ne.jp',
+        'https://si-f-radiko.smartstream.ne.jp',
+        'https://rpaa.smartstream.ne.jp',
     )
     _HOSTS_FOR_TIME_FREE_FFMPEG_SUPPORTED = (
-        "https://rd-wowza-radiko.radiko-cf.com",
-        "https://radiko.jp",
-        "https://f-radiko.smartstream.ne.jp",
+        'https://rd-wowza-radiko.radiko-cf.com',
+        'https://radiko.jp',
+        'https://f-radiko.smartstream.ne.jp',
     )
     # Following URL forcibly connects not Time Free but Live
     _HOSTS_FOR_LIVE = (
-        "https://c-radiko.smartstream.ne.jp",
+        'https://c-radiko.smartstream.ne.jp',
     )
 
     def _auth_client(self):

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -1,5 +1,4 @@
 import base64
-import re
 import urllib.parse
 
 from .common import InfoExtractor

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -15,6 +15,23 @@ from ..utils import (
 
 class RadikoBaseIE(InfoExtractor):
     _FULL_KEY = None
+    _HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED = (
+        "https://c-rpaa.smartstream.ne.jp",
+        "https://si-c-radiko.smartstream.ne.jp",
+        "https://tf-f-rpaa-radiko.smartstream.ne.jp",
+        "https://tf-c-rpaa-radiko.smartstream.ne.jp",
+        "https://si-f-radiko.smartstream.ne.jp",
+        "https://rpaa.smartstream.ne.jp",
+    )
+    _HOSTS_FOR_TIME_FREE_FFMPEG_SUPPORTED = (
+        "https://rd-wowza-radiko.radiko-cf.com",
+        "https://radiko.jp",
+        "https://f-radiko.smartstream.ne.jp",
+    )
+    # Following URL forcibly connects not Time Free but Live
+    _HOSTS_FOR_LIVE = (
+        "https://c-radiko.smartstream.ne.jp",
+    )
 
     def _auth_client(self):
         _, auth1_handle = self._download_webpage_handle(
@@ -92,9 +109,18 @@ class RadikoBaseIE(InfoExtractor):
         formats = []
         found = set()
         for url_tag in m3u8_urls:
-            pcu = url_tag.find('playlist_create_url')
+            pcu = url_tag.find('playlist_create_url').text
+            if (
+                is_onair and not pcu.startswith(self._HOSTS_FOR_LIVE)
+                # Allowlist style for Time Free to consider undiscovered URL
+                or (not is_onair and (
+                    pcu.startswith(self._HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED)
+                    or pcu.startswith(self._HOSTS_FOR_LIVE)
+                ))
+            ):
+                continue
             url_attrib = url_tag.attrib
-            playlist_url = update_url_query(pcu.text, {
+            playlist_url = update_url_query(pcu, {
                 'station_id': station,
                 **query,
                 'l': '15',

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -110,7 +110,7 @@ class RadikoBaseIE(InfoExtractor):
         found = set()
         for url_tag in m3u8_urls:
             pcu = url_tag.find('playlist_create_url').text
-            if is_onair and not pcu.startswith(self._HOSTS_FOR_LIVE) or (not is_onair and (pcu.startswith(self._HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED) or pcu.startswith(self._HOSTS_FOR_LIVE)))):
+            if is_onair and not pcu.startswith(self._HOSTS_FOR_LIVE) or (not is_onair and (pcu.startswith(self._HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED) or pcu.startswith(self._HOSTS_FOR_LIVE))):
                 continue
             url_attrib = url_tag.attrib
             playlist_url = update_url_query(pcu, {

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -110,14 +110,7 @@ class RadikoBaseIE(InfoExtractor):
         found = set()
         for url_tag in m3u8_urls:
             pcu = url_tag.find('playlist_create_url').text
-            if (
-                is_onair and not pcu.startswith(self._HOSTS_FOR_LIVE)
-                # Allowlist style for Time Free to consider undiscovered URL
-                or (not is_onair and (
-                    pcu.startswith(self._HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED)
-                    or pcu.startswith(self._HOSTS_FOR_LIVE)
-                ))
-            ):
+            if is_onair and not pcu.startswith(self._HOSTS_FOR_LIVE) or (not is_onair and (pcu.startswith(self._HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED) or pcu.startswith(self._HOSTS_FOR_LIVE)))):
                 continue
             url_attrib = url_tag.attrib
             playlist_url = update_url_query(pcu, {


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

#### Summary of issue:

Can't download radiko.jp Time Free.
See also: #6090 

#### Cause
 
The update of radiko.jp.
Some of supplied hosts are not supported by FFmpeg.
Note that the version of FFmpeg is not related with this issue.

#### Summary of update

Filter supplied hosts before check details of them.

- Condition is little complex.
  - To simplify, stop to use `is_onair` and implement method like `is_unsupported_host()` into class: `RadikoIE` and `RadikoRadioIE` instead and move condition into its method.
    - However, this pull request leave it since this is hotfix.

#### Confirmed tests

- Download radiko.jp Live
- Download radiko.jp Time Free
- Play downloaded AAC file
- Check format of donwloaded AAC file by [MediaInfo](https://mediaarea.net/MediaInfo)
- Check which supplied host is available or not

#### Investigation result

- Live has dedicated host
- The host: `radiko.jp` is the firstest host to download
  - However, some of programs doesn't support this host, it requires one more scheme to prioritize `radiko.jp`
    - So that this pull request doesn't do anything for this.
- The difference between downloaded AAC files from each host is only stream size.
- When FFmpeg connect to `c-radiko.smartstream.ne.jp`, FFmpeg forcibly connects not Time Free but Live.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)
  (Maybe, automated test for radiko.jp doesn't exist.)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
