### PR TITLE
[extractor/bravotv] Detect DRM

### DIFF
--- a/yt_dlp/extractor/bravotv.py
+++ b/yt_dlp/extractor/bravotv.py
@@ -1,5 +1,6 @@
 from .adobepass import AdobePassIE
 from ..utils import (
+    HEADRequest,
     extract_attributes,
     float_or_none,
     get_element_html_by_class,
@@ -153,8 +154,11 @@ class BravoTVIE(AdobePassIE):
         if len(chapters) == 1 and not traverse_obj(chapters, (0, 'end_time')):
             chapters = None
 
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            update_url_query(f'{tp_url}/stream.m3u8', query), video_id, 'mp4', m3u8_id='hls')
+        m3u8_url = self._request_webpage(HEADRequest(
+            update_url_query(f'{tp_url}/stream.m3u8', query)), video_id, 'Checking m3u8 URL').geturl()
+        if 'mpeg_cenc' in m3u8_url:
+            self.report_drm(video_id)
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id='hls')
 
         return {
             'id': video_id,


### PR DESCRIPTION
Detect DRM-protected HLS formats and raise

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc2995f</samp>

### Summary
📥🔒🎞️

<!--
1.  📥 This emoji represents importing or downloading something, such as a class or a module. In this case, it corresponds to the import statement for the `HEADRequest` class.
2.  🔒 This emoji represents locking or securing something, such as a file or a stream. In this case, it corresponds to the check for DRM encryption in the m3u8 URL, which is a way of preventing unauthorized access or copying of the content.
3.  🎞️ This emoji represents film or video, such as a format or a subtitle. In this case, it corresponds to the extraction of formats and subtitles from the m3u8 URL, which are the desired output of the extractor.
-->
Add DRM detection and error handling to `bravotv` extractor. Use `HEADRequest` to check m3u8 URL for encryption.

> _Sing, O Muse, of the cunning coder who devised_
> _A way to probe the hidden streams of video_
> _And thwart the schemes of those who would disguise_
> _Their m3u8 URLs with DRM's woe._

### Walkthrough
*  Import `HEADRequest` class from `yt_dlp.utils` module to make `HEAD` requests ([link](https://github.com/yt-dlp/yt-dlp/pull/7171/files?diff=unified&w=0#diff-f272ce07b05d6592bf2f42863ae128d775781b9f37aad9c78ac84d1c5371e7efR3))
*  Use `HEADRequest` to check the final URL of the m3u8 playlist and report DRM encryption if present ([link](https://github.com/yt-dlp/yt-dlp/pull/7171/files?diff=unified&w=0#diff-f272ce07b05d6592bf2f42863ae128d775781b9f37aad9c78ac84d1c5371e7efL156-R161))



</details>
