### PR TITLE
[extractors/rtvc] Add extractors

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1675,6 +1675,7 @@ from .scte import (
 )
 from .scrolller import ScrolllerIE
 from .seeker import SeekerIE
+from .senalcolombia import SenalColombiaLiveIE
 from .senategov import SenateISVPIE, SenateGovIE
 from .sendtonews import SendtoNewsIE
 from .servus import ServusIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1609,6 +1609,7 @@ from .rts import RTSIE
 from .rtvcplay import (
     RTVCPlayIE,
     RTVCPlayEmbedIE,
+    RTVCKalturaIE,
 )
 from .rtve import (
     RTVEALaCartaIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1606,6 +1606,10 @@ from .rtnews import (
 from .rtp import RTPIE
 from .rtrfm import RTRFMIE
 from .rts import RTSIE
+from .rtvcplay import (
+    RTVCPlayIE,
+    RTVCPlayEmbedIE,
+)
 from .rtve import (
     RTVEALaCartaIE,
     RTVEAudioIE,

--- a/yt_dlp/extractor/rtvcplay.py
+++ b/yt_dlp/extractor/rtvcplay.py
@@ -1,0 +1,227 @@
+import re
+
+from .common import InfoExtractor
+from ..utils import js_to_json, traverse_obj
+
+
+class RTFVPlayBaseIE(InfoExtractor):
+    _BASE_VALID_URL = r'https?://(?:www\.)?rtvcplay\.co'
+
+    def _extract_player_config(self, webpage, video_id):
+        return self._search_json(
+            r'<script\b[^>]*>[^<]*(?:var|let|const)\s+config\s*=', re.sub(r'"\s*\+\s*"', '', webpage),
+            'player_config', video_id, transform_source=js_to_json)
+
+    def _extract_formats_and_subtitles_player_config(self, player_config, video_id):
+        formats, subtitles = [], {}
+        for source_type in traverse_obj(player_config, 'sources') or ():
+            for media_source in traverse_obj(player_config, ('sources', source_type)) or ():
+                if source_type == 'hls':
+                    fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                        media_source.get('url'), video_id, 'mp4', fatal=False)
+                    formats.extend(fmts)
+                    self._merge_subtitles(subs, target=subtitles)
+                else:
+                    formats.append({
+                        'url': media_source.get('url'),
+                    })
+
+        return formats, subtitles
+
+
+class RTVCPlayIE(RTFVPlayBaseIE):
+    _VALID_URL = RTFVPlayBaseIE._BASE_VALID_URL + r'/(?P<category>[^/]+)/(?:[^?#]+/)?(?P<id>[\w-]+)'
+
+    _TESTS = [{
+        'url': 'https://www.rtvcplay.co/en-vivo/canal-institucional',
+        'info_dict': {
+            'id': 'canal-institucional',
+            'title': r're:^Canal Institucional',
+            'description': 'md5:eff9e548394175928059320c006031ea',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+        'params': {
+            'skip_download': 'Livestream',
+        },
+    }, {
+        'url': 'https://www.rtvcplay.co/en-vivo/senal-colombia',
+        'info_dict': {
+            'id': 'senal-colombia',
+            'title': r're:^Señal Colombia',
+            'description': 'md5:799f16a401d97f40c33a2c6a3e2a507b',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+        'params': {
+            'skip_download': 'Livestream',
+        },
+    }, {
+        'url': 'https://www.rtvcplay.co/en-vivo/radio-nacional',
+        'info_dict': {
+            'id': 'radio-nacional',
+            'title': r're:^Radio Nacional',
+            'description': 'md5:5de009bc6a9fa79d2a6cf0b73f977d53',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+        'params': {
+            'skip_download': 'Livestream',
+        },
+    }, {
+        'url': 'https://www.rtvcplay.co/peliculas-ficcion/senoritas',
+        'md5': '1288ee6f6d1330d880f98bff2ed710a3',
+        'info_dict': {
+            'id': 'senoritas',
+            'title': 'Señoritas',
+            'description': 'md5:f095a2bb52cb6cf279daf6302f86fb32',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'ext': 'mp4',
+        },
+    }, {
+        'url': 'https://www.rtvcplay.co/competencias-basicas-ciudadanas-y-socioemocionales/profe-en-tu-casa/james-regresa-clases-28022022',
+        'md5': 'f040a7380a269ad633cf837384d5e9fc',
+        'info_dict': {
+            'id': 'james-regresa-clases-28022022',
+            'title': 'James regresa a clases - 28/02/2022',
+            'description': 'md5:c5dcdf757c7ab29305e8763c6007e675',
+            'ext': 'mp4',
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id, category = self._match_valid_url(url).group('id', 'category')
+        webpage = self._download_webpage(url, video_id)
+
+        hydration = self._search_json(
+            r'window.__RTVCPLAY_STATE__\s*=', webpage, 'hydration', video_id, transform_source=js_to_json)
+
+        asset_id = traverse_obj(hydration, ('content', 'currentContent', 'video', 'assetid'))
+        if asset_id:
+            hls_url = hydration['content']['currentContent']['base_url_hls'].replace('[node:field_asset_id]', asset_id)
+        else:
+            hls_url = hydration['content']['currentContent']['channel']['hls']
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(hls_url, video_id, 'mp4')
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            'is_live': category == 'en-vivo',
+            'thumbnail': traverse_obj(
+                hydration, ('content', 'currentContent', 'channel', 'image', 'logo', 'path'),
+                ('content', 'currentContent', 'resource', 'image', 'cover_desktop', 'path')),
+            **traverse_obj(hydration, ('content', 'currentContent', {
+                'title': 'title',
+                'description': 'description',
+            }))
+        }
+
+
+class RTVCPlayEmbedIE(RTFVPlayBaseIE):
+    _VALID_URL = RTFVPlayBaseIE._BASE_VALID_URL + r'/embed/(?P<id>[\w-]+)'
+
+    _TESTS = [{
+        'url': 'https://www.rtvcplay.co/embed/72b0e699-248b-4929-a4a8-3782702fa7f9',
+        'md5': 'ed529aeaee7aa2a72afe91ac7d1177a8',
+        'info_dict': {
+            'id': '72b0e699-248b-4929-a4a8-3782702fa7f9',
+            'title': 'Tráiler: Señoritas',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'ext': 'mp4',
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        player_config = self._extract_player_config(webpage, video_id)
+        formats, subtitles = self._extract_formats_and_subtitles_player_config(player_config, video_id)
+
+        asset_id = traverse_obj(player_config, ('rtvcplay', 'assetid'))
+        metadata = {} if not asset_id else self._download_json(
+            f'https://cms.rtvcplay.co/api/v1/video/asset-id/{asset_id}', video_id, fatal=False)
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            **traverse_obj(metadata, {
+                'title': 'title',
+                'description': 'description',
+                'thumbnail': ('image', ..., 'thumbnail', 'path'),
+            }, get_all=False)
+        }
+
+
+
+class RTVCKalturaIE(RTFVPlayBaseIE):
+    _VALID_URL = r'https?://media\.rtvc\.gov\.co/kalturartvc/(?P<id>[\w-]+)'
+
+    _TESTS = [{
+        'url': 'https://media.rtvc.gov.co/kalturartvc/indexSC.html',
+        'info_dict': {
+            'id': 'indexSC',
+            'title': r're:^Señal Colombia',
+            'description': 'md5:799f16a401d97f40c33a2c6a3e2a507b',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+        'params': {
+            'skip_download': 'Livestream',
+        },
+    }]
+
+    _WEBPAGE_TESTS = [{
+        'url': 'https://www.rtvcplay.co/en-vivo/canal-institucional',
+        'info_dict': {
+            'id': 'indexCI',
+            'title': r're:^Canal Institucional',
+            'description': 'md5:eff9e548394175928059320c006031ea',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+        'params': {
+            'skip_download': 'Livestream',
+        },
+    }]
+
+    @classmethod
+    def _extract_embed_urls(cls, url, webpage):
+        yield from re.findall(
+            r'<iframe[^>]+src\s*=\s*"(https://media\.rtvc\.gov\.co/kalturartvc/[\w.-]+)', webpage)
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        player_config = self._extract_player_config(webpage, video_id)
+        formats, subtitles = self._extract_formats_and_subtitles_player_config(player_config, video_id)
+
+        channel_id = traverse_obj(player_config, ('rtvcplay', 'channelId'))
+        metadata = {} if not channel_id else self._download_json(
+            f'https://cms.rtvcplay.co/api/v1/taxonomy_term/streaming/{channel_id}', video_id, fatal=False)
+
+        fmts, subs = self._extract_m3u8_formats_and_subtitles(
+            traverse_obj(metadata, ('channel', 'hls')), video_id, 'mp4', fatal=False)
+        formats.extend(fmts)
+        self._merge_subtitles(subs, target=subtitles)
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            'is_live': True,
+            **traverse_obj(metadata, {
+                'title': 'title',
+                'description': 'description',
+                'thumbnail': ('channel', 'image', 'logo', 'path'),
+            })
+        }

--- a/yt_dlp/extractor/rtvcplay.py
+++ b/yt_dlp/extractor/rtvcplay.py
@@ -123,6 +123,15 @@ class RTVCPlayIE(RTFVPlayBaseIE):
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',
         },
         'playlist_mincount': 5,
+    }, {
+        'url': 'https://www.rtvcplay.co/series-al-oido/diez-versiones',
+        'info_dict': {
+            'id': 'diez-versiones',
+            'title': 'Diez versiones',
+            'description': 'md5:997471ed971cb3fd8e41969457675306',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+        },
+        'playlist_mincount': 20,
     }]
 
     def _real_extract(self, url):
@@ -149,12 +158,14 @@ class RTVCPlayIE(RTFVPlayBaseIE):
         }
 
         # Probably it's a program's page
-        if hls_url is None:
-            seasons = traverse_obj(hydration, ('content', 'currentContent', 'widgets', 0, 'contents'))
-            if seasons is None:
+        if not hls_url:
+            seasons = traverse_obj(
+                hydration, ('content', 'currentContent', 'widgets', lambda _, y: y['type'] == 'seasonList', 'contents'),
+                get_all=False)
+            if not seasons:
                 podcast_episodes = traverse_obj(hydration, ('content', 'currentContent', 'audios'))
-                if podcast_episodes is None:
-                    raise ExtractorError("Couldn't find asset_id nor program playlist nor podcast episodes")
+                if not podcast_episodes:
+                    raise ExtractorError('Could not find asset_id nor program playlist nor podcast episodes')
 
                 return self.playlist_result([self.url_result(episode['file'], **traverse_obj(episode, {
                     'title': 'title',

--- a/yt_dlp/extractor/rtvcplay.py
+++ b/yt_dlp/extractor/rtvcplay.py
@@ -178,26 +178,6 @@ class RTVCKalturaIE(RTFVPlayBaseIE):
         },
     }]
 
-    _WEBPAGE_TESTS = [{
-        'url': 'https://www.rtvcplay.co/en-vivo/canal-institucional',
-        'info_dict': {
-            'id': 'indexCI',
-            'title': r're:^Canal Institucional',
-            'description': 'md5:eff9e548394175928059320c006031ea',
-            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
-            'live_status': 'is_live',
-            'ext': 'mp4',
-        },
-        'params': {
-            'skip_download': 'Livestream',
-        },
-    }]
-
-    @classmethod
-    def _extract_embed_urls(cls, url, webpage):
-        yield from re.findall(
-            r'<iframe[^>]+src\s*=\s*"(https://media\.rtvc\.gov\.co/kalturartvc/[\w.-]+)', webpage)
-
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)

--- a/yt_dlp/extractor/rtvcplay.py
+++ b/yt_dlp/extractor/rtvcplay.py
@@ -159,7 +159,6 @@ class RTVCPlayEmbedIE(RTFVPlayBaseIE):
         }
 
 
-
 class RTVCKalturaIE(RTFVPlayBaseIE):
     _VALID_URL = r'https?://media\.rtvc\.gov\.co/kalturartvc/(?P<id>[\w-]+)'
 

--- a/yt_dlp/extractor/rtvcplay.py
+++ b/yt_dlp/extractor/rtvcplay.py
@@ -36,7 +36,7 @@ class RTFVPlayBaseIE(InfoExtractor):
 
 
 class RTVCPlayIE(RTFVPlayBaseIE):
-    _VALID_URL = RTFVPlayBaseIE._BASE_VALID_URL + r'/(?P<category>[^/]+)/(?:[^?#]+/)?(?P<id>[\w-]+)'
+    _VALID_URL = RTFVPlayBaseIE._BASE_VALID_URL + r'/(?P<category>(?!embed)[^/]+)/(?:[^?#]+/)?(?P<id>[\w-]+)'
 
     _TESTS = [{
         'url': 'https://www.rtvcplay.co/en-vivo/canal-institucional',

--- a/yt_dlp/extractor/senalcolombia.py
+++ b/yt_dlp/extractor/senalcolombia.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from ..utils import js_to_json, traverse_obj
+from .rtvcplay import RTVCKalturaIE
 
 
 class SenalColombiaLiveIE(InfoExtractor):
@@ -8,7 +8,7 @@ class SenalColombiaLiveIE(InfoExtractor):
     _TESTS = [{
         'url': 'https://www.senalcolombia.tv/senal-en-vivo',
         'info_dict': {
-            'id': 'senal-en-vivo',
+            'id': 'indexSC',
             'title': 're:^Señal Colombia',
             'description': 'md5:799f16a401d97f40c33a2c6a3e2a507b',
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',
@@ -21,63 +21,11 @@ class SenalColombiaLiveIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
 
-        player_webpage = self._download_webpage(
-            'https://media.rtvc.gov.co/kalturartvc/indexSC.html', video_id)
+        hydration = self._search_json(
+            r'<script\b[^>]*data-drupal-selector\s*=\s*"[^"]*drupal-settings-json[^"]*"[^>]*>',
+            webpage, 'hydration', display_id)
 
-        player_config = self._search_json(
-            r'<script\b[^>]*>[^<]*(?:var|let|const)\s+config\s*=', player_webpage, 'player_config', video_id,
-            transform_source=js_to_json)
-
-        # player_js = self._download_webpage(
-        #     'https://media.rtvc.gov.co/kalturartvc/kaltura-ovp-playerv2.1.js', video_id,
-        #     transform_source=js_to_json,fatal=False)
-
-        # function verifyChannelLiveInfo(channelid, urlbase) {
-        #   var url = environment() + '/api/v1/taxonomy_term/streaming/' + channelid;
-        #   return fetch(url, {
-        #     method: 'GET', // or 'PUT'
-        #     headers: {
-        #       'Content-Type': 'application/json'
-        #     }
-        #   }).then(function (res) {
-        #     return res.json();
-        #   }).catch(function (error) {
-        #     return console.error('Error:', error);
-        #   });
-        # }
-
-        channel_id = traverse_obj(player_config, ('rtvcplay', 'channelId')) or 68
-        channel_data = self._download_json(
-            f'https://cms.rtvcplay.co/api/v1/taxonomy_term/streaming/{channel_id}', video_id, fatal=False)
-
-        formats, subtitles = [], {}
-        for source_type in traverse_obj(player_config, 'sources') or ():
-            for media_source in traverse_obj(player_config, ('sources', source_type)) or ():
-                if source_type == 'hls':
-                    fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                        media_source.get('url'), video_id, 'mp4', fatal=False)
-                    formats.extend(fmts)
-                    self._merge_subtitles(subs, target=subtitles)
-                else:
-                    formats.append({
-                        'url': media_source.get('url'),
-                    })
-
-        fmts, subs = self._extract_m3u8_formats_and_subtitles(
-            traverse_obj(channel_data, ('channel', 'hls')), video_id, 'mp4', fatal=False)
-        formats.extend(fmts)
-        self._merge_subtitles(subs, target=subtitles)
-
-        return {
-            'id': video_id,
-            'formats': formats,
-            'subtitles': subtitles,
-            'is_live': True,
-            **traverse_obj(channel_data, {
-                'title': ('title', ('channel', 'title')),
-                'description': ('description', ('channel', 'description')),
-                'thumbnail': ('channel', 'image', 'logo', 'path'),
-            }),
-        }
+        return self.url_result(hydration['envivosrc'], RTVCKalturaIE, display_id)

--- a/yt_dlp/extractor/senalcolombia.py
+++ b/yt_dlp/extractor/senalcolombia.py
@@ -1,0 +1,42 @@
+from .common import InfoExtractor
+from ..utils import traverse_obj
+
+
+class SenalColombiaLiveIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?senalcolombia\.tv/(?P<id>senal-en-vivo)'
+
+    _TESTS = [{
+        'url': 'https://www.senalcolombia.tv/senal-en-vivo',
+        'info_dict': {
+            'id': 'senal-en-vivo',
+            'title': 're:^Señal Colombia',
+            'description': 'md5:799f16a401d97f40c33a2c6a3e2a507b',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+            'live_status': 'is_live',
+            'ext': 'mp4',
+        },
+        'params': {
+            'skip_download': 'Livestream',
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        api_response = self._download_json(
+            'https://cms.rtvcplay.co/api/v1/taxonomy_term/streaming/68', video_id)
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            api_response['channel']['hls'], video_id, 'mp4')
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            'is_live': True,
+            **traverse_obj(api_response, {
+                'title': 'title',
+                'description': 'description',
+                'thumbnail': ('channel', 'image', 'logo', 'path'),
+            }),
+        }

--- a/yt_dlp/extractor/senalcolombia.py
+++ b/yt_dlp/extractor/senalcolombia.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from ..utils import traverse_obj
+from ..utils import js_to_json, traverse_obj
 
 
 class SenalColombiaLiveIE(InfoExtractor):
@@ -23,20 +23,61 @@ class SenalColombiaLiveIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        api_response = self._download_json(
-            'https://cms.rtvcplay.co/api/v1/taxonomy_term/streaming/68', video_id)
+        player_webpage = self._download_webpage(
+            'https://media.rtvc.gov.co/kalturartvc/indexSC.html', video_id)
 
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            api_response['channel']['hls'], video_id, 'mp4')
+        player_config = self._search_json(
+            r'<script\b[^>]*>[^<]*(?:var|let|const)\s+config\s*=', player_webpage, 'player_config', video_id,
+            transform_source=js_to_json)
+
+        # player_js = self._download_webpage(
+        #     'https://media.rtvc.gov.co/kalturartvc/kaltura-ovp-playerv2.1.js', video_id,
+        #     transform_source=js_to_json,fatal=False)
+
+        # function verifyChannelLiveInfo(channelid, urlbase) {
+        #   var url = environment() + '/api/v1/taxonomy_term/streaming/' + channelid;
+        #   return fetch(url, {
+        #     method: 'GET', // or 'PUT'
+        #     headers: {
+        #       'Content-Type': 'application/json'
+        #     }
+        #   }).then(function (res) {
+        #     return res.json();
+        #   }).catch(function (error) {
+        #     return console.error('Error:', error);
+        #   });
+        # }
+
+        channel_id = traverse_obj(player_config, ('rtvcplay', 'channelId')) or 68
+        channel_data = self._download_json(
+            f'https://cms.rtvcplay.co/api/v1/taxonomy_term/streaming/{channel_id}', video_id, fatal=False)
+
+        formats, subtitles = [], {}
+        for source_type in traverse_obj(player_config, 'sources') or ():
+            for media_source in traverse_obj(player_config, ('sources', source_type)) or ():
+                if source_type == 'hls':
+                    fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                        media_source.get('url'), video_id, 'mp4', fatal=False)
+                    formats.extend(fmts)
+                    self._merge_subtitles(subs, target=subtitles)
+                else:
+                    formats.append({
+                        'url': media_source.get('url'),
+                    })
+
+        fmts, subs = self._extract_m3u8_formats_and_subtitles(
+            traverse_obj(channel_data, ('channel', 'hls')), video_id, 'mp4', fatal=False)
+        formats.extend(fmts)
+        self._merge_subtitles(subs, target=subtitles)
 
         return {
             'id': video_id,
             'formats': formats,
             'subtitles': subtitles,
             'is_live': True,
-            **traverse_obj(api_response, {
-                'title': 'title',
-                'description': 'description',
+            **traverse_obj(channel_data, {
+                'title': ('title', ('channel', 'title')),
+                'description': ('description', ('channel', 'description')),
                 'thumbnail': ('channel', 'image', 'logo', 'path'),
             }),
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR add extractors for RTVC Play and some subdomains needed for embeded players like https://www.senalcolombia.tv/senal-en-vivo

Fixes #6457

#### SenalColombiaLiveIE
```bash
[debug] Command-line config: ['https://www.senalcolombia.tv/senal-en-vivo', '--verbose', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.03.04 [392389b7d] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 7de39a252
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-35-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1792 extractors
[SenalColombiaLive] Extracting URL: https://www.senalcolombia.tv/senal-en-vivo
[SenalColombiaLive] senal-en-vivo: Downloading webpage
[RTVCKaltura] Extracting URL: https://media.rtvc.gov.co/kalturartvc/indexSC.html
[RTVCKaltura] indexSC: Downloading webpage
[RTVCKaltura] indexSC: Downloading m3u8 information
[RTVCKaltura] indexSC: Downloading JSON metadata
[RTVCKaltura] indexSC: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for indexSC:
ID     EXT RESOLUTION │   TBR PROTO │ VCODEC    VBR ACODEC  ABR
───────────────────────────────────────────────────────────────
500-0  mp4 unknown    │  500k m3u8  │ unknown  500k unknown  0k
500-1  mp4 unknown    │  500k m3u8  │ unknown  500k unknown  0k
3500-0 mp4 unknown    │ 3500k m3u8  │ unknown 3500k unknown  0k
3500-1 mp4 unknown    │ 3500k m3u8  │ unknown 3500k unknown  0k
```

#### RTVCPlay
```bash
[debug] Command-line config: ['https://www.rtvcplay.co/peliculas-documentales/llinas-el-cerebro-y-el-universo', '--verbose', '-F']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.03.04 [392389b7d] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 7de39a252
[debug] Python 3.10.7 (CPython x86_64 64bit) - Linux-5.19.0-35-generic-x86_64-with-glibc2.36 (OpenSSL 3.0.5 5 Jul 2022, glibc 2.36)
[debug] exe versions: ffmpeg N-108931-g4dda3b1653-20221104 (setts), ffprobe N-108931-g4dda3b1653-20221104, phantomjs broken, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, certifi-2022.09.24, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1792 extractors
[RTVCPlay] Extracting URL: https://www.rtvcplay.co/peliculas-documentales/llinas-el-cerebro-y-el-universo
[RTVCPlay] llinas-el-cerebro-y-el-universo: Downloading webpage
[download] Downloading playlist: Llinás, el cerebro y el universo
[RTVCPlay] Playlist Llinás, el cerebro y el universo: Downloading 3 items of 3
[download] Downloading item 1 of 3
[RTVCPlay] Extracting URL: https://www.rtvcplay.co/peliculas-documentales/llinas-el-cerebro-y-el-universo/llinas-cerebro-universo
[RTVCPlay] llinas-cerebro-universo: Downloading webpage
[RTVCPlay] llinas-cerebro-universo: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for llinas-cerebro-universo:
ID  EXT RESOLUTION │  TBR PROTO │ VCODEC   VBR ACODEC  ABR
──────────────────────────────────────────────────────────
270 mp4 unknown    │ 270k m3u8  │ unknown 270k unknown  0k
360 mp4 unknown    │ 360k m3u8  │ unknown 360k unknown  0k
720 mp4 unknown    │ 720k m3u8  │ unknown 720k unknown  0k
[download] Downloading item 2 of 3
[RTVCPlay] Extracting URL: https://www.rtvcplay.co/peliculas-documentales/llinas-el-cerebro-y-el-universo/concierto-cerebro
[RTVCPlay] concierto-cerebro: Downloading webpage
[RTVCPlay] concierto-cerebro: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for concierto-cerebro:
ID  EXT RESOLUTION │  TBR PROTO │ VCODEC   VBR ACODEC  ABR
──────────────────────────────────────────────────────────
270 mp4 unknown    │ 270k m3u8  │ unknown 270k unknown  0k
360 mp4 unknown    │ 360k m3u8  │ unknown 360k unknown  0k
720 mp4 unknown    │ 720k m3u8  │ unknown 720k unknown  0k
[download] Downloading item 3 of 3
[RTVCPlay] Extracting URL: https://www.rtvcplay.co/peliculas-documentales/llinas-el-cerebro-y-el-universo/llinas-audio-descriptivo-lenguaje-senas
[RTVCPlay] llinas-audio-descriptivo-lenguaje-senas: Downloading webpage
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
