### PR TITLE
Don't refer to pip in all-caps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ For ease of use, a few more compat options are available:
 [![All versions](https://img.shields.io/badge/-All_Versions-lightgrey.svg?style=for-the-badge)](https://github.com/yt-dlp/yt-dlp/releases)
 <!-- MANPAGE: END EXCLUDED SECTION -->
 
-You can install yt-dlp using [the binaries](#release-files), [PIP](https://pypi.org/project/yt-dlp) or one using a third-party package manager. See [the wiki](https://github.com/yt-dlp/yt-dlp/wiki/Installation) for detailed instructions
+You can install yt-dlp using [the binaries](#release-files), [pip](https://pypi.org/project/yt-dlp) or one using a third-party package manager. See [the wiki](https://github.com/yt-dlp/yt-dlp/wiki/Installation) for detailed instructions
 
 
 ## UPDATE
 You can use `yt-dlp -U` to update if you are using the [release binaries](#release-files)
 
-If you [installed with PIP](https://github.com/yt-dlp/yt-dlp/wiki/Installation#with-pip), simply re-run the same command that was used to install the program
+If you [installed with pip](https://github.com/yt-dlp/yt-dlp/wiki/Installation#with-pip), simply re-run the same command that was used to install the program
 
 For other third-party package managers, see [the wiki](https://github.com/yt-dlp/yt-dlp/wiki/Installation#third-party-package-managers) or refer their documentation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ deps =
 commands = pytest {posargs:"-m not download"}
 passenv = HOME  # For test_compat_expanduser
 setenv =
-    # PYTHONWARNINGS = error  # Catches PIP's warnings too
+    # PYTHONWARNINGS = error  # Catches pip's warnings too
 
 
 [isort]


### PR DESCRIPTION
The documentation (the README and wiki) refers to pip, the python package manager, as "PIP", in all caps. It took me a moment to work out that this meant the python package manager, because I don't think I've ever seen it referred to like that. Certainly, the [pip documentation](https://pip.pypa.io/en/stable/) doesn't do this; even going so far as to refer to it in all-lowercase when it's at the start of a sentence.

This just isn't the name of the thing you're trying to refer to, which, for me at least, was temporarily a source of significant confusion. This MR edits these references to refer to pip in the way that pip itself does.
