### PR TITLE
[extractor/youtube] Support shorter relative time text format

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -895,6 +895,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         Extracts a relative time from string and converts to dt object
         e.g. 'streamed 6 days ago', '5 seconds ago (edited)', 'updated today', '8 yr ago'
         """
+
+        # XXX: this could be moved to a general function in utils.py
+        # The relative time text strings are roughly the same as what
+        # Javascript's Intl.RelativeTimeFormat function generates.
+        # See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
         mobj = re.search(
             r'(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>sec(?:ond)?|s|min(?:ute)?|h(?:our|r)?|d(?:ay)?|w(?:eek|k)?|mo(?:nth)?|y(?:ear|r)?)s?\s*ago',
             relative_time_text)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -893,9 +893,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def extract_relative_time(relative_time_text):
         """
         Extracts a relative time from string and converts to dt object
-        e.g. 'streamed 6 days ago', '5 seconds ago (edited)', 'updated today'
+        e.g. 'streamed 6 days ago', '5 seconds ago (edited)', 'updated today', '8 yr ago'
         """
-        mobj = re.search(r'(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>microsecond|second|minute|hour|day|week|month|year)s?\s*ago', relative_time_text)
+        mobj = re.search(r'''(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>s(?:ec)?(?:ond)?|min(ute)?|h(?:ou)?r?|d(?:ay)?|w(?:ee)?k?|mo(?:nth)?|y(?:ea)?r?)s?\s*ago''', relative_time_text)
         if mobj:
             start = mobj.group('start')
             if start:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -895,7 +895,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         Extracts a relative time from string and converts to dt object
         e.g. 'streamed 6 days ago', '5 seconds ago (edited)', 'updated today', '8 yr ago'
         """
-        mobj = re.search(r'(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>s(?:ec)?(?:ond)?|min(ute)?|h(?:ou)?r?|d(?:ay)?|w(?:ee)?k?|mo(?:nth)?|y(?:ea)?r?)s?\s*ago', relative_time_text)
+        mobj = re.search(
+            r'(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>sec(?:ond)?|s|min(?:ute)?|h(?:our|r)?|d(?:ay)?|w(?:eek|k)?|mo(?:nth)?|y(?:ear|r)?)s?\s*ago',
+            relative_time_text)
         if mobj:
             start = mobj.group('start')
             if start:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -895,7 +895,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         Extracts a relative time from string and converts to dt object
         e.g. 'streamed 6 days ago', '5 seconds ago (edited)', 'updated today', '8 yr ago'
         """
-        mobj = re.search(r'''(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>s(?:ec)?(?:ond)?|min(ute)?|h(?:ou)?r?|d(?:ay)?|w(?:ee)?k?|mo(?:nth)?|y(?:ea)?r?)s?\s*ago''', relative_time_text)
+        mobj = re.search(r'(?P<start>today|yesterday|now)|(?P<time>\d+)\s*(?P<unit>s(?:ec)?(?:ond)?|min(ute)?|h(?:ou)?r?|d(?:ay)?|w(?:ee)?k?|mo(?:nth)?|y(?:ea)?r?)s?\s*ago', relative_time_text)
         if mobj:
             start = mobj.group('start')
             if start:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

See https://github.com/TeamNewPipe/NewPipeExtractor/issues/1067 https://github.com/FreeTubeApp/FreeTube/pull/3588

This adds support for the en-US and en-GB formats. We don't officially support en-GB but the additional changes required to support it was little so might as well.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ff52c4</samp>

### Summary
🕒🆙🗣️

<!--
1.  🕒 This emoji represents the concept of time and the relative time units that are parsed by the function.
2.  🆙 This emoji represents the improvement or update that the change brings to the function and its output.
3.  🗣️ This emoji represents the variations and abbreviations that are supported by the updated regular expression, which reflect different ways of expressing time in natural language.
-->
Improved relative time parsing for YouTube videos. Updated the regex in `yt_dlp/extractor/youtube.py` to handle more variations of time units.

> _`extract_relative_time`_
> _now matches more expressions_
> _autumn of YouTube_

### Walkthrough
*  Update the regex for relative time units to support more variations ([link](https://github.com/yt-dlp/yt-dlp/pull/7191/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L896-R898))
*  Fix a typo in the docstring of `extract_relative_time` ([link](https://github.com/yt-dlp/yt-dlp/pull/7191/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L896-R898))



</details>
