### PR TITLE
[extractor/sverigesradio] Support slug URLs

### DIFF
--- a/yt_dlp/extractor/sverigesradio.py
+++ b/yt_dlp/extractor/sverigesradio.py
@@ -30,7 +30,7 @@ class SverigesRadioBaseIE(InfoExtractor):
         if not audio_id:
             webpage = self._download_webpage(url, display_id)
             button = extract_attributes(get_element_html_by_class('audio-button', webpage) or '')
-            audio_id = traverse_obj(button, ('data-audio-id', 'data-publication-id')) or self._parse_json(
+            audio_id = traverse_obj(button, 'data-audio-id', 'data-publication-id') or self._parse_json(
                 get_element_by_id('gtm-metadata', webpage), display_id)['pageId']
 
         query = {

--- a/yt_dlp/extractor/sverigesradio.py
+++ b/yt_dlp/extractor/sverigesradio.py
@@ -6,6 +6,7 @@ from ..utils import (
     get_element_html_by_class,
     int_or_none,
     str_or_none,
+    traverse_obj,
 )
 
 
@@ -28,8 +29,8 @@ class SverigesRadioBaseIE(InfoExtractor):
         if not audio_id:
             webpage = self._download_webpage(url, display_id)
             button = extract_attributes(get_element_html_by_class('audio-button', webpage) or '')
-            audio_id = (button.get('data-audio-id') or button.get('data-publication-id')
-                        or self._parse_json(get_element_by_id('gtm-metadata', webpage), display_id)['pageId'])
+            audio_id = traverse_obj(button, ('data-audio-id', 'data-publication-id')) or self._parse_json(
+                get_element_by_id('gtm-metadata', webpage), display_id)['pageId']
 
         query = {
             'id': audio_id,

--- a/yt_dlp/extractor/sverigesradio.py
+++ b/yt_dlp/extractor/sverigesradio.py
@@ -29,9 +29,11 @@ class SverigesRadioBaseIE(InfoExtractor):
         audio_id, display_id = self._match_valid_url(url).group('id', 'slug')
         if not audio_id:
             webpage = self._download_webpage(url, display_id)
-            button = extract_attributes(get_element_html_by_class('audio-button', webpage) or '')
-            audio_id = traverse_obj(button, 'data-audio-id', 'data-publication-id') or self._parse_json(
-                get_element_by_id('gtm-metadata', webpage), display_id)['pageId']
+            audio_id = (
+                traverse_obj(
+                    get_element_html_by_class('audio-button', webpage),
+                    ({extract_attributes}, ('data-audio-id', 'data-publication-id')), get_all=False)
+                or self._parse_json(get_element_by_id('gtm-metadata', webpage), display_id)['pageId'])
 
         query = {
             'id': audio_id,

--- a/yt_dlp/extractor/sverigesradio.py
+++ b/yt_dlp/extractor/sverigesradio.py
@@ -7,6 +7,7 @@ from ..utils import (
     int_or_none,
     str_or_none,
     traverse_obj,
+    url_or_none,
 )
 
 
@@ -40,7 +41,6 @@ class SverigesRadioBaseIE(InfoExtractor):
         item = self._download_json(
             self._BASE_URL + 'audiometadata', audio_id,
             'Downloading audio JSON metadata', query=query)['items'][0]
-        title = item['subtitle']
 
         query['format'] = 'iis'
         urls = []
@@ -71,12 +71,14 @@ class SverigesRadioBaseIE(InfoExtractor):
 
         return {
             'id': audio_id,
-            'title': title,
             'formats': formats,
-            'series': item.get('title'),
-            'duration': int_or_none(item.get('duration')),
-            'thumbnail': item.get('displayimageurl'),
-            'description': item.get('description'),
+            **traverse_obj(item, {
+                'title': 'subtitle',
+                'series': 'title',
+                'duration': ('duration', {int_or_none}),
+                'thumbnail': ('displayimageurl', {url_or_none}),
+                'description': 'description',
+            }),
         }
 
 

--- a/yt_dlp/extractor/sverigesradio.py
+++ b/yt_dlp/extractor/sverigesradio.py
@@ -98,6 +98,18 @@ class SverigesRadioPublicationIE(SverigesRadioBaseIE):
             'thumbnail': r're:^https?://.*\.jpg',
         },
     }, {
+        'url': 'https://sverigesradio.se/artikel/tysk-fotbollsfeber-bayern-munchens-10-ariga-segersvit-kan-brytas',
+        'md5': 'f8a914ad50f491bb74eed403ab4bfef6',
+        'info_dict': {
+            'id': '8360345',
+            'ext': 'm4a',
+            'title': 'Tysk fotbollsfeber när Bayern Münchens 10-åriga segersvit kan brytas',
+            'series': 'Radiosporten',
+            'description': 'md5:5254610e20ce527ecb3a6102a06dcc5f',
+            'duration': 72,
+            'thumbnail': r're:^https?://.*\.jpg',
+        },
+    }, {
         'url': 'https://sverigesradio.se/sida/gruppsida.aspx?programid=3304&grupp=6247&artikel=7146887',
         'only_matching': True,
     }]
@@ -107,7 +119,7 @@ class SverigesRadioPublicationIE(SverigesRadioBaseIE):
 class SverigesRadioEpisodeIE(SverigesRadioBaseIE):
     IE_NAME = 'sverigesradio:episode'
     _VALID_URL = r'https?://(?:www\.)?sverigesradio\.se/(?:sida/)?avsnitt/(?:(?P<id>\d+)|(?P<slug>[\w-]+))(?:$|[#?])'
-    _TEST = {
+    _TESTS = [{
         'url': 'https://sverigesradio.se/avsnitt/1140922?programid=1300',
         'md5': '20dc4d8db24228f846be390b0c59a07c',
         'info_dict': {
@@ -118,6 +130,18 @@ class SverigesRadioEpisodeIE(SverigesRadioBaseIE):
             'title': 'Metoo och valen',
             'description': 'md5:fcb5c1f667f00badcc702b196f10a27e',
             'thumbnail': r're:^https?://.*\.jpg',
-        }
-    }
+        },
+    }, {
+        'url': 'https://sverigesradio.se/avsnitt/p4-live-med-first-aid-kit-scandinavium-mars-2023',
+        'md5': 'ce17fb82520a8033dbb846993d5589fe',
+        'info_dict': {
+            'id': '2160416',
+            'ext': 'm4a',
+            'title': 'P4 Live med First Aid Kit',
+            'description': 'md5:6d5b78eed3d2b65f6de04daa45e9285d',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'series': 'P4 Live',
+            'duration': 5640,
+        },
+    }]
     _AUDIO_TYPE = 'episode'


### PR DESCRIPTION
Closes #7145


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bc5549f</samp>

### Summary
🎧🇸🇪🔧

<!--
1.  🎧 - This emoji represents audio files, which are the main focus of the extraction and metadata improvements.
2.  🇸🇪 - This emoji represents Sveriges Radio, the Swedish public radio broadcaster that is the source of the publications and episodes.
3.  🔧 - This emoji represents the technical aspects of updating the code, such as the import statement, the base class method, the URL patterns, and the test cases.
-->
Improved Sveriges Radio extractor by adding support for more URL formats and metadata fields. Refactored the code in `yt_dlp/extractor/sverigesradio.py` and updated the tests.

> _Extract audio files_
> _From Sveriges Radio `URL`s_
> _More metadata, too_

### Walkthrough
*  Update import statement to include additional utility functions ([link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL4-R10))
*  Modify `_real_extract` method of `SverigesRadioBaseIE` to handle different types of URLs and extract audio ID, display ID, and common fields using various sources and functions ([link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL24-R35), [link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL33), [link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL64-R81))
*  Update `_VALID_URL` pattern of `SverigesRadioPublicationIE` to support URLs with slug and without `.aspx` extension or `artikel` query parameter ([link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL75-R87))
*  Add test case for `SverigesRadioPublicationIE` with new URL format ([link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daR101-R112))
*  Update `_VALID_URL` pattern of `SverigesRadioEpisodeIE` to support URLs with slug and without episode ID ([link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL97-R122))
*  Add test case for `SverigesRadioEpisodeIE` with new URL format ([link](https://github.com/yt-dlp/yt-dlp/pull/7220/files?diff=unified&w=0#diff-d5abdc274873d813fd60c471e0a27447baf9363d446dccde519ed8e1e53f12daL109-R146))



</details>
