### PR TITLE
[pornez] fix: resolve iframe extraction issue

### DIFF
--- a/yt_dlp/extractor/pornez.py
+++ b/yt_dlp/extractor/pornez.py
@@ -1,8 +1,5 @@
 from .common import InfoExtractor
-from ..utils import (
-    int_or_none,
-    urljoin
-)
+from ..utils import int_or_none, urljoin
 
 
 class PornezIE(InfoExtractor):
@@ -24,7 +21,7 @@ class PornezIE(InfoExtractor):
         webpage = self._download_webpage(url, video_id)
         iframe_src = self._html_search_regex(
             r'<iframe[^>]+src="([^"]+)"', webpage, 'iframe', fatal=True)
-        iframe_src = urljoin("https://pornez.net", iframe_src)
+        iframe_src = urljoin('https://pornez.net', iframe_src)
         title = self._html_search_meta(['name', 'twitter:title', 'og:title'], webpage, 'title', default=None)
         if title is None:
             title = self._search_regex(r'<h1>(.*?)</h1>', webpage, 'title', fatal=True)

--- a/yt_dlp/extractor/pornez.py
+++ b/yt_dlp/extractor/pornez.py
@@ -1,5 +1,8 @@
 from .common import InfoExtractor
-from ..utils import int_or_none
+from ..utils import (
+    int_or_none,
+    urljoin
+)
 
 
 class PornezIE(InfoExtractor):
@@ -20,7 +23,8 @@ class PornezIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
         iframe_src = self._html_search_regex(
-            r'<iframe[^>]+src="(https?://pornez\.net/player/\?[^"]+)"', webpage, 'iframe', fatal=True)
+            r'<iframe[^>]+src="([^"]+)"', webpage, 'iframe', fatal=True)
+        iframe_src = urljoin("https://pornez.net", iframe_src)
         title = self._html_search_meta(['name', 'twitter:title', 'og:title'], webpage, 'title', default=None)
         if title is None:
             title = self._search_regex(r'<h1>(.*?)</h1>', webpage, 'title', fatal=True)


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR fixes the iframe extraction issue as reported in #6162 by joining the path of the iframe, pulled from the iframe src attribute, to the domain for pornez.  

Fixes #6162

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
