### PR TITLE
[extractor/telecaribe] Add TelecaribePlay extractors

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1851,10 +1851,7 @@ from .ted import (
 from .tele5 import Tele5IE
 from .tele13 import Tele13IE
 from .telebruxelles import TeleBruxellesIE
-from .telecaribe import (
-    TelecaribePlayVODIE,
-    TelecaribePlayLiveIE,
-)
+from .telecaribe import TelecaribePlayIE
 from .telecinco import TelecincoIE
 from .telegraaf import TelegraafIE
 from .telegram import TelegramEmbedIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1851,6 +1851,10 @@ from .ted import (
 from .tele5 import Tele5IE
 from .tele13 import Tele13IE
 from .telebruxelles import TeleBruxellesIE
+from .telecaribe import (
+    TelecaribePlayVODIE,
+    TelecaribePlayLiveIE,
+)
 from .telecinco import TelecincoIE
 from .telegraaf import TelegraafIE
 from .telegram import TelegramEmbedIE

--- a/yt_dlp/extractor/telecaribe.py
+++ b/yt_dlp/extractor/telecaribe.py
@@ -69,6 +69,9 @@ class TelecaribePlayLiveIE(TelecaribeBaseIE):
             'live_status': 'is_live',
             'ext': 'mp4',
         },
+        'params': {
+            'skip_download': 'Livestream',
+        }
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/telecaribe.py
+++ b/yt_dlp/extractor/telecaribe.py
@@ -1,0 +1,89 @@
+import re
+
+from .common import InfoExtractor
+
+
+class TelecaribeBaseIE(InfoExtractor):
+    _VALID_URL_BASE = r'https?://(?:www\.)?play\.telecaribe\.co'
+
+    def _download_player_webpage(self, webpage, display_id):
+        page_id = (self._search_regex(r'window.firstPageId\s*=\s*["\']([^"\']+)', webpage, 'page_id', fatal=False)
+                   or self._search_regex(r'<div[^>]+id\s*=\s*"pageBackground_([^"]+)', webpage, 'page_id', fatal=False))
+
+        props = self._download_json(self._search_regex(
+            rf'<link[^>]+href\s*=\s*"([^"]+)"[^>]+id\s*=\s*"features_{page_id}"', webpage, 'json_props_url'),
+            display_id)['props']['render']['compProps']
+
+        # We reverse over the keys, to prefer the last dict that contains an 'url' key
+        return self._download_webpage(
+            next(props[prop_key]['url'] for prop_key in reversed(props.keys())
+                 if 'url' in dict.keys(props[prop_key])), display_id)
+
+    def _get_clean_title(self, title):
+        return re.sub(r'\s*\|\s*Telecaribe\s*VOD', '', title or '').strip() or None
+
+
+class TelecaribePlayVODIE(TelecaribeBaseIE):
+    _VALID_URL = TelecaribeBaseIE._VALID_URL_BASE + r'/(?P<id>(?!live$)[\w-]+)'
+
+    _TESTS = [{
+        'url': 'https://www.play.telecaribe.co/breicok',
+        'info_dict': {
+            'id': 'breicok',
+            'title': 'Breicok',
+        },
+        'playlist_count': 7,
+    }, {
+        'url': 'https://www.play.telecaribe.co/si-fue-gol-de-yepes',
+        'info_dict': {
+            'id': 'si-fue-gol-de-yepes',
+            'title': 'Sí Fue Gol de Yepes',
+        },
+        'playlist_count': 6,
+    }, {
+        'url': 'https://www.play.telecaribe.co/ciudad-futura',
+        'info_dict': {
+            'id': 'ciudad-futura',
+            'title': 'Ciudad Futura',
+        },
+        'playlist_count': 10,
+    }]
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+
+        return self.playlist_from_matches(
+            re.findall(r'<a[^>]+href\s*=\s*"([^"]+\.mp4)', self._download_player_webpage(webpage, display_id)),
+            playlist_id=display_id, playlist_title=self._get_clean_title(self._og_search_title(webpage)))
+
+
+class TelecaribePlayLiveIE(TelecaribeBaseIE):
+    _VALID_URL = TelecaribeBaseIE._VALID_URL_BASE + r'/(?P<id>live)$'
+
+    _TESTS = [{
+        'url': 'https://www.play.telecaribe.co/live',
+        'info_dict': {
+            'id': 'live',
+            'title': r're:^Señal en vivo',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+    }]
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            self._search_regex(
+                r'(?:let|const|var)\s+source\s*=\s*["\']([^"\']+)',
+                self._download_player_webpage(webpage, display_id), 'formats_url'), display_id, 'mp4')
+
+        return {
+            'id': display_id,
+            'title': self._get_clean_title(self._og_search_title(webpage)),
+            'formats': formats,
+            'subtitles': subtitles,
+            'is_live': True,
+        }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Telecaribe is a Colombian TV Station that provides some VODs and a livestream.

**Note:** VOD episodes don't have a direct link, that's why we can only extract the whole series as a playlist.

Fixes #6001

#### TelecaribePlayVOD
```bash
[debug] Command-line config: ['https://www.play.telecaribe.co/breicok', '--verbose', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2023.02.17 [a0a7c0154] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: f187755c9
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-31-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1784 extractors
[TelecaribePlayVOD] Extracting URL: https://www.play.telecaribe.co/breicok
[TelecaribePlayVOD] breicok: Downloading webpage
[TelecaribePlayVOD] breicok: Downloading JSON metadata
[TelecaribePlayVOD] breicok: Downloading webpage
[download] Downloading playlist: Breicok
[TelecaribePlayVOD] Playlist Breicok: Downloading 7 items of 7
[download] Downloading item 1 of 7
[generic] Extracting URL: https://telecaribeplay.s3.us-east-2.amazonaws.com/b/B01.mp4
[generic] B01: Downloading webpage
[debug] Identified a direct video link
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for B01:
ID  EXT RESOLUTION │ PROTO │ VCODEC  ACODEC
────────────────────────────────────────────
mp4 mp4 unknown    │ https │ unknown unknown
[download] Downloading item 2 of 7
[generic] Extracting URL: https://telecaribeplay.s3.us-east-2.amazonaws.com/b/B02.mp4
[generic] B02: Downloading webpage
[debug] Identified a direct video link
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for B02:
ID  EXT RESOLUTION │ PROTO │ VCODEC  ACODEC
────────────────────────────────────────────
mp4 mp4 unknown    │ https │ unknown unknown
[download] Downloading item 3 of 7
[generic] Extracting URL: https://telecaribeplay.s3.us-east-2.amazonaws.com/b/B03.mp4
...
```

#### TelecaribePlayLive
```bash
[debug] Command-line config: ['https://www.play.telecaribe.co/live', '--verbose', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2023.02.17 [a0a7c0154] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: f187755c9
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-31-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1784 extractors
[TelecaribePlayLive] Extracting URL: https://www.play.telecaribe.co/live
[TelecaribePlayLive] live: Downloading webpage
[TelecaribePlayLive] live: Downloading JSON metadata
[TelecaribePlayLive] live: Downloading webpage
[TelecaribePlayLive] live: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for live:
ID   EXT RESOLUTION │   TBR PROTO │ VCODEC        VBR ACODEC    ABR
───────────────────────────────────────────────────────────────────
400  mp4 448x252    │  400k m3u8  │ avc1.64001f  400k mp4a.40.2  0k
700  mp4 640x360    │  700k m3u8  │ avc1.64001f  700k mp4a.40.2  0k
1200 mp4 960x540    │ 1200k m3u8  │ avc1.64001f 1200k mp4a.40.2  0k
1800 mp4 960x540    │ 1800k m3u8  │ avc1.64001f 1800k mp4a.40.2  0k
2100 mp4 1280x720   │ 2100k m3u8  │ avc1.64001f 2100k mp4a.40.2  0k
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
