### PR TITLE
[extractor/tubetugraz] Implement two-factor authentication (#6424)

### DIFF
--- a/yt_dlp/extractor/tubetugraz.py
+++ b/yt_dlp/extractor/tubetugraz.py
@@ -21,17 +21,36 @@ class TubeTuGrazBaseIE(InfoExtractor):
         if not urlh:
             return
 
-        urlh = self._request_webpage(
+        content, urlh = self._download_webpage_handle(
             urlh.geturl(), None, fatal=False, headers={'referer': urlh.geturl()},
-            note='logging in', errnote='unable to log in', data=urlencode_postdata({
+            note='logging in', errnote='unable to log in',
+            data=urlencode_postdata({
                 'lang': 'de',
                 '_eventId_proceed': '',
                 'j_username': username,
                 'j_password': password
             }))
+        if not urlh or urlh.geturl() == 'https://tube.tugraz.at/paella/ui/index.html':
+            return
 
-        if urlh and urlh.geturl() != 'https://tube.tugraz.at/paella/ui/index.html':
+        if not self._html_search_regex(
+                r'<p\b[^>]*>(Bitte geben Sie einen OTP-Wert ein:)</p>',
+                content, 'TFA prompt', default=None):
             self.report_warning('unable to login: incorrect password')
+            return
+
+        content, urlh = self._download_webpage_handle(
+            urlh.geturl(), None, fatal=False, headers={'referer': urlh.geturl()},
+            note='logging in with TFA', errnote='unable to log in with TFA',
+            data=urlencode_postdata({
+                'lang': 'de',
+                '_eventId_proceed': '',
+                'j_tokenNumber': self._get_tfa_info(),
+            }))
+        if not urlh or urlh.geturl() == 'https://tube.tugraz.at/paella/ui/index.html':
+            return
+
+        self.report_warning('unable to login: incorrect TFA code')
 
     def _extract_episode(self, episode_info):
         id = episode_info.get('id')


### PR DESCRIPTION
This PR adds two-factor authentication to the TubeTuGraz extractor. This allows login to work again, since 2FA became mandatory a while ago. Until this fix, metadata download for many lecture videos was effectively broken in YT-DLP, since it was impossible to log in.

Since accounts on [tube.tugraz.at](https://tube.tugraz.at) cannot be created by anyone (only students and university personnel), I cannot provide an automated testcase that anyone can verify. However, there is a testcase that is already in the code can be used by any TU Graz student to check whether TFA works:

`yt-dlp https://tube.tugraz.at/paella/ui/watch.html?id=2df6d787-e56a-428d-8ef4-d57f07eef238 --username USERNAME`
- expected title without login: `TubeTuGraz video #2df6d787-e56a-428d-8ef4-d57f07eef238`
- expected title with login: `#24 - Exakte DGL und integrierende Faktoren; lineare DGL beliebiger Ordnung`

Fixes #6424

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
