### PR TITLE
[extractor/crunchyroll] Extract other language versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1806,6 +1806,7 @@ The following extractors use this feature:
 #### crunchyrollbeta (Crunchyroll)
 * `format`: Which stream type(s) to extract (default: `adaptive_hls`). Potentially useful values include `adaptive_hls`, `adaptive_dash`, `vo_adaptive_hls`, `vo_adaptive_dash`, `download_hls`, `download_dash`, `multitrack_adaptive_hls_v2`
 * `hardsub`: Preference order for which hardsub versions to extract, or `all` (default: `None` = no hardsubs), e.g. `crunchyrollbeta:hardsub=en-US,None`
+* `language`: Specify the languages to extract. `default` (the default language of the extraction URL), `all` (will override all other keys) and `unknown` (formats with unknown languages) can also be used. (Note: Extracting languages other than `default` can significantly slow down the extraction process) <br> e.g. `crunchyrollbeta:language=default,ja-JP,unknown` -> Extract the URL\'s language, japanese and unknown languages
 
 #### vikichannel
 * `video_types`: Types of videos to download - one or more of `episodes`, `movies`, `clips`, `trailers`

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -249,8 +249,8 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
         for version_id, responses in versions.items():
             episode_response, stream_response = responses
             # Skip version, if audio lang is not in requested_langs.
-            audio_lang = (stream_response.get('audio_locale') or '').lower()
-            if requested_langs and audio_lang not in requested_langs:
+            audio_lang = stream_response.get('audio_locale') or ''
+            if requested_langs and audio_lang.lower() not in requested_langs:
                 continue
 
             # Lambda to get values of key from stream_response.

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -122,7 +122,7 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
             'season_number': 1,
             'episode': 'To the Future',
             'episode_number': 73,
-            'thumbnail': r're:^https://www.crunchyroll.com/imgsrv/.*\.jpeg$',
+            'thumbnail': r're:^https://www.crunchyroll.com/imgsrv/.*\.jpeg?$',
             'chapters': 'count:2',
         },
         'params': {'skip_download': 'm3u8', 'format': 'all[format_id~=hardsub]'},

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -218,12 +218,12 @@ class CrunchyrollBetaIE(CrunchyrollBaseIE):
         # Specifying the 'language' option can significantly slow down the extraction process,
         # but formats for different languages will be found as a result.
         # Set 'all' to extract all versions (All other keys will be ignored if 'all' is set).
-        # Use the language key 'default' to specify whether the URL`s language version,
+        # Use the language key 'default' to specify whether the URL\'s language version,
         # should be kept alongside the other requested languages.
         # Use the language key 'unknown' to specify whether unknown language versions
         # should be kept alongside the other requested languages.
         # e.g. requested_langs = ['default', 'ja-JP', 'unknown']
-        # -> Would keep the URL`s language, plus Japanese and unknown languages.
+        # -> Would keep the URL\'s language, plus Japanese and unknown languages.
         # Also, the code will behave like the previous version of the extractor,
         # if 'language' is not set or is set to only ['default'].
         if ['default'] == requested_langs:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Some shows on crunchyroll now have multiple audio languages attached to them e.g. [This one](https://www.crunchyroll.com/de/watch/G8WUN838K/time-will-tell). When switching to a different language in the video player, the URL changes to a different video ID. Currently the extractor only extracts the formats of one language.
My MR changes this and allows to specify languages to extract (or `all`). By default it will still only extract a single language, since extracting other ones is expensive. But when required, this can be enabled using the `language` extractor argument.
Since these languages are distributed over multiple pages you will get different `titles`, `season_ids` and `season` names. I therefore added these fields to every format returned (if more than one language is being extracted). This way when the user requests a format (with `-f ...`) the default info dict returned will be overwritten with the correct arguments (titles, etc.) from the selected format.

**Summary: The way the extraction process works is still the same as before. The only thing that really changed is that the extractor can now iterate through multiple versions and extract their formats as well.**


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
