### PR TITLE
[DigitalConcertHall] Support for Films

### DIFF
--- a/yt_dlp/extractor/digitalconcerthall.py
+++ b/yt_dlp/extractor/digitalconcerthall.py
@@ -116,7 +116,7 @@ class DigitalConcertHallIE(InfoExtractor):
                     'start_time': chapter.get('time'),
                     'end_time': try_get(chapter, lambda x: x['time'] + x['duration']),
                     'title': chapter.get('text'),
-                } for chapter in item['cuepoints']] if item.get('cuepoints') and type_ == "concert" else None,
+                } for chapter in item['cuepoints']] if item.get('cuepoints') and type_ == 'concert' else None,
             }
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/digitalconcerthall.py
+++ b/yt_dlp/extractor/digitalconcerthall.py
@@ -11,7 +11,7 @@ from ..utils import (
 
 class DigitalConcertHallIE(InfoExtractor):
     IE_DESC = 'DigitalConcertHall extractor'
-    _VALID_URL = r'https?://(?:www\.)?digitalconcerthall\.com/(?P<language>[a-z]+)/concert/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?digitalconcerthall\.com/(?P<language>[a-z]+)/(?P<type>film|concert)/(?P<id>[0-9]+)'
     _OAUTH_URL = 'https://api.digitalconcerthall.com/v2/oauth2/token'
     _ACCESS_TOKEN = None
     _NETRC_MACHINE = 'digitalconcerthall'
@@ -40,6 +40,19 @@ class DigitalConcertHallIE(InfoExtractor):
         },
         'params': {'skip_download': 'm3u8'},
         'playlist_count': 3,
+    }, {
+        'url': 'https://www.digitalconcerthall.com/en/film/388',
+        'info_dict': {
+            'id': '388',
+            'ext': 'mp4',
+            'title': 'The Berliner Philharmoniker and Frank Peter Zimmermann',
+            'description': 'md5:cfe25a7044fa4be13743e5089b5b5eb2',
+            'thumbnail': r're:^https?://images.digitalconcerthall.com/cms/thumbnails.*\.jpg$',
+            'upload_date': '20220714',
+            'timestamp': 1657785600,
+            'album_artist': 'Frank Peter Zimmermann / Benedikt von Bernstorff / Jakob von Bernstorff',
+        },
+        'params': {'skip_download': 'm3u8'},
     }]
 
     def _perform_login(self, username, password):
@@ -75,7 +88,7 @@ class DigitalConcertHallIE(InfoExtractor):
         if not self._ACCESS_TOKEN:
             self.raise_login_required(method='password')
 
-    def _entries(self, items, language, **kwargs):
+    def _entries(self, items, language, type_, **kwargs):
         for item in items:
             video_id = item['id']
             stream_info = self._download_json(
@@ -103,11 +116,11 @@ class DigitalConcertHallIE(InfoExtractor):
                     'start_time': chapter.get('time'),
                     'end_time': try_get(chapter, lambda x: x['time'] + x['duration']),
                     'title': chapter.get('text'),
-                } for chapter in item['cuepoints']] if item.get('cuepoints') else None,
+                } for chapter in item['cuepoints']] if item.get('cuepoints') and type_ == "concert" else None,
             }
 
     def _real_extract(self, url):
-        language, video_id = self._match_valid_url(url).group('language', 'id')
+        language, type_, video_id = self._match_valid_url(url).group('language', 'type', 'id')
         if not language:
             language = 'en'
 
@@ -120,18 +133,18 @@ class DigitalConcertHallIE(InfoExtractor):
         }]
 
         vid_info = self._download_json(
-            f'https://api.digitalconcerthall.com/v2/concert/{video_id}', video_id, headers={
+            f'https://api.digitalconcerthall.com/v2/{type_}/{video_id}', video_id, headers={
                 'Accept': 'application/json',
                 'Accept-Language': language
             })
         album_artist = ' / '.join(traverse_obj(vid_info, ('_links', 'artist', ..., 'name')) or '')
+        videos = [vid_info] if type_ == 'film' else traverse_obj(vid_info, ('_embedded', ..., ...))
 
         return {
             '_type': 'playlist',
             'id': video_id,
             'title': vid_info.get('title'),
-            'entries': self._entries(traverse_obj(vid_info, ('_embedded', ..., ...)), language,
-                                     thumbnails=thumbnails, album_artist=album_artist),
+            'entries': self._entries(videos, language, thumbnails=thumbnails, album_artist=album_artist, type_=type_),
             'thumbnails': thumbnails,
             'album_artist': album_artist,
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The PR adds support for films to an existing extractor that previously only supported concerts.

Fixes #7184


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33df3da</samp>

### Summary
🎥🎼🛠️

<!--
1.  🎥 - This emoji represents the addition of support for `film` videos, which are a different type of content from `concert` videos and may have different formats and metadata.
2.  🎼 - This emoji represents the extraction of `chapters` for `concert` videos, which are a useful feature for navigating and identifying the different musical pieces and performers in a concert.
3.  🛠️ - This emoji represents the update of the extractor code and the addition of a new test case, which are both necessary tasks for implementing and verifying the changes.
-->
Improve the Digital Concert Hall extractor by adding support for different video types and more metadata. Update tests accordingly.

> _`film` or `concert`, we don't care, we just want to rock_
> _We scrape the hall for every bit of metadata we can unlock_
> _We split the `concert` into `chapters`, we don't miss a note_
> _We test our code with `film` videos, we make the extractor float_

### Walkthrough
*  Update `_VALID_URL` regex to support `film` and `concert` types of videos ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL14-R14))
*  Add a new test case for a `film` type video with expected metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcR43-R55))
   * Extract `type_` group from URL and use it to request appropriate JSON data from API ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL106-R123))
   * Handle different structures of `videos` list for `film` and `concert` videos ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL106-R123))
   * Pass `type_` parameter to `_entries` method ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL123-R141))
   * Accept `type_` parameter and use it to conditionally extract `chapters` field from `cuepoints` key of each video item ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL78-R91), [link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL133-R147))
   * Return a list of entries with video metadata and formats ([link](https://github.com/yt-dlp/yt-dlp/pull/7202/files?diff=unified&w=0#diff-ec781d6032769743854814b17eb49f18a75456f429a07ff12bb2dcf494bd20bcL78-R91))



</details>
