### PR TITLE
[WDR] Fix not adding two of the same manifest values

### DIFF
--- a/yt_dlp/extractor/wdr.py
+++ b/yt_dlp/extractor/wdr.py
@@ -59,6 +59,9 @@ class WDRIE(InfoExtractor):
 
         formats = []
         subtitles = {}
+        
+        # list to track the urls and ensure that not a second manifest url with the same value is added
+        avoid_duplicate_manifest_urls = []
 
         # check if the metadata contains a direct URL to a file
         for kind, media in media_resource.items():
@@ -74,9 +77,14 @@ class WDRIE(InfoExtractor):
                 continue
             if not isinstance(media, dict):
                 continue
-
+            
             for tag_name, medium_url in media.items():
                 if tag_name not in ('videoURL', 'audioURL'):
+                    continue
+                    
+                if medium_url not in avoid_duplicate_manifest_urls:
+                    avoid_duplicate_manifest_urls.append(medium_url)
+                else:
                     continue
 
                 ext = determine_ext(medium_url)
@@ -164,7 +172,7 @@ class WDRPageIE(WDRIE):  # XXX: Do not subclass from concrete IE
                 'ext': 'mp3',
                 'display_id': 'wdr3-gespraech-am-samstag/audio-schriftstellerin-juli-zeh-100',
                 'title': 'Schriftstellerin Juli Zeh',
-                'alt_title': 'WDR 3 Gespräch am Samstag',
+                'alt_title': 'WDR 3 GesprÃ¤ch am Samstag',
                 'upload_date': '20160312',
                 'description': 'md5:e127d320bc2b1f149be697ce044a3dd7',
                 'is_live': False,
@@ -232,7 +240,7 @@ class WDRPageIE(WDRIE):  # XXX: Do not subclass from concrete IE
             'info_dict': {
                 'id': 'mdb-1556012',
                 'ext': 'mp4',
-                'title': 'DHB-Vizepräsident Bob Hanning - "Die Weltspitze ist extrem breit"',
+                'title': 'DHB-VizeprÃ¤sident Bob Hanning - "Die Weltspitze ist extrem breit"',
                 'upload_date': '20180111',
             },
             'params': {


### PR DESCRIPTION
(Sometimes I hate it when technology is implemented like this in the first place: Link to a "alternative", but it's just the original)

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information
Some WDR videos produce the same "alternative" url value compared with "default".
It doesn't make sense to have both analyzed by yt-dlp if the url is identical.
The best practice would be to actually implement this on higher level.
But fixing it for WDR works too, in this case.

I provide this code as a suggestion, the actual implementation can look different for all I care.
I just didn't want to open this as an issue about this, since I am more of a developer than most yt-dlp users.
I wanted to report the issue by providing a simple, possible solution that I have tested in my own evironment.

(The result of listing every format twice just confuses users who chose the quality manually.)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
