### PR TITLE
[youtube:tab] Detect looping feeds

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4759,7 +4759,7 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
                 break
             continuation_token = continuation.get('continuation')
             if continuation_token is not None and continuation_token in seen_continuations:
-                self.report_warning('Detected YouTube feed looping - assuming end of feed.')
+                self.write_debug('Detected YouTube feed looping - assuming end of feed.')
                 break
             seen_continuations.add(continuation_token)
             headers = self.generate_api_headers(

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4753,10 +4753,15 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
             or try_get(tab_content, lambda x: x['richGridRenderer'], dict) or {})
         yield from extract_entries(parent_renderer)
         continuation = continuation_list[0]
-
+        seen_continuations = set()
         for page_num in itertools.count(1):
             if not continuation:
                 break
+            continuation_token = continuation.get('continuation')
+            if continuation_token is not None and continuation_token in seen_continuations:
+                self.report_warning('Detected YouTube feed looping - assuming end of feed.')
+                break
+            seen_continuations.add(continuation_token)
             headers = self.generate_api_headers(
                 ytcfg=ytcfg, account_syncid=account_syncid, visitor_data=visitor_data)
             response = self._extract_response(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes https://github.com/yt-dlp/yt-dlp/issues/5555

YouTube is rolling out a change where they loop (channel?) feeds at the end. Fortunately the continuations appear to be identical, so we can detect when it loops using those.

https://github.com/yt-dlp/yt-dlp/issues/5555#issuecomment-1482291174

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e53d87</samp>

### Summary
🐛📺🔀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It conveys that the change fixes a problem or error in the code or functionality.
2.  📺 - This emoji represents YouTube, which is the source of the feed pages that the change affects. It conveys that the change is related to video or media content from YouTube.
3.  🔀 - This emoji represents a loop, which is the mechanism that the change modifies. It conveys that the change involves breaking or controlling a loop or iteration.
-->
Fix infinite loop bug in YouTube feed extraction. Use a set to track seen continuation tokens in `yt_dlp/extractor/youtube.py`.

> _`set` stops the loop_
> _YouTube feed pages bug fixed_
> _autumn leaves falling_

### Walkthrough
*  Prevent infinite looping when fetching YouTube feed pages by using a set to store seen continuation tokens and breaking the loop if the same token is encountered again ([link](https://github.com/yt-dlp/yt-dlp/pull/6621/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L4756-R4764))

