### PR TITLE
[extractor/twitch] Update thumbnail size

### DIFF
--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -463,13 +463,10 @@ class TwitchVodIE(TwitchBaseIE):
                 is_live = False
                 # for p in ('width', 'height'):
                     # thumbnail = thumbnail.replace('{%s}' % p, '0')
-                common_res = [(0, 0), (160, 90), (320, 180), (480, 720), (640, 360), (768, 432), (1024, 576), (1280, 720), (1366, 768), (1920, 1080)]
-                thumbnails = [{
-                    'url': re.sub(r'\d+x\d+\.jpg', f'{w}x{h}.jpg', thumbnail),
-                    'width': w,
-                    'height': h,
-                } for w, h in common_res]
-                thumbnails.append({'url': thumbnail})
+                thumbnails = [
+                    {'url': re.sub(r'\d+x\d+\.jpg', '0x0.jpg', thumbnail), 'preference': 1},
+                    {'url': thumbnail},
+                ]
 
         return {
             'id': vod_id,
@@ -1050,14 +1047,10 @@ class TwitchStreamIE(TwitchBaseIE):
         thumbnail = url_or_none(try_get(
             gql, lambda x: x[2]['data']['user']['stream']['previewImageURL'],
             compat_str))
-        common_res = [(0, 0), (160, 90), (320, 180), (480, 720), (640, 360), (768, 432), (1024, 576), (1280, 720), (1366, 768), (1920, 1080)]
-        thumbnails = [{
-            'url': re.sub(r'\d+x\d+\.jpg', f'{w}x{h}.jpg', thumbnail),
-            'width': w,
-            'height': h,
-        } for w, h in common_res] if thumbnail else None
-        if thumbnails:
-            thumbnails.append({'url': thumbnail})
+        thumbnails = [
+            {'url': re.sub(r'\d+x\d+\.jpg', '0x0.jpg', thumbnail), 'preference': 1},
+            {'url': thumbnail},
+        ] if thumbnail else None
 
         title = uploader or channel_name
         stream_type = stream.get('type')

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -462,6 +462,7 @@ class TwitchVodIE(TwitchBaseIE):
                 is_live = False
                 for p in ('width', 'height'):
                     thumbnail = thumbnail.replace('{%s}' % p, '0')
+                thumbnail = re.sub(r"(\d+)x(\d+)\.jpg", "0x0.jpg", thumbnail)
 
         return {
             'id': vod_id,
@@ -1042,6 +1043,7 @@ class TwitchStreamIE(TwitchBaseIE):
         thumbnail = url_or_none(try_get(
             gql, lambda x: x[2]['data']['user']['stream']['previewImageURL'],
             compat_str))
+        thumbnail = re.sub(r"(\d+)x(\d+)\.jpg", "0x0.jpg", thumbnail)
 
         title = uploader or channel_name
         stream_type = stream.get('type')

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -181,7 +181,7 @@ class TwitchBaseIE(InfoExtractor):
 
     def _get_thumbnails(self, thumbnail):
         return [{
-            'url': re.sub(r'\d+x\d+(\.\w+)($|(?=[?#]))', '0x0\g<1>', thumbnail),
+            'url': re.sub(r'\d+x\d+(\.\w+)($|(?=[?#]))', r'0x0\g<1>', thumbnail),
             'preference': 1,
         }, {
             'url': thumbnail,

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -181,7 +181,7 @@ class TwitchBaseIE(InfoExtractor):
 
     def _get_thumbnails(self, thumbnail):
         return [{
-            'url': re.sub(r'\d+x\d+\.jpg', '0x0.jpg', thumbnail),
+            'url': re.sub(r'\d+x\d+(\.\w+)($|(?=[?#]))', '0x0\g<1>', thumbnail),
             'preference': 1,
         }, {
             'url': thumbnail,

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -463,22 +463,18 @@ class TwitchVodIE(TwitchBaseIE):
             vod_id = 'v%s' % vod_id
         thumbnail = url_or_none(info.get('previewThumbnailURL'))
         is_live = None
-        thumbnails = None
         if thumbnail:
             if re.findall(r'/404_processing_[^.?#]+\.png', thumbnail):
-                is_live = True
+                is_live, thumbnail = True, None
             else:
                 is_live = False
-                # for p in ('width', 'height'):
-                    # thumbnail = thumbnail.replace('{%s}' % p, '0')
-                thumbnails = self._get_thumbnails(thumbnail)
 
         return {
             'id': vod_id,
             'title': info.get('title') or 'Untitled Broadcast',
             'description': info.get('description'),
             'duration': int_or_none(info.get('lengthSeconds')),
-            'thumbnails': thumbnails,
+            'thumbnails': self._get_thumbnails(thumbnail),
             'uploader': try_get(info, lambda x: x['owner']['displayName'], compat_str),
             'uploader_id': try_get(info, lambda x: x['owner']['login'], compat_str),
             'timestamp': unified_timestamp(info.get('publishedAt')),
@@ -1052,7 +1048,6 @@ class TwitchStreamIE(TwitchBaseIE):
         thumbnail = url_or_none(try_get(
             gql, lambda x: x[2]['data']['user']['stream']['previewImageURL'],
             compat_str))
-        thumbnails = self._get_thumbnails(thumbnail)
 
         title = uploader or channel_name
         stream_type = stream.get('type')
@@ -1064,7 +1059,7 @@ class TwitchStreamIE(TwitchBaseIE):
             'display_id': channel_name,
             'title': title,
             'description': description,
-            'thumbnails': thumbnails,
+            'thumbnails': self._get_thumbnails(thumbnail),
             'uploader': uploader,
             'uploader_id': channel_name,
             'timestamp': timestamp,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Currently, using `--write-thumbnail` when downloading vod will only give you a `90*60` size thumbnail.
like <https://www.twitch.tv/videos/1773257171>
<https://static-cdn.jtvnw.net/cf_vods/d2nvs31859zcd8/3afded6c325c0f62cc4e_dashducks_41995346187_1679578217//thumb/thumb0-90x60.jpg>
\> <https://static-cdn.jtvnw.net/cf_vods/d2nvs31859zcd8/3afded6c325c0f62cc4e_dashducks_41995346187_1679578217//thumb/thumb0-0x0.jpg>
Use `thumbnail = re.sub(r"(\d+)x(\d+)\.jpg", "0x0.jpg", thumbnail)` to replace the thumbnail with size `0*0` (original size?)
And Live even though the highest picture quality is `1920*1080`, currently only get `1280*720` thumbnail, using the same code modified to `0*0`
like <https://www.twitch.tv/dashducks>
<https://static-cdn.jtvnw.net/previews-ttv/live_user_dashducks-1280x720.jpg>
\> <https://static-cdn.jtvnw.net/previews-ttv/live_user_dashducks-0x0.jpg>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bc2e1f9</samp>

### Summary
🛠️📺🆗

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the code was refactored or improved in some way.
2.  📺 - This emoji represents a television or a video, and can be used to indicate that the code relates to Twitch videos and live streams.
3.  🆗 - This emoji represents a check mark or an approval, and can be used to indicate that the code provides a fallback option or a reliable solution.
-->
Refactor `twitch.py` to use a new method for thumbnail extraction that handles fallbacks better.

> _We'll haul away the old code, me hearties, haul away_
> _We'll make the thumbnails better, with a fallback today_
> _We'll use the `extract_thumbs` method, on the count of three_
> _We'll refactor Twitch videos, and live streams, yo ho heave_

### Walkthrough
* Add a new method `_get_thumbnails` to the `TwitchBaseIE` class that returns a list of two thumbnails with different resolutions for a given URL ([link](https://github.com/yt-dlp/yt-dlp/pull/6629/files?diff=unified&w=0#diff-2804898417af0aad967097ad6fd96e53abe8cfb292fb4ab2928f5752b2e7eda0L182-R190))
* Replace the `thumbnail` field with a `thumbnails` field in the info dictionary of the `TwitchVodIE` and `TwitchStreamIE` classes that use the `_get_thumbnails` method to provide a fallback thumbnail option ([link](https://github.com/yt-dlp/yt-dlp/pull/6629/files?diff=unified&w=0#diff-2804898417af0aad967097ad6fd96e53abe8cfb292fb4ab2928f5752b2e7eda0L471-R477), [link](https://github.com/yt-dlp/yt-dlp/pull/6629/files?diff=unified&w=0#diff-2804898417af0aad967097ad6fd96e53abe8cfb292fb4ab2928f5752b2e7eda0L1056-R1062))
* Remove the code that replaced the width and height parameters in the thumbnail URL with zeros in the `TwitchVodIE` class, as it is no longer needed ([link](https://github.com/yt-dlp/yt-dlp/pull/6629/files?diff=unified&w=0#diff-2804898417af0aad967097ad6fd96e53abe8cfb292fb4ab2928f5752b2e7eda0L463-L464))

