### PR TITLE
[extractor/biliIntl] Fix subtitle extraction and include ass subs. Update log output to include lang_key

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -895,22 +895,21 @@ class BiliIntlBaseIE(InfoExtractor):
 
         for sub in sub_json.get('video_subtitle') or []:
             srt_sub = sub.get('srt')
-            srt_sub_url = srt_sub.get('url')
-            if not srt_sub_url:
-                continue
-            sub_data = self._download_json(
-                srt_sub_url, ep_id or aid, errnote='Unable to download subtitles', fatal=False,
-                note='Downloading subtitles%s' % f' for {sub["lang"]}' if sub.get('lang') else '')
-            if not sub_data:
-                continue
-            subtitles.setdefault(sub.get('lang_key', 'en'), []).append({
-                'ext': 'srt',
-                'data': self.json2srt(sub_data)
-            })
-
             ass_sub = sub.get('ass')
+            sub_formats = subtitles.setdefault(sub.get('lang_key', 'en'), [])
+
+            if srt_sub:
+                sub_data = self._download_json(
+                    srt_sub.get('url'), ep_id or aid, errnote='Unable to download subtitles', fatal=False,
+                    note='Downloading subtitles%s' % f' for {sub["lang"]} ({sub["lang_key"]})' if sub.get('lang') else '')
+                if sub_data:
+                    sub_formats.append({
+                        'ext': 'srt',
+                        'data': self.json2srt(sub_data)
+                    })
+
             if ass_sub:
-                subtitles.setdefault(sub.get('lang_key', 'en'), []).append({
+                sub_formats.append({
                     'ext': 'ass',
                     'url': ass_sub.get('url')
                 })

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -892,12 +892,14 @@ class BiliIntlBaseIE(InfoExtractor):
                 'aid': aid,
             })) or {}
         subtitles = {}
-        for sub in sub_json.get('subtitles') or []:
-            sub_url = sub.get('url')
-            if not sub_url:
+
+        for sub in sub_json.get('video_subtitle') or []:
+            srt_sub = sub.get('srt')
+            srt_sub_url = srt_sub.get('url')
+            if not srt_sub_url:
                 continue
             sub_data = self._download_json(
-                sub_url, ep_id or aid, errnote='Unable to download subtitles', fatal=False,
+                srt_sub_url, ep_id or aid, errnote='Unable to download subtitles', fatal=False,
                 note='Downloading subtitles%s' % f' for {sub["lang"]}' if sub.get('lang') else '')
             if not sub_data:
                 continue
@@ -905,6 +907,14 @@ class BiliIntlBaseIE(InfoExtractor):
                 'ext': 'srt',
                 'data': self.json2srt(sub_data)
             })
+
+            ass_sub = sub.get('ass')
+            if ass_sub:
+                subtitles.setdefault(sub.get('lang_key', 'en'), []).append({
+                    'ext': 'ass',
+                    'url': ass_sub.get('url')
+                })
+
         return subtitles
 
     def _get_formats(self, *, ep_id=None, aid=None):

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -893,15 +893,16 @@ class BiliIntlBaseIE(InfoExtractor):
             })) or {}
         subtitles = {}
 
-        for sub in sub_json.get('video_subtitle') or []:
+        for sub in traverse_obj(sub_json, ('video_subtitle', ..., {dict})):
             srt_sub = sub.get('srt')
             ass_sub = sub.get('ass')
-            sub_formats = subtitles.setdefault(sub.get('lang_key', 'en'), [])
+            lang_key = sub.get('lang_key', 'en')
+            sub_formats = subtitles.setdefault(lang_key, [])
 
             if srt_sub:
                 sub_data = self._download_json(
                     srt_sub.get('url'), ep_id or aid, errnote='Unable to download subtitles', fatal=False,
-                    note='Downloading subtitles%s' % f' for {sub["lang"]} ({sub["lang_key"]})' if sub.get('lang') else '')
+                    note='Downloading subtitles%s' % f' for {sub["lang"]} ({lang_key})' if sub.get('lang') else '')
                 if sub_data:
                     sub_formats.append({
                         'ext': 'srt',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fixes #7075.
The JSON output has changed recently. Needed to update the logic of sub extraction. Included ass subtitles with this fix. Also updated the log text for different subs to include the lang_key. New log output would look like this: `[BiliIntl] 12779488: Downloading subtitles for 中文（简体） (zh-Hans)`. Checked the fix with geoblocked video as well as international ones, and it's working fine.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 75e965a</samp>

### Summary

No summary available (The summary was empty or could not be parsed)



### Walkthrough
  - Iterate over `video_subtitle` key instead of `subtitles` key in `_get_subtitles` function



</details>
