### PR TITLE
[core] Workaround erroneous urllib Windows proxy parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ offlinetest: codetest
 	$(PYTHON) -m pytest -k "not download"
 
 # XXX: This is hard to maintain
-CODE_FOLDERS = yt_dlp yt_dlp/downloader yt_dlp/extractor yt_dlp/postprocessor yt_dlp/compat yt_dlp/utils yt_dlp/dependencies
+CODE_FOLDERS = yt_dlp yt_dlp/downloader yt_dlp/extractor yt_dlp/postprocessor yt_dlp/compat yt_dlp/compat/urllib yt_dlp/utils yt_dlp/dependencies
 yt-dlp: yt_dlp/*.py yt_dlp/*/*.py
 	mkdir -p zip
 	for d in $(CODE_FOLDERS) ; do \

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -25,6 +25,7 @@ import urllib.request
 
 from .cache import Cache
 from .compat import compat_os_name, compat_shlex_quote
+from .compat.urllib.request import getproxies
 from .cookies import load_cookies
 from .downloader import FFmpegFD, get_suitable_downloader, shorten_protocol_name
 from .downloader.rtmp import rtmpdump_version
@@ -3890,7 +3891,7 @@ class YoutubeDL:
             else:
                 proxies = {'http': opts_proxy, 'https': opts_proxy}
         else:
-            proxies = urllib.request.getproxies()
+            proxies = getproxies()
             # Set HTTPS proxy to HTTP one if given (https://github.com/ytdl-org/youtube-dl/issues/805)
             if 'http' in proxies and 'https' not in proxies:
                 proxies['https'] = proxies['http']

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -21,11 +21,10 @@ import time
 import tokenize
 import traceback
 import unicodedata
-import urllib.request
 
 from .cache import Cache
+from .compat import urllib  # isort: split
 from .compat import compat_os_name, compat_shlex_quote
-from .compat.urllib.request import getproxies
 from .cookies import load_cookies
 from .downloader import FFmpegFD, get_suitable_downloader, shorten_protocol_name
 from .downloader.rtmp import rtmpdump_version
@@ -3891,7 +3890,7 @@ class YoutubeDL:
             else:
                 proxies = {'http': opts_proxy, 'https': opts_proxy}
         else:
-            proxies = getproxies()
+            proxies = urllib.request.getproxies()
             # Set HTTPS proxy to HTTP one if given (https://github.com/ytdl-org/youtube-dl/issues/805)
             if 'http' in proxies and 'https' not in proxies:
                 proxies['https'] = proxies['http']

--- a/yt_dlp/compat/urllib/__init__.py
+++ b/yt_dlp/compat/urllib/__init__.py
@@ -1,0 +1,7 @@
+# flake8: noqa: F405
+from urllib import *  # noqa: F403
+
+from ..compat_utils import passthrough_module
+
+passthrough_module(__name__, 'urllib')
+del passthrough_module

--- a/yt_dlp/compat/urllib/request.py
+++ b/yt_dlp/compat/urllib/request.py
@@ -1,12 +1,13 @@
 # flake8: noqa: F405
 from urllib.request import *  # noqa: F403
-from .. import compat_os_name
+
 from ..compat_utils import passthrough_module
-import sys
 
 passthrough_module(__name__, 'urllib.request')
 del passthrough_module
 
+
+from .. import compat_os_name
 
 if compat_os_name == 'nt':
     # On older python versions, proxies are extracted from Windows registry erroneously. [1]
@@ -16,6 +17,7 @@ if compat_os_name == 'nt':
     # This also applies for ftp proxy type, as ftp:// proxy scheme is not supported.
     # 1: https://github.com/python/cpython/issues/86793
     # 2: https://github.com/python/cpython/blob/51f1ae5ceb0673316c4e4b0175384e892e33cc6e/Lib/urllib/request.py#L2683-L2698
+    import sys
     from urllib.request import getproxies_environment, getproxies_registry
 
     def getproxies_registry_patched():
@@ -34,3 +36,5 @@ if compat_os_name == 'nt':
 
     def getproxies():
         return getproxies_environment() or getproxies_registry_patched()
+
+del compat_os_name

--- a/yt_dlp/compat/urllib/request.py
+++ b/yt_dlp/compat/urllib/request.py
@@ -1,0 +1,36 @@
+# flake8: noqa: F405
+from urllib.request import *  # noqa: F403
+from .. import compat_os_name
+from ..compat_utils import passthrough_module
+import sys
+
+passthrough_module(__name__, 'urllib.request')
+del passthrough_module
+
+
+if compat_os_name == 'nt':
+    # On older python versions, proxies are extracted from Windows registry erroneously. [1]
+    # If the https proxy in the registry does not have a scheme, urllib will incorrectly add https:// to it. [2]
+    # It is unlikely that the user has actually set it to be https, so we should be fine to safely downgrade
+    # it to http on these older python versions to avoid issues
+    # This also applies for ftp proxy type, as ftp:// proxy scheme is not supported.
+    # 1: https://github.com/python/cpython/issues/86793
+    # 2: https://github.com/python/cpython/blob/51f1ae5ceb0673316c4e4b0175384e892e33cc6e/Lib/urllib/request.py#L2683-L2698
+    from urllib.request import getproxies_environment, getproxies_registry
+
+    def getproxies_registry_patched():
+        proxies = getproxies_registry()
+        if (
+            sys.version_info >= (3, 10, 5)  # https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-5-final
+            or (3, 9, 13) <= sys.version_info < (3, 10)  # https://docs.python.org/3.9/whatsnew/changelog.html#python-3-9-13-final
+        ):
+            return proxies
+
+        for scheme in ('https', 'ftp'):
+            if scheme in proxies and proxies[scheme].startswith(f'{scheme}://'):
+                proxies[scheme] = 'http' + proxies[scheme][len(scheme):]
+
+        return proxies
+
+    def getproxies():
+        return getproxies_environment() or getproxies_registry_patched()


### PR DESCRIPTION
Authored by: coletdjnz

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Backport from Network Rework.

Workaround for https://github.com/python/cpython/issues/86793 for older Python versions.

See https://github.com/yt-dlp/yt-dlp/pull/4136 for explanation.

Note: this issue doesn't impact the current yt-dlp as https proxies are treated as http, but for when we add support for https proxies in the future this will be needed. 
(In saying that we may want to add a warning if a user does pass a https proxy in the current state)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe6249d</samp>

### Summary
📦🛠️🔄

<!--
1.  📦 for creating a new module that re-exports the standard `urllib` module.
2.  🛠️ for patching the `getproxies` function to fix proxy detection issues on Windows.
3.  🔄 for updating the `YoutubeDL.py` file to use the custom `getproxies` function.
-->
Patch `urllib.request.getproxies` to fix proxy detection on Windows. Create a new `compat.urllib` package that re-exports and patches the standard `urllib` module.

> _To fix proxy issues on Windows_
> _We patch `urllib` with some hints_
> _We use `compat` to re-export_
> _The standard modules with some support_
> _And update `YoutubeDL` with our prints_

### Walkthrough
* Create and use a custom version of `getproxies` to fix proxy detection issues on Windows ([link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-247128269a2771fbfdf907ed66158ad912ff08ce1c7e2691917de5c65c77f096R1-R36), [link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR28), [link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL3893-R3894))
  * Add a new module `compat/urllib/request.py` that re-exports and patches `urllib.request.getproxies` ([link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-247128269a2771fbfdf907ed66158ad912ff08ce1c7e2691917de5c65c77f096R1-R36))
  * Import `getproxies` from `compat/urllib/request.py` instead of `urllib.request` in `YoutubeDL.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR28))
  * Replace the call to `urllib.request.getproxies` with the local `getproxies` in `YoutubeDL.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL3893-R3894))
* Create a proxy module for `urllib` in `compat/urllib/__init__.py` to allow importing `urllib` from `compat` without breaking existing code ([link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-4bce3e391f7f667fee50b6b8eafa77cf4f1aeb2a8ca29d0c219d16640709ecdeR1-R7))
  * Use a helper function `passthrough_module` to re-export all the symbols from `urllib` and make the local module act as a proxy for the standard module ([link](https://github.com/yt-dlp/yt-dlp/pull/7092/files?diff=unified&w=0#diff-4bce3e391f7f667fee50b6b8eafa77cf4f1aeb2a8ca29d0c219d16640709ecdeR1-R7))



</details>
