### PR TITLE
[Crtvg] Add Extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -413,6 +413,7 @@ from .crunchyroll import (
     CrunchyrollMusicIE,
     CrunchyrollArtistIE,
 )
+from .crtvg import CrtvgIE
 from .cspan import CSpanIE, CSpanCongressIE
 from .ctsnews import CtsNewsIE
 from .ctv import CTVIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -407,13 +407,13 @@ from .crowdbunker import (
     CrowdBunkerIE,
     CrowdBunkerChannelIE,
 )
+from .crtvg import CrtvgIE
 from .crunchyroll import (
     CrunchyrollBetaIE,
     CrunchyrollBetaShowIE,
     CrunchyrollMusicIE,
     CrunchyrollArtistIE,
 )
-from .crtvg import CrtvgIE
 from .cspan import CSpanIE, CSpanCongressIE
 from .ctsnews import CtsNewsIE
 from .ctv import CTVIE

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -9,7 +9,7 @@ class CrtvgIE(InfoExtractor):
         'md5': 'c0958d9ff90e4503a75544358758921d',
         'info_dict': {
             'id': '5839623',
-            'title': 'Os caimáns do Tea | CRTVG',
+            'title': 'Os caimáns do Tea',
             'ext': 'mp4',
             'description': 'md5:f71cfba21ae564f0a6f415b31de1f842',
             'thumbnail': r're:^https?://.*\.(?:jpg|png)',

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -19,7 +19,7 @@ class CrtvgIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        video_url = self._search_regex(r'var\s+url\s*=\s*["\']([^"\']+)', webpage, 'url')
+        video_url = self._search_regex(r'var\s+url\s*=\s*["\']([^"\']+)', webpage, 'video url')
         formats = self._extract_m3u8_formats_and_subtitles(video_url + '/playlist.m3u8', video_id, fatal=False)
         formats.extend(self._extract_mpd_formats(video_url + '/manifest.mpd', video_id, fatal=False))
 

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -1,4 +1,5 @@
 from .common import InfoExtractor
+from ..utils import remove_end
 
 
 class CrtvgIE(InfoExtractor):

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -21,7 +21,7 @@ class CrtvgIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
         video_url = self._search_regex(r'var\s+url\s*=\s*["\']([^"\']+)', webpage, 'video url')
-        formats = self._extract_m3u8_formats_and_subtitles(video_url + '/playlist.m3u8', video_id, fatal=False)
+        formats = self._extract_m3u8_formats(video_url + '/playlist.m3u8', video_id, fatal=False)
         formats.extend(self._extract_mpd_formats(video_url + '/manifest.mpd', video_id, fatal=False))
 
         return {

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -1,0 +1,32 @@
+from .common import InfoExtractor
+
+
+class CrtvgIE(InfoExtractor):
+    _VALID_URL = r'https?://www\.crtvg\.es/tvg/a-carta/[^/]+-(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://www.crtvg.es/tvg/a-carta/os-caimans-do-tea-5839623',
+        'md5': 'c0958d9ff90e4503a75544358758921d',
+        'info_dict': {
+            'id': '5839623',
+            'title': 'Os caimáns do Tea | CRTVG',
+            'ext': 'mp4',
+            'description': 'md5:f71cfba21ae564f0a6f415b31de1f842',
+            'thumbnail': r're:^https?://.*\.(?:jpg|png)',
+        },
+        'params': {'skip_download': 'm3u8'}
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        video_url = self._search_regex(r'var\s+url\s*=\s*["\']([^"\']+)', webpage, 'url')
+        formats = self._extract_m3u8_formats_and_subtitles(video_url + '/playlist.m3u8', video_id, fatal=False)
+        formats.extend(self._extract_mpd_formats(video_url + '/manifest.mpd', video_id, fatal=False))
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'title': self._html_search_meta(['og:title', 'twitter:title'], webpage, 'title', default=None),
+            'description': self._html_search_meta('description', webpage, 'description', default=None),
+            'thumbnail': self._html_search_meta(['og:image', 'twitter:image'], webpage, 'thumbnail', default=None),
+        }

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -2,7 +2,7 @@ from .common import InfoExtractor
 
 
 class CrtvgIE(InfoExtractor):
-    _VALID_URL = r'https?://www\.crtvg\.es/tvg/a-carta/[^/]+-(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?crtvg\.es/tvg/a-carta/[^/#?]+-(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.crtvg.es/tvg/a-carta/os-caimans-do-tea-5839623',
         'md5': 'c0958d9ff90e4503a75544358758921d',

--- a/yt_dlp/extractor/crtvg.py
+++ b/yt_dlp/extractor/crtvg.py
@@ -26,7 +26,8 @@ class CrtvgIE(InfoExtractor):
         return {
             'id': video_id,
             'formats': formats,
-            'title': self._html_search_meta(['og:title', 'twitter:title'], webpage, 'title', default=None),
+            'title': remove_end(self._html_search_meta(
+                ['og:title', 'twitter:title'], webpage, 'title', default=None), ' | CRTVG'),
             'description': self._html_search_meta('description', webpage, 'description', default=None),
             'thumbnail': self._html_search_meta(['og:image', 'twitter:image'], webpage, 'thumbnail', default=None),
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

CRTVG or Televisión de Galicia, commonly known as A Galega, is a Spanish free-to-air television channel owned and operated by Televisión de Galicia S.A., the television subsidiary of Galician regional-owned public broadcaster Corporación Radio e Televisión de Galicia. [Wikipedia](https://en.wikipedia.org/wiki/Televisi%C3%B3n_de_Galicia)

```
[debug] Loaded 1823 extractors
[Crtvg] Extracting URL: https://www.crtvg.es/tvg/a-carta/os-caimans-do-tea-5839623
[Crtvg] 5839623: Downloading webpage
https://ondemand-crtvg-origin.flumotion.com/videos/MD/2022/10/ac818cb4-6dc9-4377-8acf-20d5b2a6e601.mp4
[Crtvg] 5839623: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, filesize, fs_approx, tbr, vbr, abr, asr, proto, vext, aext, hasaud, source, id
[info] 5839623: Downloading 1 format(s): 3268
[info] Writing video metadata as JSON to: test_Crtvg_5839623.info.json
ok

----------------------------------------------------------------------
Ran 1 test in 2.088s

OK
```

Fixes #6609


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at abca7ec</samp>

### Summary
📦🆕🎥

<!--
1.  📦 - This emoji represents the import statement, which is a way of packaging or bundling code from one module to another. It also implies that the `crtvg.py` module is a new addition to the project.
2.  🆕 - This emoji represents the creation of the `crtvg.py` module and the `CrtvgIE` class, which are new features that extend the functionality of the project. It also implies that the `crtvg.es` website is a new source of videos that the project can handle.
3.  🎥 - This emoji represents the video content that the `CrtvgIE` class can extract and download from the `crtvg.es` website. It also implies that the project is related to media and entertainment.
-->
Add a new extractor for `crtvg.es` videos. Create a new module `crtvg.py` that defines the `CrtvgIE` class and import it in `_extractors.py`.

> _`CrtvgIE` class_
> _adds Galician videos_
> _autumn leaves fall_

### Walkthrough
*  Add support for downloading videos from `crtvg.es` ([link](https://github.com/yt-dlp/yt-dlp/pull/7168/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R416), [link](https://github.com/yt-dlp/yt-dlp/pull/7168/files?diff=unified&w=0#diff-aafc3c84f84df81aaf5e97e439de5e33fb67700a87f1b25e952e687baa9f4e55R1-R32))
   * Import `CrtvgIE` class from `crtvg.py` module in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7168/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R416))
   * Define `CrtvgIE` class in `crtvg.py` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7168/files?diff=unified&w=0#diff-aafc3c84f84df81aaf5e97e439de5e33fb67700a87f1b25e952e687baa9f4e55R1-R32))



</details>
