### PR TITLE
[Prankcast] Tags are no longer a JSON list

### DIFF
--- a/yt_dlp/extractor/prankcast.py
+++ b/yt_dlp/extractor/prankcast.py
@@ -18,7 +18,7 @@ class PrankCastIE(InfoExtractor):
             'cast': ['Devonanustart', 'Phonelosers'],
             'description': '',
             'categories': ['prank'],
-            'tags': "prank call,prank,live show",
+            'tags': ['prank call', 'prank', 'live show'],
             'upload_date': '20220825'
         }
     }, {
@@ -35,7 +35,7 @@ class PrankCastIE(InfoExtractor):
             'cast': ['phonelosers'],
             'description': '',
             'categories': ['prank'],
-            'tags': "prank call,prank,live show",
+            'tags': ['prank call', 'prank', 'live show'],
             'upload_date': '20221006'
         }
     }]
@@ -62,5 +62,5 @@ class PrankCastIE(InfoExtractor):
             'cast': list(filter(None, [uploader] + traverse_obj(guests_json, (..., 'name')))),
             'description': json_info.get('broadcast_description'),
             'categories': [json_info.get('broadcast_category')],
-            'tags': json_info.get('broadcast_tags')
+            'tags': try_call(lambda: json_info['broadcast_tags'].split(','))
         }

--- a/yt_dlp/extractor/prankcast.py
+++ b/yt_dlp/extractor/prankcast.py
@@ -18,7 +18,7 @@ class PrankCastIE(InfoExtractor):
             'cast': ['Devonanustart', 'Phonelosers'],
             'description': '',
             'categories': ['prank'],
-            'tags': ['prank call', 'prank'],
+            'tags': "prank call,prank,live show",
             'upload_date': '20220825'
         }
     }, {
@@ -35,7 +35,7 @@ class PrankCastIE(InfoExtractor):
             'cast': ['phonelosers'],
             'description': '',
             'categories': ['prank'],
-            'tags': ['prank call', 'prank'],
+            'tags': "prank call,prank,live show",
             'upload_date': '20221006'
         }
     }]
@@ -62,5 +62,5 @@ class PrankCastIE(InfoExtractor):
             'cast': list(filter(None, [uploader] + traverse_obj(guests_json, (..., 'name')))),
             'description': json_info.get('broadcast_description'),
             'categories': [json_info.get('broadcast_category')],
-            'tags': self._parse_json(json_info.get('broadcast_tags') or '{}', video_id)
+            'tags': json_info.get('broadcast_tags')
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

At some point in the last week the tags field has changed from a JSON list to a string. This caused the extractor to fail:

> ERROR: [PrankCast] 1380: 1380: Failed to parse JSON (caused by JSONDecodeError("Expecting value in '': line 1 column 1 (char 0)")); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U

I've changed the tests to reflect this change and updated the extractor to no longer try to parse the string into JSON.

I'm not sure if it would be better to try and "convert" the string into a list manually (replacing commas with the proper formatting for a list) or just leave it as it is. If converting it to a list would be preferred let me know and I'll change it.

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
