### PR TITLE
[youtube] Support --download-sections with formats --live-from-start

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -415,10 +415,12 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(unified_timestamp('Sep 11, 2013 | 5:49 AM'), 1378878540)
         self.assertEqual(unified_timestamp('December 15, 2017 at 7:49 am'), 1513324140)
         self.assertEqual(unified_timestamp('2018-03-14T08:32:43.1493874+00:00'), 1521016363)
+        self.assertEqual(unified_timestamp('2022-10-13T02:37:47.831Z'), 1665628667)
 
         self.assertEqual(unified_timestamp('December 31 1969 20:00:01 EDT'), 1)
         self.assertEqual(unified_timestamp('Wednesday 31 December 1969 18:01:26 MDT'), 86)
         self.assertEqual(unified_timestamp('12/31/1969 20:01:18 EDT', False), 78)
+        self.assertEqual(unified_timestamp('2023-03-09T18:01:33.646Z', with_milliseconds=True), 1678384893.646)
 
     def test_determine_ext(self):
         self.assertEqual(determine_ext('http://example.com/foo/bar.mp4/?download'), 'mp4')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -26,7 +26,12 @@ from string import ascii_letters
 from .cache import Cache
 from .compat import compat_os_name, compat_shlex_quote
 from .cookies import load_cookies
-from .downloader import FFmpegFD, get_suitable_downloader, shorten_protocol_name
+from .downloader import (
+    DashSegmentsFD,
+    FFmpegFD,
+    get_suitable_downloader,
+    shorten_protocol_name,
+)
 from .downloader.rtmp import rtmpdump_version
 from .extractor import gen_extractor_classes, get_info_extractor
 from .extractor.common import UnsupportedURLIE
@@ -3143,8 +3148,8 @@ class YoutubeDL:
                 fd, success = None, True
                 if info_dict.get('protocol') or info_dict.get('url'):
                     fd = get_suitable_downloader(info_dict, self.params, to_stdout=temp_filename == '-')
-                    if fd is not FFmpegFD and 'no-direct-merge' not in self.params['compat_opts'] and (
-                            info_dict.get('section_start') or info_dict.get('section_end')):
+                    if not(fd is FFmpegFD or fd is DashSegmentsFD) and 'no-direct-merge' not in self.params['compat_opts'] and (
+                        info_dict.get('section_start') or info_dict.get('section_end')):
                         msg = ('This format cannot be partially downloaded' if FFmpegFD.available()
                                else 'You have requested downloading the video partially, but ffmpeg is not installed')
                         self.report_error(f'{msg}. Aborting')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3148,8 +3148,7 @@ class YoutubeDL:
                 fd, success = None, True
                 if info_dict.get('protocol') or info_dict.get('url'):
                     fd = get_suitable_downloader(info_dict, self.params, to_stdout=temp_filename == '-')
-                    if not(fd is FFmpegFD or fd is DashSegmentsFD) and 'no-direct-merge' not in self.params['compat_opts'] and (
-                        info_dict.get('section_start') or info_dict.get('section_end')):
+                    if not (fd is FFmpegFD or fd is DashSegmentsFD) and 'no-direct-merge' not in self.params['compat_opts'] and (info_dict.get('section_start') or info_dict.get('section_end')):
                         msg = ('This format cannot be partially downloaded' if FFmpegFD.available()
                                else 'You have requested downloading the video partially, but ffmpeg is not installed')
                         self.report_error(f'{msg}. Aborting')

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -331,7 +331,7 @@ def validate_options(opts):
             if re.match(r'[\d:]+', x):
                 return parse_duration(x)
 
-            return datetime_from_str(x, precision='second').timestamp()
+            return datetime_from_str(x, precision='second', use_utc=False).timestamp()
 
         chapters, ranges = [], []
         for regex in value or []:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -322,9 +322,10 @@ def validate_options(opts):
 
     def parse_chapters(name, value):
         def parse_timestamp(x):
-            # FIXME: This should be smarter, e.g. 'inf-1day'?
+            # FIXME: Maybe there's a better way to remove parenthesis
             x = x.replace('(', '').replace(')', '')
 
+            # FIXME: This should be smarter, e.g. 'inf-1day'?
             if x in ('inf', 'infinite'):
                 return float('inf')
 
@@ -337,7 +338,7 @@ def validate_options(opts):
         for regex in value or []:
             if regex.startswith('*'):
                 for range_ in map(str.strip, regex[1:].split(',')):
-                    # FIXME: This is really sensible
+                    # FIXME: This should match correctly '(now-1hour)-(now-20minutes)'
                     mobj = range_ != '-' and re.fullmatch(r'(.+)?\s*-\s*(.+)?', range_)
                     dur = mobj and (parse_timestamp(mobj.group(1) or '0'), parse_timestamp(mobj.group(2) or 'inf'))
                     if None in (dur or [None]):

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -337,6 +337,7 @@ def validate_options(opts):
         for regex in value or []:
             if regex.startswith('*'):
                 for range_ in map(str.strip, regex[1:].split(',')):
+                    # FIXME: This is really sensible
                     mobj = range_ != '-' and re.fullmatch(r'(.+)?\s*-\s*(.+)?', range_)
                     dur = mobj and (parse_timestamp(mobj.group(1) or '0'), parse_timestamp(mobj.group(2) or 'inf'))
                     if None in (dur or [None]):

--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -33,6 +33,8 @@ class DashSegmentsFD(FragmentFD):
                 'filename': fmt.get('filepath') or filename,
                 'live': 'is_from_start' if fmt.get('is_from_start') else fmt.get('is_live'),
                 'total_frags': fragment_count,
+                'section_start': info_dict.get('section_start'),
+                'section_end': info_dict.get('section_end'),
             }
 
             if real_downloader:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2566,7 +2566,7 @@ class InfoExtractor:
                             r = int(s.get('r', 0))
                             ms_info['total_number'] += 1 + r
                             ms_info['s'].append({
-                                't': int(s.get('t', 0)),
+                                't': int_or_none(s.get('t')),
                                 # @d is mandatory (see [1, 5.3.9.6.2, Table 17, page 60])
                                 'd': int(s.attrib['d']),
                                 'r': r,
@@ -2608,9 +2608,16 @@ class InfoExtractor:
             return ms_info
 
         mpd_duration = parse_duration(mpd_doc.get('mediaPresentationDuration'))
+        availability_start_time = unified_timestamp(
+            mpd_doc.get('availabilityStartTime'), with_milliseconds=True) or 0
         formats, subtitles = [], {}
         stream_numbers = collections.defaultdict(int)
         for period in mpd_doc.findall(_add_ns('Period')):
+            # segmentIngestTime is completely out of spec, but YT Livestream do this
+            segment_ingest_time = period.get('{http://youtube.com/yt/2012/10/10}segmentIngestTime')
+            if segment_ingest_time:
+                availability_start_time = unified_timestamp(segment_ingest_time, with_milliseconds=True)
+
             period_duration = parse_duration(period.get('duration')) or mpd_duration
             period_ms_info = extract_multisegment_info(period, {
                 'start_number': 1,
@@ -2784,13 +2791,17 @@ class InfoExtractor:
                                     'Bandwidth': bandwidth,
                                     'Number': segment_number,
                                 }
+                                duration = float_or_none(segment_d, representation_ms_info['timescale'])
+                                start = float_or_none(segment_time, representation_ms_info['timescale'])
                                 representation_ms_info['fragments'].append({
                                     media_location_key: segment_url,
-                                    'duration': float_or_none(segment_d, representation_ms_info['timescale']),
+                                    'duration': duration,
+                                    'start': availability_start_time + start,
+                                    'end': availability_start_time + start + duration,
                                 })
 
                             for num, s in enumerate(representation_ms_info['s']):
-                                segment_time = s.get('t') or segment_time
+                                segment_time = s['t'] if s.get('t') is not None else segment_time
                                 segment_d = s['d']
                                 add_segment_url()
                                 segment_number += 1
@@ -2806,6 +2817,7 @@ class InfoExtractor:
                         fragments = []
                         segment_index = 0
                         timescale = representation_ms_info['timescale']
+                        start = 0
                         for s in representation_ms_info['s']:
                             duration = float_or_none(s['d'], timescale)
                             for r in range(s.get('r', 0) + 1):
@@ -2813,8 +2825,11 @@ class InfoExtractor:
                                 fragments.append({
                                     location_key(segment_uri): segment_uri,
                                     'duration': duration,
+                                    'start': availability_start_time + start,
+                                    'end': availability_start_time + start + duration,
                                 })
                                 segment_index += 1
+                                start += duration
                         representation_ms_info['fragments'] = fragments
                     elif 'segment_urls' in representation_ms_info:
                         # Segment URLs with no SegmentTimeline

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2853,12 +2853,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         known_idx = idx - 1
                         raise ExtractorError('breaking out of outer loop')
 
-                    last_segment_url = urljoin(fragment_base_url, 'sq/%d' % idx)
                     frag_duration = last_fragment['duration']
                     frag_start = last_fragment['start'] - (last_seq - idx) * frag_duration
                     frag_end = frag_start + frag_duration
 
                     if frag_start >= section_start and frag_end <= section_end:
+                        last_segment_url = urljoin(fragment_base_url, f'sq/{idx}')
+
                         yield {
                             'url': last_segment_url,
                             'duration': frag_duration,

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1843,7 +1843,7 @@ def unified_strdate(date_str, day_first=True):
         return str(upload_date)
 
 
-def unified_timestamp(date_str, day_first=True):
+def unified_timestamp(date_str, day_first=True, with_milliseconds=False):
     if date_str is None:
         return None
 
@@ -1869,7 +1869,7 @@ def unified_timestamp(date_str, day_first=True):
     for expression in date_formats(day_first):
         with contextlib.suppress(ValueError):
             dt = datetime.datetime.strptime(date_str, expression) - timezone + datetime.timedelta(hours=pm_delta)
-            return calendar.timegm(dt.timetuple())
+            return calendar.timegm(dt.timetuple()) + (dt.microsecond/1e6 if with_milliseconds else 0)
 
     timetuple = email.utils.parsedate_tz(date_str)
     if timetuple:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1869,7 +1869,7 @@ def unified_timestamp(date_str, day_first=True, with_milliseconds=False):
     for expression in date_formats(day_first):
         with contextlib.suppress(ValueError):
             dt = datetime.datetime.strptime(date_str, expression) - timezone + datetime.timedelta(hours=pm_delta)
-            return calendar.timegm(dt.timetuple()) + (dt.microsecond/1e6 if with_milliseconds else 0)
+            return calendar.timegm(dt.timetuple()) + (dt.microsecond / 1e6 if with_milliseconds else 0)
 
     timetuple = email.utils.parsedate_tz(date_str)
     if timetuple:

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -1893,7 +1893,7 @@ def subtitles_filename(filename, sub_lang, sub_format, expected_real_ext=None):
     return replace_extension(filename, sub_lang + '.' + sub_format, expected_real_ext)
 
 
-def datetime_from_str(date_str, precision='auto', format='%Y%m%d'):
+def datetime_from_str(date_str, precision='auto', format='%Y%m%d', use_utc=True):
     R"""
     Return a datetime object from a string.
     Supported format:
@@ -1902,12 +1902,13 @@ def datetime_from_str(date_str, precision='auto', format='%Y%m%d'):
     @param format       strftime format of DATE
     @param precision    Round the datetime object: auto|microsecond|second|minute|hour|day
                         auto: round to the unit provided in date_str (if applicable).
+    @param use_utc      Use UTC instead of local timezone for 'now' timestamps.
     """
     auto_precision = False
     if precision == 'auto':
         auto_precision = True
         precision = 'microsecond'
-    today = datetime_round(datetime.datetime.utcnow(), precision)
+    today = datetime_round(datetime.datetime.utcnow() if use_utc else datetime.datetime.now(), precision)
     if date_str in ('now', 'today'):
         return today
     if date_str == 'yesterday':
@@ -1916,7 +1917,7 @@ def datetime_from_str(date_str, precision='auto', format='%Y%m%d'):
         r'(?P<start>.+)(?P<sign>[+-])(?P<time>\d+)(?P<unit>microsecond|second|minute|hour|day|week|month|year)s?',
         date_str)
     if match is not None:
-        start_time = datetime_from_str(match.group('start'), precision, format)
+        start_time = datetime_from_str(match.group('start'), precision, format, use_utc)
         time = int(match.group('time')) * (-1 if match.group('sign') == '-' else 1)
         unit = match.group('unit')
         if unit == 'month' or unit == 'year':


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Like #5822, this PR adds support for downloading a specific section of a YT livestream format with --live-from-start, but with a different approach.

The Dash parser now extracts the `start` and `end` timestamps of each fragment and the fragment_generator code uses them to filter based on the selected range. A big advantage over #5822 is that these changes could allow support for --download-sections on any Dash livestream, if/when that downloader is implemented.

I haven't tested this thoroughly but I'd like to know your opinions on this path n-n

**PS:** It would be great if someone can improve --download-sections, because I started using .* just to get it working but it fails in a lot of cases, like `*(now-1hour)-(now-45minutes)`

Fixes #3451

```bash
yt-dlp "https://www.youtube.com/watch?v=w_DfTc7F5oQ" --verbose --live-from-start --download-sections "*(now-15minutes)-now" -f '136+140' -N 4 -o venice-beach
```

```bash
[debug] Command-line config: ['https://www.youtube.com/watch?v=w_DfTc7F5oQ', '--verbose', '--live-from-start', '--download-sections', '*(now-15minutes)-now', '-f', '136+140', '-N', '4', '-o', 'venice-beach']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.03.04 [392389b7d] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 932758707
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-35-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1788 extractors
[youtube] Extracting URL: https://www.youtube.com/watch?v=w_DfTc7F5oQ
[youtube] w_DfTc7F5oQ: Downloading webpage
[youtube] w_DfTc7F5oQ: Downloading android player API JSON
[youtube] w_DfTc7F5oQ: Downloading MPD manifest
[youtube] w_DfTc7F5oQ: Downloading MPD manifest
[debug] Sort order given by extractor: quality, res, fps, hdr:12, source, vcodec:vp9.2, channels, acodec, lang, proto
[debug] Formats sorted by: hasvid, ie_pref, quality, res, fps, hdr:12(7), source, vcodec:vp9.2(10), channels, acodec, lang, proto, filesize, fs_approx, tbr, vbr, abr, asr, vext, aext, hasaud, id
[info] w_DfTc7F5oQ: Downloading 1 format(s): 136+140
[info] w_DfTc7F5oQ: Downloading 1 time ranges: 1678413529.0-1678414429.0
[debug] Invoking dashsegments downloader on "https://manifest.googlevideo.com/api/manifest/dash/expire/1678436030/ei/XpIKZIkRp6WW7w-3rYZo/ip/XXX/id/w_DfTc7F5oQ.1/source/yt_live_broadcast/requiressl/yes/as/fmp4_audio_clear%2Cwebm_audio_clear%2Cwebm2_audio_clear%2Cfmp4_sd_hd_clear%2Cwebm2_sd_hd_clear/spc/H3gIhnYl7K65Op_r0g7dQt0nHMsV3Ts/vprv/1/pacing/0/itag_bl/376%2C377%2C384%2C385%2C612%2C613%2C617%2C619%2C623%2C628%2C655%2C656%2C660%2C662%2C666%2C671/keepalive/yes/fexp/24007246/itag/0/playlist_type/DVR/sparams/expire%2Cei%2Cip%2Cid%2Csource%2Crequiressl%2Cas%2Cspc%2Cvprv%2Citag%2Cplaylist_type/sig/AOq0QJ8wRQIgYToGUF3fyySh_BnRGOolCz-_dSadsojE2dvAGYAtSuECIQCoijYyWYBczAA5HOco4JZpiUKsy-QHcCJIflnHjbFaUw%3D%3D", "https://manifest.googlevideo.com/api/manifest/dash/expire/1678436030/ei/XpIKZIkRp6WW7w-3rYZo/ip/XXX/id/w_DfTc7F5oQ.1/source/yt_live_broadcast/requiressl/yes/as/fmp4_audio_clear%2Cwebm_audio_clear%2Cwebm2_audio_clear%2Cfmp4_sd_hd_clear%2Cwebm2_sd_hd_clear/spc/H3gIhnYl7K65Op_r0g7dQt0nHMsV3Ts/vprv/1/pacing/0/itag_bl/376%2C377%2C384%2C385%2C612%2C613%2C617%2C619%2C623%2C628%2C655%2C656%2C660%2C662%2C666%2C671/keepalive/yes/fexp/24007246/itag/0/playlist_type/DVR/sparams/expire%2Cei%2Cip%2Cid%2Csource%2Crequiressl%2Cas%2Cspc%2Cvprv%2Citag%2Cplaylist_type/sig/AOq0QJ8wRQIgYToGUF3fyySh_BnRGOolCz-_dSadsojE2dvAGYAtSuECIQCoijYyWYBczAA5HOco4JZpiUKsy-QHcCJIflnHjbFaUw%3D%3D"
[dashsegments] Total fragments: unknown (live)
[download] Destination: venice-beach.f136.mp4
[dashsegments] Total fragments: unknown (live)
[download] Destination: venice-beach.f140.mp4
WARNING: The download speed shown is only of one thread. This is a known issue
WARNING: [youtube] Starting download from the last 120 hours of the live stream since YouTube does not have data before that. If you think this is wrong, please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: The download speed shown is only of one thread. This is a known issue
[debug] [youtube] [w_DfTc7F5oQ] Generating fragments for format 136
[debug] [youtube] [w_DfTc7F5oQ] Generating fragments for format 140
[download] 100% of  167.70MiB in 00:01:09 at 2.41MiB/s
[download] 100% of   18.27MiB in 00:00:42 at 435.30KiB/s
[Merger] Merging formats into "venice-beach.mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i file:venice-beach.f136.mp4 -i file:venice-beach.f140.mp4 -c copy -map 0:v:0 -map 1:a:0 -movflags +faststart file:venice-beach.temp.mp4
Deleting original file venice-beach.f136.mp4 (pass -k to keep)
Deleting original file venice-beach.f140.mp4 (pass -k to keep)
```


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
