### PR TITLE
Human-friendly language selection in --format-sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,7 +1540,8 @@ The available fields are:
  - `hasvid`: Gives priority to formats that have a video stream
  - `hasaud`: Gives priority to formats that have an audio stream
  - `ie_pref`: The format preference
- - `lang`: The language preference
+ - `lang`: The language preference (note that this is an internal value set by the extractor)
+ - `lang_match`: The language
  - `quality`: The quality of the format
  - `source`: The preference of the source
  - `proto`: Protocol used for download (`https`/`ftps` > `http`/`ftp` > `m3u8_native`/`m3u8` > `http_dash_segments`> `websocket_frag` > `mms`/`rtsp` > `f4f`/`f4m`)

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -6444,6 +6444,8 @@ class FormatSorter:
             in_list = self._get_field_setting(field, 'in_list')
             not_in_list = self._get_field_setting(field, 'not_in_list')
             value = 0 if ((in_list is None or value in in_list) and (not_in_list is None or value not in not_in_list)) else -1
+        elif type == 'exact_match':
+            value = int(value == limit)
         elif type == 'ordered':
             value = self._resolve_field_value(field, value, True)
 
@@ -6461,7 +6463,7 @@ class FormatSorter:
                 else (-1, value, 0))
 
     def _calculate_field_preference(self, format, field):
-        type = self._get_field_setting(field, 'type')  # extractor, boolean, ordered, field, multiple
+        type = self._get_field_setting(field, 'type')  # extractor, boolean, ordered, field, multiple, exact_match
         get_value = lambda f: format.get(self._get_field_setting(f, 'field'))
         if type == 'multiple':
             type = 'field'  # Only 'field' is allowed in multiple for now

--- a/yt_dlp/utils.py
+++ b/yt_dlp/utils.py
@@ -6249,6 +6249,7 @@ class FormatSorter:
         'hasvid': {'priority': True, 'field': 'vcodec', 'type': 'boolean', 'not_in_list': ('none',)},
         'hasaud': {'field': 'acodec', 'type': 'boolean', 'not_in_list': ('none',)},
         'lang': {'convert': 'float', 'field': 'language_preference', 'default': -1},
+        'lang_match': {'convert': 'string', 'field': 'language', 'type': 'exact_match'},
         'quality': {'convert': 'float', 'default': -1},
         'filesize': {'convert': 'bytes'},
         'fs_approx': {'convert': 'bytes', 'field': 'filesize_approx'},


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This PR addresses #6755. It adds a generic sorting type `exact_match` for anchor-based sorting, and a sorting field `language` to match based on the language.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
