### PR TITLE
6720: Pressing enter uses default format

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2732,7 +2732,12 @@ class YoutubeDL:
         while True:
             if interactive_format_selection:
                 req_format = input(
-                    self._format_screen('\nEnter format selector: ', self.Styles.EMPHASIS))
+                    self._format_screen('\nEnter format selector (press ENTER for default, or CTRL+C to quit): ', self.Styles.EMPHASIS))
+
+                if req_format.strip() == '':
+                    req_format = self._default_format_spec(info_dict, download=download)
+                    self.write_debug('Nothing selected, using default format spec: %s' % req_format)
+                
                 try:
                     format_selector = self.build_format_selector(req_format)
                 except SyntaxError as err:

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2724,24 +2724,23 @@ class YoutubeDL:
             return info_dict
 
         format_selector = self.format_selector
-        if format_selector is None:
-            req_format = self._default_format_spec(info_dict, download=download)
-            self.write_debug('Default format spec: %s' % req_format)
-            format_selector = self.build_format_selector(req_format)
-
         while True:
             if interactive_format_selection:
-                req_format = input(
-                    self._format_screen('\nEnter format selector (press ENTER for default, or CTRL+C to quit): ', self.Styles.EMPHASIS))
-
-                if req_format.strip() == '':
-                    req_format = self._default_format_spec(info_dict, download=download)
-                    self.write_debug('Nothing selected, using default format spec: %s' % req_format)
+                req_format = input(' '.join((
+                    self._format_screen('\nEnter format selector', self.Styles.EMPHASIS),
+                    '(Press ENTER for default, or Ctrl+C to quit)',
+                    self._format_screen(': ', self.Styles.EMPHASIS))
+                ))
                 try:
-                    format_selector = self.build_format_selector(req_format)
+                    format_selector = self.build_format_selector(req_format) if req_format else None
                 except SyntaxError as err:
                     self.report_error(err, tb=False, is_error=False)
                     continue
+
+            if format_selector is None:
+                req_format = self._default_format_spec(info_dict, download=download)
+                self.write_debug(f'Default format spec: {req_format}')
+                format_selector = self.build_format_selector(req_format)
 
             formats_to_download = list(format_selector({
                 'formats': formats,

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2737,7 +2737,6 @@ class YoutubeDL:
                 if req_format.strip() == '':
                     req_format = self._default_format_spec(info_dict, download=download)
                     self.write_debug('Nothing selected, using default format spec: %s' % req_format)
-                
                 try:
                     format_selector = self.build_format_selector(req_format)
                 except SyntaxError as err:

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -984,9 +984,6 @@ class YoutubeDL:
     def _format_screen(self, *args, **kwargs):
         return self._format_text(self._out_files.screen, self._allow_colors.screen, *args, **kwargs)
 
-    def _format_screen_bold(self, *args):
-        return self._format_screen(*args, self.Styles.EMPHASIS)
-
     def _format_err(self, *args, **kwargs):
         return self._format_text(self._out_files.error, self._allow_colors.error, *args, **kwargs)
 
@@ -2729,9 +2726,9 @@ class YoutubeDL:
         format_selector = self.format_selector
         while True:
             if interactive_format_selection:
-                req_format = input(self._format_screen_bold('\nEnter format selector ')
+                req_format = input(self._format_screen('\nEnter format selector ', self.Styles.EMPHASIS)
                                    + '(Press ENTER for default, or Ctrl+C to quit)'
-                                   + self._format_screen_bold(': '))
+                                   + self._format_screen(': ', self.Styles.EMPHASIS))
                 try:
                     format_selector = self.build_format_selector(req_format) if req_format else None
                 except SyntaxError as err:

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -983,6 +983,9 @@ class YoutubeDL:
 
     def _format_screen(self, *args, **kwargs):
         return self._format_text(self._out_files.screen, self._allow_colors.screen, *args, **kwargs)
+    
+    def _format_screen_bold(self, *args):
+        return self._format_screen(*args, self.Styles.EMPHASIS)
 
     def _format_err(self, *args, **kwargs):
         return self._format_text(self._out_files.error, self._allow_colors.error, *args, **kwargs)
@@ -2726,10 +2729,10 @@ class YoutubeDL:
         format_selector = self.format_selector
         while True:
             if interactive_format_selection:
-                req_format = input(' '.join((
-                    self._format_screen('\nEnter format selector', self.Styles.EMPHASIS),
+                req_format = input(''.join((
+                    self._format_screen_bold('\nEnter format selector '),
                     '(Press ENTER for default, or Ctrl+C to quit)',
-                    self._format_screen(': ', self.Styles.EMPHASIS))
+                    self._format_screen_bold(': '))
                 ))
                 try:
                     format_selector = self.build_format_selector(req_format) if req_format else None

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -983,7 +983,7 @@ class YoutubeDL:
 
     def _format_screen(self, *args, **kwargs):
         return self._format_text(self._out_files.screen, self._allow_colors.screen, *args, **kwargs)
-    
+
     def _format_screen_bold(self, *args):
         return self._format_screen(*args, self.Styles.EMPHASIS)
 
@@ -2732,8 +2732,7 @@ class YoutubeDL:
                 req_format = input(''.join((
                     self._format_screen_bold('\nEnter format selector '),
                     '(Press ENTER for default, or Ctrl+C to quit)',
-                    self._format_screen_bold(': '))
-                ))
+                    self._format_screen_bold(': '))))
                 try:
                     format_selector = self.build_format_selector(req_format) if req_format else None
                 except SyntaxError as err:

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2729,10 +2729,9 @@ class YoutubeDL:
         format_selector = self.format_selector
         while True:
             if interactive_format_selection:
-                req_format = input(''.join((
-                    self._format_screen_bold('\nEnter format selector '),
-                    '(Press ENTER for default, or Ctrl+C to quit)',
-                    self._format_screen_bold(': '))))
+                req_format = input(self._format_screen_bold('\nEnter format selector ')
+                                   + '(Press ENTER for default, or Ctrl+C to quit)'
+                                   + self._format_screen_bold(': '))
                 try:
                     format_selector = self.build_format_selector(req_format) if req_format else None
                 except SyntaxError as err:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

[Original Issue](https://github.com/yt-dlp/yt-dlp/issues/6720) Description:
> Using -f- prompts "Enter format selector:"
> When entering nothing (i.e. just pressing Enter) outputs "ERROR: Requested format is not available"
> 
> It would be more helpful in this case to autoselect the default format (i.e. the format which would have been selected 
 by not using the -f switch at all) instead of asking again (which doesn't make too much sense IMO).

- Pressing enter will use default format.
- Updated the wording of the message 

Fixes #6720

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7239233</samp>

### Summary
🆕🎛️📝

<!--
1.  🆕 - This emoji means "new" and can be used to indicate that a new feature or option has been added to the program.
2.  🎛️ - This emoji means "control knobs" and can be used to indicate that the user has more control or flexibility over the program's behavior or settings.
3.  📝 - This emoji means "memo" and can be used to indicate that a message or information has been added or updated in the program.
-->
Add default format spec option and debug message to interactive format selection mode in `yt_dlp/YoutubeDL.py`

> _`format` selection_
> _press ENTER or CTRL+C_
> _autumn leaves falling_

### Walkthrough
* Add a feature to the interactive format selection mode that allows using the default format spec or quitting with keyboard shortcuts ([link](https://github.com/yt-dlp/yt-dlp/pull/7101/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL2735-R2740))
* Display a debug message with the default format spec used in the interactive mode ([link](https://github.com/yt-dlp/yt-dlp/pull/7101/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL2735-R2740))



</details>
