### PR TITLE
[extractor/youtube] Extract title in YouTube Music search results

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4579,8 +4579,11 @@ class YoutubeTabBaseInfoExtractor(YoutubeBaseInfoExtractor):
     def _music_reponsive_list_entry(self, renderer):
         video_id = traverse_obj(renderer, ('playlistItemData', 'videoId'))
         if video_id:
+            title = traverse_obj(renderer, (
+                'flexColumns', 0, 'musicResponsiveListItemFlexColumnRenderer',
+                'text', 'runs', 0, 'text'))
             return self.url_result(f'https://music.youtube.com/watch?v={video_id}',
-                                   ie=YoutubeIE.ie_key(), video_id=video_id)
+                                   ie=YoutubeIE.ie_key(), video_id=video_id, title=title)
         playlist_id = traverse_obj(renderer, ('navigationEndpoint', 'watchEndpoint', 'playlistId'))
         if playlist_id:
             video_id = traverse_obj(renderer, ('navigationEndpoint', 'watchEndpoint', 'videoId'))


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR extracts the video title of YouTube Music search results and returns them as a new `title` field in the output.

Fixes #7095

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)
    - _I checked flake8 but didn't manage to run the tests. `python test/test_download.py TestDownload.youtube` said TestDownload has no such attribute; neither when replacing `youtube` with `YouTube`, `YouTubeIE`, or `Youtube`_

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
    - _I did not update tests because I was unsure how. Grepping for `musicResponsiveListItemRenderer` didn't turn up anything so at first I assumed that entire renderer extractor was untested, but while writing I realize the tests query the YouTube API in real-time? Looking at `YoutubeMusicSearchURLIE._TESTS`, is `url` the URL to be queried and `info_dict` the expected extracted value?_
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 73830e1</samp>

### Summary
🎵🛠️🏷️

<!--
1.  🎵 - This emoji represents music, which is the main topic of the YouTube Music tab and the videos that are returned by the function.
2.  🛠️ - This emoji represents a tool or a fix, which is the intention of the change to add the missing titles to the url results.
3.  🏷️ - This emoji represents a label or a tag, which is the function of the title attribute in the url result. The title helps to identify and describe the video.
-->
Add video titles to YouTube Music tab urls. Fix missing titles for some music videos by extracting them from the renderer object in `yt_dlp/extractor/youtube.py`.

> _`_music_responsive_list_entry`_
> _Adds video title to url_
> _Fixing a bug in autumn_

### Walkthrough
* Add video title to url result in YouTube Music tab extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/7102/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L4582-R4586))



</details>
