### PR TITLE
[extractor/nhk] Add NHK Radiru (らじる) extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1232,6 +1232,7 @@ from .nhk import (
     NhkForSchoolBangumiIE,
     NhkForSchoolSubjectIE,
     NhkForSchoolProgramListIE,
+    NhkRadiruIE,
 )
 from .nhl import NHLIE
 from .nick import (

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1232,6 +1232,7 @@ from .nhk import (
     NhkForSchoolBangumiIE,
     NhkForSchoolSubjectIE,
     NhkForSchoolProgramListIE,
+    NhkRadioNewsPageIE,
     NhkRadiruIE,
 )
 from .nhl import NHLIE

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -407,6 +407,7 @@ class NhkRadiruIE(InfoExtractor):
     def _extract_episode_info(self, headline, programme_id, series_meta):
         episode_id = f'{programme_id}_{headline["headline_id"]}'
         episode = traverse_obj(headline, ('file_list', 0, {dict}))
+
         return {
             **series_meta,
             'id': episode_id,
@@ -455,7 +456,7 @@ class NhkRadiruIE(InfoExtractor):
 
 
 class NhkRadioNewsPageIE(InfoExtractor):
-    _VALID_URL = r'https?://www\.nhk\.or\.jp/radionews/?'
+    _VALID_URL = r'https?://www\.nhk\.or\.jp/radionews/?(?:$|[?#])'
     _TESTS = [{
         # airs daily, on-the-hour most hours
         'url': 'https://www.nhk.or.jp/radionews/',

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -341,14 +341,12 @@ class NhkRadiruIE(InfoExtractor):
     _GEO_COUNTRIES = ['JP']
     IE_DESC = 'NHK らじる (Radiru/Rajiru)'
     _VALID_URL = r'https?://www\.nhk\.or\.jp/radio/(?:player/ondemand|ondemand/detail)\.html\?p=(?P<site>[\da-zA-Z]+)_(?P<corner>[\da-zA-Z]+)(?:_(?P<headline>[\da-zA-Z]+))?'
-    # match https://www.nhk.or.jp/radio/player/ondemand.html (player) or https://www.nhk.or.jp/radio/ondemand/detail.html (programme page)
-    # then grab contents of p and split the numbers up into what they are in the api
     _TESTS = [{
         'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=0449_01_3853544',
         'skip': 'Episode expired on 2023-04-16',
         'info_dict': {
             'channel': 'NHK-FM',
-            'description': '今回の前半は「ＮＥＷジャズ」特集と題して、曲名や演奏者の名前に「ＮＥＷ」がつく演奏や、新人の初リーダー作などを集めて聴いていく。',
+            'description': 'md5:94b08bdeadde81a97df4ec882acce3e9',
             'ext': 'm4a',
             'id': '0449_01_3853544',
             'series': 'ジャズ・トゥナイト',
@@ -361,6 +359,7 @@ class NhkRadiruIE(InfoExtractor):
             'was_live': True,
         },
     }, {
+        # playlist, airs every weekday so it should _hopefully_ be okay forever
         'url': 'https://www.nhk.or.jp/radio/ondemand/detail.html?p=0458_01',
         'info_dict': {
             'id': '0458_01',
@@ -369,10 +368,10 @@ class NhkRadiruIE(InfoExtractor):
             'channel': 'NHK-FM',
             'thumbnail': 'https://www.nhk.or.jp/prog/img/458/g458.jpg',
         },
-        'playlist_mincount': 3,  # airs every weekday so this should _hopefully_ be okay forever
-        'skip_download': True,
+        'playlist_mincount': 3,
     }, {
-        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F300_06_3738470',  # one with letters in the id
+        # one with letters in the id
+        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F300_06_3738470',
         'note': 'Expires on 2024-03-31',
         'info_dict': {
             'id': 'F300_06_3738470',
@@ -388,7 +387,8 @@ class NhkRadiruIE(InfoExtractor):
             'upload_date': '20211101',
         }
     }, {
-        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F261_01_3855109',  # news
+        # news
+        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F261_01_3855109',
         'skip': 'Expires on 2023-04-17',
         'info_dict': {
             'id': 'F261_01_3855109',
@@ -427,7 +427,7 @@ class NhkRadiruIE(InfoExtractor):
         site_id, corner_id, headline_id = self._match_valid_url(url).group('site', 'corner', 'headline')
         programme_id = f'{site_id}_{corner_id}'
 
-        if site_id == "F261":
+        if site_id == 'F261':
             json_url = 'https://www.nhk.or.jp/s-media/news/news-site/list/v1/all.json'
         else:
             json_url = f'https://www.nhk.or.jp/radioondemand/json/{site_id}/bangumi_{programme_id}.json'
@@ -449,6 +449,7 @@ class NhkRadiruIE(InfoExtractor):
         def entries():
             for headline in traverse_obj(meta, ('detail_list', ..., {dict})):
                 yield self._extract_episode_info(headline, programme_id, series_meta)
+
         return self.playlist_result(
             entries(), programme_id, playlist_description=meta.get('site_detail'), **series_meta)
 
@@ -456,17 +457,17 @@ class NhkRadiruIE(InfoExtractor):
 class NhkRadioNewsPageIE(InfoExtractor):
     _VALID_URL = r'https?://www\.nhk\.or\.jp/radionews/?'
     _TESTS = [{
+        # airs daily, on-the-hour most hours
         'url': 'https://www.nhk.or.jp/radionews/',
-        'playlist_mincount': 5,  # airs daily, on-the-hour most hours
-        'skip_download': True,
+        'playlist_mincount': 5,
         'info_dict': {
             'id': 'F261_01',
             'thumbnail': 'https://www.nhk.or.jp/radioondemand/json/F261/img/RADIONEWS_640.jpg',
-            'description': '日本、そして世界の動きを　わかりやすく、深く多角的にお伝えします。\r\n２４時間３６５日放送を続けるラジオ第１放送。\r\nいざという時には、命を守る情報を最優先でお伝えします。',
+            'description': 'md5:bf2c5b397e44bc7eb26de98d8f15d79d',
             'channel': 'NHKラジオ第1',
             'title': 'NHKラジオニュース',
         }
     }]
 
     def _real_extract(self, url):
-        return self.url_result('https://www.nhk.or.jp/radio/ondemand/detail.html?p=F261_01')
+        return self.url_result('https://www.nhk.or.jp/radio/ondemand/detail.html?p=F261_01', NhkRadiruIE)

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -340,7 +340,7 @@ class NhkForSchoolProgramListIE(InfoExtractor):
 class NhkRadiruIE(InfoExtractor):
     _GEO_COUNTRIES = ['JP']
     IE_DESC = 'NHK らじる (Radiru/Rajiru)'
-    _VALID_URL = r'https://www\.nhk\.or\.jp/radio/(?:player/ondemand|ondemand/detail)\.html\?p=(?P<id>(?P<site>\d+)_(?P<corner>\d+)(?:_(?P<headline>\d+))?)'
+    _VALID_URL = r'https://www\.nhk\.or\.jp/radio/(?:player/ondemand|ondemand/detail)\.html\?p=(?P<id>(?P<site>[\da-zA-Z]+)_(?P<corner>[\da-zA-Z]+)(?:_(?P<headline>[\da-zA-Z]+))?)'
     # match https://www.nhk.or.jp/radio/player/ondemand.html (player) or https://www.nhk.or.jp/radio/ondemand/detail.html (programme page)
     # then grab contents of p and split the numbers up into what they are in the api
     _TESTS = [{
@@ -373,7 +373,24 @@ class NhkRadiruIE(InfoExtractor):
         },
         'playlist_mincount': 3,  # airs every weekday so this should _hopefully_ be okay forever
         'skip_download': True,
-    },
+    }, {
+        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F300_06_3738470',  # one with letters in the id
+        '_type': 'video',
+        'skip': 'Expires on 2024-03-31',
+        'info_dict': {
+            'id': 'F300_06_3738470',
+            'ext': 'm4a',
+            'title': '有島武郎「一房のぶどう」',
+            'description': '朗読：川野一宇（ラジオ深夜便アンカー）\r\n\r\n（2016年12月8日放送「ラジオ深夜便『アンカー朗読シリーズ』」より）',
+            'channel': 'NHKラジオ第1、NHK-FM',
+            'timestamp': 1635757200,
+            'thumbnail': 'https://www.nhk.or.jp/radioondemand/json/F300/img/corner/box_109_thumbnail.jpg',
+            'release_date': '20161207',
+            'series': 'らじる文庫 by ラジオ深夜便 ',
+            'release_timestamp': 1481126700,
+            'upload_date': '20211101',
+        }
+    }
     ]
 # https://www.nhk.or.jp/radionews/ known not working - doesnt use same api
 # https://www.nhk.or.jp/s-media/news/podcast/list/v1/all.xml podcast feed if you need it

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -10,6 +10,7 @@ from ..utils import (
     url_or_none
 )
 
+
 class NhkBaseIE(InfoExtractor):
     _API_URL_TEMPLATE = 'https://nwapi.nhk.jp/nhkworld/%sod%slist/v7b/%s/%s/%s/all%s.json'
     _BASE_URL_REGEX = r'https?://www3\.nhk\.or\.jp/nhkworld/(?P<lang>[a-z]{2})/ondemand'
@@ -428,6 +429,7 @@ class NhkRadiruIE(InfoExtractor):
                 traverse_obj(meta, (
                     'detail_list', lambda _, v: v['headline_id'] == headline_id), get_all=False),
                 programme_id, series_meta)
+
         def entries():
             for headline in traverse_obj(meta, ('detail_list', ..., {dict})):
                 yield self._extract_episode_info(headline, programme_id, series_meta)

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 
 from .common import InfoExtractor
 from ..utils import (
@@ -334,3 +335,73 @@ class NhkForSchoolProgramListIE(InfoExtractor):
             for x in traverse_obj(bangumi_list, ('part', ..., 'part-video-dasid')) or []]
 
         return self.playlist_result(bangumis, program_id, title, description)
+
+class NhkRadiruIE(InfoExtractor):
+    _GEO_COUNTRIES = ['JP']
+    _VALID_URL = r'https?://www\.nhk\.or\.jp/radio/player/ondemand\.html\?p=(?P<id>[0-9]+_[0-9]+_[0-9]+)'
+    _TESTS = [{
+        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=0449_01_3853544',
+        'info_dict': {
+            'channel': 'NHK-FM',
+            'description': '今回の前半は「ＮＥＷジャズ」特集と題して、曲名や演奏者の名前に「ＮＥＷ」がつく演奏や、新人の初リーダー作などを集めて聴いていく。',
+            'ext': 'm4a',
+            'id': '0449_01_3853544',
+            'series': 'ジャズ・トゥナイト',
+            'thumbnail': 'https://www.nhk.or.jp/prog/img/449/g449.jpg',
+            'timestamp': 1680962400,
+            'title': 'ジャズ・トゥナイト　ＮＥＷジャズ特集',
+            'upload_date': '20230408',
+            'was_live': True,
+        },
+        'skip': 'Episode removed on 2023-04-16',
+    }]
+# https://www.nhk.or.jp/radionews/ known not working - doesnt use same api
+# https://www.nhk.or.jp/s-media/news/podcast/list/v1/all.xml podcast feed if you need it
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        ids = video_id.split('_')
+        site_id = ids[0]
+        corner_id = ids[1]
+        headline_id = ids[2]
+
+        json_url = f'https://www.nhk.or.jp/radioondemand/json/{site_id}/bangumi_{site_id}_{corner_id}.json'
+        meta = self._download_json(json_url, f'{site_id}_{corner_id}').get('main')
+
+        series = meta.get('program_name')
+        channel = meta.get('media_name')
+
+        detail_list = meta.get('detail_list')
+        headline = next((i for i in detail_list if i.get('headline_id') == headline_id), None)
+
+        file = next((i for i in headline.get('file_list') if i.get('file_id') == headline_id), None)
+        # this will break if there's an episode with multiple files, but i don't think that's ever actually the case
+        
+        url = file.get('file_name')
+        title = file.get('file_title')
+        description = file.get('file_title_sub')
+        webpage_url = file.get('share_url')
+
+        thumbnail = headline.get('headline_image') or meta.get('thumbnail_c') or meta.get('thumbnail_p')
+
+        time_format = '%Y-%m-%dT%H:%M:%S%z'
+        aa_vinfo4 = file.get('aa_vinfo4')
+        # there are open_time/close_time variables in there, but they're when it was put on vod/when it gets taken off
+        # theres also an onair_date var, but >natural language that doesnt have half of what we need anyway
+        start_time = datetime.strptime(aa_vinfo4.split('_')[0],  time_format).timestamp() or None
+
+        formats = self._extract_m3u8_formats(url, video_id)
+
+        return {
+            'container': 'm4a_dash', # force fixup so seeking works
+            'channel': channel,
+            'description': description,
+            'formats': formats,
+            'id': video_id,
+            'series': series,
+            'thumbnail': thumbnail,
+            'timestamp': start_time,
+            'title': title,
+            'was_live': True,
+            'webpage_url': webpage_url,
+        }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds support for [NHK らじる★らじる](https://www.nhk.or.jp/radio/), the radio streaming site of Japan's public broadcaster.
- [About page](https://www.nhk.or.jp/radio/info/about.html) (in Japanese)
- [Wikipedia article](https://ja.wikipedia.org/wiki/NHK%E3%83%8D%E3%83%83%E3%83%88%E3%83%A9%E3%82%B8%E3%82%AA_%E3%82%89%E3%81%98%E3%82%8B%E2%98%85%E3%82%89%E3%81%98%E3%82%8B) (in Japanese)

It supports downloading individual episodes and entire series (or at least, what's available - the episodes expire eventually), but does not support the live streams.

Downloading entire series sometimes gets episodes that aren't listed on the site, but are still in the API. Example: [site listing](https://user-images.githubusercontent.com/76261416/232220582-8a4de1e7-affe-463e-b0de-a6422cef7990.png) vs [actual download](https://user-images.githubusercontent.com/76261416/232232541-239af202-52fd-4bd3-9127-82bd3a552f53.png).
I'm unsure whether this is a bug or a feature.

Adding live support is definitely possible - [the stream urls are sitting out in the open](https://www.nhk.or.jp/radio/config/config_web.xml) - but there are regional variations. The region is not reflected in the player url, so I'm not sure how to handle it.

#### Example URLs (chosen at random)

- https://www.nhk.or.jp/radio/player/ondemand.html?p=1929_01_3854588 - single episode (link expires on 2023-06-08)
- https://www.nhk.or.jp/radio/ondemand/detail.html?p=0456_01 - entire series

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
