### PR TITLE
[youtube] Check for incomplete data in watch initial data

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4224,12 +4224,15 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         initial_data = None
         if webpage:
             initial_data = self.extract_yt_initial_data(video_id, webpage, fatal=False)
+            if not traverse_obj(initial_data, 'contents'):
+                self.report_warning('Incomplete data received in embedded initial data; re-fetching using API.')
+                initial_data = None
         if not initial_data:
             query = {'videoId': video_id}
             query.update(self._get_checkok_params())
             initial_data = self._extract_response(
                 item_id=video_id, ep='next', fatal=False,
-                ytcfg=master_ytcfg, query=query,
+                ytcfg=master_ytcfg, query=query, check_get_keys='contents',
                 headers=self.generate_api_headers(ytcfg=master_ytcfg),
                 note='Downloading initial data API JSON')
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Currently observing YouTube giving incomplete data for this initial data occasionally, leading to missing metadata (and non-UTC upload date in some situations).

Added functionality so it falls back to the API in this case. In YoutubeTab we re-download the webpage in this case, but since the webpage in YoutubeIE is downloaded as part of the player response process it is probably easier to do it this way.

```
yt-dlp --print upload_date https://www.youtube.com/watch\?v\=tjjjtzRLHvA -v --proxy ''
[debug] Command-line config: ['--print', 'upload_date', 'https://www.youtube.com/watch?v=tjjjtzRLHvA', '-v', '--proxy', '']
[debug] User config "/home/coletdjnz/.config/yt-dlp.conf": ['--ffmpeg-location', '/opt/yt-dlp-ffmpeg']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.03.04 [392389b7d] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: c0de21bf7
[debug] Python 3.11.0rc2 (CPython x86_64 64bit) - Linux-5.19.17-2-MANJARO-x86_64-with-glibc2.37 (OpenSSL 1.1.1t  7 Feb 2023, glibc 2.37)
[debug] exe versions: ffmpeg N-107674-gf0abd07996-20220805 (setts), ffprobe N-107674-gf0abd07996-20220805, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Plugin directories: ['/home/coletdjnz/.pyenv/versions/3.11.0rc2/envs/venv311rc2-ytdlp/lib/python3.11/site-packages/yt_dlp_plugins']
[debug] Loaded 1788 extractors
[youtube] Extracting URL: https://www.youtube.com/watch?v=tjjjtzRLHvA
[youtube] tjjjtzRLHvA: Downloading webpage
[youtube] tjjjtzRLHvA: Downloading android player API JSON
WARNING: [youtube] Incomplete data received in embedded initial data; re-fetching using API.
[youtube] tjjjtzRLHvA: Downloading initial data API JSON
[debug] Sort order given by extractor: quality, res, fps, hdr:12, source, vcodec:vp9.2, channels, acodec, lang, proto
[debug] Formats sorted by: hasvid, ie_pref, quality, res, fps, hdr:12(7), source, vcodec:vp9.2(10), channels, acodec, lang, proto, filesize, fs_approx, tbr, vbr, abr, asr, vext, aext, hasaud, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] tjjjtzRLHvA: Downloading 1 format(s): 247+251
20220323

```


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
