### PR TITLE
[extractor/twitch] Update and add extractor-arg for `_CLIENT_ID`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1846,6 +1846,9 @@ The following extractors use this feature:
 ### wrestleuniverse
 * `device_id`: UUID value assigned by the website and used to enforce device limits for paid livestream content. Can be found in browser local storage
 
+#### twitchstream (Twitch)
+* `client_id`: Client ID value to be sent with GraphQL requests, e.g. `twitchstream:client_id=kimne78kx3ncx6brgo4mv6wki5h1ko`
+
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 
 <!-- MANPAGE: MOVE "INSTALLATION" SECTION HERE -->

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -60,7 +60,7 @@ class TwitchBaseIE(InfoExtractor):
     @property
     def _CLIENT_ID(self):
         return self._configuration_arg(
-            'client_id', ['ue6666qo983tsx6so1t0vnawi233wa'], ie_key=TwitchStreamIE)[0]
+            'client_id', ['ue6666qo983tsx6so1t0vnawi233wa'], ie_key=TwitchStreamIE, casesense=True)[0]
 
     def _perform_login(self, username, password):
         def fail(message):

--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -41,7 +41,6 @@ class TwitchBaseIE(InfoExtractor):
     _USHER_BASE = 'https://usher.ttvnw.net'
     _LOGIN_FORM_URL = 'https://www.twitch.tv/login'
     _LOGIN_POST_URL = 'https://passport.twitch.tv/login'
-    _CLIENT_ID = 'kimne78kx3ncx6brgo4mv6wki5h1ko'
     _NETRC_MACHINE = 'twitch'
 
     _OPERATION_HASHES = {
@@ -57,6 +56,11 @@ class TwitchBaseIE(InfoExtractor):
         'VideoPlayer_ChapterSelectButtonVideo': '8d2793384aac3773beab5e59bd5d6f585aedb923d292800119e03d40cd0f9b41',
         'VideoPlayer_VODSeekbarPreviewVideo': '07e99e4d56c5a7c67117a154777b0baf85a5ffefa393b213f4bc712ccaf85dd6',
     }
+
+    @property
+    def _CLIENT_ID(self):
+        return self._configuration_arg(
+            'client_id', ['ue6666qo983tsx6so1t0vnawi233wa'], ie_key=TwitchStreamIE)[0]
 
     def _perform_login(self, username, password):
         def fail(message):


### PR DESCRIPTION
Updates the `_CLIENT_ID` value to fix livestream extraction

Credit to [aeongdesu](https://github.com/aeongdesu) for [finding the ID value](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/94#issuecomment-1360683876) and to @Gregaras for sharing the info in our issue tracker

Also adds an extractor-arg to set the client ID, as I suspect the updated ID may not work for very long. Usage:
```
yt-dlp --extractor-arg "twitchstream:client_id=kimne78kx3ncx6brgo4mv6wki5h1ko" "URL"
```

Closes #7183, #7058
(for now)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58da9af</samp>

### Summary
🛠️🔧🔄

<!--
1.  🛠️ - This emoji represents a tool or a fix, and could be used to indicate that the changes removed a hard-coded value and made the extractor more flexible and reliable.
2.  🔧 - This emoji also represents a tool or an adjustment, and could be used to indicate that the changes added a property to get the client ID from different sources and improved the extractor's functionality.
3.  🔄 - This emoji represents a refresh or an update, and could be used to indicate that the changes updated the extractor to use a more dynamic and robust way of getting the client ID.
-->
Improved TwitchStreamIE extractor by using configurable Twitch API client ID instead of hard-coded value. Modified `yt_dlp/extractor/twitch.py` to implement this change.

> _Oh we're the crew of the TwitchStreamIE_
> _And we work with the code and the API_
> _We don't want no hard-coded client ID_
> _So we fetch it from the config or the fallback list_

### Walkthrough
* Remove hard-coded client ID for Twitch API and make it a property that can be dynamically obtained from configuration arguments ([link](https://github.com/yt-dlp/yt-dlp/pull/7200/files?diff=unified&w=0#diff-2804898417af0aad967097ad6fd96e53abe8cfb292fb4ab2928f5752b2e7eda0L44), [link](https://github.com/yt-dlp/yt-dlp/pull/7200/files?diff=unified&w=0#diff-2804898417af0aad967097ad6fd96e53abe8cfb292fb4ab2928f5752b2e7eda0R60-R64) in `yt_dlp/extractor/twitch.py`)



</details>
