### PR TITLE
[extractor/sonyliv] Fix login with token

### DIFF
--- a/yt_dlp/extractor/sonyliv.py
+++ b/yt_dlp/extractor/sonyliv.py
@@ -10,6 +10,8 @@ from ..compat import compat_HTTPError
 from ..utils import (
     ExtractorError,
     int_or_none,
+    jwt_decode_hs256,
+    try_call,
     try_get,
 )
 
@@ -77,8 +79,10 @@ class SonyLIVIE(InfoExtractor):
         self._HEADERS['device_id'] = self._get_device_id()
         self._HEADERS['content-type'] = 'application/json'
 
-        if username.lower() == 'token' and len(password) > 1198:
+        if username.lower() == 'token' and try_call(lambda: jwt_decode_hs256(password)):
             self._HEADERS['authorization'] = password
+            self.report_login()
+            return
         elif len(username) != 10 or not username.isdigit():
             raise ExtractorError(f'Invalid username/password; {self._LOGIN_HINT}')
 


### PR DESCRIPTION
The current extractor code has too great of a length requirement for the auth token, and the `_perform_login` method does not return after accepting the token; instead it requests an OTP and gets an error 400 response (because it's sending username `'token'` to the SonyLIV API).
This patch fixes that:

Partially addresses #4916


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f86c7fe</samp>

### Summary
:sparkles::lock::tv:

<!--
1.  :sparkles: - This emoji means "new feature" and can be used to indicate that the SonyLIV extractor now supports a new authentication method with JWT tokens.
2.  :lock: - This emoji means "security" and can be used to indicate that the JWT token authentication provides a more secure way of accessing videos without SMS verification.
3.  :tv: - This emoji means "video" and can be used to indicate that the changes affect the video downloading functionality of the SonyLIV extractor.
-->
Added JWT token authentication option for `sonyliv` extractor. This allows users to bypass SMS verification and download videos from SonyLIV with a `token` username and a JWT password.

> _`SonyLIV` videos_
> _Download with `token` and password_
> _No SMS in spring_

### Walkthrough
*  Add support for JWT token authentication ([link](https://github.com/yt-dlp/yt-dlp/pull/7223/files?diff=unified&w=0#diff-d9971183e411a09c446abe16f649fb8a0c30aa34262e18e444ea1d45f8af328cR13-R14), [link](https://github.com/yt-dlp/yt-dlp/pull/7223/files?diff=unified&w=0#diff-d9971183e411a09c446abe16f649fb8a0c30aa34262e18e444ea1d45f8af328cL80-R85))



</details>
