### PR TITLE
[extractor/yle_areena] Extract non-Kaltura videos

### DIFF
--- a/yt_dlp/extractor/yle_areena.py
+++ b/yt_dlp/extractor/yle_areena.py
@@ -106,7 +106,22 @@ class YleAreenaIE(InfoExtractor):
                     'name': sub.get('kind'),
                 })
 
-        info_dict = {
+        kaltura_id = traverse_obj(video_data, ('data', 'ongoing_ondemand', 'kaltura', 'id'), expected_type=str)
+        if kaltura_id:
+            info_dict = {
+                '_type': 'url_transparent',
+                'url': smuggle_url(f'kaltura:1955031:{kaltura_id}', {'source_url': url}),
+                'ie_key': KalturaIE.ie_key(),
+            }
+        else:
+            info_dict = {
+                'id': video_id,
+                'formats': self._extract_m3u8_formats(
+                    video_data['data']['ongoing_ondemand']['manifest_url'], video_id, 'mp4', m3u8_id='hls'),
+            }
+
+        return {
+            **info_dict,
             'title': (traverse_obj(video_data, ('data', 'ongoing_ondemand', 'title', 'fin'), expected_type=str)
                       or episode or info.get('title')),
             'description': description,
@@ -121,19 +136,3 @@ class YleAreenaIE(InfoExtractor):
             'subtitles': subtitles,
             'release_date': unified_strdate(traverse_obj(video_data, ('data', 'ongoing_ondemand', 'start_time'), expected_type=str)),
         }
-
-        kaltura_id = traverse_obj(video_data, ('data', 'ongoing_ondemand', 'kaltura', 'id'), expected_type=str)
-        if kaltura_id:
-            info_dict.update({
-                '_type': 'url_transparent',
-                'url': smuggle_url(f'kaltura:1955031:{kaltura_id}', {'source_url': url}),
-                'ie_key': KalturaIE.ie_key(),
-            })
-        else:
-            info_dict.update({
-                'id': video_id,
-                'formats': self._extract_m3u8_formats(
-                    video_data['data']['ongoing_ondemand']['manifest_url'], video_id, 'mp4', m3u8_id='hls'),
-            })
-
-        return info_dict

--- a/yt_dlp/extractor/yle_areena.py
+++ b/yt_dlp/extractor/yle_areena.py
@@ -61,7 +61,22 @@ class YleAreenaIE(InfoExtractor):
                 'age_limit': 0,
                 'webpage_url': 'https://areena.yle.fi/1-2158940'
             }
-        }
+        },
+        {
+            'url': 'https://areena.yle.fi/1-64829589',
+            'info_dict': {
+                'id': '1-64829589',
+                'ext': 'mp4',
+                'title': 'HKO & Mälkki & Tanner',
+                'description': 'md5:b4f1b1af2c6569b33f75179a86eea156',
+                'series': 'Helsingin kaupunginorkesterin konsertteja',
+                'thumbnail': r're:^https?://.+\.jpg$',
+                'release_date': '20230120',
+            },
+            'params': {
+                'skip_download': 'm3u8',
+            },
+        },
     ]
 
     def _real_extract(self, url):
@@ -91,12 +106,7 @@ class YleAreenaIE(InfoExtractor):
                     'name': sub.get('kind'),
                 })
 
-        return {
-            '_type': 'url_transparent',
-            'url': smuggle_url(
-                f'kaltura:1955031:{video_data["data"]["ongoing_ondemand"]["kaltura"]["id"]}',
-                {'source_url': url}),
-            'ie_key': KalturaIE.ie_key(),
+        info_dict = {
             'title': (traverse_obj(video_data, ('data', 'ongoing_ondemand', 'title', 'fin'), expected_type=str)
                       or episode or info.get('title')),
             'description': description,
@@ -111,3 +121,19 @@ class YleAreenaIE(InfoExtractor):
             'subtitles': subtitles,
             'release_date': unified_strdate(traverse_obj(video_data, ('data', 'ongoing_ondemand', 'start_time'), expected_type=str)),
         }
+
+        kaltura_id = traverse_obj(video_data, ('data', 'ongoing_ondemand', 'kaltura', 'id'), expected_type=str)
+        if kaltura_id:
+            info_dict.update({
+                '_type': 'url_transparent',
+                'url': smuggle_url(f'kaltura:1955031:{kaltura_id}', {'source_url': url}),
+                'ie_key': KalturaIE.ie_key(),
+            })
+        else:
+            info_dict.update({
+                'id': video_id,
+                'formats': self._extract_m3u8_formats(
+                    video_data['data']['ongoing_ondemand']['manifest_url'], video_id, 'mp4', m3u8_id='hls'),
+            })
+
+        return info_dict


### PR DESCRIPTION
Fixes #6066


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
