### PR TITLE
[extractor/youtube:comments] Deep check response for incomplete data

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3314,7 +3314,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 expected_comment_count = self._get_count(
                     comments_header_renderer, 'countText', 'commentsCount')
 
-                if expected_comment_count:
+                if expected_comment_count is not None:
                     tracker['est_total'] = expected_comment_count
                     self.to_screen(f'Downloading ~{expected_comment_count} comments')
                 comment_sort_index = int(get_single_config_arg('comment_sort') != 'top')  # 1 = new, 0 = top
@@ -3385,7 +3385,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         if not tracker:
             tracker = dict(
                 running_total=0,
-                est_total=0,
+                est_total=None,
                 current_page_thread=0,
                 total_parent_comments=0,
                 total_reply_comments=0,
@@ -3436,9 +3436,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     '       ' if parent else '', ' replies' if parent else '',
                     page_num, comment_prog_str)
 
+            # Do a deep check for incomplete data as sometimes YouTube may return no comments for a continuation
+            # Ignore check if YouTube says the comment count is 0.
             check_get_keys = None
-            if not is_forced_continuation:
-                # Do a deep check for incomplete data as sometimes YouTube may return no comments for a continuation
+            if not is_forced_continuation and not (tracker['est_total'] == 0 and tracker['running_total'] == 0):
                 check_get_keys = [[*continuation_items_path, ..., (
                     'commentsHeaderRenderer' if is_first_continuation else ('commentThreadRenderer', 'commentRenderer'))]]
             try:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3424,7 +3424,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             if not continuation:
                 break
             headers = self.generate_api_headers(ytcfg=ytcfg, visitor_data=self._extract_visitor_data(response))
-            comment_prog_str = f"({tracker['running_total']}/{tracker['est_total']})"
+            comment_prog_str = f"({tracker['running_total']}/~{tracker['est_total']})"
             if page_num == 0:
                 if is_first_continuation:
                     note_prefix = 'Downloading comment section API JSON'


### PR DESCRIPTION
YouTube may sometimes return no comments for a continuation

Authored by: coletdjnz

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
Sometimes YouTube may return no comments for a continuation. This introduces a more throughout deep check for incomplete data to handle this case better.

Example: https://www.youtube.com/watch?v=d_n1qT9uEdU (newest and top sort)


TODO: more thorough testing


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4f8c1e2</samp>

### Summary
🛠️🔎🗣️

<!--
1.  🛠️ - This emoji represents the improvement of the extraction code by defining a common path variable and simplifying the loop over continuation items, which are both tasks that involve fixing or modifying something.
2.  🔎 - This emoji represents the enhancement of the extraction code by performing a deep check for comment data, which is a task that involves searching or finding something.
3.  🗣️ - This emoji represents the topic of the extraction code, which is comments from YouTube, which are a form of communication or speech.
-->
Improve YouTube comment extraction in `yt_dlp/extractor/youtube.py` by refactoring and enhancing the logic for finding and processing comment data.

> _Sing, O Muse, of the skillful coder who refined_
> _The extraction of comments from YouTube's vast domain,_
> _Defining a common path, a clear and constant guide,_
> _To traverse the nested data with ease and without strain._

### Walkthrough
*  Define a common path to access continuation items in YouTube responses (`yt_dlp/extractor/youtube.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/7148/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506R3421-R3422))
*  Pass a list of nested keys to check for comment data in responses, depending on the continuation type (`yt_dlp/extractor/youtube.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/7148/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3436-R3448))
*  Simplify the loop over continuation items by using the defined path and removing unused assignment (`yt_dlp/extractor/youtube.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/7148/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3452-R3461))



</details>
