### PR TITLE
[utils] Don't trust Content-length when Content-encoding is present

### DIFF
--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -211,9 +211,9 @@ class HttpFD(FileDownloader):
                 ctx.stream = None
 
         def download():
-            data_len = ctx.data.info().get('Content-length', None)
+            data_len = ctx.data.info().get('Content-length')
 
-            if ctx.data.info().get('Content-encoding', None):
+            if ctx.data.info().get('Content-encoding'):
                 # Content-encoding is present, Content-length is not reliable anymore as we are
                 # doing auto decompression.
                 data_len = None

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -215,7 +215,7 @@ class HttpFD(FileDownloader):
 
             if ctx.data.info().get('Content-encoding'):
                 # Content-encoding is present, Content-length is not reliable anymore as we are
-                # doing auto decompression.
+                # doing auto decompression. (See: https://github.com/yt-dlp/yt-dlp/pull/6176)
                 data_len = None
 
             # Range HTTP header may be ignored/unsupported by a webserver

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -213,6 +213,11 @@ class HttpFD(FileDownloader):
         def download():
             data_len = ctx.data.info().get('Content-length', None)
 
+            if ctx.data.info().get('Content-encoding', None):
+                # Content-encoding is present, Content-length is not reliable anymore as we are
+                # doing auto decompression.
+                data_len = None
+
             # Range HTTP header may be ignored/unsupported by a webserver
             # (e.g. extractor/scivee.py, extractor/bambuser.py).
             # However, for a test we still would like to download just a piece of a file.

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1438,19 +1438,16 @@ class YoutubeDLHandler(urllib.request.HTTPHandler):
                     raise original_ioerror
             resp = urllib.request.addinfourl(uncompressed, old_resp.headers, old_resp.url, old_resp.code)
             resp.msg = old_resp.msg
-            del resp.headers['Content-encoding']
         # deflate
         if resp.headers.get('Content-encoding', '') == 'deflate':
             gz = io.BytesIO(self.deflate(resp.read()))
             resp = urllib.request.addinfourl(gz, old_resp.headers, old_resp.url, old_resp.code)
             resp.msg = old_resp.msg
-            del resp.headers['Content-encoding']
         # brotli
         if resp.headers.get('Content-encoding', '') == 'br':
             resp = urllib.request.addinfourl(
                 io.BytesIO(self.brotli(resp.read())), old_resp.headers, old_resp.url, old_resp.code)
             resp.msg = old_resp.msg
-            del resp.headers['Content-encoding']
         # Percent-encode redirect URL of Location HTTP header to satisfy RFC 3986 (see
         # https://github.com/ytdl-org/youtube-dl/issues/6457).
         if 300 <= resp.code < 400:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Our YoutubeDLHandler is doing auto-decompression, so that we cannot compare Content-length to the size of extracted data. Although HttpFD has specified Youtubedl-no-compression, the web server may still ignore this and return deflated data (as the situation in #3772).

This change attempts to retain the Content-encoding header for later comparison in HttpFD so that we could discard data_len when the web server returns compressed data. I didn't find the reason why this header was previously removed but didn't yet find a counter example either.

Fixes #3772 in my experiments.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
