### PR TITLE
[extractor/youtube] Extract more metadata for comments

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -315,7 +315,7 @@ class InfoExtractor:
                         * "author_id" - user ID of the comment author
                         * "author_thumbnail" - The thumbnail of the comment author
                         * "author_url" - The url to the comment author's page
-                        * "author_is_verified" - Whether the author is a verified
+                        * "author_is_verified" - Whether the author is verified
                                                  on the platform
                         * "author_is_uploader" - Whether the comment is made by
                                                  the video uploader
@@ -330,7 +330,8 @@ class InfoExtractor:
                         * "dislike_count" - Number of negative ratings of the comment
                         * "is_favorited" - Whether the comment is marked as
                                            favorite by the video uploader
-                        * "is_pinned" - Whether the comment is pinned to the top of the comments
+                        * "is_pinned" - Whether the comment is pinned to
+                                        the top of the comments
     age_limit:      Age restriction for the video, as an integer (years)
     webpage_url:    The URL to the video webpage, if given to yt-dlp it
                     should allow to get the same result again. (It will be set

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -314,6 +314,11 @@ class InfoExtractor:
                         * "author" - human-readable name of the comment author
                         * "author_id" - user ID of the comment author
                         * "author_thumbnail" - The thumbnail of the comment author
+                        * "author_url" - The url to the comment author's page
+                        * "author_is_verified" - Whether the author is a verified
+                                                 user on the platform
+                        * "author_is_uploader" - Whether the comment is made by
+                                                 the video uploader
                         * "id" - Comment ID
                         * "html" - Comment as HTML
                         * "text" - Plain text of the comment
@@ -325,8 +330,7 @@ class InfoExtractor:
                         * "dislike_count" - Number of negative ratings of the comment
                         * "is_favorited" - Whether the comment is marked as
                                            favorite by the video uploader
-                        * "author_is_uploader" - Whether the comment is made by
-                                                 the video uploader
+                        * "is_pinned" - Whether the comment is pinned to the top of the comments
     age_limit:      Age restriction for the video, as an integer (years)
     webpage_url:    The URL to the video webpage, if given to yt-dlp it
                     should allow to get the same result again. (It will be set

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -316,7 +316,7 @@ class InfoExtractor:
                         * "author_thumbnail" - The thumbnail of the comment author
                         * "author_url" - The url to the comment author's page
                         * "author_is_verified" - Whether the author is a verified
-                                                 user on the platform
+                                                 on the platform
                         * "author_is_uploader" - Whether the comment is made by
                                                  the video uploader
                         * "id" - Comment ID

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -292,7 +292,6 @@ class BadgeType(enum.Enum):
     AVAILABILITY_PREMIUM = enum.auto()
     AVAILABILITY_SUBSCRIPTION = enum.auto()
     LIVE_NOW = enum.auto()
-    VERIFIED_USER = enum.auto()
 
 
 class YoutubeBaseInfoExtractor(InfoExtractor):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3287,7 +3287,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         info.update({
             # FIXME: non-standard, but we need a way of showing that it is an estimate.
-            'time_text': time_text,
+            '_time_text': time_text,
             'timestamp': timestamp,
         })
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Introduces the following fields for comments:
* `author_url` - The url to the comment author's page
* `author_is_verified` - Whether the author is verified on the platform*
* `is_pinned` - Whether the comment is pinned to the top of the comments

\* also adding for general infodict in (in progress, will be another PR).

Closes https://github.com/yt-dlp/yt-dlp/issues/5411
Related: https://github.com/yt-dlp/yt-dlp/issues/7166

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f7d565</samp>

### Summary
🆕🧑‍💻🗨️

<!--
1.  🆕 This emoji can be used to indicate that new fields are added to the comment dictionary, which enrich the information available for YouTube comments.
2.  🧑‍💻 This emoji can be used to indicate that the code is simplified and refactored, which improves the readability and maintainability of the extraction logic.
3.  🗨️ This emoji can be used to indicate that the changes are related to comments, which are a form of communication and feedback on YouTube videos.
-->
This pull request improves the extraction of YouTube comments by adding more information about the comment authors and their comments, such as verification status, uploader status, and pin status. It also refactors the code in `yt_dlp/extractor/youtube.py` to make it more concise and readable. It affects the files `yt_dlp/extractor/common.py` and `yt_dlp/extractor/youtube.py`.

> _We're scraping the comments from YouTube's site_
> _We're adding new fields to make them more bright_
> _`author_url` and `author_is_verified`_
> _Heave away, me hearties, heave away with pride_

### Walkthrough
*  Add new fields to comment dictionary documentation in `InfoExtractor` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7179/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6R317-R321), [link](https://github.com/yt-dlp/yt-dlp/pull/7179/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L328-R334))
*  Refactor `_extract_comment` function in `YoutubeIE` class to use a dictionary for extracted fields and add new fields from comment renderer ([link](https://github.com/yt-dlp/yt-dlp/pull/7179/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3274-R3282), [link](https://github.com/yt-dlp/yt-dlp/pull/7179/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3280-R3318))
*  Simplify `extract_thread` function in `_comment_entries` function in `YoutubeIE` class to use the result of `_extract_comment` function and check for `is_pinned` field ([link](https://github.com/yt-dlp/yt-dlp/pull/7179/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3352-R3371))



</details>
