### PR TITLE
Make subtitle language selection more powerful

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2829,12 +2829,20 @@ class YoutubeDL:
                 alias_dict = {'all': all_sub_langs, '#all': all_sub_langs_merged,
                               'allnorm': normal_sub_langs, 'allauto': auto_sub_langs}
                 for option in self.params.get('subtitleslangs'):
+                    merge = False
                     if option.startswith('#') and option != "#all":
-                        lang = option[1:]
-                        requested_langs.extend(_get_one_lang(lang, select_default=False))
-                    else:
-                        requested_langs = orderedSet_from_options(
-                            [option], alias_dict, use_regex=True, start=requested_langs)
+                        merge = True
+                        option = option[1:]
+                    for lang in option.split("/"):
+                        old_len = len(requested_langs)
+                        if merge:
+                            requested_langs.extend(_get_one_lang(lang, select_default=False))
+                        else:
+                            requested_langs = orderedSet_from_options(
+                                [lang], alias_dict, use_regex=True, start=requested_langs)
+                        if len(requested_langs) != old_len:
+                            # New langs were selected, we are done
+                            break
                 requested_langs = orderedSet(requested_langs)
             except re.error as e:
                 raise ValueError(f'Wrong regex for subtitlelangs: {e.pattern}')


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

`--sub-langs` should allow selecting one or more subtitle languages of the following types: normal, auto, both, normal if available else auto. Currently `--sub-langs` does not support all such combinations (see #2262). For example, current behavior is to _merge_: a normal sub is selected if present otherwise the auto sub. Let's call this a **simple merge**. There is currently no way to download both normal and auto sub for the same lang.

When `--sub-langs` is not specified, the current default behavior (see my PR #6240) is to select the first matching sub in the following order. Let's call it a **special merge**.
* Normal sub named exactly `en`
* Normal sub that starts with `en`. This is to handle cases where subs are named as `en-US` or `en-qlPKC2UN_YU`.
* Auto sub named exactly `en`
* Auto sub that starts with `en`
* Any normal sub and then any auto sub. This is handle the case when no `en` subs were found.

Note that this does not allow the ability to download _only_ `en` subs. Thus, if `en` subs are missing, it will download an arbitrary (first) non-en lang.

This PR makes language selection much more flexible be making the following major changes. 
*  Rename auto subs by prepending `auto-` (e.g., `en` -> `auto-en`). The main reason is to enable selecting auto subs separately from the normal subs (e.g., `en.*` vs `auto-en.*`). A secondary benefit is that auto subs are named differently on disk, which make is easy to distinguish them from normal subs just from the file name (also see https://github.com/yt-dlp/yt-dlp/issues/2262#issuecomment-1221318103). 
* Disables merging by default in `--sub-langs`  and introduces a new special merging operator `#<lang>` to selectively enable merging as per the default behavior described above, with the change that if `<lang>` is not found, no other lang will be arbitrarily selected.
* User can specify lang precedence: `en/fr` will download `en` if available, else `fr` if available, else nothing 

I'm giving a comprehensive set of examples to show the new behavior of `--sub-langs`. The table assumes that subs are written to disk only. See https://github.com/yt-dlp/yt-dlp/issues/630#issuecomment-893659460 for corresponding embedding options.

Option | Behavior | Notes
-- | --  | --
`--write-subs` | Select one normal sub
`--write-auto-subs` | Select one auto sub
`--write-subs --write-auto-subs` | Special merge subs and select one as described above
`--write-subs --write-auto-subs --sub-langs 'all'` | Select all normal and auto subs _without_ merge | Changed behavior, selects both `en` and `auto-en`
`--write-subs --write-auto-subs --sub-langs '#all'` | Select all normal and auto subs after simple merge | New, selects `en` if present else `auto-en`, same as existing `all`
`--write-subs --write-auto-subs --sub-langs 'allnorm'` | Select all normal subs | New
`--write-subs --write-auto-subs --sub-langs 'allauto'` | Select all auto subs | New
`--write-subs --write-auto-subs --sub-langs 'en'` | Select one `en` normal subs | Changed, will select normal subs only
`--write-subs --write-auto-subs --sub-langs 'auto-en'` | Select one `en` auto subs | New
`--write-subs --write-auto-subs --sub-langs 'en,auto-en'` | Select both `en` normal and auto subs | New
`--write-subs --write-auto-subs --sub-langs 'en/auto-en'` | Select one `en` normal sub if present else auto subs | New, same as existing `en`
`--write-subs --write-auto-subs --sub-langs '#en'` | Select one `en` sub after special merge | New, shortcut for above but uses special merge
`--write-subs --write-auto-subs --sub-langs 'en,ja,auto-ja,es'` | Select listed subs | Changed: no merging, auto subs need to be explicitly selected
`--write-subs --write-auto-subs --sub-langs 'en.*,auto-en.*'` | Select subs using regex | Changed: no merging, auto subs need to be explicitly selected
`--write-subs --write-auto-subs --sub-langs 'allnorm,auto-en-orig/auto-en'` | Select all normal subs and one `en-orig` auto sub if present else `en` auto sub | New
`--write-subs --write-auto-subs --sub-langs 'allnorm,auto-.*-orig'` | Select all normal subs and one `*-orig` auto sub | New
`--write-subs --write-auto-subs --sub-langs 'en/auto-en/fr/auto-fr'` | Set precedence order for subs, `fr` will only be selected if `en` is not present  | New
`--write-subs --write-auto-subs --sub-langs '#en/fr'` | Same as above but with special merging | New

The above design was chosen to make the code and options simpler, but it breaks existing behavior. Backward compatibility can be maintained at the cost of more complex code and likely needs 2 operators instead of 1. To summarize the break in behavior:
Option | Current | New
-- | --  | -- 
`--write-subs --write-auto-subs` | Default behavior as described in the beginning | No change
`--write-subs --write-auto-subs --sub-langs 'all'` | Normal and auto subs are merged and only one is selected for each lang | Both normal and auto subs for each lang will be selected without merging. Use `--sub-langs '#all'` for old behavior.
`--write-subs --write-auto-subs --sub-langs 'en'` | Either normal or auto sub for `en` is selected | Only normal sub for `en` is selected. Use `--sub-langs 'en/orig-en'` for old behavior.

TODOs
- [ ] Perform and add tests. I have done some preliminary testing.
- [ ] Update documentation. Need to decide how detailed the merging logic should be explained.

Let me know if this is an acceptable way to proceed. Once we come to a decision on the main design: renaming auto subs, `#` and `/` operators and the general code, I can work on the TODOs.

Fixes #2262 #4178 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
