### PR TITLE
[utils] Fix non-blocking only filesystems

### DIFF
--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2192,9 +2192,8 @@ else:
             except OSError:
                 try:
                     fcntl.lockf(f, fcntl.LOCK_UN)
-                except OSError: # Workaround for non-blocking only filesystems like virtiofs
+                except OSError:  # Workaround for non-blocking only filesystems like virtiofs
                     fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
-
 
     except ImportError:
 

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -2190,7 +2190,11 @@ else:
             try:
                 fcntl.flock(f, fcntl.LOCK_UN)
             except OSError:
-                fcntl.lockf(f, fcntl.LOCK_UN)
+                try:
+                    fcntl.lockf(f, fcntl.LOCK_UN)
+                except OSError: # Workaround for non-blocking only filesystems like virtiofs
+                    fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
+
 
     except ImportError:
 


### PR DESCRIPTION
This workaround is needed for some filesystems like virtiofs where any file locking or unlocking operation must be non-blocking

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds a workaround for the file unlocking operation on some filesystems like virtiofs by adding the `UNLOCK_NB` flag on error.

Fixes #6823


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
