### PR TITLE
[extractor/tencent] Fix fatal metadata extraction

### DIFF
--- a/yt_dlp/extractor/tencent.py
+++ b/yt_dlp/extractor/tencent.py
@@ -174,7 +174,7 @@ class VQQVideoIE(VQQBaseIE):
 
     _TESTS = [{
         'url': 'https://v.qq.com/x/page/q326831cny0.html',
-        'md5': '84568b3722e15e9cd023b5594558c4a7',
+        'md5': 'b11c9cb781df710d686b950376676e2a',
         'info_dict': {
             'id': 'q326831cny0',
             'ext': 'mp4',
@@ -185,7 +185,7 @@ class VQQVideoIE(VQQBaseIE):
         },
     }, {
         'url': 'https://v.qq.com/x/page/o3013za7cse.html',
-        'md5': 'cc431c4f9114a55643893c2c8ebf5592',
+        'md5': 'a1bcf42c6d28c189bd2fe2d468abb287',
         'info_dict': {
             'id': 'o3013za7cse',
             'ext': 'mp4',
@@ -206,6 +206,7 @@ class VQQVideoIE(VQQBaseIE):
             'series': '鸡毛飞上天',
             'format_id': r're:^shd',
         },
+        'skip': '404',
     }, {
         'url': 'https://v.qq.com/x/cover/mzc00200p29k31e/s0043cwsgj0.html',
         'md5': 'fadd10bf88aec3420f06f19ee1d24c5b',
@@ -218,6 +219,7 @@ class VQQVideoIE(VQQBaseIE):
             'series': '青年理工工作者生活研究所',
             'format_id': r're:^shd',
         },
+        'params': {'skip_download': 'm3u8'},
     }, {
         # Geo-restricted to China
         'url': 'https://v.qq.com/x/cover/mcv8hkc8zk8lnov/x0036x5qqsr.html',

--- a/yt_dlp/extractor/tencent.py
+++ b/yt_dlp/extractor/tencent.py
@@ -163,11 +163,9 @@ class VQQBaseIE(TencentBaseIE):
     _REFERER = 'v.qq.com'
 
     def _get_webpage_metadata(self, webpage, video_id):
-        return self._parse_json(
-            self._search_regex(
-                r'(?s)<script[^>]*>[^<]*window\.__pinia\s*=\s*([^<]+)</script>',
-                webpage, 'pinia data', fatal=False),
-            video_id, transform_source=js_to_json, fatal=False)
+        return self._search_json(
+            r'<script[^>]*>[^<]*window\.__(?:pinia|PINIA__)\s*=',
+            webpage, 'pinia data', video_id, transform_source=js_to_json, fatal=False)
 
 
 class VQQVideoIE(VQQBaseIE):


### PR DESCRIPTION
Update regex pattern, use `_search_json` to make metadata extraction actually non-fatal

Closes #7177


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b6f0e8c</samp>

### Summary
🛠️🆙🚫

<!--
1.  🛠️ - This emoji can be used to represent the improvement of the extraction and parsing of metadata and formats, as it suggests fixing or repairing something that was not working well before.
2.  🆙 - This emoji can be used to represent the updating of the test cases, as it suggests bringing something up to date or to a higher standard.
3.  🚫 - This emoji can be used to represent the skipping of the tests and downloads for unavailable or encrypted videos, as it suggests blocking or preventing something from happening.
-->
Improved Tencent video extraction in `yt_dlp/extractor/tencent.py`. Used a better JSON parser and updated tests.

> _`Tencent` videos_
> _Metadata and formats parsed_
> _Winter tests skipped_

### Walkthrough
*  Simplify metadata extraction using `_search_json` helper method ([link](https://github.com/yt-dlp/yt-dlp/pull/7219/files?diff=unified&w=0#diff-9c30878face4ffafa46a250f104af8cc42253ceaf19fa921bbf6af6f8f86a186L166-R168))
*  Update md5 values of test cases to match current checksums of downloaded files ([link](https://github.com/yt-dlp/yt-dlp/pull/7219/files?diff=unified&w=0#diff-9c30878face4ffafa46a250f104af8cc42253ceaf19fa921bbf6af6f8f86a186L179-R177), [link](https://github.com/yt-dlp/yt-dlp/pull/7219/files?diff=unified&w=0#diff-9c30878face4ffafa46a250f104af8cc42253ceaf19fa921bbf6af6f8f86a186L190-R188))
*  Skip test case for unavailable video ([link](https://github.com/yt-dlp/yt-dlp/pull/7219/files?diff=unified&w=0#diff-9c30878face4ffafa46a250f104af8cc42253ceaf19fa921bbf6af6f8f86a186R209))
*  Skip m3u8 format download for encrypted video in test case ([link](https://github.com/yt-dlp/yt-dlp/pull/7219/files?diff=unified&w=0#diff-9c30878face4ffafa46a250f104af8cc42253ceaf19fa921bbf6af6f8f86a186R222))



</details>
