### PR TITLE
[extractor/youtube] Add the first 3 characters of client name in `format_note`

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3747,7 +3747,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     'DRC' if fmt.get('isDrc') else None,
                     try_get(fmt, lambda x: x['projectionType'].replace('RECTANGULAR', '').lower()),
                     try_get(fmt, lambda x: x['spatialAudioType'].replace('SPATIAL_AUDIO_TYPE_', '').lower()),
-                    throttled and 'THROTTLED', is_damaged and 'DAMAGED', delim=', '),
+                    throttled and 'THROTTLED', is_damaged and 'DAMAGED',
+                    # for convenience of seeing client name in -F without debugging
+                    traverse_obj(query, ('c', 0, {str}, {lambda x: x[0:3]})),
+                    delim=', '),
                 # Format 22 is likely to be damaged. See https://github.com/yt-dlp/yt-dlp/issues/3372
                 'source_preference': -10 if throttled else -5 if itag == '22' else -1,
                 'fps': int_or_none(fmt.get('fps')) or None,

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -66,6 +66,8 @@ from ..utils import (
     variadic,
 )
 
+
+STRAMING_DATA_CLIENT_NAME = '@@youtubeplzdontusethis@@client_name'
 # any clients starting with _ cannot be explicitly requested by the user
 INNERTUBE_CLIENTS = {
     'web': {
@@ -278,8 +280,6 @@ def build_innertube_clients():
 
 build_innertube_clients()
 
-
-STRAMING_DATA_CLIENT_NAME = '@@youtubeplzdontusethis@@client_name'
 
 class BadgeType(enum.Enum):
     AVAILABILITY_UNLISTED = enum.auto()

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -67,7 +67,7 @@ from ..utils import (
 )
 
 
-STRAMING_DATA_CLIENT_NAME = '@@youtubeplzdontusethis@@client_name'
+STREAMING_DATA_CLIENT_NAME = '__yt_dlp_client'
 # any clients starting with _ cannot be explicitly requested by the user
 INNERTUBE_CLIENTS = {
     'web': {

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3621,7 +3621,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         f'Skipping player response from {client} client (got player response for video "{pr_video_id}" instead of "{video_id}")' + bug_reports_message())
                 else:
                     # set the client name in streamingData so that we can show it on -F
-                    (traverse_obj(pr, ('streamingData', {dict})) or {})[STRAMING_DATA_CLIENT_NAME] = client
+                    (traverse_obj(pr, ('streamingData', {dict})) or {})[STREAMING_DATA_CLIENT_NAME] = client
                     prs.append(pr)
 
             # creator clients can bypass AGE_VERIFICATION_REQUIRED if logged in
@@ -3741,7 +3741,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 self.report_warning(
                     f'{video_id}: Some formats are possibly damaged. They will be deprioritized', only_once=True)
 
-            client_name = (traverse_obj(query, ('c', 0, {str})) or fmt.get(STRAMING_DATA_CLIENT_NAME) or '')[0:3].upper()
+            client_name = (traverse_obj(query, ('c', 0, {str})) or fmt.get(STREAMING_DATA_CLIENT_NAME) or '')[0:3].upper()
             dct = {
                 'asr': int_or_none(fmt.get('audioSampleRate')),
                 'filesize': int_or_none(fmt.get('contentLength')),
@@ -3833,7 +3833,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         subtitles = {}
         for sd in streaming_data:
-            client_name = (sd.get(STRAMING_DATA_CLIENT_NAME) or '')[0:3].upper()
+            client_name = (sd.get(STREAMING_DATA_CLIENT_NAME) or '')[0:3].upper()
 
             hls_manifest_url = 'hls' not in skip_manifests and sd.get('hlsManifestUrl')
             if hls_manifest_url:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This PR adds the client names to `format_note` returned by the Youtube extractor for convenience
If you wish to enforce this to all the formats (MPD and HLS), a little rewrite would be required

p.s. make a release before reviewing this

```
$ ./yt-dlp.sh -s test:youtube_2 --extractor-args youtube:player_client=all -F
[TestURL] Extracting URL: test:youtube_2
[TestURL] Test URL: https://www.youtube.com/watch?v=BaW_jenozKc&v=yZIXLfi8CZQ
[youtube] Extracting URL: https://www.youtube.com/watch?v=BaW_jenozKc&v=yZIXLfi8CZQ
(snip)
[info] Available formats for BaW_jenozKc:
ID      EXT  RESOLUTION FPS CH │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC      ABR ASR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
233     mp4  audio only        │                  m3u8  │ audio only          unknown             Default
234     mp4  audio only        │                  m3u8  │ audio only          unknown             Default
249-drc webm audio only      2 │   62.24KiB   52k https │ audio only          opus        52k 48k low, DRC, TVH, webm_dash
250-drc webm audio only      2 │   80.49KiB   67k https │ audio only          opus        67k 48k low, DRC, TVH, webm_dash
139     m4a  audio only      2 │   58.59KiB   48k https │ audio only          mp4a.40.5   48k 22k low, AND, m4a_dash
249     webm audio only      2 │   58.17KiB   48k https │ audio only          opus        48k 48k low, AND, webm_dash
250     webm audio only      2 │   76.07KiB   63k https │ audio only          opus        63k 48k low, AND, webm_dash
140-drc m4a  audio only      2 │  157.22KiB  130k https │ audio only          mp4a.40.2  130k 44k medium, DRC, TVH, m4a_dash
251-drc webm audio only      2 │  138.80KiB  115k https │ audio only          opus       115k 48k medium, DRC, TVH, webm_dash
140     m4a  audio only      2 │  154.06KiB  128k https │ audio only          mp4a.40.2  128k 44k medium, AND, m4a_dash
251     webm audio only      2 │  138.96KiB  116k https │ audio only          opus       116k 48k medium, AND, webm_dash
17      3gp  176x144     12  1 │   55.79KiB   45k https │ mp4v.20.3       45k mp4a.40.2    0k 22k 144p, AND
269     mp4  256x144     15    │ ~214.75KiB  172k m3u8  │ avc1.4D400C    172k video only
160     mp4  256x144     15    │  135.08KiB  113k https │ avc1.4d400c    113k video only          144p, AND, mp4_dash
603     mp4  256x144     30    │ ~127.69KiB  102k m3u8  │ vp09.00.11.08  102k video only
278     webm 256x144     30    │   52.22KiB   44k https │ vp9             44k video only          144p, AND, webm_dash
229     mp4  426x240     30    │ ~386.34KiB  309k m3u8  │ avc1.4D4015    309k video only
133     mp4  426x240     30    │  294.27KiB  246k https │ avc1.4d4015    246k video only          240p, AND, mp4_dash
604     mp4  426x240     30    │ ~ 99.87KiB   80k m3u8  │ vp09.00.20.08   80k video only
242     webm 426x240     30    │   33.27KiB   28k https │ vp9             28k video only          240p, AND, webm_dash
230     mp4  640x360     30    │ ~553.39KiB  443k m3u8  │ avc1.4D401E    443k video only
134     mp4  640x360     30    │  349.59KiB  292k https │ avc1.4d401e    292k video only          360p, AND, mp4_dash
18      mp4  640x360     30  2 │ ~525.60KiB  420k https │ avc1.42001E    420k mp4a.40.2    0k 44k 360p, AND
605     mp4  640x360     30    │ ~255.57KiB  204k m3u8  │ vp09.00.21.08  204k video only
243     webm 640x360     30    │   75.55KiB   63k https │ vp9             63k video only          360p, AND, webm_dash
231     mp4  854x480     30    │ ~  1.10MiB  898k m3u8  │ avc1.4D401F    898k video only
135     mp4  854x480     30    │  849.41KiB  710k https │ avc1.4d401f    710k video only          480p, AND, mp4_dash
606     mp4  854x480     30    │ ~375.46KiB  300k m3u8  │ vp09.00.30.08  300k video only
244     webm 854x480     30    │  165.49KiB  138k https │ vp9            138k video only          480p, AND, webm_dash
22      mp4  1280x720    30  2 │ ~  1.82MiB 1493k https │ avc1.64001F   1493k mp4a.40.2    0k 44k 720p, AND
232     mp4  1280x720    30    │ ~  1.99MiB 1631k m3u8  │ avc1.4D401F   1631k video only
136     mp4  1280x720    30    │    1.60MiB 1366k https │ avc1.4d401f   1366k video only          720p, AND, mp4_dash
609     mp4  1280x720    30    │ ~756.27KiB  605k m3u8  │ vp09.00.31.08  605k video only
247     webm 1280x720    30    │  504.68KiB  420k https │ vp9            420k video only          720p, AND, webm_dash
270     mp4  1920x1080   30    │ ~  2.52MiB 2061k m3u8  │ avc1.640028   2061k video only
137     mp4  1920x1080   30    │    2.11MiB 1803k https │ avc1.640028   1803k video only          1080p, AND, mp4_dash
614     mp4  1920x1080   30    │ ~  1.29MiB 1057k m3u8  │ vp09.00.40.08 1057k video only
248     webm 1920x1080   30    │  965.31KiB  804k https │ vp9            804k video only          1080p, AND, webm_dash
[info] BaW_jenozKc: Downloading 1 format(s): 248+251
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
