### PR TITLE
[extractor/nebula] Support public videos without an account and channel extractor improvements

### DIFF
--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -1,14 +1,9 @@
+import itertools
 import json
 import urllib.error
 
 from .common import InfoExtractor
-from ..utils import (
-    ExtractorError,
-    format_field,
-    parse_iso8601,
-    traverse_obj,
-    OnDemandPagedList,
-)
+from ..utils import ExtractorError, parse_iso8601
 
 _BASE_URL_RE = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app|nebula\.tv)'
 
@@ -112,7 +107,6 @@ class NebulaBaseIE(InfoExtractor):
 
     def _perform_login(self, username=None, password=None):
         self._nebula_api_token = self._perform_nebula_auth(username, password)
-        self._nebula_bearer_token = self._fetch_nebula_bearer_token()
 
 
 class NebulaIE(NebulaBaseIE):
@@ -120,7 +114,6 @@ class NebulaIE(NebulaBaseIE):
     _TESTS = [
         {
             'url': 'https://nebula.tv/videos/that-time-disney-remade-beauty-and-the-beast',
-            'md5': '14944cfee8c7beeea106320c47560efc',
             'info_dict': {
                 'id': '5c271b40b13fd613090034fd',
                 'ext': 'mp4',
@@ -142,7 +135,7 @@ class NebulaIE(NebulaBaseIE):
                 'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
             'params': {
-                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 756.00B',
+                'skip_download': 'm3u8',
             },
         },
         {
@@ -216,7 +209,7 @@ class NebulaIE(NebulaBaseIE):
                 'ext': 'mp4',
             },
             'params': {
-                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 3.20KiB',
+                'skip_download': 'm3u8',
             },
         },
     ]

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -1,4 +1,3 @@
-import itertools
 import json
 import urllib.error
 
@@ -8,6 +7,7 @@ from ..utils import (
     format_field,
     parse_iso8601,
     traverse_obj,
+    OnDemandPagedList,
 )
 
 _BASE_URL_RE = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app|nebula\.tv)'
@@ -289,27 +289,29 @@ class NebulaChannelIE(NebulaBaseIE):
         },
     ]
 
-    def _generate_playlist_entries(self, collection_id, channel):
-        episodes = channel['episodes']['results']
-        for page_num in itertools.count(2):
-            for episode in episodes:
-                yield self._build_video_info(episode)
-            next_url = channel['episodes']['next']
-            if not next_url:
-                break
-            channel = self._call_nebula_api(next_url, collection_id, auth_type='bearer',
-                                            note=f'Retrieving channel page {page_num}')
-            episodes = channel['episodes']['results']
-
     def _real_extract(self, url):
         collection_id = self._match_id(url)
-        channel_url = f'https://content.watchnebula.com/video/channels/{collection_id}/'
-        channel = self._call_nebula_api(channel_url, collection_id, auth_type='bearer', note='Retrieving channel')
-        channel_details = channel['details']
+        first_api_response = self._call_nebula_api(
+            f'https://content.watchnebula.com/video/channels/{collection_id}/', collection_id,
+            auth_type='bearer', note='Retrieving channel')
 
+        page_api_response = first_api_response
+
+        def page_func(page_num):
+            nonlocal page_api_response
+
+            if page_num > 0:
+                next_url = page_api_response['episodes'].get('next')
+                if not next_url:
+                    return []
+
+                page_api_response = self._call_nebula_api(
+                    next_url, collection_id, auth_type='bearer', note=f'Downloading page {page_num}')
+
+            return [self.url_result(episode['share_url'], ie=NebulaIE, **self._extract_video_metadata(episode))
+                    for episode in page_api_response['episodes']['results']]
+
+        entries = OnDemandPagedList(page_func, len(first_api_response['episodes']['results']))
         return self.playlist_result(
-            entries=self._generate_playlist_entries(collection_id, channel),
-            playlist_id=collection_id,
-            playlist_title=channel_details['title'],
-            playlist_description=channel_details['description']
-        )
+            entries, collection_id, playlist_title=traverse_obj(first_api_response, ('details', 'title')),
+            playlist_description=traverse_obj(first_api_response, ('details', 'description')))

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -18,6 +18,9 @@ class NebulaBaseIE(InfoExtractor):
     _nebula_api_token = None
     _nebula_bearer_token = None
 
+    def _real_initialize(self):
+        self._nebula_bearer_token = self._fetch_nebula_bearer_token()
+
     def _perform_nebula_auth(self, username, password):
         if not username or not password:
             self.raise_login_required(method='password')
@@ -45,7 +48,8 @@ class NebulaBaseIE(InfoExtractor):
         def inner_call():
             authorization = f'Token {self._nebula_api_token}' if auth_type == 'api' else f'Bearer {self._nebula_bearer_token}'
             return self._download_json(
-                url, video_id, note=note, headers={'Authorization': authorization},
+                url, video_id, note=note,
+                headers={'Authorization': authorization} if self._nebula_api_token or self._nebula_bearer_token else {},
                 data=b'' if method == 'POST' else None)
 
         try:
@@ -136,6 +140,9 @@ class NebulaIE(NebulaBaseIE):
                 'duration': 2212,
                 'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
+            'params': {
+                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 756.00B',
+            },
         },
         {
             'url': 'https://nebula.tv/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
@@ -186,6 +193,30 @@ class NebulaIE(NebulaBaseIE):
         {
             'url': 'https://watchnebula.com/videos/money-episode-1-the-draw',
             'only_matching': True,
+        }, {
+            'url': 'https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
+            'info_dict': {
+                'id': '63f64c74366fcd00017c1513',
+                'display_id': 'tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
+                'title': 'Did the US Really Blow Up the NordStream Pipelines?',
+                'description': 'md5:b4e2a14e3ff08f546a3209c75261e789',
+                'upload_date': '20230223',
+                'timestamp': 1677144070,
+                'channel': 'TLDR News EU',
+                'channel_id': 'tldrnewseu',
+                'uploader': 'TLDR News EU',
+                'uploader_id': 'tldrnewseu',
+                'uploader_url': 'https://nebula.tv/tldrnewseu',
+                'duration': 524,
+                'channel_url': 'https://nebula.tv/tldrnewseu',
+                'series': 'TLDR News EU',
+                'thumbnail': r're:https?://.*\.jpeg',
+                'creator': 'TLDR News EU',
+                'ext': 'mp4',
+            },
+            'params': {
+                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 3.20KiB',
+            },
         },
     ]
 

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -3,7 +3,11 @@ import json
 import urllib.error
 
 from .common import InfoExtractor
-from ..utils import ExtractorError, parse_iso8601
+from ..utils import (
+    ExtractorError,
+    parse_iso8601,
+    traverse_obj,
+)
 
 _BASE_URL_RE = r'https?://(?:www\.)?(?:watchnebula\.com|nebula\.app|nebula\.tv)'
 
@@ -74,23 +78,23 @@ class NebulaBaseIE(InfoExtractor):
 
     def _build_video_info(self, episode):
         fmts, subs = self._fetch_video_formats(episode['slug'])
-        channel_slug = episode['channel_slug']
-        channel_title = episode['channel_title']
+        channel_slug = episode.get('channel_slug')
+        channel_title = episode.get('channel_title')
         return {
             'id': episode['zype_id'],
             'display_id': episode['slug'],
             'formats': fmts,
             'subtitles': subs,
             'webpage_url': f'https://nebula.tv/{episode["slug"]}',
-            'title': episode['title'],
-            'description': episode['description'],
-            'timestamp': parse_iso8601(episode['published_at']),
+            'title': episode.get('title'),
+            'description': episode.get('description'),
+            'timestamp': parse_iso8601(episode.get('published_at')),
             'thumbnails': [{
                 # 'id': tn.get('name'),  # this appears to be null
                 'url': tn['original'],
                 'height': key,
-            } for key, tn in episode['assets']['thumbnail'].items()],
-            'duration': episode['duration'],
+            } for key, tn in traverse_obj(episode, ('assets', 'thumbnail'), default={}).items()],
+            'duration': episode.get('duration'),
             'channel': channel_title,
             'channel_id': channel_slug,
             'channel_url': f'https://nebula.tv/{channel_slug}',

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -81,39 +81,33 @@ class NebulaBaseIE(InfoExtractor):
         manifest_url = stream_info['manifest']
         return self._extract_m3u8_formats_and_subtitles(manifest_url, slug)
 
-    def _extract_video_metadata(self, episode):
-        channel_url = format_field(episode, 'channel_slug', 'https://nebula.tv/%s')
+    def _build_video_info(self, episode):
+        fmts, subs = self._fetch_video_formats(episode['slug'])
+        channel_slug = episode['channel_slug']
+        channel_title = episode['channel_title']
         return {
-            **traverse_obj(episode, {
-                'id': 'zype_id',
-                'display_id': 'slug',
-                'title': 'title',
-                'description': 'description',
-                'timestamp': ('published_at', {parse_iso8601}),
-                'duration': 'duration',
-                'channel_id': 'channel_slug',
-                'uploader_id': 'channel_slug',
-                'channel': 'channel_title',
-                'uploader': 'channel_title',
-                'series': 'channel_title',
-                'creator': 'channel_title',
-            }),
-            'channel_url': channel_url,
-            'uploader_url': channel_url,
+            'id': episode['zype_id'],
+            'display_id': episode['slug'],
+            'formats': fmts,
+            'subtitles': subs,
+            'webpage_url': f'https://nebula.tv/{episode["slug"]}',
+            'title': episode['title'],
+            'description': episode['description'],
+            'timestamp': parse_iso8601(episode['published_at']),
             'thumbnails': [{
                 # 'id': tn.get('name'),  # this appears to be null
                 'url': tn['original'],
                 'height': key,
-            } for key, tn in traverse_obj(episode, ('assets', 'thumbnail'), default={}).items()],
-        }
-
-    def _build_video_info(self, episode):
-        fmts, subs = self._fetch_video_formats(episode['slug'])
-        return {
-            **self._extract_video_metadata(episode),
-            'formats': fmts,
-            'subtitles': subs,
-            'webpage_url': f'https://nebula.tv/{episode["slug"]}',
+            } for key, tn in episode['assets']['thumbnail'].items()],
+            'duration': episode['duration'],
+            'channel': channel_title,
+            'channel_id': channel_slug,
+            'channel_url': f'https://nebula.tv/{channel_slug}',
+            'uploader': channel_title,
+            'uploader_id': channel_slug,
+            'uploader_url': f'https://nebula.tv/{channel_slug}',
+            'series': channel_title,
+            'creator': channel_title,
         }
 
     def _perform_login(self, username=None, password=None):
@@ -138,6 +132,7 @@ class NebulaIE(NebulaBaseIE):
                 'channel_id': 'lindsayellis',
                 'uploader': 'Lindsay Ellis',
                 'uploader_id': 'lindsayellis',
+                'timestamp': 1533009600,
                 'uploader_url': 'https://nebula.tv/lindsayellis',
                 'series': 'Lindsay Ellis',
                 'display_id': 'that-time-disney-remade-beauty-and-the-beast',
@@ -297,29 +292,27 @@ class NebulaChannelIE(NebulaBaseIE):
         },
     ]
 
+    def _generate_playlist_entries(self, collection_id, channel):
+        episodes = channel['episodes']['results']
+        for page_num in itertools.count(2):
+            for episode in episodes:
+                yield self._build_video_info(episode)
+            next_url = channel['episodes']['next']
+            if not next_url:
+                break
+            channel = self._call_nebula_api(next_url, collection_id, auth_type='bearer',
+                                            note=f'Retrieving channel page {page_num}')
+            episodes = channel['episodes']['results']
+
     def _real_extract(self, url):
         collection_id = self._match_id(url)
-        first_api_response = self._call_nebula_api(
-            f'https://content.watchnebula.com/video/channels/{collection_id}/', collection_id,
-            auth_type='bearer', note='Retrieving channel')
+        channel_url = f'https://content.watchnebula.com/video/channels/{collection_id}/'
+        channel = self._call_nebula_api(channel_url, collection_id, auth_type='bearer', note='Retrieving channel')
+        channel_details = channel['details']
 
-        page_api_response = first_api_response
-
-        def page_func(page_num):
-            nonlocal page_api_response
-
-            if page_num > 0:
-                next_url = page_api_response['episodes'].get('next')
-                if not next_url:
-                    return []
-
-                page_api_response = self._call_nebula_api(
-                    next_url, collection_id, auth_type='bearer', note=f'Downloading page {page_num}')
-
-            return [self.url_result(episode['share_url'], ie=NebulaIE, **self._extract_video_metadata(episode))
-                    for episode in page_api_response['episodes']['results']]
-
-        entries = OnDemandPagedList(page_func, len(first_api_response['episodes']['results']))
         return self.playlist_result(
-            entries, collection_id, playlist_title=traverse_obj(first_api_response, ('details', 'title')),
-            playlist_description=traverse_obj(first_api_response, ('details', 'description')))
+            entries=self._generate_playlist_entries(collection_id, channel),
+            playlist_id=collection_id,
+            playlist_title=channel_details['title'],
+            playlist_description=channel_details['description']
+        )

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -286,6 +286,14 @@ class NebulaChannelIE(NebulaBaseIE):
                 'description': 'Enjoy these hottest of takes on Disney, Transformers, and Musicals.',
             },
             'playlist_mincount': 2,
+        }, {
+            'url': 'https://nebula.tv/johnnyharris',
+            'info_dict': {
+                'id': 'johnnyharris',
+                'title': 'Johnny Harris',
+                'description': 'I make videos about maps and many other things.',
+            },
+            'playlist_mincount': 90,
         },
     ]
 

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -131,7 +131,6 @@ class NebulaIE(NebulaBaseIE):
                 'channel_id': 'lindsayellis',
                 'uploader': 'Lindsay Ellis',
                 'uploader_id': 'lindsayellis',
-                'timestamp': 1533009600,
                 'uploader_url': 'https://nebula.tv/lindsayellis',
                 'series': 'Lindsay Ellis',
                 'display_id': 'that-time-disney-remade-beauty-and-the-beast',

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -5,6 +5,7 @@ import urllib.error
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    format_field,
     parse_iso8601,
     traverse_obj,
 )
@@ -80,33 +81,39 @@ class NebulaBaseIE(InfoExtractor):
         manifest_url = stream_info['manifest']
         return self._extract_m3u8_formats_and_subtitles(manifest_url, slug)
 
-    def _build_video_info(self, episode):
-        fmts, subs = self._fetch_video_formats(episode['slug'])
-        channel_slug = episode.get('channel_slug')
-        channel_title = episode.get('channel_title')
+    def _extract_video_metadata(self, episode):
+        channel_url = format_field(episode, 'channel_slug', 'https://nebula.tv/%s')
         return {
-            'id': episode['zype_id'],
-            'display_id': episode['slug'],
-            'formats': fmts,
-            'subtitles': subs,
-            'webpage_url': f'https://nebula.tv/{episode["slug"]}',
-            'title': episode.get('title'),
-            'description': episode.get('description'),
-            'timestamp': parse_iso8601(episode.get('published_at')),
+            **traverse_obj(episode, {
+                'id': 'zype_id',
+                'display_id': 'slug',
+                'title': 'title',
+                'description': 'description',
+                'timestamp': ('published_at', {parse_iso8601}),
+                'duration': 'duration',
+                'channel_id': 'channel_slug',
+                'uploader_id': 'channel_slug',
+                'channel': 'channel_title',
+                'uploader': 'channel_title',
+                'series': 'channel_title',
+                'creator': 'channel_title',
+            }),
+            'channel_url': channel_url,
+            'uploader_url': channel_url,
             'thumbnails': [{
                 # 'id': tn.get('name'),  # this appears to be null
                 'url': tn['original'],
                 'height': key,
             } for key, tn in traverse_obj(episode, ('assets', 'thumbnail'), default={}).items()],
-            'duration': episode.get('duration'),
-            'channel': channel_title,
-            'channel_id': channel_slug,
-            'channel_url': f'https://nebula.tv/{channel_slug}',
-            'uploader': channel_title,
-            'uploader_id': channel_slug,
-            'uploader_url': f'https://nebula.tv/{channel_slug}',
-            'series': channel_title,
-            'creator': channel_title,
+        }
+
+    def _build_video_info(self, episode):
+        fmts, subs = self._fetch_video_formats(episode['slug'])
+        return {
+            **self._extract_video_metadata(episode),
+            'formats': fmts,
+            'subtitles': subs,
+            'webpage_url': f'https://nebula.tv/{episode["slug"]}',
         }
 
     def _perform_login(self, username=None, password=None):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
As the linked issues describes, some Nebula videos can be watched without an account. The extractor has been updated to reflect that the app always requests a **guest** Bearer token, but to get this token we don't need to be authenticated. 

I don't have a premium account, but maybe @hheimbuerger or someone else can test it with pay-walled videos just to make sure it works.

Fixes #4300

#### Downloading public video
```bash
[debug] Command-line config: ['https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines', '--verbose', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version 2023.02.17 [a0a7c0154] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 41432863b
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-31-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1782 extractors
[Nebula] Authorizing to Nebula
[Nebula] Extracting URL: https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines
[Nebula] tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines: Fetching video meta data
[Nebula] tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines: Fetching video stream info
[Nebula] tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 63f64c74366fcd00017c1513:
ID            EXT  RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC     MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────
audio-Unknown m3u8 audio only     │                  m3u8  │ audio only          unknown    [und] Unknown
456           mp4  640x360     30 │ ~ 29.19MiB  456k m3u8  │ avc1.42C01E    456k video only
815           mp4  960x540     30 │ ~ 52.16MiB  815k m3u8  │ avc1.42C028    815k video only
1361          mp4  1280x720    30 │ ~ 87.11MiB 1362k m3u8  │ avc1.640029   1362k video only
1273          mp4  1920x1080   30 │ ~ 81.45MiB 1273k m3u8  │ hvc1.2.4.L123 1273k video only
2008          mp4  2560x1440   30 │ ~128.48MiB 2009k m3u8  │ hvc1.2.4.L150 2009k video only
4419          mp4  3840x2160   30 │ ~282.66MiB 4419k m3u8  │ hvc1.2.4.L153 4419k video only
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
