### PR TITLE
[extractor/dlf] Add support for Deutschlandfunk

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -444,6 +444,7 @@ from .deezer import (
 )
 from .democracynow import DemocracynowIE
 from .detik import DetikEmbedIE
+from .dlf import DLFIE
 from .dfb import DFBIE
 from .dhm import DHMIE
 from .digg import DiggIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -444,7 +444,10 @@ from .deezer import (
 )
 from .democracynow import DemocracynowIE
 from .detik import DetikEmbedIE
-from .dlf import DLFIE
+from .dlf import (
+    DLFIE,
+    DLFCorpusIE,
+)
 from .dfb import DFBIE
 from .dhm import DHMIE
 from .digg import DiggIE

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -1,4 +1,5 @@
 import re
+
 from .common import InfoExtractor
 from ..utils import (
     determine_ext,
@@ -41,9 +42,8 @@ class DLFBaseIE(InfoExtractor):
 
 
 class DLFIE(DLFBaseIE):
-    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'[\w-]+-dlf-(?P<id>[\da-f]{8})-100\.html'
-
     IE_NAME = 'dlf'
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'[\w-]+-dlf-(?P<id>[\da-f]{8})-100\.html'
     _TESTS = [
         # Audio as an HLS stream
         {
@@ -86,10 +86,9 @@ class DLFIE(DLFBaseIE):
 
 
 class DLFCorpusIE(DLFBaseIE):
-    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>(?![\w-]+-dlf-[\da-f]{8})[\w-]+-\d+)\.html'
-
     IE_NAME = 'dlf:corpus'
     IE_DESC = 'DLF Multi-feed Archives'
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>(?![\w-]+-dlf-[\da-f]{8})[\w-]+-\d+)\.html'
     _TESTS = [
         # Recorded news broadcast with referrals to related broadcasts
         {

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -87,7 +87,7 @@ class DLFIE(DLFBaseIE):
 
 
 class DLFCorpusIE(DLFBaseIE):
-    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>(?:[a-z]+-)+\d+)\.html'
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>[\w-]+-\d+)\.html'
 
     IE_NAME = 'dlf:corpus'
     IE_DESC = 'DLF Multi-feed Archives'

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -42,7 +42,7 @@ class DLFBaseIE(InfoExtractor):
 
 
 class DLFIE(DLFBaseIE):
-    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?:\w+-)+(?P<id>[^-]*\d[^-]*)-100\.html'
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'[\w-]+-dlf-(?P<id>[\da-f]{8})-100\.html'
 
     IE_NAME = 'dlf'
     _TESTS = [
@@ -87,7 +87,7 @@ class DLFIE(DLFBaseIE):
 
 
 class DLFCorpusIE(DLFBaseIE):
-    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>[\w-]+-\d+)\.html'
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>(?![\w-]+-dlf-[\da-f]{8})[\w-]+-\d+)\.html'
 
     IE_NAME = 'dlf:corpus'
     IE_DESC = 'DLF Multi-feed Archives'

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -66,7 +66,8 @@ class DLFIE(DLFBaseIE):
             },
             'params': {
                 'skip_download': 'm3u8'
-            }
+            },
+            'skip': 'This webpage no longer exists'
         }, {
             'url': 'https://www.deutschlandfunk.de/russische-athleten-kehren-zurueck-auf-die-sportbuehne-ein-gefaehrlicher-tueroeffner-dlf-d9cc1856-100.html',
             'info_dict': {

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -4,6 +4,7 @@ from ..utils import (
     determine_ext,
     extract_attributes,
     int_or_none,
+    traverse_obj,
     url_or_none,
 )
 
@@ -12,36 +13,31 @@ class DLFBaseIE(InfoExtractor):
     _VALID_URL_BASE = r'https?://(?:www\.)?deutschlandfunk\.de/'
     _BUTTON_REGEX = r'(<button[^>]+alt="Anhören"[^>]+data-audio-diraid[^>]*>)'
 
-    def _parse_button_attrs(self, button, id=None):
+    def _parse_button_attrs(self, button, audio_id=None):
         attrs = extract_attributes(button)
-        id = id or attrs['data-audio-diraid']
+        audio_id = audio_id or attrs['data-audio-diraid']
 
-        # Note: DLF's mp3 recordings are in two distinct locations on the web:
-        # A direct download location, https://download.deutschlandfunk.de/ ... .mp3
-        # A stream with playback controls, https://ondemand-mp3.dradio.de/ ... .mp3
-        url = url_or_none(
-            attrs.get('data-audio-download-src')
-            or attrs.get('data-audio')
-            or attrs.get('data-audioreference')
-            or attrs['data-audio-src'])
+        url = traverse_obj(
+            attrs, 'data-audio-download-src', 'data-audio', 'data-audioreference',
+            'data-audio-src', expected_type=url_or_none)
+
+        ext = determine_ext(url)
 
         return {
-            'id': id,
-            'title': (
-                attrs.get('data-audiotitle')
-                or attrs.get('data-audio-title')
-                or attrs.get('data-audio-download-tracking-title')),
-            'url': url,
-            'formats': (
-                self._extract_m3u8_formats(url, id) if determine_ext(url) == 'm3u8'
-                else None),
-            'duration': int_or_none(
-                attrs.get('data-audioduration')
-                or attrs.get('data-audio-duration')),
-            'thumbnail': attrs.get('data-audioimage'),
-            'uploader': attrs.get('data-audio-producer'),
-            'series': attrs.get('data-audio-series'),
-            'channel': attrs.get('data-audio-origin-site-name'),
+            'id': audio_id,
+            'extractor_key': DLFIE.ie_key(),
+            'extractor': DLFIE.IE_NAME,
+            **traverse_obj(attrs, {
+                'title': (('data-audiotitle', 'data-audio-title', 'data-audio-download-tracking-title'), {str}),
+                'duration': (('data-audioduration', 'data-audio-duration'), {int_or_none}),
+                'thumbnail': ('data-audioimage', {url_or_none}),
+                'uploader': 'data-audio-producer',
+                'series': 'data-audio-series',
+                'channel': 'data-audio-origin-site-name',
+                'webpage_url': ('data-audio-download-tracking-path', {url_or_none}),
+            }, get_all=False),
+            'formats': (self._extract_m3u8_formats(url, audio_id, fatal=False)
+                        if ext == 'm3u8' else [{'url': url, 'ext': ext, 'vcodec': 'none'}])
         }
 
 
@@ -56,7 +52,6 @@ class DLFIE(DLFBaseIE):
             'info_dict': {
                 'id': '03a3eb19',
                 'title': r're:Tanz der Saiteninstrumente [-/] Das Wild Strings Trio aus Slowenien',
-                'url': 'https://dradiohls.akamaized.net/hls/2023/03/03/tanz_der_saiteninstrumente_das_wild_strings_trio_aus_dlf_20230303_2105_03a3eb19/128/seglist.m3u8',
                 'ext': 'm4a',
                 'duration': 3298,
                 'thumbnail': 'https://assets.deutschlandfunk.de/FALLBACK-IMAGE-AUDIO/512x512.png?t=1603714364673',
@@ -73,7 +68,6 @@ class DLFIE(DLFBaseIE):
             'info_dict': {
                 'id': 'd9cc1856',
                 'title': 'Russische Athleten kehren zurück auf die Sportbühne: Ein gefährlicher Türöffner',
-                'url': r're:https://(download.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/04/01/russische_athleten_kehren_zurueck_auf_die_sportbuehne_ein_dlf_20230401_1905_d9cc1856\.mp3',
                 'ext': 'mp3',
                 'duration': 291,
                 'thumbnail': 'https://assets.deutschlandfunk.de/FALLBACK-IMAGE-AUDIO/512x512.png?t=1603714364673',
@@ -85,15 +79,15 @@ class DLFIE(DLFBaseIE):
     ]
 
     def _real_extract(self, url):
-        id = self._match_id(url)
-        webpage = self._download_webpage(url, id)
+        audio_id = self._match_id(url)
+        webpage = self._download_webpage(url, audio_id)
 
         return self._parse_button_attrs(
-            self._search_regex(DLFBaseIE._BUTTON_REGEX, webpage, 'button'), id)
+            self._search_regex(self._BUTTON_REGEX, webpage, 'button'), audio_id)
 
 
 class DLFCorpusIE(DLFBaseIE):
-    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?:[a-z]+-)+\d+\.html'
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?P<id>(?:[a-z]+-)+\d+)\.html'
 
     IE_NAME = 'dlf:corpus'
     IE_DESC = 'DLF Multi-feed Archives'
@@ -102,7 +96,7 @@ class DLFCorpusIE(DLFBaseIE):
         {
             'url': 'https://www.deutschlandfunk.de/fechten-russland-belarus-ukraine-protest-100.html',
             'info_dict': {
-                'id': False,
+                'id': 'fechten-russland-belarus-ukraine-protest-100',
                 'title': r're:Wiederzulassung als neutrale Athleten [-/] Was die Rückkehr russischer und belarussischer Sportler beim Fechten bedeutet',
                 'description': 'md5:91340aab29c71aa7518ad5be13d1e8ad'
             },
@@ -110,7 +104,6 @@ class DLFCorpusIE(DLFBaseIE):
                 'info_dict': {
                     'id': '1fc5d64a',
                     'title': r're:Wiederzulassung als neutrale Athleten [-/] Was die Rückkehr russischer und belarussischer Sportler beim Fechten bedeutet',
-                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/22/rueckkehr_russischer_athleten_ukraine_will_fecht_wettbewerbe_dlf_20230322_1245_1fc5d64a\.mp3',
                     'ext': 'mp3',
                     'duration': 252,
                     'thumbnail': 'https://assets.deutschlandfunk.de/aad16241-6b76-4a09-958b-96d0ee1d6f57/512x512.jpg?t=1679480020313',
@@ -122,7 +115,6 @@ class DLFCorpusIE(DLFBaseIE):
                 'info_dict': {
                     'id': '2ada145f',
                     'title': r're:(?:Sportpolitik / )?Fechtverband votiert für Rückkehr russischer Athleten',
-                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/11/deutschlandfunknova_sportpolitik_fechtverband_20230311_2ada145f\.mp3',
                     'ext': 'mp3',
                     'duration': 336,
                     'thumbnail': 'https://assets.deutschlandfunk.de/FILE_93982766f7317df30409b8a184ac044a/512x512.jpg?t=1678547581005',
@@ -134,7 +126,6 @@ class DLFCorpusIE(DLFBaseIE):
                 'info_dict': {
                     'id': '5e55e8c9',
                     'title': r're:Wiederzulassung von Russland und Belarus [-/] "Herumlavieren" des Fechter-Bundes sorgt für Unverständnis',
-                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/18/fechten_unverstaendnis_und_wut_nach_wiederzulassung_dlf_20230318_1930_5e55e8c9\.mp3',
                     'ext': 'mp3',
                     'duration': 187,
                     'thumbnail': 'https://assets.deutschlandfunk.de/a595989d-1ed1-4a2e-8370-b64d7f11d757/512x512.jpg?t=1679173825412',
@@ -146,7 +137,6 @@ class DLFCorpusIE(DLFBaseIE):
                 'info_dict': {
                     'id': '47e1a096',
                     'title': r're:Rückkehr Russlands im Fechten [-/] "Fassungslos, dass es einfach so passiert ist"',
-                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/11/weltfechtverband_laesst_russen_und_belarussen_wieder_zu_dlf_20230311_1912_47e1a096\.mp3',
                     'ext': 'mp3',
                     'duration': 602,
                     'thumbnail': 'https://assets.deutschlandfunk.de/da4c494a-21cc-48b4-9cc7-40e09fd442c2/512x512.jpg?t=1678562155770',
@@ -158,7 +148,6 @@ class DLFCorpusIE(DLFBaseIE):
                 'info_dict': {
                     'id': '5e55e8c9',
                     'title': r're:Wiederzulassung von Russland und Belarus [-/] "Herumlavieren" des Fechter-Bundes sorgt für Unverständnis',
-                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/18/fechten_unverstaendnis_und_wut_nach_wiederzulassung_dlf_20230318_1930_5e55e8c9\.mp3',
                     'ext': 'mp3',
                     'duration': 187,
                     'thumbnail': 'https://assets.deutschlandfunk.de/a595989d-1ed1-4a2e-8370-b64d7f11d757/512x512.jpg?t=1679173825412',
@@ -173,7 +162,7 @@ class DLFCorpusIE(DLFBaseIE):
         {
             'url': 'https://www.deutschlandfunk.de/corso-100.html',
             'info_dict': {
-                'id': False,
+                'id': 'corso-100',
                 'title': r're:Kunst & Pop [-/] Corso',
                 'description': 'md5:ba0f80303683591bff4b7459077bef58'
             },
@@ -184,9 +173,8 @@ class DLFCorpusIE(DLFBaseIE):
         {
             'url': 'https://www.deutschlandfunk.de/podcast-tolle-idee-100.html',
             'info_dict': {
-                'id': False,
+                'id': 'podcast-tolle-idee-100',
                 'title': 'Wissenschaftspodcast - Tolle Idee! - Was wurde daraus?',
-                'description': None
             },
             'playlist_mincount': 11,
             'params': {'skip_download': True}
@@ -194,16 +182,16 @@ class DLFCorpusIE(DLFBaseIE):
     ]
 
     def _real_extract(self, url):
-        # Multi-feed pages do not embed an ID within the URL
-        webpage = self._download_webpage(url, None)
+        playlist_id = self._match_id(url)
+        webpage = self._download_webpage(url, playlist_id)
 
         return {
             '_type': 'playlist',
-            'id': False,
+            'id': playlist_id,
             'description': self._html_search_meta(
                 ['description', 'og:description', 'twitter:description'], webpage, default=None),
             'title': self._html_search_meta(
-                ['og:title', 'twitter:title'], webpage),
+                ['og:title', 'twitter:title'], webpage, default=None),
             'entries': [self._parse_button_attrs(button)
                         for button in re.findall(self._BUTTON_REGEX, webpage)],
         }

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -98,6 +98,7 @@ class DLFCorpusIE(DLFBaseIE):
                 'title': r're:Wiederzulassung als neutrale Athleten [-/] Was die Rückkehr russischer und belarussischer Sportler beim Fechten bedeutet',
                 'description': 'md5:91340aab29c71aa7518ad5be13d1e8ad'
             },
+            'playlist_mincount': 5,
             'playlist': [{
                 'info_dict': {
                     'id': '1fc5d64a',
@@ -155,7 +156,7 @@ class DLFCorpusIE(DLFBaseIE):
                 }
             }]
         },
-        # Podcast feed with tag buttons
+        # Podcast feed with tag buttons, playlist count fluctuates
         {
             'url': 'https://www.deutschlandfunk.de/kommentare-und-themen-der-woche-100.html',
             'info_dict': {
@@ -163,7 +164,7 @@ class DLFCorpusIE(DLFBaseIE):
                 'title': 'Meinung - Kommentare und Themen der Woche',
                 'description': 'md5:2901bbd65cd2d45e116d399a099ce5d5',
             },
-            'playlist_mincount': 20
+            'playlist_mincount': 10,
         },
         # Podcast feed with no description
         {
@@ -172,7 +173,7 @@ class DLFCorpusIE(DLFBaseIE):
                 'id': 'podcast-tolle-idee-100',
                 'title': 'Wissenschaftspodcast - Tolle Idee! - Was wurde daraus?',
             },
-            'playlist_mincount': 11
+            'playlist_mincount': 11,
         },
     ]
 

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -160,13 +160,13 @@ class DLFCorpusIE(DLFBaseIE):
         },
         # Podcast feed with tag buttons
         {
-            'url': 'https://www.deutschlandfunk.de/corso-100.html',
+            'url': 'https://www.deutschlandfunk.de/kommentare-und-themen-der-woche-100.html',
             'info_dict': {
-                'id': 'corso-100',
-                'title': r're:Kunst & Pop [-/] Corso',
-                'description': 'md5:ba0f80303683591bff4b7459077bef58'
+                'id': 'kommentare-und-themen-der-woche-100',
+                'title': 'Meinung - Kommentare und Themen der Woche',
+                'description': 'md5:2901bbd65cd2d45e116d399a099ce5d5',
             },
-            'playlist_mincount': 34,
+            'playlist_mincount': 20,
             'params': {'skip_download': True}
         },
         # Podcast feed with no description

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -20,7 +20,6 @@ class DLFBaseIE(InfoExtractor):
         url = traverse_obj(
             attrs, 'data-audio-download-src', 'data-audio', 'data-audioreference',
             'data-audio-src', expected_type=url_or_none)
-
         ext = determine_ext(url)
 
         return {
@@ -155,8 +154,7 @@ class DLFCorpusIE(DLFBaseIE):
                     'series': 'Sport am Samstag',
                     'channel': 'deutschlandfunk'
                 }
-            }],
-            'params': {'skip_download': 'm3u8'}
+            }]
         },
         # Podcast feed with tag buttons
         {
@@ -166,8 +164,7 @@ class DLFCorpusIE(DLFBaseIE):
                 'title': 'Meinung - Kommentare und Themen der Woche',
                 'description': 'md5:2901bbd65cd2d45e116d399a099ce5d5',
             },
-            'playlist_mincount': 20,
-            'params': {'skip_download': True}
+            'playlist_mincount': 20
         },
         # Podcast feed with no description
         {
@@ -176,8 +173,7 @@ class DLFCorpusIE(DLFBaseIE):
                 'id': 'podcast-tolle-idee-100',
                 'title': 'Wissenschaftspodcast - Tolle Idee! - Was wurde daraus?',
             },
-            'playlist_mincount': 11,
-            'params': {'skip_download': True}
+            'playlist_mincount': 11
         },
     ]
 
@@ -192,6 +188,5 @@ class DLFCorpusIE(DLFBaseIE):
                 ['description', 'og:description', 'twitter:description'], webpage, default=None),
             'title': self._html_search_meta(
                 ['og:title', 'twitter:title'], webpage, default=None),
-            'entries': [self._parse_button_attrs(button)
-                        for button in re.findall(self._BUTTON_REGEX, webpage)],
+            'entries': map(self._parse_button_attrs, re.findall(self._BUTTON_REGEX, webpage)),
         }

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -1,3 +1,4 @@
+import re
 from .common import InfoExtractor
 from ..utils import (
     determine_ext,
@@ -88,3 +89,120 @@ class DLFIE(DLFBaseIE):
 
         return self._parse_button_attrs(
             self._search_regex(DLFBaseIE._BUTTON_REGEX, webpage, 'button'), id)
+
+
+class DLFCorpusIE(DLFBaseIE):
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?:[a-z]+-)+\d+\.html'
+
+    IE_NAME = 'dlf:corpus'
+    IE_DESC = 'DLF Multi-feed Archives'
+    _TESTS = [
+        # Recorded news broadcast with referrals to related broadcasts
+        {
+            'url': 'https://www.deutschlandfunk.de/fechten-russland-belarus-ukraine-protest-100.html',
+            'info_dict': {
+                'id': False,
+                'title': r're:Wiederzulassung als neutrale Athleten [-/] Was die Rückkehr russischer und belarussischer Sportler beim Fechten bedeutet',
+                'description': 'md5:91340aab29c71aa7518ad5be13d1e8ad'
+            },
+            'playlist': [{
+                'info_dict': {
+                    'id': '1fc5d64a',
+                    'title': r're:Wiederzulassung als neutrale Athleten [-/] Was die Rückkehr russischer und belarussischer Sportler beim Fechten bedeutet',
+                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/22/rueckkehr_russischer_athleten_ukraine_will_fecht_wettbewerbe_dlf_20230322_1245_1fc5d64a\.mp3',
+                    'ext': 'mp3',
+                    'duration': 252,
+                    'thumbnail': 'https://assets.deutschlandfunk.de/aad16241-6b76-4a09-958b-96d0ee1d6f57/512x512.jpg?t=1679480020313',
+                    'uploader': 'Deutschlandfunk',
+                    'series': 'Sport',
+                    'channel': 'deutschlandfunk'
+                }
+            }, {
+                'info_dict': {
+                    'id': '2ada145f',
+                    'title': r're:(?:Sportpolitik / )?Fechtverband votiert für Rückkehr russischer Athleten',
+                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/11/deutschlandfunknova_sportpolitik_fechtverband_20230311_2ada145f\.mp3',
+                    'ext': 'mp3',
+                    'duration': 336,
+                    'thumbnail': 'https://assets.deutschlandfunk.de/FILE_93982766f7317df30409b8a184ac044a/512x512.jpg?t=1678547581005',
+                    'uploader': 'Deutschlandfunk',
+                    'series': 'Deutschlandfunk Nova',
+                    'channel': 'deutschlandfunk-nova'
+                }
+            }, {
+                'info_dict': {
+                    'id': '5e55e8c9',
+                    'title': r're:Wiederzulassung von Russland und Belarus [-/] "Herumlavieren" des Fechter-Bundes sorgt für Unverständnis',
+                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/18/fechten_unverstaendnis_und_wut_nach_wiederzulassung_dlf_20230318_1930_5e55e8c9\.mp3',
+                    'ext': 'mp3',
+                    'duration': 187,
+                    'thumbnail': 'https://assets.deutschlandfunk.de/a595989d-1ed1-4a2e-8370-b64d7f11d757/512x512.jpg?t=1679173825412',
+                    'uploader': 'Deutschlandfunk',
+                    'series': 'Sport am Samstag',
+                    'channel': 'deutschlandfunk'
+                }
+            }, {
+                'info_dict': {
+                    'id': '47e1a096',
+                    'title': r're:Rückkehr Russlands im Fechten [-/] "Fassungslos, dass es einfach so passiert ist"',
+                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/11/weltfechtverband_laesst_russen_und_belarussen_wieder_zu_dlf_20230311_1912_47e1a096\.mp3',
+                    'ext': 'mp3',
+                    'duration': 602,
+                    'thumbnail': 'https://assets.deutschlandfunk.de/da4c494a-21cc-48b4-9cc7-40e09fd442c2/512x512.jpg?t=1678562155770',
+                    'uploader': 'Deutschlandfunk',
+                    'series': 'Sport am Samstag',
+                    'channel': 'deutschlandfunk'
+                }
+            }, {
+                'info_dict': {
+                    'id': '5e55e8c9',
+                    'title': r're:Wiederzulassung von Russland und Belarus [-/] "Herumlavieren" des Fechter-Bundes sorgt für Unverständnis',
+                    'url': r're:https://(?:download\.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/03/18/fechten_unverstaendnis_und_wut_nach_wiederzulassung_dlf_20230318_1930_5e55e8c9\.mp3',
+                    'ext': 'mp3',
+                    'duration': 187,
+                    'thumbnail': 'https://assets.deutschlandfunk.de/a595989d-1ed1-4a2e-8370-b64d7f11d757/512x512.jpg?t=1679173825412',
+                    'uploader': 'Deutschlandfunk',
+                    'series': 'Sport am Samstag',
+                    'channel': 'deutschlandfunk'
+                }
+            }],
+            'params': {'skip_download': 'm3u8'}
+        },
+        # Podcast feed with tag buttons
+        {
+            'url': 'https://www.deutschlandfunk.de/corso-100.html',
+            'info_dict': {
+                'id': False,
+                'title': r're:Kunst & Pop [-/] Corso',
+                'description': 'md5:ba0f80303683591bff4b7459077bef58'
+            },
+            'playlist_mincount': 34,
+            'params': {'skip_download': True}
+        },
+        # Podcast feed with no description
+        {
+            'url': 'https://www.deutschlandfunk.de/podcast-tolle-idee-100.html',
+            'info_dict': {
+                'id': False,
+                'title': 'Wissenschaftspodcast - Tolle Idee! - Was wurde daraus?',
+                'description': None
+            },
+            'playlist_mincount': 11,
+            'params': {'skip_download': True}
+        },
+    ]
+
+    def _real_extract(self, url):
+        # Multi-feed pages do not embed an ID within the URL
+        webpage = self._download_webpage(url, None)
+
+        return {
+            '_type': 'playlist',
+            'id': False,
+            'description': self._html_search_meta(
+                ['description', 'og:description', 'twitter:description'], webpage, default=None),
+            'title': self._html_search_meta(
+                ['og:title', 'twitter:title'], webpage),
+            'entries': [self._parse_button_attrs(button)
+                        for button in re.findall(self._BUTTON_REGEX, webpage)],
+        }

--- a/yt_dlp/extractor/dlf.py
+++ b/yt_dlp/extractor/dlf.py
@@ -1,0 +1,90 @@
+from .common import InfoExtractor
+from ..utils import (
+    determine_ext,
+    extract_attributes,
+    int_or_none,
+    url_or_none,
+)
+
+
+class DLFBaseIE(InfoExtractor):
+    _VALID_URL_BASE = r'https?://(?:www\.)?deutschlandfunk\.de/'
+    _BUTTON_REGEX = r'(<button[^>]+alt="Anhören"[^>]+data-audio-diraid[^>]*>)'
+
+    def _parse_button_attrs(self, button, id=None):
+        attrs = extract_attributes(button)
+        id = id or attrs['data-audio-diraid']
+
+        # Note: DLF's mp3 recordings are in two distinct locations on the web:
+        # A direct download location, https://download.deutschlandfunk.de/ ... .mp3
+        # A stream with playback controls, https://ondemand-mp3.dradio.de/ ... .mp3
+        url = url_or_none(
+            attrs.get('data-audio-download-src')
+            or attrs.get('data-audio')
+            or attrs.get('data-audioreference')
+            or attrs['data-audio-src'])
+
+        return {
+            'id': id,
+            'title': (
+                attrs.get('data-audiotitle')
+                or attrs.get('data-audio-title')
+                or attrs.get('data-audio-download-tracking-title')),
+            'url': url,
+            'formats': (
+                self._extract_m3u8_formats(url, id) if determine_ext(url) == 'm3u8'
+                else None),
+            'duration': int_or_none(
+                attrs.get('data-audioduration')
+                or attrs.get('data-audio-duration')),
+            'thumbnail': attrs.get('data-audioimage'),
+            'uploader': attrs.get('data-audio-producer'),
+            'series': attrs.get('data-audio-series'),
+            'channel': attrs.get('data-audio-origin-site-name'),
+        }
+
+
+class DLFIE(DLFBaseIE):
+    _VALID_URL = DLFBaseIE._VALID_URL_BASE + r'(?:\w+-)+(?P<id>[^-]*\d[^-]*)-100\.html'
+
+    IE_NAME = 'dlf'
+    _TESTS = [
+        # Audio as an HLS stream
+        {
+            'url': 'https://www.deutschlandfunk.de/tanz-der-saiteninstrumente-das-wild-strings-trio-aus-slowenien-dlf-03a3eb19-100.html',
+            'info_dict': {
+                'id': '03a3eb19',
+                'title': r're:Tanz der Saiteninstrumente [-/] Das Wild Strings Trio aus Slowenien',
+                'url': 'https://dradiohls.akamaized.net/hls/2023/03/03/tanz_der_saiteninstrumente_das_wild_strings_trio_aus_dlf_20230303_2105_03a3eb19/128/seglist.m3u8',
+                'ext': 'm4a',
+                'duration': 3298,
+                'thumbnail': 'https://assets.deutschlandfunk.de/FALLBACK-IMAGE-AUDIO/512x512.png?t=1603714364673',
+                'uploader': 'Deutschlandfunk',
+                'series': 'On Stage',
+                'channel': 'deutschlandfunk'
+            },
+            'params': {
+                'skip_download': 'm3u8'
+            }
+        }, {
+            'url': 'https://www.deutschlandfunk.de/russische-athleten-kehren-zurueck-auf-die-sportbuehne-ein-gefaehrlicher-tueroeffner-dlf-d9cc1856-100.html',
+            'info_dict': {
+                'id': 'd9cc1856',
+                'title': 'Russische Athleten kehren zurück auf die Sportbühne: Ein gefährlicher Türöffner',
+                'url': r're:https://(download.deutschlandfunk|ondemand-mp3\.dradio)\.de/file/dradio/2023/04/01/russische_athleten_kehren_zurueck_auf_die_sportbuehne_ein_dlf_20230401_1905_d9cc1856\.mp3',
+                'ext': 'mp3',
+                'duration': 291,
+                'thumbnail': 'https://assets.deutschlandfunk.de/FALLBACK-IMAGE-AUDIO/512x512.png?t=1603714364673',
+                'uploader': 'Deutschlandfunk',
+                'series': 'Kommentare und Themen der Woche',
+                'channel': 'deutschlandfunk'
+            }
+        },
+    ]
+
+    def _real_extract(self, url):
+        id = self._match_id(url)
+        webpage = self._download_webpage(url, id)
+
+        return self._parse_button_attrs(
+            self._search_regex(DLFBaseIE._BUTTON_REGEX, webpage, 'button'), id)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Deutschlandfunk is a radio broadcasting corporation based in Germany. They cover a wide variety of contemporary news topics.

Currently, this extractor exclusively supports pre-recorded broadcasts. DLF distributes its pre-recorded audio sources in one of the `mp3` or `m3u8` formats. ~~The tests check for both of these cases.~~ I do not have a single-recording test case for `m3u8` sources.

As suggested in #6430, this extractor retrieves all the metadata from the `<button>` tag's HTML attributes.

Fixes #6430 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [X] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
