### PR TITLE
[mixbox] Add extractor for "mixbox.live"

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1062,7 +1062,10 @@ from .mirrativ import (
 from .mirrorcouk import MirrorCoUKIE
 from .mit import TechTVMITIE, OCWMITIE
 from .mitele import MiTeleIE
-from .mixbox import MixBoxHomepageIE
+from .mixbox import (
+    MixBoxHomepageIE,
+    MixBoxCampaignIE,
+)
 from .mixch import (
     MixchIE,
     MixchArchiveIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1062,6 +1062,7 @@ from .mirrativ import (
 from .mirrorcouk import MirrorCoUKIE
 from .mit import TechTVMITIE, OCWMITIE
 from .mitele import MiTeleIE
+from .mixbox import MixBoxHomepageIE
 from .mixch import (
     MixchIE,
     MixchArchiveIE,

--- a/yt_dlp/extractor/mixbox.py
+++ b/yt_dlp/extractor/mixbox.py
@@ -3,6 +3,11 @@ import re
 
 from ..utils import (
     ExtractorError,
+    int_or_none,
+    js_to_json,
+    time_seconds,
+    traverse_obj,
+    unified_timestamp,
 )
 from .common import InfoExtractor
 
@@ -60,6 +65,124 @@ class MixBoxHomepageIE(InfoExtractor):
         return {
             'id': video_id,
             'title': 'MixBox',
+            'formats': formats,
+            'live_status': live_status,
+        }
+
+
+class MixBoxCampaignIE(InfoExtractor):
+    IE_NAME = 'MixBox:campaign'
+    IE_DESC = 'ミックスボックス：イベント'
+    _VALID_URL = r'https?://mixbox\.live/(?:campaign|campaign_live)/(?P<id>\d{3,})$'
+    _TESTS = [{
+        'url': 'https://mixbox.live/campaign/023',
+        'info_dict': {
+            'id': '023',
+            'ext': 'mp4',
+        },
+        'skip': 'This event is too old to be supported',
+    }, {
+        'url': 'https://mixbox.live/campaign_live/039',
+        'info_dict': {
+            'id': '039',
+            'ext': 'mp4',
+        },
+        'skip': 'This event has ended',
+    }, {
+        'url': 'https://mixbox.live/campaign/046',
+        'info_dict': {
+            'id': '046',
+            'title': 'MixBox 『ウマ娘 プリティーダービー WINNING LIVE 10』発売記念イベント',
+            'ext': 'mp4',
+            'live_status': 'was_live',
+        },
+    }, {
+        'url': 'https://mixbox.live/campaign_live/046',
+        'info_dict': {
+            'id': '046',
+            'title': 'MixBox 『ウマ娘 プリティーダービー WINNING LIVE 10』発売記念イベント',
+            'ext': 'mp4',
+            'live_status': 'was_live',
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        if int_or_none(video_id, default=-1) < 39:
+            raise ExtractorError('This event is too old to be supported', expected=True)
+        # In the webpage of the non-existing 47th event, I've seen new data structure. Sigh...
+
+        webpage = self._download_webpage(f'https://mixbox.live/campaign_live/{video_id}', video_id)
+        title = self._html_search_regex(
+            r'<section class="campaign__section" data-v-\w+><p class="campaign__heading-first" data-v-\w+>(.+?)</p>',
+            webpage, 'title')
+        asset_js_urls = re.findall(r'<script src="(/assets/.+?\.js)"', webpage)
+
+        asset_js_content = ''
+        info_json = {}
+        for asset_js_url in asset_js_urls:
+            asset_js_content = self._download_webpage(
+                f'https://mixbox.live/{asset_js_url}', video_id,
+                note='Fetching asset js file', errnote='Unable to fetch asset js file')
+            info_json = self._search_json(
+                r'data:\s*function\(\)\s*{\s*return\s*', asset_js_content, 'data', video_id,
+                contains_pattern=r'\{event:.+movieStatus:.+', transform_source=js_to_json, default={})
+            if info_json:
+                break
+        if not info_json:
+            raise ExtractorError('Cannot find event info', expected=True)
+
+        _, archive_start_datetime, _, archive_end_datetime = self._search_regex(
+            r'openArchiveTimer\s*\(\s*"([^"]+)",\s*"([^"]+)",\s*"([^"]+)",\s*"([^"]+)"',
+            asset_js_content, 'archive info', group=(1, 2, 3, 4))
+
+        archive_start_timestamp = int_or_none(unified_timestamp(archive_start_datetime, day_first=False))
+        archive_end_timestamp = int_or_none(unified_timestamp(archive_end_datetime, day_first=False))
+        if not archive_start_timestamp or not archive_end_timestamp:
+            raise ExtractorError('Wrong timestamps in archive info', expected=True)
+
+        timestamp_now = time_seconds(hours=9)
+        if timestamp_now > archive_end_timestamp:
+            raise ExtractorError('This event has ended', expected=True)
+        elif timestamp_now > archive_start_timestamp:
+            live_status = 'was_live'
+        else:
+            # TODO: support live streaming and upcoming live streaming
+            raise ExtractorError('Downloading live streaming is not yet supported. PR is welcomed', expected=True)
+
+        formats = []
+
+        if live_status == 'was_live':
+            src_archive_url = traverse_obj(info_json, ('event', 'srcArchive'))
+            if not src_archive_url:
+                raise ExtractorError('Unable to extract archive url', expected=True)
+
+            archive_authorization_info_page = self._download_webpage(
+                src_archive_url, video_id, headers={'Referer': 'https://mixbox.live/'},
+                note='Fetching archive authorization info', errnote='Unable to fetch archive authorization info')
+            authtoken, tenant_id, episode_aid = self._search_regex(
+                r'data-authtoken="([^"]+)"\s+data-tenant_id="([^"]+)"\s+data-episode_id="([^"]+)"\s+',
+                archive_authorization_info_page, 'archive authorization info', group=(1, 2, 3))
+
+            play_params_json = self._download_json(
+                'https://npfbgn.b-ch.com/api/episode/playparam', video_id,
+                query={
+                    'authtoken': authtoken,
+                    'tenant_id': tenant_id,
+                    'episode_aid': episode_aid,
+                },
+                note='Fetching play parameters', errnote='Unable to fetch play parameters')
+
+            m3u8_url = traverse_obj(play_params_json, ('data', 'playparam', 'url'))
+            title = traverse_obj(play_params_json, ('data', 'display_title'), default=title)
+
+            if m3u8_url:
+                formats = self._extract_m3u8_formats(m3u8_url, video_id=video_id)
+
+        return {
+            'id': video_id,
+            'title': title,
             'formats': formats,
             'live_status': live_status,
         }

--- a/yt_dlp/extractor/mixbox.py
+++ b/yt_dlp/extractor/mixbox.py
@@ -1,0 +1,59 @@
+import hashlib
+import re
+
+from .common import InfoExtractor
+
+
+class MixBoxHomepageIE(InfoExtractor):
+    IE_NAME = 'MixBox:homepage'
+    IE_DESC = 'ミックスボックス'
+    _VALID_URL = r'https?://mixbox\.live/?$'
+    _TESTS = [{
+        'url': 'https://mixbox.live/',
+        'info_dict': {
+            'id': 'mixbox-live',
+            'title': 'MixBox',
+            'ext': 'ts',
+            'live_status': 'is_live',
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = 'mixbox-live'
+
+        asset_js_urls = re.findall(
+            r'<script src="(/assets/.+?\.js)"', self._download_webpage(url, video_id))
+        asset_js_urls.reverse()  # the live video info always seems to be placed in the last file
+
+        live_video_key, live_video_url = '', ''
+        for asset_js_url in asset_js_urls:
+            asset_js_content = self._download_webpage(
+                f'https://mixbox.live/{asset_js_url}', video_id,
+                note='Fetching asset js file', errnote='Unable to fetch asset js file')
+            live_video_key, live_video_url = self._search_regex(
+                r'LIVE_VIDEO_key:\s*"(?P<key>[\dA-Z]{64})".+LIVE_VIDEO_url:\s*"(?P<url>https://[^"]+)"',
+                asset_js_content, name='live video info', fatal=False,
+                group=('key', 'url'), default=(None, None))
+            if live_video_key and live_video_url:
+                break
+        if not live_video_key or not live_video_url:
+            self.raise_no_formats('no live video info found')
+
+        a_string = 'just a meaningless but non-empty string'
+        bearer_token = hashlib.sha256((live_video_key + a_string).encode()).hexdigest().upper()
+
+        live_video_json = self._download_json(
+            live_video_url, video_id=video_id, query={'hash': a_string},
+            note='Fetching playlist json', errnote='Unable to fetch playlist json',
+            headers={'Authorization': f'Bearer {bearer_token}'})
+
+        m3u8_url = live_video_json.get('url')
+        if not m3u8_url:
+            self.raise_no_formats('no m3u8 playlist found')
+
+        return {
+            'id': video_id,
+            'title': 'MixBox',
+            'formats': self._extract_m3u8_formats(m3u8_url, video_id=video_id, ext='ts'),
+            'live_status': 'is_live',
+        }


### PR DESCRIPTION
For live on the homepage of "mixbox" (Japanese: ミックスボックス). https://mixbox.live/

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Hello! This is a simple extractor for [MixBox（ミックスボックス）](https://mixbox.live/). No account required.

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

### Info from the "asset_js"

#### Data

```js
...
LIVE_VIDEO_key: "04C8BEEEB092D9659F9EAC1574FEB12E63F2A1F3C797166028276AABF1360435",
LIVE_VIDEO_url: "https://xeqhc35g1h.execute-api.ap-northeast-1.amazonaws.com/default/0015MediaLiveApi/streamingurl",
...

```

#### Algorithm

```js
...
for (; ; ) switch (t.prev = t.next) {
  case 0:
    return (o = e.commit) ('clearUrl'),
    r = '',
    l = 'https://xeqhc35g1h.execute-api.ap-northeast-1.amazonaws.com/default/0015MediaLiveApi/streamingurl',
    '04C8BEEEB092D9659F9EAC1574FEB12E63F2A1F3C797166028276AABF1360435',
    10,
    h = n(625).randomBytes(10).toString('base64').substring(0, 10),
    (m = new d.a('SHA-256', 'TEXT')).update(''.concat('04C8BEEEB092D9659F9EAC1574FEB12E63F2A1F3C797166028276AABF1360435').concat(h)),
    t.next = 11,
    m.getHash('HEX');
  case 11:
    return r = t.sent,
    f = ''.concat(l, '?hash=').concat(h),
    t.next = 15,
    c.a.get(f, {
      headers: {
        Authorization: 'Bearer '.concat(r)
      }
    }).then((function (e) {
      o('setUrl', e.data.url)
    })).catch((function () {
      o('setUrl', null)
    }));
  case 15:
  case 'end':
    return t.stop()
}
...

```

### M3u8 playlist

```m3u8
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:12
#EXT-X-MEDIA-SEQUENCE:1191605
#EXT-X-DISCONTINUITY-SEQUENCE:2
#EXT-X-KEY:METHOD=AES-128,URI="https://d1v045aykfix0b.cloudfront.net/key/aes128.key",IV=0x00000000000000000000000000122EB5
#EXT-X-PROGRAM-DATE-TIME:2023-04-04T15:12:33.000Z
#EXTINF:12.00000,
Mixbox_1_1191605.ts
...

```

### Failed during download test

```log
> python test/test_download.py TestDownload.test_MixBoxHomepage
[debug] Loaded 1792 extractors 
[MixBox:homepage] Extracting URL: https://mixbox.live/ 
[MixBox:homepage] mixbox-live: Downloading webpage 
[MixBox:homepage] mixbox-live: Fetching asset js file 
[MixBox:homepage] mixbox-live: Fetching playlist json 
[MixBox:homepage] mixbox-live: Downloading m3u8 information 
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id 
[info] mixbox-live: Downloading 1 format(s): 0 
[info] Writing video metadata as JSON to: test_MixBoxHomepage_mixbox-live.info.json 
[debug] Invoking ffmpeg downloader on "https://d1v045aykfix0b.cloudfront.net/live/Mixbox_1.m3u8?key=1bdd63d2d234562b945e7d53ea6aa58fc0516c4df5dfe02946671a5bdb5f3946" 
[download] Destination: test_MixBoxHomepage_mixbox-live.ts 
[debug] ffmpeg command line: ffmpeg -y -loglevel verbose -headers "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Sec-Fetch-Mode: navigate
" -i "https://d1v045aykfix0b.cloudfront.net/live/Mixbox_1.m3u8?key=1bdd63d2d234562b945e7d53ea6aa58fc0516c4df5dfe02946671a5bdb5f3946" -c copy -fs 10241 -f mpegts "file:test_MixBoxHomepage_mixbox-live.ts.part" 
ffmpeg version n6.0-12-ga6dc92968a-20230404 Copyright (c) 2000-2023 the FFmpeg developers
  built with gcc 12.2.0 (crosstool-NG 1.25.0.152_89671bf)
  configuration: --prefix=/ffbuild/prefix --pkg-config-flags=--static --pkg-config=pkg-config --cross-prefix=x86_64-w64-mingw32- --arch=x86_64 --target-os=mingw32 --enable-gpl --enable-version3 --disable-debug --disable-w32threads --enable-pthreads 
--enable-iconv --enable-libxml2 --enable-zlib --enable-libfreetype --enable-libfribidi --enable-gmp --enable-lzma --enable-fontconfig --enable-libvorbis --enable-opencl --disable-libpulse --enable-libvmaf --disable-libxcb --disable-xlib --enable-amf --enable-libaom --enable-libaribb24 --enable-avisynth --enable-chromaprint --enable-libdav1d --enable-libdavs2 --disable-libfdk-aac --enable-ffnvcodec --enable-cuda-llvm --enable-frei0r --enable-libgme --enable-libkvazaar --enable-libass --enable-libbluray --enable-libjxl --enable-libmp3lame --enable-libopus --enable-librist --enable-libssh --enable-libtheora --enable-libvpx --enable-libwebp --enable-lv2 --disable-libmfx --enable-libvpl --enable-openal --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenh264 --enable-libopenjpeg --enable-libopenmpt --enable-librav1e --enable-librubberband --enable-schannel --enable-sdl2 --enable-libsoxr --enable-libsrt --enable-libsvtav1 --enable-libtwolame --enable-libuavs3d --disable-libdrm --disable-vaapi --enable-libvidstab --enable-vulkan --enable-libshaderc --enable-libplacebo --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxvid --enable-libzimg --enable-libzvbi --extra-cflags=-DLIBTWOLAME_STATIC --extra-cxxflags= --extra-ldflags=-pthread --extra-ldexeflags= --extra-libs=-lgomp --extra-version=20230404
  libavutil      58.  2.100 / 58.  2.100
  libavcodec     60.  3.100 / 60.  3.100
  libavformat    60.  3.100 / 60.  3.100
  libavdevice    60.  1.100 / 60.  1.100
  libavfilter     9.  3.100 /  9.  3.100
  libswscale      7.  1.100 /  7.  1.100
  libswresample   4. 10.100 /  4. 10.100
  libpostproc    57.  1.100 / 57.  1.100
[tcp @ 000001d4e020d400] Starting connection attempt to 13.33.62.3 port 443
[tcp @ 000001d4e020d400] Successfully connected to 13.33.62.3 port 443
[tls @ 000001d4e020ad00] Server closed the connection
[hls @ 000001d4e020a200] Skip ('#EXT-X-VERSION:3')
[hls @ 000001d4e020a200] Skip ('#EXT-X-DISCONTINUITY-SEQUENCE:2')
[hls @ 000001d4e020a200] Skip ('#EXT-X-PROGRAM-DATE-TIME:2023-04-04T15:53:21.000Z')
[hls @ 000001d4e020a200] HLS request for url 'https://d1v045aykfix0b.cloudfront.net/live/Mixbox_1_1191816.ts', offset 0, playlist 0
[hls @ 000001d4e020a200] Opening 'https://d1v045aykfix0b.cloudfront.net/key/aes128.key' for reading
[tcp @ 000001d4e19d1680] Starting connection attempt to 13.33.62.3 port 443
[tcp @ 000001d4e19d1680] Successfully connected to 13.33.62.3 port 443
[AVIOContext @ 000001d4e19d1880] Statistics: 16 bytes read, 0 seeks
[hls @ 000001d4e020a200] Opening 'crypto+https://d1v045aykfix0b.cloudfront.net/live/Mixbox_1_1191816.ts' for reading
[tcp @ 000001d4e19d2140] Starting connection attempt to 13.33.62.3 port 443
[tcp @ 000001d4e19d2140] Successfully connected to 13.33.62.3 port 443
[h264 @ 000001d4e19fd680] Reinit context to 1280x720, pix_fmt: yuv420p
[mpegts @ 000001d4e020e980] parser not found for codec timed_id3, packets or times may be invalid.
Input #0, hls, from 'https://d1v045aykfix0b.cloudfront.net/live/Mixbox_1.m3u8?key=1bdd63d2d234562b945e7d53ea6aa58fc0516c4df5dfe02946671a5bdb5f3946':
  Duration: N/A, start: 80668.364356, bitrate: N/A
  Program 0
    Metadata:
      variant_bitrate : 0
  Stream #0:0: Video: h264 (Main), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(left), 1280x720 [SAR 1:1 DAR 16:9], 30 fps, 30 tbr, 90k tbn
    Metadata:
      variant_bitrate : 0
  Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp
    Metadata:
      variant_bitrate : 0
  Stream #0:2: Data: timed_id3 (ID3  / 0x20334449)
    Metadata:
      variant_bitrate : 0
[mpegts @ 000001d4e1a40e40] service 1 using PCR in pid=256, pcr_period=100ms
[mpegts @ 000001d4e1a40e40] muxrate VBR, sdt every 500 ms, pat/pmt every 100 ms
Output #0, mpegts, to 'file:test_MixBoxHomepage_mixbox-live.ts.part':
  Metadata:
    encoder         : Lavf60.3.100
  Stream #0:0: Video: h264 (Main), 1 reference frame ([27][0][0][0] / 0x001B), yuv420p(left), 1280x720 (0x0) [SAR 1:1 DAR 16:9], q=2-31, 30 fps, 30 tbr, 90k tbn
    Metadata:
      variant_bitrate : 0
  Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp
    Metadata:
      variant_bitrate : 0
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
[out#0/mpegts @ 000001d4e1a33140] Error muxing a packet00.03 bitrate=  -0.0kbits/s speed=N/A
[out#0/mpegts @ 000001d4e1a33140] Terminating muxer thread
No more output streams to write to, finishing.
[AVIOContext @ 000001d4e247bd00] Statistics: 348740 bytes written, 0 seeks, 2 writeouts
frame=   24 fps=0.0 q=-1.0 Lsize=     341kB time=00:00:00.76 bitrate=3639.0kbits/s speed=18.6x    
video:327kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 3.993153%
Input file #0 (https://d1v045aykfix0b.cloudfront.net/live/Mixbox_1.m3u8?key=1bdd63d2d234562b945e7d53ea6aa58fc0516c4df5dfe02946671a5bdb5f3946):
  Input stream #0:0 (video): 25 packets read (336310 bytes);
  Input stream #0:1 (audio): 12 packets read (6049 bytes); 
  Input stream #0:2 (data): 1 packets read (26 bytes);
  Total: 38 packets (342385 bytes) demuxed
Output file #0 (file:test_MixBoxHomepage_mixbox-live.ts.part):
  Output stream #0:0 (video): 24 packets muxed (334850 bytes);
  Output stream #0:1 (audio): 1 packets muxed (499 bytes);
  Total: 25 packets (335349 bytes) muxed
Terminating demuxer thread 0
[AVIOContext @ 000001d4e1a073c0] Statistics: 494160 bytes read, 0 seeks
[AVIOContext @ 000001d4e19c4dc0] Statistics: 1772 bytes read, 0 seeks
Conversion failed!
 

ERROR: ffmpeg exited with code 3753488571 

```

I'm using "ffmpeg-n6.0-12-ga6dc92968a-win64-gpl-6.0-yt-dlp.zip" of "Auto-Build 2023-04-04 12:54" from [yt-dlp/FFmpeg-Builds](https://github.com/yt-dlp/FFmpeg-Builds/releases).

Am I missing something?

<br>


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
