### PR TITLE
[extractor/iwara] Fix and improve authentication

### DIFF
--- a/yt_dlp/extractor/iwara.py
+++ b/yt_dlp/extractor/iwara.py
@@ -19,79 +19,65 @@ from ..utils import (
 )
 
 
-# https://github.com/yt-dlp/yt-dlp/issues/6671
 class IwaraBaseIE(InfoExtractor):
+    _NETRC_MACHINE = 'iwara'
     _USERTOKEN = None
     _MEDIATOKEN = None
-    _NETRC_MACHINE = 'iwara'
 
-    def _get_user_token(self, invalidate=False):
-        if not invalidate and self._USERTOKEN:
-            return self._USERTOKEN
+    def _is_token_expired(self, token, token_type):
+        # User token TTL == ~3 weeks, Media token TTL == ~1 hour
+        if (try_call(lambda: jwt_decode_hs256(token)['exp']) or 0) <= int(time.time() - 120):
+            self.to_screen(f'{token_type} token has expired')
+            return True
 
+    def _get_user_token(self):
         username, password = self._get_login_info()
-        IwaraBaseIE._USERTOKEN = username and self.cache.load(self._NETRC_MACHINE, username)
-        expiry = try_call(lambda: jwt_decode_hs256(IwaraBaseIE._USERTOKEN)['exp']) or 0
-        if not IwaraBaseIE._USERTOKEN or invalidate or expiry <= time.time():
-            IwaraBaseIE._USERTOKEN = self._download_json(
+        if not username or not password:
+            return
+
+        user_token = IwaraBaseIE._USERTOKEN or self.cache.load(self._NETRC_MACHINE, username)
+        if not user_token or self._is_token_expired(user_token, 'User'):
+            response = self._download_json(
                 'https://api.iwara.tv/user/login', None, note='Logging in',
-                data=json.dumps({
+                headers={'Content-Type': 'application/json'}, data=json.dumps({
                     'email': username,
                     'password': password
-                }).encode('utf-8'),
-                headers={
-                    'Content-Type': 'application/json'
-                })['token']
+                }).encode(), expected_status=lambda x: True)
+            user_token = traverse_obj(response, ('token', {str}))
+            if not user_token:
+                error = traverse_obj(response, ('message', {str}))
+                if 'invalidLogin' in error:
+                    raise ExtractorError('Invalid login credentials', expected=True)
+                else:
+                    raise ExtractorError(f'Iwara API said: {error or "nothing"}')
 
-            self.cache.store(self._NETRC_MACHINE, username, IwaraBaseIE._USERTOKEN)
+            self.cache.store(self._NETRC_MACHINE, username, user_token)
 
-        return self._USERTOKEN
+        IwaraBaseIE._USERTOKEN = user_token
 
-    def _get_media_token(self, invalidate=False):
-        if not invalidate and self._MEDIATOKEN:
-            return self._MEDIATOKEN
-        elif invalidate:
-            IwaraBaseIE._MEDIATOKEN = None
+    def _get_media_token(self):
+        self._get_user_token()
+        if not IwaraBaseIE._USERTOKEN:
+            return  # user has not passed credentials
 
-        try:
+        if not IwaraBaseIE._MEDIATOKEN or self._is_token_expired(IwaraBaseIE._MEDIATOKEN, 'Media'):
             IwaraBaseIE._MEDIATOKEN = self._download_json(
                 'https://api.iwara.tv/user/token', None, note='Fetching media token',
-                data=b'',  # Need to have some data here, even if it's empty
-                headers={
-                    'Authorization': f'Bearer {self._get_user_token()}',
+                data=b'', headers={
+                    'Authorization': f'Bearer {IwaraBaseIE._USERTOKEN}',
                     'Content-Type': 'application/json'
                 })['accessToken']
-        except ExtractorError as e:
-            if not isinstance(e.cause, urllib.error.HTTPError) and e.cause.code == 403:
-                raise
-            self.write_debug('User token has expired')
-        return self._MEDIATOKEN
+
+        return {'Authorization': f'Bearer {IwaraBaseIE._MEDIATOKEN}'}
 
     def _perform_login(self, username, password):
-        if self._USERTOKEN and self._MEDIATOKEN:
-            return
-        elif self.cache.load(self._NETRC_MACHINE, username) and self._get_media_token():
-            self.write_debug('Skipping logging in')
-            return
-
-        IwaraBaseIE._USERTOKEN = self._get_user_token(True)
-        self._get_media_token(True)
-        self.cache.store(self._NETRC_MACHINE, username, IwaraBaseIE._USERTOKEN)
-
-    def _prepare_auth_header(self):
-        username, password = self._get_login_info()
-        if username and password:
-            self._get_media_token()
-
-        return {'Authorization': f'Bearer {self._MEDIATOKEN}'} if self._MEDIATOKEN else None
+        self._get_media_token()
 
 
 class IwaraIE(IwaraBaseIE):
     IE_NAME = 'iwara'
     _VALID_URL = r'https?://(?:www\.|ecchi\.)?iwara\.tv/videos?/(?P<id>[a-zA-Z0-9]+)'
     _TESTS = [{
-        # this video cannot be played because of migration
-        'only_matching': True,
         'url': 'https://www.iwara.tv/video/k2ayoueezfkx6gvq',
         'info_dict': {
             'id': 'k2ayoueezfkx6gvq',
@@ -108,25 +94,29 @@ class IwaraIE(IwaraBaseIE):
             'timestamp': 1677843869,
             'modified_timestamp': 1679056362,
         },
+        'skip': 'this video cannot be played because of migration',
     }, {
         'url': 'https://iwara.tv/video/1ywe1sbkqwumpdxz5/',
-        'md5': '20691ce1473ec2766c0788e14c60ce66',
+        'md5': '7645f966f069b8ec9210efd9130c9aad',
         'info_dict': {
             'id': '1ywe1sbkqwumpdxz5',
             'ext': 'mp4',
             'age_limit': 18,
-            'title': 'Aponia 阿波尼亚SEX  Party Tonight 手动脱衣 大奶 裸腿',
-            'description': 'md5:0c4c310f2e0592d68b9f771d348329ca',
-            'uploader': '龙也zZZ',
+            'title': 'Aponia アポニア SEX  Party Tonight 手の脱衣 巨乳 ',
+            'description': 'md5:3f60016fff22060eef1ef26d430b1f67',
+            'uploader': 'Lyu ya',
             'uploader_id': 'user792540',
             'tags': [
                 'uncategorized'
             ],
-            'like_count': 1809,
-            'view_count': 25156,
-            'comment_count': 1,
+            'like_count': int,
+            'view_count': int,
+            'comment_count': int,
             'timestamp': 1678732213,
-            'modified_timestamp': 1679110271,
+            'modified_timestamp': int,
+            'thumbnail': 'https://files.iwara.tv/image/thumbnail/581d12b5-46f4-4f15-beb2-cfe2cde5d13d/thumbnail-00.jpg',
+            'modified_date': '20230614',
+            'upload_date': '20230313',
         },
     }, {
         'url': 'https://iwara.tv/video/blggmfno8ghl725bg',
@@ -141,12 +131,15 @@ class IwaraIE(IwaraBaseIE):
             'tags': [
                 'pee'
             ],
-            'like_count': 192,
-            'view_count': 12119,
-            'comment_count': 0,
+            'like_count': int,
+            'view_count': int,
+            'comment_count': int,
             'timestamp': 1598880567,
-            'modified_timestamp': 1598908995,
-            'availability': 'needs_auth',
+            'modified_timestamp': int,
+            'upload_date': '20200831',
+            'modified_date': '20230605',
+            'thumbnail': 'https://files.iwara.tv/image/thumbnail/7693e881-d302-42a4-a780-f16d66b5dadd/thumbnail-00.jpg',
+            # 'availability': 'needs_auth',
         },
     }]
 
@@ -174,13 +167,13 @@ class IwaraIE(IwaraBaseIE):
         username, _ = self._get_login_info()
         video_data = self._download_json(
             f'https://api.iwara.tv/video/{video_id}', video_id,
-            expected_status=lambda x: True, headers=self._prepare_auth_header())
+            expected_status=lambda x: True, headers=self._get_media_token())
         errmsg = video_data.get('message')
         # at this point we can actually get uploaded user info, but do we need it?
         if errmsg == 'errors.privateVideo':
-            self.raise_login_required('Private video. Login if you have permissions to watch')
+            self.raise_login_required('Private video. Login if you have permissions to watch', method='password')
         elif errmsg == 'errors.notFound' and not username:
-            self.raise_login_required('Video may need login to view')
+            self.raise_login_required('Video may need login to view', method='password')
         elif errmsg:  # None if success
             raise ExtractorError(f'Iwara says: {errmsg}')
 
@@ -219,12 +212,14 @@ class IwaraUserIE(IwaraBaseIE):
         'url': 'https://iwara.tv/profile/user792540/videos',
         'info_dict': {
             'id': 'user792540',
+            'title': 'Lyu ya',
         },
-        'playlist_mincount': 80,
+        'playlist_mincount': 70,
     }, {
         'url': 'https://iwara.tv/profile/theblackbirdcalls/videos',
         'info_dict': {
             'id': 'theblackbirdcalls',
+            'title': 'TheBlackbirdCalls',
         },
         'playlist_mincount': 723,
     }, {
@@ -237,8 +232,9 @@ class IwaraUserIE(IwaraBaseIE):
         'url': 'https://www.iwara.tv/profile/lumymmd',
         'info_dict': {
             'id': 'lumymmd',
+            'title': 'Lumy MMD',
         },
-        'playlist_mincount': 10,
+        'playlist_mincount': 1,
     }]
 
     def _entries(self, playlist_id, user_id, page):
@@ -250,7 +246,7 @@ class IwaraUserIE(IwaraBaseIE):
                 'sort': 'date',
                 'user': user_id,
                 'limit': self._PER_PAGE,
-            }, headers=self._prepare_auth_header())
+            }, headers=self._get_media_token())
         for x in traverse_obj(videos, ('results', ..., 'id')):
             yield self.url_result(f'https://iwara.tv/video/{x}')
 
@@ -269,7 +265,6 @@ class IwaraUserIE(IwaraBaseIE):
 
 
 class IwaraPlaylistIE(IwaraBaseIE):
-    # the ID is an UUID but I don't think it's necessary to write concrete regex
     _VALID_URL = r'https?://(?:www\.)?iwara\.tv/playlist/(?P<id>[0-9a-f-]+)'
     IE_NAME = 'iwara:playlist'
     _PER_PAGE = 32
@@ -286,7 +281,7 @@ class IwaraPlaylistIE(IwaraBaseIE):
         videos = self._download_json(
             'https://api.iwara.tv/videos', playlist_id, f'Downloading page {page}',
             query={'page': page, 'limit': self._PER_PAGE},
-            headers=self._prepare_auth_header()) if page else first_page
+            headers=self._get_media_token()) if page else first_page
         for x in traverse_obj(videos, ('results', ..., 'id')):
             yield self.url_result(f'https://iwara.tv/video/{x}')
 
@@ -294,7 +289,7 @@ class IwaraPlaylistIE(IwaraBaseIE):
         playlist_id = self._match_id(url)
         page_0 = self._download_json(
             f'https://api.iwara.tv/playlist/{playlist_id}?page=0&limit={self._PER_PAGE}', playlist_id,
-            note='Requesting playlist info', headers=self._prepare_auth_header())
+            note='Requesting playlist info', headers=self._get_media_token())
 
         return self.playlist_result(
             OnDemandPagedList(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This is the same issue in #6671 where access token is needed for some NSFW video. Update to allow user profile and playlist extractors to use the same access token.

Also has fix to renew expired user token in the cache (#7207)

Fixes #7035, Fixes #7207


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 64c1ecb</samp>

### Summary
🔒📦✅

<!--
1.  🔒 for improving the authentication logic
2.  📦 for improving the extraction logic
3.  ✅ for adding a new test case
-->
Improve `IwaraIE` and related extractors. This pull request enhances the authentication and extraction logic for the `IwaraIE`, `IwaraUserIE`, and `IwaraPlaylistIE` extractors, which handle videos from the Iwara website. It also adds a new test case and a helper method for the API headers.

> _We are the extractors of Iwara_
> _We defy the limits of the media_
> _We forge the headers for the API_
> _We renew the tokens before they die_

### Walkthrough
*  Add error handling and debug message for media token request failure ([link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL49-R59))
*  Simplify header construction for API requests by introducing a new helper method `_prepare_auth_header` in `IwaraIE` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL145-R149), [link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL193-R202))
*  Use `IwaraIE` class as the parent class for `IwaraUserIE` and `IwaraPlaylistIE` classes to inherit the new helper method ([link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL193-R202), [link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL246-R260))
*  Add headers from `_prepare_auth_header` method to API requests for user, playlist, and playlist information extraction in `yt_dlp/extractor/iwara.py` to support private and restricted videos ([link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL228-R242), [link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL263-R278), [link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fL271-R286))
*  Add a new test case for `IwaraUserIE` class to extract videos from a user profile page ([link](https://github.com/yt-dlp/yt-dlp/pull/7137/files?diff=unified&w=0#diff-4a8876f0a8d1dc4bba3feba0da2679799abf8bf4b8080c92fdfb3d069b6a279fR225-R230))



</details>
