### PR TITLE
Niconico seriesIE no longer working after url update

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -691,9 +691,8 @@ class NiconicoSeriesIE(InfoExtractor):
             webpage, 'title', fatal=False)
         if title:
             title = unescapeHTML(title)
-        playlist = [
-            self.url_result(f'https://www.nicovideo.jp/watch/{v_id}', video_id=v_id)
-            for v_id in re.findall(r'[\'"]url[\'"]:[\'"]https:\\/\\/www.nicovideo.jp\\/watch\\/([a-z0-9]+)', webpage)]
+        json_data = next(self._yield_json_ld(webpage, None, fatal=False))
+        playlist = [self.url_result(item['url']) for item in json_data['itemListElement']]
         return self.playlist_result(playlist, list_id, title)
 
 

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -660,10 +660,10 @@ class NiconicoPlaylistIE(NiconicoPlaylistBaseIE):
 
 class NiconicoSeriesIE(InfoExtractor):
     IE_NAME = 'niconico:series'
-    _VALID_URL = r'https?://(?:(?:www\.|sp\.)?nicovideo\.jp|nico\.ms)/series/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:(?:www\.|sp\.)?nicovideo\.jp(?:/user/\d+)?|nico\.ms)/series/(?P<id>\d+)'
 
     _TESTS = [{
-        'url': 'https://www.nicovideo.jp/series/110226',
+        'url': 'https://www.nicovideo.jp/user/44113208/series/110226',
         'info_dict': {
             'id': '110226',
             'title': 'ご立派ァ！のシリーズ',
@@ -683,7 +683,7 @@ class NiconicoSeriesIE(InfoExtractor):
 
     def _real_extract(self, url):
         list_id = self._match_id(url)
-        webpage = self._download_webpage(f'https://www.nicovideo.jp/series/{list_id}', list_id)
+        webpage = self._download_webpage(url, list_id)
 
         title = self._search_regex(
             (r'<title>「(.+)（全',
@@ -693,7 +693,7 @@ class NiconicoSeriesIE(InfoExtractor):
             title = unescapeHTML(title)
         playlist = [
             self.url_result(f'https://www.nicovideo.jp/watch/{v_id}', video_id=v_id)
-            for v_id in re.findall(r'data-href=[\'"](?:https://www\.nicovideo\.jp)?/watch/([a-z0-9]+)', webpage)]
+            for v_id in re.findall(r',[\'"]url[\'"]:[\'"]https:\\/\\/www.nicovideo.jp\\/watch\\/([a-z0-9]+)', webpage)]
         return self.playlist_result(playlist, list_id, title)
 
 

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -692,8 +692,9 @@ class NiconicoSeriesIE(InfoExtractor):
         if title:
             title = unescapeHTML(title)
         json_data = next(self._yield_json_ld(webpage, None, fatal=False))
-        playlist = [self.url_result(item['url']) for item in json_data['itemListElement']]
-        return self.playlist_result(playlist, list_id, title)
+        return self.playlist_from_matches(
+            [item['url'] for item in json_data['itemListElement']],
+            playlist_id=list_id, playlist_title=title, ie=NiconicoIE.ie_key())
 
 
 class NiconicoHistoryIE(NiconicoPlaylistBaseIE):

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -693,8 +693,7 @@ class NiconicoSeriesIE(InfoExtractor):
             title = unescapeHTML(title)
         json_data = next(self._yield_json_ld(webpage, None, fatal=False))
         return self.playlist_from_matches(
-            [item['url'] for item in json_data['itemListElement']],
-            playlist_id=list_id, playlist_title=title, ie=NiconicoIE.ie_key())
+            traverse_obj(json_data, ('itemListElement', ..., 'url')), list_id, title, ie=NiconicoIE)
 
 
 class NiconicoHistoryIE(NiconicoPlaylistBaseIE):

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -693,7 +693,7 @@ class NiconicoSeriesIE(InfoExtractor):
             title = unescapeHTML(title)
         playlist = [
             self.url_result(f'https://www.nicovideo.jp/watch/{v_id}', video_id=v_id)
-            for v_id in re.findall(r',[\'"]url[\'"]:[\'"]https:\\/\\/www.nicovideo.jp\\/watch\\/([a-z0-9]+)', webpage)]
+            for v_id in re.findall(r'[\'"]url[\'"]:[\'"]https:\\/\\/www.nicovideo.jp\\/watch\\/([a-z0-9]+)', webpage)]
         return self.playlist_result(playlist, list_id, title)
 
 


### PR DESCRIPTION
Basically the url format for series pages on niconico changed from just pointing at the series to including the user information in the url. Example:
https://www.nicovideo.jp/series/110226 now redirects to https://www.nicovideo.jp/user/44113208/series/110226
Old urls are still valid through the redirect but the previous extractor's way of extracting  the videos is not so that was updated as well.
Also in lieu of adding a specific test for this new url format I just edited one of the old format ones since we had multiple.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
</details>