### PR TITLE
acast: fix test data, support embeds in other pages

### DIFF
--- a/yt_dlp/extractor/acast.py
+++ b/yt_dlp/extractor/acast.py
@@ -50,18 +50,22 @@ class ACastIE(ACastBaseIE):
                     '''
     _TESTS = [{
         'url': 'https://www.acast.com/sparpodcast/2.raggarmordet-rosterurdetforflutna',
-        'md5': 'f5598f3ad1e4776fed12ec1407153e4b',
         'info_dict': {
             'id': '2a92b283-1a75-4ad8-8396-499c641de0d9',
             'ext': 'mp3',
             'title': '2. Raggarmordet - Röster ur det förflutna',
-            'description': 'md5:a992ae67f4d98f1c0141598f7bebbf67',
+            'description': 'md5:013959207e05011ad14a222cf22278cc',
             'timestamp': 1477346700,
             'upload_date': '20161024',
             'duration': 2766,
-            'creator': 'Anton Berg & Martin Johnson',
+            'creator': 'Third Ear Studio',
             'series': 'Spår',
             'episode': '2. Raggarmordet - Röster ur det förflutna',
+            'thumbnail': 'https://assets.pippa.io/shows/616ebe1886d7b1398620b943/616ebe33c7e6e70013cae7da.jpg',
+            'episode_number': 2,
+            'display_id': '2.raggarmordet-rosterurdetforflutna',
+            'season_number': 4,
+            'season': 'Season 4',
         }
     }, {
         'url': 'http://embed.acast.com/adambuxton/ep.12-adam-joeschristmaspodcast2015',

--- a/yt_dlp/extractor/acast.py
+++ b/yt_dlp/extractor/acast.py
@@ -40,14 +40,15 @@ class ACastBaseIE(InfoExtractor):
 
 class ACastIE(ACastBaseIE):
     IE_NAME = 'acast'
-    _VALID_URL = r'''(?x)
+    _VALID_URL = r'''(?x:
                     https?://
                         (?:
                             (?:(?:embed|www)\.)?acast\.com/|
                             play\.acast\.com/s/
                         )
-                        (?P<channel>[^/]+)/(?P<id>[^/#?]+)
-                    '''
+                        (?P<channel>[^/]+)/(?P<id>[^/#?"]+)
+                    )'''
+    _EMBED_REGEX = [rf'(?x)<iframe[^>]+\bsrc=[\'"](?P<url>{_VALID_URL})']
     _TESTS = [{
         'url': 'https://www.acast.com/sparpodcast/2.raggarmordet-rosterurdetforflutna',
         'info_dict': {
@@ -76,6 +77,23 @@ class ACastIE(ACastBaseIE):
     }, {
         'url': 'https://play.acast.com/s/sparpodcast/2a92b283-1a75-4ad8-8396-499c641de0d9',
         'only_matching': True,
+    }]
+    _WEBPAGE_TESTS = [{
+        'url': 'https://ausi.anu.edu.au/news/democracy-sausage-episode-can-labor-be-long-form-government',
+        'info_dict': {
+            'id': '646c68fb21fbf20011e9c651',
+            'ext': 'mp3',
+            'creator': 'The Australian National University',
+            'display_id': 'can-labor-be-a-long-form-government',
+            'duration': 2618,
+            'thumbnail': 'https://assets.pippa.io/shows/6113e8578b4903809f16f7e5/1684821529295-515b9520db9ce53275b995eb302f941c.jpeg',
+            'title': 'Can Labor be a long-form government?',
+            'episode': 'Can Labor be a long-form government?',
+            'upload_date': '20230523',
+            'series': 'Democracy Sausage with Mark Kenny',
+            'timestamp': 1684826362,
+            'description': 'md5:feabe1fc5004c78ee59c84a46bf4ba16',
+        }
     }]
 
     def _real_extract(self, url):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fix the acast extractor test data and add support for checking web pages for embeds.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb8a488</samp>

### Summary
🐛🛠️🌐

<!--
1.  🐛 for fixing a bug in the `_VALID_URL` attribute.
2.  🛠️ for improving the clarity and functionality of the `_VALID_URL` attribute.
3.  🌐 for adding support for extracting acast URLs from embedded players in webpages.
-->
Fix and enhance acast extractor. Allow extraction from embedded players by adding `_EMBED_REGEX` and `_WEBPAGE_TESTS` to `ACastIE` in `yt_dlp/extractor/acast.py`.

> _Sing, O Muse, of the skillful coder who refined the `ACastIE` class_
> _And made it fit to parse the webpages where the podcasts are enmassed_
> _He changed the `_VALID_URL` to match the acast domain and path_
> _And added `_EMBED_REGEX` and `_WEBPAGE_TESTS` to aid his craft_

### Walkthrough
*  Rename and update `_VALID_URL` attribute and add `_EMBED_REGEX` attribute to `ACastIE` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7212/files?diff=unified&w=0#diff-389b95318aaf2ec91132ddaf10a3fb72c6b082cf9f580651e4e383bc4ef38da9L43-R43), [link](https://github.com/yt-dlp/yt-dlp/pull/7212/files?diff=unified&w=0#diff-389b95318aaf2ec91132ddaf10a3fb72c6b082cf9f580651e4e383bc4ef38da9L49-R71))
* Add `_WEBPAGE_TESTS` attribute to `ACastIE` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7212/files?diff=unified&w=0#diff-389b95318aaf2ec91132ddaf10a3fb72c6b082cf9f580651e4e383bc4ef38da9R83-R99))



</details>
