### PR TITLE
[extractor/pgatour] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1390,6 +1390,7 @@ from .periscope import (
     PeriscopeIE,
     PeriscopeUserIE,
 )
+from .pgatour import PGATourIE
 from .philharmoniedeparis import PhilharmonieDeParisIE
 from .phoenix import PhoenixIE
 from .photobucket import PhotobucketIE

--- a/yt_dlp/extractor/pgatour.py
+++ b/yt_dlp/extractor/pgatour.py
@@ -1,0 +1,47 @@
+from .brightcove import BrightcoveNewIE
+from .common import InfoExtractor
+
+
+class PGATourIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?pgatour\.com/video/[\w-]+/(?P<tc>T)?(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://www.pgatour.com/video/competition/T6322447785112/adam-hadwin-2023-the-players-round-4-18th-hole-shot-1',
+        'info_dict': {
+            'id': '6322447785112',
+            'ext': 'mp4',
+            'title': 'Adam Hadwin | 2023 THE PLAYERS | Round 4 | 18th hole | Shot 1',
+            'uploader_id': '6116716431001',
+            'upload_date': '20230312',
+            'timestamp': 1678653136,
+            'duration': 20.011,
+            'thumbnail': r're:^https://.+\.jpg',
+            'tags': 'count:7',
+        },
+        'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://www.pgatour.com/video/features/6322506425112/follow-the-players-trophy-on-championship-sunday',
+        'info_dict': {
+            'id': '6322506425112',
+            'ext': 'mp4',
+            'title': 'Follow THE PLAYERS trophy on Championship Sunday',
+            'description': 'md5:4d29e4bdfa03694a0ebfd08950398568',
+            'uploader_id': '6082840763001',
+            'upload_date': '20230313',
+            'timestamp': 1678739835,
+            'duration': 123.435,
+            'thumbnail': r're:^https://.+\.jpg',
+            'tags': 'count:8',
+        },
+        'params': {'skip_download': 'm3u8'},
+    }]
+
+    def _real_extract(self, url):
+        video_id, is_tourcast = self._match_valid_url(url).group('id', 'tc')
+
+        # From https://www.pgatour.com/_next/static/chunks/pages/_app-8bcf849560daf38d.js
+        account_id = '6116716431001' if is_tourcast else '6082840763001'
+        player_id = 'Vsd5Umu8r' if is_tourcast else 'FWIBYMBPj'
+
+        return self.url_result(
+            f'https://players.brightcove.net/{account_id}/{player_id}_default/index.html?videoId={video_id}',
+            BrightcoveNewIE)


### PR DESCRIPTION
Closes #6537

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
