### PR TITLE
[extractor/cbc] Workaround CBC returning a http 426 when querying file data

### DIFF
--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -422,7 +422,7 @@ class CBCGemPlaylistIE(InfoExtractor):
         match = self._match_valid_url(url)
         season_id = match.group('id')
         show = match.group('show')
-        show_info = self._download_json(self._API_BASE + show, season_id)
+        show_info = self._download_json(self._API_BASE + show, season_id, expected_status=426)
         season = int(match.group('season'))
 
         season_info = next((s for s in show_info['seasons'] if s.get('season') == season), None)

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -349,8 +349,9 @@ class CBCGemIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        video_info = self._download_json('https://services.radio-canada.ca/ott/cbc-api/v2/assets/' + video_id, video_id,
-                                         expected_status=426)
+        video_info = self._download_json(
+            f'https://services.radio-canada.ca/ott/cbc-api/v2/assets/{video_id}',
+            video_id, expected_status=426)
 
         email, password = self._get_login_info()
         if email and password:

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -349,7 +349,8 @@ class CBCGemIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        video_info = self._download_json('https://services.radio-canada.ca/ott/cbc-api/v2/assets/' + video_id, video_id)
+        video_info = self._download_json('https://services.radio-canada.ca/ott/cbc-api/v2/assets/' + video_id, video_id,
+                                         expected_status=426)
 
         email, password = self._get_login_info()
         if email and password:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Walkaround CBC.ca returning a return code of 426 when querying the file data.

```
curl -v https://services.radio-canada.ca/ott/cbc-api/v2/assets/murdoch-mysteries/s11e08
*   Trying 23.78.210.233:443...
* TCP_NODELAY set
* Connected to services.radio-canada.ca (23.78.210.233) port 443 (#0)
* {truncated for pertinence}
* Mark bundle as not supporting multiuse
< HTTP/1.1 426 Upgrade Required
< {truncated for pertinence}
<
{"id":"murdoch-mysteries/s11e08","title":"Brackenreid Boudoir","description":"To investigate an artist’s murder, Brackenreid picks up his paintbrush again and attracts a wealthy patron’s very personal attention.","image":"https://images.radio-canada.ca/v1/synps-cbc/episode/perso/cbc_murdoch_mysteries_season_11e08_thumbnail_v01.jpeg?impolicy=ott&im=Resize=(_Size_)&quality=75","series":"Murdoch Mysteries","season":11,"episode":8,"isTrailer":false,"duration":2652,"contentTier":"MEMBER","playSession":{"url":"https://services.radio-canada.ca/media/validation/v2?appCode=gem&idMedia=164817&manifestType=desktop&output=json&tech=hls","mediaId":"164817"},"rating":"PG","category":"crime-and-police","availableDate":1537830000000,"airDate":1512345600000,"showId":"murdoch-mysteries","appleContentId":"CBC_MURDOCH_MYSTERIES_SEASON_11_S11E08","credits":{},"chainplay":{"id":"murdoch-mysteries/s11e09","cuepoint":2621,"title":"The Talking Dead","description":"After obituaries are published in advance of two men’s deaths, Murdoch discovers more intended victims - including a member of Station House No. 4 - that he must keep alive before their predicted demise.","season":11,"episode":9,"image":"https://images.radio-canada.ca/v1/synps-cbc/episode/perso/cbc_murdoch_mysteries_season_11e09_thumbnail_v01.jpeg?impolicy=ott&im=Resize=(_Size_)&quality=75"},"adParameters":{"adUnit":"5876/entertainment/shows/murdochmysteries","adUrl":"https://pubads.g.doubleclick.net/gampad/ads?description_url=https%3a%2f%2fgem.cbc.ca%2fmurdoch-mysteries%2fs11e08&pp=web-app&scp=bu%3dgem&env=vp&gdfp_req=1&unviewed_position_start=1&correlator=1363087&output=xml_vast&iu=5876%2fentertainment%2fshows%2fmurdochmysteries&sz=320x240&vid=164817&url=https%3a%2f%2fgem.cbc.ca%2fmurdoch-mysteries%2fs11e08&cust_params=plat%3dott%26client%3dweb-app%26ut%3dano&ad_rule=1&ciu_szs=300x250&cmsid=2556398&hl=en&label=viewable_impression&nofb=2","hasAds":true,"restrictsAds":false,"mandatoryAdsForAllUsers":false},"amplitudeAnalytics":{"id":"murdoch-mysteries/s11e08","title":"bra* Connection #0 to host services.radio-canada.ca left intact
ckenreid-boudoir","series":"murdoch-mysteries","season":"s11","episode":"e08","duration":2652,"bookmark":null,"contentTier":"member"},"comscoreAnalytics":{"title":"brackenreid-boudoir","series":"murdoch-mysteries","season":11,"episode":8,"rating":"pg","duration":2652,"id":"murdoch-mysteries/s11e08","keyword":"crime-and-police"},"isCompleted":false}```
```

Fixes #6716


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
