### PR TITLE
[extractor/shemaroome] Pass `stream_key` header to downloader

### DIFF
--- a/yt_dlp/extractor/shemaroome.py
+++ b/yt_dlp/extractor/shemaroome.py
@@ -73,7 +73,10 @@ class ShemarooMeIE(InfoExtractor):
         key = bytes_to_intlist(compat_b64decode(data_json['key']))
         iv = [0] * 16
         m3u8_url = unpad_pkcs7(intlist_to_bytes(aes_cbc_decrypt(url_data, key, iv))).decode('ascii')
-        formats, m3u8_subs = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, fatal=False, headers={'stream_key': data_json['stream_key']})
+        headers = {'stream_key': data_json['stream_key']}
+        formats, m3u8_subs = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, fatal=False, headers=headers)
+        for fmt in formats:
+            fmt['http_headers'] = headers
 
         release_date = self._html_search_regex(
             (r'itemprop="uploadDate">\s*([\d-]+)', r'id="release_date" value="([\d-]+)'),


### PR DESCRIPTION
Video format downloads fail without a `stream_key` header.

Closes #7133


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8dcb28d</samp>

### Summary
🛠️🔑🎥

<!--
1.  🛠️ - This emoji represents the fix or improvement aspect of the change, as it shows a wrench and a hammer, which are tools for repairing or enhancing something.
2.  🔑 - This emoji represents the stream_key header that is required for downloading the encrypted formats, as it shows a key, which is a symbol for unlocking or accessing something.
3.  🎥 - This emoji represents the video streaming service and the formats that are being downloaded, as it shows a movie camera, which is a device for recording or playing videos.
-->
Add stream_key header to formats in `shemaroome.py` extractor. This fixes the download failure for some encrypted videos.

> _`headers` variable_
> _adds stream key to formats_
> _winter encryption_

### Walkthrough
* Fix stream key header issue for some formats ([link](https://github.com/yt-dlp/yt-dlp/pull/7224/files?diff=unified&w=0#diff-46520e6ad030eae31d4fa91797e13a88f51e4ded5837bee8faca69d313a924c6L76-R79))



</details>
