### PR TITLE
Fix Pluto TV

### DIFF
--- a/yt_dlp/extractor/plutotv.py
+++ b/yt_dlp/extractor/plutotv.py
@@ -114,7 +114,7 @@ class PlutoTVIE(InfoExtractor):
                     compat_urlparse.urljoin(first_segment_url.group(1), '0-end/master.m3u8'))
                 continue
             first_segment_url = re.search(
-                r'^(http?://sily-hybrik.pluto.tv.s3.amazonaws.com/.*/).+\-0+[0-1]0\.ts$', res,
+                r'^(http?://silo-hybrik.pluto.tv.s3.amazonaws.com/.*/).+\-0+[0-1]0\.ts$', res,
                 re.MULTILINE)
             if first_segment_url:
                 m3u8_urls.add(

--- a/yt_dlp/extractor/plutotv.py
+++ b/yt_dlp/extractor/plutotv.py
@@ -107,14 +107,14 @@ class PlutoTVIE(InfoExtractor):
             if not res:
                 continue
             first_segment_url = re.search(
-                r'^(https?://.*/)0\-(end|[0-9]+)/[^/]+\.ts$', res,
+                r'^(http?://silo-hybrik.pluto.tv.amazonaws.com/.*/)0\-(end|[0-9]+)/[^/]+\.ts$', res,
                 re.MULTILINE)
             if first_segment_url:
                 m3u8_urls.add(
                     compat_urlparse.urljoin(first_segment_url.group(1), '0-end/master.m3u8'))
                 continue
             first_segment_url = re.search(
-                r'^(https?://.*/).+\-0+[0-1]0\.ts$', res,
+                r'^(http?://sily-hybrik.pluto.tv.s3.amazonaws.com/.*/).+\-0+[0-1]0\.ts$', res,
                 re.MULTILINE)
             if first_segment_url:
                 m3u8_urls.add(


### PR DESCRIPTION
Fix 403 forbidden. See #6639.

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #6639 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1e71718</samp>

### Summary
🚫📺🚀

<!--
1.  🚫 This emoji can be used to indicate that ad segments are filtered out or blocked from the playlists.
2.  📺 This emoji can be used to represent Pluto TV as a streaming service that offers free TV channels and shows.
3.  🚀 This emoji can be used to suggest that the playback quality and download speed are improved or boosted by the extractor.
-->
Improve Pluto TV extractor by filtering out ad segments from HLS and DASH playlists. This affects the file `yt_dlp/extractor/plutotv.py`.

> _`Pluto TV` extracts_
> _No more ad segments in `HLS`_
> _Winter stream is clear_

### Walkthrough
*  Filter out ad segments from HLS and DASH playlists by matching only specific URL prefixes ([link](https://github.com/yt-dlp/yt-dlp/pull/6679/files?diff=unified&w=0#diff-73930e95f920b842e4d951b4be62158257819351b2929b332eec8f01f9da0115L110-R110), [link](https://github.com/yt-dlp/yt-dlp/pull/6679/files?diff=unified&w=0#diff-73930e95f920b842e4d951b4be62158257819351b2929b332eec8f01f9da0115L117-R117)) in `yt_dlp/extractor/plutotv.py`


