### PR TITLE
[extractor/radiofrance] Add RadioFranceProgramSchedule extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1484,7 +1484,11 @@ from .radiocanada import (
 from .radiode import RadioDeIE
 from .radiojavan import RadioJavanIE
 from .radiobremen import RadioBremenIE
-from .radiofrance import FranceCultureIE, RadioFranceIE
+from .radiofrance import (
+    FranceCultureIE,
+    RadioFranceIE,
+    RadioFranceProgramScheduleIE,
+)
 from .radiozet import RadioZetPodcastIE
 from .radiokapital import (
     RadioKapitalIE,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds an extractor for the program schedule ('grille de programmes') of the different RadioFrance stations.

As dirkf said https://github.com/yt-dlp/yt-dlp/issues/4282#issuecomment-1178160436 , these playlists often contain duplicates but maybe that's okay?

Fixes #4282

```bash
[debug] Command-line config: ['https://www.radiofrance.fr/franceinter/grille-programmes', '--verbose', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2023.01.06 [6becd2508] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 032199c1b
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-31-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.17, brotli-1.0.9, certifi-2022.12.07, mutagen-1.46.0, pyxattr-0.7.2, secretstorage-3.3.3, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1762 extractors
[RadioFranceProgramSchedule] Extracting URL: https://www.radiofrance.fr/franceinter/grille-programmes
[RadioFranceProgramSchedule] franceinter-program: Downloading JSON metadata
[download] Downloading playlist: franceinter-program-20230221
[RadioFranceProgramSchedule] Playlist franceinter-program-20230221: Downloading 22 items of 22
[download] Downloading item 1 of 22
[FranceCulture] Extracting URL: https://www.radiofrance.fr/franceinter/podcasts/le-5-7/le-5-7-du-lundi-20-fevrier-2023-7799718
[FranceCulture] le-5-7-du-lundi-20-fevrier-2023: Downloading webpage
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 7799718:
ID EXT        RESOLUTION │ PROTO │ VCODEC  ACODEC
──────────────────────────────────────────────────
0  audio/mpeg unknown    │ https │ unknown unknown
[download] Downloading item 2 of 22
[FranceCulture] Extracting URL: https://www.radiofrance.fr/franceinter/podcasts/le-7-9-30/le-7-9-30-du-lundi-20-fevrier-2023-8039137
[FranceCulture] le-7-9-30-du-lundi-20-fevrier-2023: Downloading webpage
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 8039137:
ID EXT        RESOLUTION │ PROTO │ VCODEC  ACODEC
──────────────────────────────────────────────────
0  audio/mpeg unknown    │ https │ unknown unknown
[download] Downloading item 3 of 22
[FranceCulture] Extracting URL: https://www.radiofrance.fr/franceinter/podcasts/l-invite-de-9h10/le-7-9h30-l-interview-de-9h10-du-lundi-20-fevrier-2023-9087912
[FranceCulture] le-7-9h30-l-interview-de-9h10-du-lundi-20-fevrier-2023: Downloading webpage
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 9087912:
ID EXT        RESOLUTION │ PROTO │ VCODEC  ACODEC
──────────────────────────────────────────────────
0  audio/mpeg unknown    │ https │ unknown unknown
[download] Downloading item 4 of 22
[FranceCulture] Extracting URL: https://www.radiofrance.fr/franceinter/podcasts/totemic/totemic-du-lundi-20-fevrier-2023-4911983
[FranceCulture] totemic-du-lundi-20-fevrier-2023: Downloading webpage
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 4911983:
ID EXT        RESOLUTION │ PROTO │ VCODEC  ACODEC
──────────────────────────────────────────────────
0  audio/mpeg unknown    │ https │ unknown unknown
[download] Downloading item 5 of 22
[FranceCulture] Extracting URL: https://www.radiofrance.fr/franceinter/podcasts/grand-bien-vous-fasse/grand-bien-vous-fasse-du-lundi-20-fevrier-2023-6251133
[FranceCulture] grand-bien-vous-fasse-du-lundi-20-fevrier-2023: Downloading webpage
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
