### PR TITLE
Adding an option to keep .vtt when with --convert-subs to .srt for most video players as a fallback subtitle

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3472,6 +3472,10 @@ class YoutubeDL:
         if self.params.get('keepvideo', False):
             for f in files_to_delete:
                 infodict['__files_to_move'].setdefault(f, '')
+        elif self.params.get('keepsubs', False):
+            for f in files_to_delete:
+                if f.endswith('.vtt'):
+                    infodict['__files_to_move'].setdefault(f, '')
         else:
             self._delete_downloaded_files(
                 *files_to_delete, info=infodict, msg='Deleting original file %s (pass -k to keep)')


### PR DESCRIPTION
### Description of your *pull request* and other information
Adding an option to keep .vtt when with --convert-subs to .srt for most video players as a fallback subtitle.
When having `--keep-subs`, the `.vtt` will be kept for new players that can play `.vtt` correctly, because most players can only play .srt, .ass.

WIP:
- [X] use `keepsubs` in `YoutubeDL.py` (need to separate the `keepvideo` to work only for video formats?)
- [ ] add options `--keep-subs` in `options.py`
- [ ] add docs
- [ ] add test?

Fixes https://github.com/yt-dlp/yt-dlp/issues/6330


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
