### PR TITLE
Improve how default youtube subs are selected

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2811,9 +2811,13 @@ class YoutubeDL:
             except re.error as e:
                 raise ValueError(f'Wrong regex for subtitlelangs: {e.pattern}')
         else:
-            en_list = sorted(filter(lambda f: f.startswith('en'), normal_sub_langs))
-            en_list.extend(sorted(filter(lambda f: f.startswith('en'), all_sub_langs)))
-            requested_langs = en_list[:1]
+            # Check for `en` subs first
+            subs_list = sorted(filter(lambda f: f.startswith('en'), normal_sub_langs))
+            subs_list.extend(sorted(filter(lambda f: f.startswith('en'), all_sub_langs)))
+            # Append all langs at the end in case there are no `en` subs
+            subs_list.extend(sorted(normal_sub_langs))
+            subs_list.extend(sorted(all_sub_langs))
+            requested_langs = subs_list[:1]
         if requested_langs:
             self.to_screen(f'[info] {video_id}: Downloading subtitles: {", ".join(requested_langs)}')
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2810,10 +2810,10 @@ class YoutubeDL:
                     self.params.get('subtitleslangs'), {'all': all_sub_langs}, use_regex=True)
             except re.error as e:
                 raise ValueError(f'Wrong regex for subtitlelangs: {e.pattern}')
-        elif normal_sub_langs:
-            requested_langs = ['en'] if 'en' in normal_sub_langs else normal_sub_langs[:1]
         else:
-            requested_langs = ['en'] if 'en' in all_sub_langs else all_sub_langs[:1]
+            en_list = sorted(filter(lambda f: f.startswith('en'), normal_sub_langs))
+            en_list.extend(sorted(filter(lambda f: f.startswith('en'), all_sub_langs)))
+            requested_langs = en_list[:1]
         if requested_langs:
             self.to_screen(f'[info] {video_id}: Downloading subtitles: {", ".join(requested_langs)}')
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2811,13 +2811,13 @@ class YoutubeDL:
             except re.error as e:
                 raise ValueError(f'Wrong regex for subtitlelangs: {e.pattern}')
         else:
-            # Check for `en` subs first
-            subs_list = sorted(filter(lambda f: f.startswith('en'), normal_sub_langs))
-            subs_list.extend(sorted(filter(lambda f: f.startswith('en'), all_sub_langs)))
-            # Append all langs at the end in case there are no `en` subs
-            subs_list.extend(sorted(normal_sub_langs))
-            subs_list.extend(sorted(all_sub_langs))
-            requested_langs = subs_list[:1]
+            requested_langs = LazyList(itertools.chain(
+                ['en'] if 'en' in normal_sub_langs else [],
+                filter(lambda f: f.startswith('en'), normal_sub_langs),
+                ['en'] if 'en' in all_sub_langs else [],
+                filter(lambda f: f.startswith('en'), all_sub_langs),
+                normal_sub_langs, all_sub_langs,
+            ))[:1]
         if requested_langs:
             self.to_screen(f'[info] {video_id}: Downloading subtitles: {", ".join(requested_langs)}')
 


### PR DESCRIPTION
### Description of your *pull request* and other information

Currently when `--write-subs --write-auto-subs` is enabled and no explicit format is mentioned, `yt-dlp` tries to search for the specific `en` subtitles for both uploaded and auto subs. This works most of the times.

However, many videos have english subtitles of the form [en-US](https://www.youtube.com/watch?v=rpwkgMX4IlQ) or even something like [en-qlPKC2UN_YU](https://www.youtube.com/watch?v=9H6muyZjms0). For videos like these, yt-dlp currently will not select the uploaded english subtitle but instead will either select the auto `en` one or some other arbitrary non english subtitle such as [es-419](https://www.youtube.com/watch?v=wW920zWkIQI), [ja](https://www.youtube.com/watch?v=UxMlGRThKws), etc.

This PR is a quick fix to first sort all english subtitles that start with `en`, uploaded ones first and then the auto ones, then selects the first one among those. If there are no `en` subtitles, the code does not select an arbitrary non-en language anymore and simply exits with no subtitles.

I saw that there are other subtitle related issues open (https://github.com/yt-dlp/yt-dlp/issues/2262 https://github.com/yt-dlp/yt-dlp/issues/946), but this is a quick fix to mostly keep the same functionality as before but improves the correctness of the selection.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
