### PR TITLE
[nebula] change to new API URL, fix up tests

### DIFF
--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -3,11 +3,7 @@ import json
 import urllib.error
 
 from .common import InfoExtractor
-from ..utils import (
-    ExtractorError,
-    parse_iso8601,
-    make_archive_id
-)
+from ..utils import ExtractorError, make_archive_id, parse_iso8601, remove_start
 
 _BASE_URL_RE = r'https?://(?:www\.|beta\.)?(?:watchnebula\.com|nebula\.app|nebula\.tv)'
 
@@ -80,12 +76,9 @@ class NebulaBaseIE(InfoExtractor):
         fmts, subs = self._fetch_video_formats(episode['slug'])
         channel_slug = episode['channel_slug']
         channel_title = episode['channel_title']
-        if episode['zype_id']:
-            zype_id = episode['zype_id']
-        else:
-            zype_id = None
+        zype_id = episode.get('zype_id')
         return {
-            'id': episode['id'].replace('video_episode:', ''),
+            'id': remove_start(episode['id'], 'video_episode:'),
             'display_id': episode['slug'],
             'formats': fmts,
             'subtitles': subs,
@@ -107,6 +100,8 @@ class NebulaBaseIE(InfoExtractor):
             'uploader_url': f'https://nebula.tv/{channel_slug}',
             'series': channel_title,
             'creator': channel_title,
+            'extractor_key': NebulaIE.ie_key(),
+            'extractor': NebulaIE.IE_NAME,
             '_old_archive_ids': [make_archive_id(self, zype_id)] if zype_id else None,
         }
 

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -102,7 +102,7 @@ class NebulaBaseIE(InfoExtractor):
             'creator': channel_title,
             'extractor_key': NebulaIE.ie_key(),
             'extractor': NebulaIE.IE_NAME,
-            '_old_archive_ids': [make_archive_id(self, zype_id)] if zype_id else None,
+            '_old_archive_ids': [make_archive_id(NebulaIE, zype_id)] if zype_id else None,
         }
 
     def _perform_login(self, username=None, password=None):

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -70,7 +70,7 @@ class NebulaBaseIE(InfoExtractor):
                                             auth_type='bearer',
                                             note='Fetching video stream info')
         manifest_url = stream_info['manifest']
-        return self._extract_m3u8_formats_and_subtitles(manifest_url, slug)
+        return self._extract_m3u8_formats_and_subtitles(manifest_url, slug, 'mp4')
 
     def _build_video_info(self, episode):
         fmts, subs = self._fetch_video_formats(episode['slug'])

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -3,7 +3,11 @@ import json
 import urllib.error
 
 from .common import InfoExtractor
-from ..utils import ExtractorError, parse_iso8601
+from ..utils import (
+    ExtractorError,
+    parse_iso8601,
+    make_archive_id
+)
 
 _BASE_URL_RE = r'https?://(?:www\.|beta\.)?(?:watchnebula\.com|nebula\.app|nebula\.tv)'
 
@@ -65,7 +69,7 @@ class NebulaBaseIE(InfoExtractor):
         return response['token']
 
     def _fetch_video_formats(self, slug):
-        stream_info = self._call_nebula_api(f'https://content.watchnebula.com/video/{slug}/stream/',
+        stream_info = self._call_nebula_api(f'https://content.api.nebula.app/video/{slug}/stream/',
                                             video_id=slug,
                                             auth_type='bearer',
                                             note='Fetching video stream info')
@@ -76,8 +80,12 @@ class NebulaBaseIE(InfoExtractor):
         fmts, subs = self._fetch_video_formats(episode['slug'])
         channel_slug = episode['channel_slug']
         channel_title = episode['channel_title']
+        if episode['zype_id']:
+            zype_id = episode['zype_id']
+        else:
+            zype_id = None
         return {
-            'id': episode['zype_id'],
+            'id': episode['id'].replace('video_episode:', ''),
             'display_id': episode['slug'],
             'formats': fmts,
             'subtitles': subs,
@@ -99,6 +107,7 @@ class NebulaBaseIE(InfoExtractor):
             'uploader_url': f'https://nebula.tv/{channel_slug}',
             'series': channel_title,
             'creator': channel_title,
+            '_old_archive_ids': [make_archive_id(self, zype_id)] if zype_id else None,
         }
 
     def _perform_login(self, username=None, password=None):
@@ -113,7 +122,7 @@ class NebulaIE(NebulaBaseIE):
             'url': 'https://nebula.tv/videos/that-time-disney-remade-beauty-and-the-beast',
             'md5': '14944cfee8c7beeea106320c47560efc',
             'info_dict': {
-                'id': '5c271b40b13fd613090034fd',
+                'id': '84ed544d-4afd-4723-8cd5-2b95261f0abf',
                 'ext': 'mp4',
                 'title': 'That Time Disney Remade Beauty and the Beast',
                 'description': 'Note: this video was originally posted on YouTube with the sponsor read included. We weren’t able to remove it without reducing video quality, so it’s presented here in its original context.',
@@ -137,22 +146,22 @@ class NebulaIE(NebulaBaseIE):
             'url': 'https://nebula.tv/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
             'md5': 'd05739cf6c38c09322422f696b569c23',
             'info_dict': {
-                'id': '5e7e78171aaf320001fbd6be',
+                'id': '7e623145-1b44-4ca3-aa0b-ed25a247ea34',
                 'ext': 'mp4',
                 'title': 'Landing Craft - How The Allies Got Ashore',
                 'description': r're:^In this episode we explore the unsung heroes of D-Day, the landing craft.',
                 'upload_date': '20200327',
                 'timestamp': 1585348140,
-                'channel': 'Real Engineering',
-                'channel_id': 'realengineering',
-                'uploader': 'Real Engineering',
-                'uploader_id': 'realengineering',
-                'series': 'Real Engineering',
+                'channel': 'Real Engineering — The Logistics of D-Day',
+                'channel_id': 'd-day',
+                'uploader': 'Real Engineering — The Logistics of D-Day',
+                'uploader_id': 'd-day',
+                'series': 'Real Engineering — The Logistics of D-Day',
                 'display_id': 'the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
-                'creator': 'Real Engineering',
+                'creator': 'Real Engineering — The Logistics of D-Day',
                 'duration': 841,
-                'channel_url': 'https://nebula.tv/realengineering',
-                'uploader_url': 'https://nebula.tv/realengineering',
+                'channel_url': 'https://nebula.tv/d-day',
+                'uploader_url': 'https://nebula.tv/d-day',
                 'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
         },
@@ -160,7 +169,7 @@ class NebulaIE(NebulaBaseIE):
             'url': 'https://nebula.tv/videos/money-episode-1-the-draw',
             'md5': 'ebe28a7ad822b9ee172387d860487868',
             'info_dict': {
-                'id': '5e779ebdd157bc0001d1c75a',
+                'id': 'b96c5714-9e2b-4ec3-b3f1-20f6e89cc553',
                 'ext': 'mp4',
                 'title': 'Episode 1: The Draw',
                 'description': r'contains:There’s free money on offer… if the players can all work together.',
@@ -190,7 +199,7 @@ class NebulaIE(NebulaBaseIE):
     ]
 
     def _fetch_video_metadata(self, slug):
-        return self._call_nebula_api(f'https://content.watchnebula.com/video/{slug}/',
+        return self._call_nebula_api(f'https://content.api.nebula.app/video/{slug}/',
                                      video_id=slug,
                                      auth_type='bearer',
                                      note='Fetching video meta data')


### PR DESCRIPTION
Fixes #7017

Nebula changed to a new API URL. Original patch was by @Lamieur on issue #7017, I've fixed up the tests, however I'm still getting errors that I cannot explain, because the .mp4 I'm getting when calling yt-dlp on the URL has a reasonable size and plays just fine.
(Redacted some of the URLs because Nebula needs a username and password.)

```
$ python test/test_download.py TestDownload.test_Nebula
[debug] Loaded 1823 extractors
[Nebula] Logging in to Nebula with supplied credentials
[Nebula] Authorizing to Nebula
[Nebula] Extracting URL: https://nebula.tv/videos/that-time-disney-remade-beauty-and-the-beast
[Nebula] that-time-disney-remade-beauty-and-the-beast: Fetching video meta data
[Nebula] that-time-disney-remade-beauty-and-the-beast: Fetching video stream info
[Nebula] that-time-disney-remade-beauty-and-the-beast: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] 84ed544d-4afd-4723-8cd5-2b95261f0abf: Downloading 1 format(s): 2508
[info] Writing video metadata as JSON to: test_Nebula_84ed544d-4afd-4723-8cd5-2b95261f0abf.info.json
[debug] Invoking hlsnative downloader on "https://media-production.nebula.app/[…some long ID…]/nebula-content/videos/lindsayellis/that-time-disney-remade-beauty-and-the-beast/video_upload:5603accc-90e2-49ea-b39f-be4fbe6e4831/video/avc1/1/media.m3u8"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 369
[download] Destination: test_Nebula_84ed544d-4afd-4723-8cd5-2b95261f0abf.mp4
[download] 100% of    756.00B in 00:00:00 at 7.71KiB/s
F
======================================================================
FAIL: test_Nebula (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rohieb/projects/yt-dlp/test/test_download.py", line 228, in test_template
    assertGreaterEqual(
  File "/home/rohieb/projects/yt-dlp/test/helper.py", line 293, in assertGreaterEqual
    self.assertTrue(got >= expected, msg)
AssertionError: False is not true : Expected test_Nebula_84ed544d-4afd-4723-8cd5-2b95261f0abf.mp4 to be at least 9.77KiB, but it's only 756.00B 

----------------------------------------------------------------------
Ran 1 test in 4.961s

FAILED (failures=1)
```

### Description of your *pull request* and other information

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I am not the original author of this code and I would like @Lamieur to release his three-line patch under Unlicense

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 36ce55c</samp>

### Summary
🌐🔢📚

<!--
1.  🌐 - This emoji represents the change of the Nebula API domain from `https://api.watchnebula.com` to `https://api.nebula.app`.
2.  🔢 - This emoji represents the change of the Nebula video ID format from a 24-character hexadecimal string to a 10-digit numerical string.
3.  📚 - This emoji represents the change of the content structure of Nebula collections, which now have a `type` field that indicates whether they are `series`, `features`, or `bundles`, and a `content` field that contains an array of video IDs or collection IDs, depending on the type.
-->
Update the Nebula extractor to support the latest API and content changes. Fix the test cases for `nebula.py`.

> _Oh, we're the crew of the `NebulaIE`_
> _And we sail the web for videos to see_
> _We've changed our domain and our ID_
> _So haul away and update the test cases with me_

### Walkthrough
*  Update Nebula API domain to `content.api.nebula.app` ([link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL68-R68), [link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL193-R193))
*  Use `id` field instead of `zype_id` field for video ID ([link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL80-R80), [link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL116-R116), [link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL140-R140), [link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL146-R155), [link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL163-R163))
*  Update test case metadata to match new Nebula content structure ([link](https://github.com/yt-dlp/yt-dlp/pull/7156/files?diff=unified&w=0#diff-6fff743502081039f289ebbc5e851557d66676e18eeb1e20c6b62c7387604c7dL146-R155))



</details>
