### PR TITLE
[extractor/sbs] Overhaul extractor for new APIs

### DIFF
--- a/yt_dlp/extractor/sbs.py
+++ b/yt_dlp/extractor/sbs.py
@@ -104,10 +104,12 @@ class SBSIE(InfoExtractor):
 
         if not formats:
             urlh = self._request_webpage(
-                HEADRequest('https://sbs-vod-prod-01.akamized.net/'), video_id,
-                note='checking geo-restriction', fatal=False, expected_status=403)
-            if urlh and 'geo-blocked' in urlh.headers.get_all('x-error-reason'):
-                self.raise_geo_restricted(countries=['AU'])
+                HEADRequest('https://sbs-vod-prod-01.akamaized.net/'), video_id,
+                note='Checking geo-restriction', fatal=False, expected_status=403)
+            if urlh:
+                error_reasons = urlh.headers.get_all('x-error-reason') or []
+                if 'geo-blocked' in error_reasons:
+                    self.raise_geo_restricted(countries=['AU'])
             self.raise_no_formats('No formats are available', video_id=video_id)
 
         media = traverse_obj(self._download_json(

--- a/yt_dlp/extractor/sbs.py
+++ b/yt_dlp/extractor/sbs.py
@@ -1,7 +1,25 @@
+
+import sys
+
 from .common import InfoExtractor
+from ..compat import (
+    compat_HTTPError,
+    compat_kwargs,
+    compat_str,
+)
 from ..utils import (
-    smuggle_url,
+    error_to_compat_str,
     ExtractorError,
+    float_or_none,
+    GeoRestrictedError,
+    int_or_none,
+    parse_duration,
+    parse_iso8601,
+    smuggle_url,
+    traverse_obj,
+    update_url_query,
+    url_or_none,
+    variadic,
 )
 
 
@@ -11,7 +29,7 @@ class SBSIE(InfoExtractor):
         https?://(?:www\.)?sbs\.com\.au/(?:
             ondemand(?:
                 /video/(?:single/)?|
-                /movie/[^/]+/|
+                /(?:movie|tv-program)/[^/]+/|
                 /(?:tv|news)-series/(?:[^/]+/){3}|
                 .*?\bplay=|/watch/
             )|news/(?:embeds/)?video/
@@ -27,18 +45,19 @@ class SBSIE(InfoExtractor):
         # Original URL is handled by the generic IE which finds the iframe:
         # http://www.sbs.com.au/thefeed/blog/2014/08/21/dingo-conservation
         'url': 'http://www.sbs.com.au/ondemand/video/single/320403011771/?source=drupal&vertical=thefeed',
-        'md5': '3150cf278965eeabb5b4cea1c963fe0a',
+        'md5': 'e49d0290cb4f40d893b8dfe760dce6b0',
         'info_dict': {
-            'id': '_rFBPRPO4pMR',
+            'id': '320403011771',  # '_rFBPRPO4pMR',
             'ext': 'mp4',
             'title': 'Dingo Conservation (The Feed)',
             'description': 'md5:f250a9856fca50d22dec0b5b8015f8a5',
-            'thumbnail': r're:http://.*\.jpg',
+            'thumbnail': r're:https?://.*\.jpg',
             'duration': 308,
             'timestamp': 1408613220,
             'upload_date': '20140821',
             'uploader': 'SBSC',
         },
+        'expected_warnings': ['Unable to download JSON metadata'],
     }, {
         'url': 'http://www.sbs.com.au/ondemand/video/320403011771/Dingo-Conservation-The-Feed',
         'only_matching': True,
@@ -70,34 +89,175 @@ class SBSIE(InfoExtractor):
     }, {
         'url': 'https://www.sbs.com.au/ondemand/tv-series/the-handmaids-tale/season-5/the-handmaids-tale-s5-ep1/2065631811776',
         'only_matching': True,
+    }, {
+        'url': 'https://www.sbs.com.au/ondemand/tv-program/autun-romes-forgotten-sister/2116212803602',
+        'only_matching': True,
     }]
+
+    def __handle_request_webpage_error(self, err, video_id=None, errnote=None, fatal=True):
+        if errnote is False:
+            return False
+        if errnote is None:
+            errnote = 'Unable to download webpage'
+
+        errmsg = '%s: %s' % (errnote, error_to_compat_str(err))
+        if fatal:
+            raise ExtractorError(errmsg, sys.exc_info()[2], cause=err, video_id=video_id)
+        else:
+            self._downloader.report_warning(errmsg)
+            return False
+
+    def _download_webpage_handle(self, url, video_id, *args, **kwargs):
+        # note, errnote, fatal, encoding, data, headers={}, query, expected_status
+        # specialised to detect geo-block
+
+        errnote = args[2] if len(args) > 2 else kwargs.get('errnote')
+        fatal = args[3] if len(args) > 3 else kwargs.get('fatal')
+        exp = args[7] if len(args) > 7 else kwargs.get('expected_status')
+
+        exp = variadic(exp or [], allowed_types=(compat_str, ))
+        if 403 not in exp and '403' not in exp:
+            exp = list(exp)
+            exp.append(403)
+        else:
+            exp = None
+
+        if exp:
+            if len(args) > 7:
+                args = list(args)
+                args[7] = exp
+            else:
+                kwargs['expected_status'] = exp
+                kwargs = compat_kwargs(kwargs)
+
+        ret = super(SBSIE, self)._download_webpage_handle(url, video_id, *args, **kwargs)
+        if ret is False:
+            return ret
+        webpage, urlh = ret
+
+        if urlh.getcode() == 403:
+            if urlh.headers.get('x-error-reason') == 'geo-blocked':
+                countries = ['AU']
+                if fatal:
+                    self.raise_geo_restricted(countries=countries)
+                err = GeoRestrictedError(
+                    'This Australian content is not available from your location due to geo restriction',
+                    countries=countries)
+            else:
+                err = compat_HTTPError(urlh.geturl(), 403, 'HTTP Error 403: Forbidden', urlh.headers, urlh)
+            ret = self.__handle_request_webpage_error(err, video_id, errnote, fatal)
+
+        return ret
+
+    def _extract_m3u8_formats(self, m3u8_url, video_id, *args, **kwargs):
+        # ext, entry_protocol, preference, m3u8_id, note, errnote, fatal,
+        # live, data, headers, query
+        entry_protocol = args[1] if len(args) > 1 else kwargs.get('entry_protocol')
+        if not entry_protocol:
+            entry_protocol = 'm3u8_native'
+            if len(args) > 1:
+                args = list(args)
+                args[1] = entry_protocol
+            else:
+                kwargs['entry_protocol'] = entry_protocol
+                kwargs = compat_kwargs(kwargs)
+
+        return super(SBSIE, self)._extract_m3u8_formats(m3u8_url, video_id, *args, **kwargs)
+
+    _AUS_TV_PARENTAL_GUIDELINES = {
+        'P': 0,
+        'C': 7,
+        'G': 0,
+        'PG': 0,
+        'M': 14,
+        'MA15+': 15,
+        'MAV15+': 15,
+        'R18+': 18,
+    }
+    _PLAYER_API = 'https://www.sbs.com.au/api/v3'
+    _CATALOGUE_API = 'https://catalogue.pr.sbsod.com/'
+
+    def _call_api(self, video_id, path, query=None, data=None, headers=None, fatal=True):
+        return self._download_json(update_url_query(
+            self._CATALOGUE_API + path, query),
+            video_id, headers=headers, fatal=fatal) or {}
+
+    def _get_smil_url(self, video_id):
+        return update_url_query(
+            self._PLAYER_API + 'video_smil', {'id': video_id})
+
+    def _get_player_data(self, video_id, headers=None, fatal=False):
+        return self._download_json(update_url_query(
+            self._PLAYER_API + 'video_stream', {'id': video_id, 'context': 'tv'}),
+            video_id, headers=headers, fatal=fatal) or {}
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        player_params = self._download_json(
-            'http://www.sbs.com.au/api/video_pdkvars/id/%s?form=json' % video_id, video_id)
+        # get media links directly though later metadata may contain contentUrl
+        smil_url = self._get_smil_url(video_id)
+        formats, subtitles = self._extract_smil_formats_and_subtitles(smil_url, video_id, fatal=False) or ([], {})
 
-        error = player_params.get('error')
-        if error:
-            error_message = 'Sorry, The video you are looking for does not exist.'
-            video_data = error.get('results') or {}
-            error_code = error.get('errorCode')
-            if error_code == 'ComingSoon':
-                error_message = '%s is not yet available.' % video_data.get('title', '')
-            elif error_code in ('Forbidden', 'intranetAccessOnly'):
-                error_message = 'Sorry, This video cannot be accessed via this website'
-            elif error_code == 'Expired':
-                error_message = 'Sorry, %s is no longer available.' % video_data.get('title', '')
-            raise ExtractorError('%s said: %s' % (self.IE_NAME, error_message), expected=True)
+        # try for metadata from the same source
+        player_data = self._get_player_data(video_id, fatal=False)
+        media = traverse_obj(player_data, 'video_object', expected_type=dict) or {}
+        # get, or add, metadata from catalogue
+        media.update(self._call_api(video_id, 'mpx-media/' + video_id, fatal=not media))
 
-        urls = player_params['releaseUrls']
-        theplatform_url = (urls.get('progressive') or urls.get('html')
-                           or urls.get('standard') or player_params['relatedItemsURL'])
+        # utils candidate for use with traverse_obj()
+        def txt_or_none(s):
+            return (s.strip() or None) if isinstance(s, compat_str) else None
+
+        # expected_type fn for thumbs
+        def xlate_thumb(t):
+            u = url_or_none(t.get('contentUrl'))
+            return u and {
+                'id': t.get('name'),
+                'url': u,
+                'width': int_or_none(t.get('width')),
+                'height': int_or_none(t.get('height')),
+            }
+
+        # may be numeric or timecoded
+        def really_parse_duration(d):
+            result = float_or_none(d)
+            if result is None:
+                result = parse_duration(d)
+            return result
+
+        def traverse_media(*args, **kwargs):
+            if 'expected_type' not in kwargs:
+                kwargs['expected_type'] = txt_or_none
+                kwargs = compat_kwargs(kwargs)
+            return traverse_obj(media, *args, **kwargs)
 
         return {
-            '_type': 'url_transparent',
-            'ie_key': 'ThePlatform',
             'id': video_id,
-            'url': smuggle_url(self._proto_relative_url(theplatform_url), {'force_smil_url': True}),
-            'is_live': player_params.get('streamType') == 'live',
+            'title': media['name'],
+            'formats': formats,
+            'description': traverse_media('description'),
+            'categories': traverse_media(
+                ('genres', Ellipsis), ('taxonomy', ('genre', 'subgenre'), 'name')),
+            'tags': traverse_media(
+                (('consumerAdviceTexts', ('sbsSubCertification', 'consumerAdvice')), Ellipsis)),
+            'age_limit': self._AUS_TV_PARENTAL_GUIDELINES.get(traverse_media(
+                'classificationID', 'contentRating', default='').upper()),
+            'thumbnails': traverse_media(('thumbnails', Ellipsis),
+                                         expected_type=xlate_thumb),
+            'duration': traverse_media('duration',
+                                       expected_type=really_parse_duration),
+            'series': traverse_media(('partOfSeries', 'name'), 'seriesTitle'),
+            'series_id': traverse_media(('partOfSeries', 'uuid'), 'seriesID'),
+            'season_number': traverse_media(
+                (('partOfSeries', None), 'seasonNumber'),
+                expected_type=int_or_none, get_all=False),
+            'episode_number': traverse_media('episodeNumber',
+                                             expected_type=int_or_none),
+            'release_year': traverse_media('releaseYear',
+                                           expected_type=int_or_none),
+            'subtitles': subtitles,
+            'timestamp': traverse_media(
+                'datePublished', ('publication', 'startDate'),
+                expected_type=parse_iso8601),
+            'channel': traverse_media(('taxonomy', 'channel', 'name')),
+            'uploader': 'SBSC',
         }

--- a/yt_dlp/extractor/sbs.py
+++ b/yt_dlp/extractor/sbs.py
@@ -1,4 +1,3 @@
-
 from .common import InfoExtractor
 from ..utils import (
     float_or_none,

--- a/yt_dlp/extractor/sbs.py
+++ b/yt_dlp/extractor/sbs.py
@@ -15,7 +15,6 @@ from ..utils import (
     int_or_none,
     parse_duration,
     parse_iso8601,
-    smuggle_url,
     traverse_obj,
     update_url_query,
     url_or_none,
@@ -45,7 +44,7 @@ class SBSIE(InfoExtractor):
         # Original URL is handled by the generic IE which finds the iframe:
         # http://www.sbs.com.au/thefeed/blog/2014/08/21/dingo-conservation
         'url': 'http://www.sbs.com.au/ondemand/video/single/320403011771/?source=drupal&vertical=thefeed',
-        'md5': 'e49d0290cb4f40d893b8dfe760dce6b0',
+        'md5': '31f84a7a19b53635db63c73f8ab0c4a7',
         'info_dict': {
             'id': '320403011771',  # '_rFBPRPO4pMR',
             'ext': 'mp4',
@@ -56,6 +55,8 @@ class SBSIE(InfoExtractor):
             'timestamp': 1408613220,
             'upload_date': '20140821',
             'uploader': 'SBSC',
+            'tags': [],
+            'categories': [],
         },
         'expected_warnings': ['Unable to download JSON metadata'],
     }, {

--- a/yt_dlp/extractor/sbs.py
+++ b/yt_dlp/extractor/sbs.py
@@ -1,7 +1,7 @@
 from .common import InfoExtractor
 from ..utils import (
-    float_or_none,
     HEADRequest,
+    float_or_none,
     int_or_none,
     parse_duration,
     parse_iso8601,
@@ -136,6 +136,7 @@ class SBSIE(InfoExtractor):
                 'timestamp': (('datePublished', ('publication', 'startDate')), {parse_iso8601}),
                 'release_year': ('releaseYear', {int_or_none}),
                 'duration': ('duration', ({float_or_none}, {parse_duration})),
+                'is_live': ('liveStream', {bool}),
                 'age_limit': (
                     ('classificationID', 'contentRating'), {str.upper}, {self._AUS_TV_PARENTAL_GUIDELINES.get}),
             }, get_all=False),

--- a/yt_dlp/extractor/sbs.py
+++ b/yt_dlp/extractor/sbs.py
@@ -4,7 +4,6 @@ import sys
 from .common import InfoExtractor
 from ..compat import (
     compat_HTTPError,
-    compat_kwargs,
     compat_str,
 )
 from ..utils import (
@@ -129,7 +128,6 @@ class SBSIE(InfoExtractor):
                 args[7] = exp
             else:
                 kwargs['expected_status'] = exp
-                kwargs = compat_kwargs(kwargs)
 
         ret = super(SBSIE, self)._download_webpage_handle(url, video_id, *args, **kwargs)
         if ret is False:
@@ -161,7 +159,6 @@ class SBSIE(InfoExtractor):
                 args[1] = entry_protocol
             else:
                 kwargs['entry_protocol'] = entry_protocol
-                kwargs = compat_kwargs(kwargs)
 
         return super(SBSIE, self)._extract_m3u8_formats(m3u8_url, video_id, *args, **kwargs)
 
@@ -228,7 +225,6 @@ class SBSIE(InfoExtractor):
         def traverse_media(*args, **kwargs):
             if 'expected_type' not in kwargs:
                 kwargs['expected_type'] = txt_or_none
-                kwargs = compat_kwargs(kwargs)
             return traverse_obj(media, *args, **kwargs)
 
         return {

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4093,6 +4093,9 @@ def dfxp2srt(dfxp_data):
         def close(self):
             return self._out.strip()
 
+    # KLUDGE: confirm convert-subs works for dxfp with correct encoding. Note will not match actual UTF-16, given longer encoding.
+    dfxp_data = dfxp_data.replace(b'encoding=\'UTF-16\'', b'encoding=\'UTF-8\'')
+
     def parse_node(node):
         target = TTMLPElementParser()
         parser = xml.etree.ElementTree.XMLParser(target=target)

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -4093,7 +4093,8 @@ def dfxp2srt(dfxp_data):
         def close(self):
             return self._out.strip()
 
-    # KLUDGE: confirm convert-subs works for dxfp with correct encoding. Note will not match actual UTF-16, given longer encoding.
+    # Fix UTF-8 encoded file wrongly marked as UTF-16. See https://github.com/yt-dlp/yt-dlp/issues/6543#issuecomment-1477169870
+    # This will not trigger false positives since only UTF-8 text is being replaced
     dfxp_data = dfxp_data.replace(b'encoding=\'UTF-16\'', b'encoding=\'UTF-8\'')
 
     def parse_node(node):


### PR DESCRIPTION
### Description of your *pull request* and other information

From dirkf's PR: Australian provider SBS has changed its hosting arrangements and APIs, breaking the existing extractor.

The PR is intended to deal with the new APIs.

Some specialisations of extractor methods are included:

-    `_download_webpage_handle()` detects geo-restriction
-    `_extract_m3u8_formats()` defaults to the native downloader.

That PR was developed for upstream, so adjusted for deprecations and other legacy compatibility inclusions. It also addresses issue with extracting and converting dxfp subtitles to other formats, since SBS deliver their UTF-8 encoded files with `encoding='UTF-16'`, in error. The workaround is included in utils.py. Note that it will *not* be triggered where a file actually encoded with UTF-16 is downloaded.

Fixes #6543. Adapt dirkf's PR [ytdl-org/youtube-dl#31880](https://github.com/ytdl-org/youtube-dl/pull/31880), with adjustments:
* Use media['name'] for title;
* Support urls including 'tv-program', and add a test url;
* Remove deprecated sort_formats() call;
* Support for capture and return of subtitles, with UTF-16 coding issue work-around when converting dfxp subs to srt.

See also [ytdl-org/youtube-dl#31841](https://github.com/ytdl-org/youtube-dl/issues/31841).

There are a few TODOs such as handling metadata for episode titles more nicely, and the downloaded subtitles (if not converted) will still have the wrong encoding. However these can be worked-around and don't cause exceptions during yt-dlp processing, so have raised this PR in order to get core extractor functions back ASAP.

<details open><summary>Boilerplate: bug fix, derived code, own tweaks.</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) See dirkf's release in [ytdl-org/youtube-dl#31880](https://github.com/ytdl-org/youtube-dl/pull/31880).

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
