### PR TITLE
[extractor/ntvru] Extract HLS and DASH formats

### DIFF
--- a/yt_dlp/extractor/ntvru.py
+++ b/yt_dlp/extractor/ntvru.py
@@ -21,6 +21,7 @@ class NTVRuIE(InfoExtractor):
             'description': 'Командующий Черноморским флотом провел переговоры в штабе ВМС Украины',
             'thumbnail': r're:^http://.*\.jpg',
             'duration': 136,
+            'view_count': int,
         },
     }, {
         'url': 'http://www.ntv.ru/video/novosti/750370/',
@@ -32,6 +33,7 @@ class NTVRuIE(InfoExtractor):
             'description': 'Родные пассажиров пропавшего Boeing не верят в трагический исход',
             'thumbnail': r're:^http://.*\.jpg',
             'duration': 172,
+            'view_count': int,
         },
     }, {
         'url': 'http://www.ntv.ru/peredacha/segodnya/m23700/o232416',
@@ -43,6 +45,7 @@ class NTVRuIE(InfoExtractor):
             'description': '«Сегодня». 21 марта 2014 года. 16:00',
             'thumbnail': r're:^http://.*\.jpg',
             'duration': 1496,
+            'view_count': int,
         },
     }, {
         'url': 'https://www.ntv.ru/kino/Koma_film/m70281/o336036/video/',
@@ -54,6 +57,7 @@ class NTVRuIE(InfoExtractor):
             'description': 'Остросюжетный фильм «Кома»',
             'thumbnail': r're:^http://.*\.jpg',
             'duration': 5592,
+            'view_count': int,
         },
     }, {
         'url': 'http://www.ntv.ru/serial/Delo_vrachey/m31760/o233916/',
@@ -65,6 +69,7 @@ class NTVRuIE(InfoExtractor):
             'description': '«Дело врачей»: «Деревце жизни»',
             'thumbnail': r're:^http://.*\.jpg',
             'duration': 2590,
+            'view_count': int,
         },
     }, {
         # Schemeless file URL
@@ -115,6 +120,14 @@ class NTVRuIE(InfoExtractor):
                 'url': file_,
                 'filesize': int_or_none(xpath_text(video, './%ssize' % format_id)),
             })
+        hls_manifest = xpath_text(video, './playback/hls')
+        if hls_manifest:
+            formats.extend(self._extract_m3u8_formats(
+                hls_manifest, video_id, m3u8_id='hls', fatal=False))
+        dash_manifest = xpath_text(video, './playback/dash')
+        if dash_manifest:
+            formats.extend(self._extract_mpd_formats(
+                dash_manifest, video_id, mpd_id='dash', fatal=False))
 
         return {
             'id': xpath_text(video, './id'),


### PR DESCRIPTION
Fixes #5915


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
