### PR TITLE
[extractor/twitter:spaces] Add scheduled time (release_timestamp) for live spaces

### DIFF
--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1298,6 +1298,7 @@ class TwitterSpacesIE(TwitterBaseIE):
 
         metadata = space_data['metadata']
         live_status = try_call(lambda: self.SPACE_STATUS[metadata['state'].lower()])
+        scheduled_timestamp = int_or_none(metadata['scheduled_start'], scale=1000)
 
         formats = []
         if live_status == 'is_upcoming':
@@ -1327,6 +1328,7 @@ class TwitterSpacesIE(TwitterBaseIE):
             'uploader_id': traverse_obj(
                 metadata, ('creator_results', 'result', 'legacy', 'screen_name')),
             'live_status': live_status,
+            'release_timestamp': scheduled_timestamp,
             'timestamp': metadata.get('created_at'),
             'formats': formats,
         }

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -705,7 +705,7 @@ class TwitterIE(TwitterBaseIE):
             'uploader': r're:Monique Camarra.+?',
             'uploader_id': 'MoniqueCamarra',
             'live_status': 'was_live',
-            "release_timestamp": 1658417414,
+            'release_timestamp': 1658417414,
             'description': 'md5:acce559345fd49f129c20dbcda3f1201',
             'timestamp': 1658407771464,
         },
@@ -1299,7 +1299,6 @@ class TwitterSpacesIE(TwitterBaseIE):
 
         metadata = space_data['metadata']
         live_status = try_call(lambda: self.SPACE_STATUS[metadata['state'].lower()])
-        scheduled_timestamp = int_or_none(metadata['scheduled_start'], scale=1000)
 
         formats = []
         if live_status == 'is_upcoming':
@@ -1329,7 +1328,8 @@ class TwitterSpacesIE(TwitterBaseIE):
             'uploader_id': traverse_obj(
                 metadata, ('creator_results', 'result', 'legacy', 'screen_name')),
             'live_status': live_status,
-            'release_timestamp': scheduled_timestamp,
+            'release_timestamp': try_call(
+                lambda: int_or_none(metadata['scheduled_start'], scale=1000)),
             'timestamp': metadata.get('created_at'),
             'formats': formats,
         }

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -705,6 +705,7 @@ class TwitterIE(TwitterBaseIE):
             'uploader': r're:Monique Camarra.+?',
             'uploader_id': 'MoniqueCamarra',
             'live_status': 'was_live',
+            "release_timestamp": 1658417414,
             'description': 'md5:acce559345fd49f129c20dbcda3f1201',
             'timestamp': 1658407771464,
         },


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Add scheduled start time for spaces

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb3b3b1</samp>

### Summary
🕒🔊🐦

<!--
1.  🕒 - This emoji can be used to represent the addition of a time-related field, such as `release_timestamp`, to the audio streams. It suggests the idea of scheduling, planning, or timing something in advance.
2.  🔊 - This emoji can be used to represent the audio streams themselves, as it indicates sound, volume, or speaker output. It can also imply broadcasting, streaming, or listening to audio content.
3.  🐦 - This emoji can be used to represent Twitter Spaces, as it is the official logo of Twitter and its associated products. It can also suggest social media, communication, or networking.
-->
Add support for extracting release timestamps from Twitter Spaces audio streams. Use the `release_timestamp` field in `yt_dlp/extractor/twitter.py` to store the scheduled start time of the stream.

> _Oh we're the coders of the Twitter Spaces_
> _We stream the audio from many places_
> _We add `release_timestamp` to the streams_
> _To schedule them ahead, so we can dream_

### Walkthrough
* Extract the scheduled start time of Twitter Spaces audio streams and convert it to Unix timestamp ([link](https://github.com/yt-dlp/yt-dlp/pull/7186/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103R1301))
* Add the extracted start time as `release_timestamp` field to the info dictionary of the audio streams ([link](https://github.com/yt-dlp/yt-dlp/pull/7186/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103R1331))



</details>
