### PR TITLE
[extractor/substack] Fix extraction

### DIFF
--- a/yt_dlp/extractor/substack.py
+++ b/yt_dlp/extractor/substack.py
@@ -2,7 +2,7 @@ import re
 import urllib.parse
 
 from .common import InfoExtractor
-from ..utils import str_or_none, traverse_obj
+from ..utils import js_to_json, str_or_none, traverse_obj
 
 
 class SubstackIE(InfoExtractor):
@@ -14,7 +14,7 @@ class SubstackIE(InfoExtractor):
             'id': '47660949',
             'ext': 'mp4',
             'title': 'I MADE A VLOG',
-            'description': 'md5:10c01ff93439a62e70ce963b2aa0b7f6',
+            'description': 'md5:9248af9a759321e1027226f988f54d96',
             'thumbnail': 'md5:bec758a34d8ee9142d43bcebdf33af18',
             'uploader': 'Maybe Baby',
             'uploader_id': '33628',
@@ -77,7 +77,9 @@ class SubstackIE(InfoExtractor):
         display_id, username = self._match_valid_url(url).group('id', 'username')
         webpage = self._download_webpage(url, display_id)
 
-        webpage_info = self._search_json(r'<script[^>]*>\s*window\._preloads\s*=', webpage, 'preloads', display_id)
+        webpage_info = self._parse_json(self._search_json(
+            r'window\._preloads\s*=\s*JSON\.parse\(', webpage, 'json string',
+            display_id, transform_source=js_to_json, contains_pattern=r'"{(?s:.+)}"'), display_id)
 
         post_type = webpage_info['post']['type']
         formats, subtitles = [], {}


### PR DESCRIPTION
Double parses the page JSON since it is now stringified in a `JSON.parse` call.
All substack pages w/media that I can find (including all extractor test URLs) follow this new JS format

Closes #7155


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9b805ea</samp>

### Summary
🛠️🔄🧪

<!--
1.  🛠️ - This emoji represents a wrench or a tool, and it can be used to indicate that something was fixed, modified, or improved. In this case, it could signify that the Substack extractor was adapted to handle a different JSON format and avoid errors or missing data.
2.  🔄 - This emoji represents a clockwise arrow or a refresh icon, and it can be used to indicate that something was updated, changed, or renewed. In this case, it could signify that the source data was transformed with a new function before being parsed and searched.
3.  🧪 - This emoji represents a test tube or an experiment, and it can be used to indicate that something was tested, verified, or experimented with. In this case, it could signify that the test case was updated to reflect the correct video description and ensure that the extractor works as expected.
-->
Fix Substack extractor to handle new JSON format. Update test case accordingly.

> _Substack extractor_
> _`js_to_json` transforms source_
> _Autumn leaves change too_

### Walkthrough
* Import and use `js_to_json` function to convert JavaScript objects to JSON strings ([link](https://github.com/yt-dlp/yt-dlp/pull/7218/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL5-R5), [link](https://github.com/yt-dlp/yt-dlp/pull/7218/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL80-R82))
* Update `description` field of test case to match actual video description ([link](https://github.com/yt-dlp/yt-dlp/pull/7218/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL17-R17))
* Change `webpage_info` variable assignment to handle different webpage data format using `self._parse_json` and `self._search_json` methods with `transform_source` and `contains_pattern` arguments ([link](https://github.com/yt-dlp/yt-dlp/pull/7218/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL80-R82))



</details>
