### PR TITLE
Add support for cc.com movies

### DIFF
--- a/yt_dlp/extractor/comedycentral.py
+++ b/yt_dlp/extractor/comedycentral.py
@@ -2,7 +2,7 @@ from .mtv import MTVServicesInfoExtractor
 
 
 class ComedyCentralIE(MTVServicesInfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?cc\.com/(?:episodes|video(?:-clips)?|collection-playlist)/(?P<id>[0-9a-z]{6})'
+    _VALID_URL = r'https?://(?:www\.)?cc\.com/(?:episodes|video(?:-clips)?|collection-playlist|movies)/(?P<id>[0-9a-z]{6})'
     _FEED_URL = 'http://comedycentral.com/feeds/mrss/'
 
     _TESTS = [{
@@ -24,6 +24,9 @@ class ComedyCentralIE(MTVServicesInfoExtractor):
         'only_matching': True,
     }, {
         'url': 'https://www.cc.com/collection-playlist/cosnej/stand-up-specials/t6vtjb',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.cc.com/topic/a-clusterfunke-christmas',
         'only_matching': True,
     }]
 

--- a/yt_dlp/extractor/comedycentral.py
+++ b/yt_dlp/extractor/comedycentral.py
@@ -26,7 +26,7 @@ class ComedyCentralIE(MTVServicesInfoExtractor):
         'url': 'https://www.cc.com/collection-playlist/cosnej/stand-up-specials/t6vtjb',
         'only_matching': True,
     }, {
-        'url': 'https://www.cc.com/topic/a-clusterfunke-christmas',
+        'url': 'https://www.cc.com/movies/tkp406/a-cluesterfuenke-christmas',
         'only_matching': True,
     }]
 


### PR DESCRIPTION

Extraction logic is identical to what we already have the url just didn't match.

Fixes #1926 


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a01fa8a</samp>

### Summary
🎬🆕✅

<!--
1.  🎬 - This emoji represents movies or cinema, and can be used to indicate that the extractor now supports movie URLs from Comedy Central.
2.  🆕 - This emoji represents something new or updated, and can be used to indicate that the extractor has been improved or modified to handle a different type of URL.
3.  ✅ - This emoji represents a check mark or success, and can be used to indicate that a test case has been added to verify the functionality of the extractor for movie URLs.
-->
Improved `ComedyCentralIE` extractor to handle movie URLs. Added a test case for `yt_dlp/extractor/comedycentral.py`.

> _Oh we are the coders of the Comedy Central_
> _We scrape the movies from the web so fine_
> _We update the `ComedyCentralIE` extractor_
> _And we add a test case on the count of three_

### Walkthrough
* Update the URL pattern to support movie URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/7108/files?diff=unified&w=0#diff-c3cd878bca61955700d8d35d88132a1a76a6b8ea2b6a81a66c8dd80c289bae83L5-R5))
* Add a test case for movie extraction ([link](https://github.com/yt-dlp/yt-dlp/pull/7108/files?diff=unified&w=0#diff-c3cd878bca61955700d8d35d88132a1a76a6b8ea2b6a81a66c8dd80c289bae83R28-R30))



</details>
