### PR TITLE
[extractor/europarl] Rewrite extractor to use new api url

### DIFF
--- a/yt_dlp/extractor/europa.py
+++ b/yt_dlp/extractor/europa.py
@@ -93,8 +93,8 @@ class EuropaIE(InfoExtractor):
 
 class EuroParlWebstreamIE(InfoExtractor):
     _VALID_URL = r'''(?x)
-        https?://(?:multimedia|webstreaming)\.europarl\.europa\.eu/[^/#?]+/
-        (?:embed/embed\.html\?event=|(?!video)[^/#?]+/[\w-]+_)(?P<id>[\w-]+)
+        https?://multimedia\.europarl\.europa\.eu/[^/#?]+/
+        (?:(?!video)[^/#?]+/[\w-]+_)(?P<id>[\w-]+)
     '''
     _TESTS = [{
         'url': 'https://multimedia.europarl.europa.eu/pl/webstreaming/plenary-session_20220914-0900-PLENARY',

--- a/yt_dlp/extractor/europa.py
+++ b/yt_dlp/extractor/europa.py
@@ -109,33 +109,6 @@ class EuroParlWebstreamIE(InfoExtractor):
             'skip_download': True,
         }
     }, {
-        'url': 'https://multimedia.europarl.europa.eu/pl/webstreaming/eu-cop27-un-climate-change-conference-in-sharm-el-sheikh-egypt-ep-delegation-meets-with-ngo-represen_20221114-1600-SPECIAL-OTHER',
-        'info_dict': {
-            'id': 'a8428de8-b9cd-6a2e-11e4-3805d9c9ff5c',
-            'ext': 'mp4',
-            'release_timestamp': 1668434400,
-            'release_date': '20221114',
-            'title': 'md5:d3550280c33cc70e0678652e3d52c028',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'skip': 'Webpage Not Found'
-    }, {
-        # embed webpage
-        'url': 'https://webstreaming.europarl.europa.eu/ep/embed/embed.html?event=20220914-0900-PLENARY&language=en&autoplay=true&logo=true',
-        'info_dict': {
-            'id': 'bcaa1db4-76ef-7e06-8da7-839bd0ad1dbe',
-            'ext': 'mp4',
-            'title': 'Plenary session',
-            'release_date': '20220914',
-            'release_timestamp': 1663137900,
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'skip': 'Can\'t redirect without using js'
-    }, {
         # live webstream
         'url': 'https://multimedia.europarl.europa.eu/en/webstreaming/euroscola_20221115-1000-SPECIAL-EUROSCOLA',
         'info_dict': {


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR change the api url from `vuplay` to `arbor.nl`. This PR rewrite almost all component of the extractor. This PR also get different id from the old api and afaik, there is no way to know how the old id can get or linked. Embed url is not supported anymore because the embed url need js to get processed.

Fixes #6396 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 759a787</samp>

### Summary
🔄🔧📺

<!--
1.  🔄 for updating the extractor to use a new API endpoint and a new JSON structure.
2.  🔧 for simplifying the URL pattern and importing a utility function.
3.  📺 for adding support for live streams.
-->
Update `EuropaTVIE` extractor to use new API and JSON format, simplify URL pattern, and add live stream support. This improves compatibility and functionality for the `europa.eu` website.

> _`EuropaTVIE` changed_
> _New API and JSON_
> _Live streams in autumn_

### Walkthrough
*  Simplify `_VALID_URL` pattern and update test cases ([link](https://github.com/yt-dlp/yt-dlp/pull/7114/files?diff=unified&w=0#diff-f0fb19a18e079371531dbfbd8a1302f9746af5cb9796b42b91a28baed9843952L95-R105), [link](https://github.com/yt-dlp/yt-dlp/pull/7114/files?diff=unified&w=0#diff-f0fb19a18e079371531dbfbd8a1302f9746af5cb9796b42b91a28baed9843952L111-R172))
* Import `traverse_obj` function from `utils` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7114/files?diff=unified&w=0#diff-f0fb19a18e079371531dbfbd8a1302f9746af5cb9796b42b91a28baed9843952R9))
* Rewrite `_real_extract` method to use new API and JSON structure ([link](https://github.com/yt-dlp/yt-dlp/pull/7114/files?diff=unified&w=0#diff-f0fb19a18e079371531dbfbd8a1302f9746af5cb9796b42b91a28baed9843952L111-R172))
* Update or add test cases for new API and JSON structure ([link](https://github.com/yt-dlp/yt-dlp/pull/7114/files?diff=unified&w=0#diff-f0fb19a18e079371531dbfbd8a1302f9746af5cb9796b42b91a28baed9843952L111-R172))



</details>
