### PR TITLE
[TikTok] Fix format resolution sorting

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -218,8 +218,8 @@ class TikTokBaseIE(InfoExtractor):
         def extract_addr(addr, add_meta={}):
             parsed_meta, res = parse_url_key(addr.get('url_key', ''))
             if res:
-                known_resolutions.setdefault(res, {}).setdefault('height', add_meta.get('height'))
-                known_resolutions[res].setdefault('width', add_meta.get('width'))
+                known_resolutions.setdefault(res, {}).setdefault('height', add_meta.get('height', addr.get('height')))
+                known_resolutions[res].setdefault('width', add_meta.get('width', addr.get('width')))
                 parsed_meta.update(known_resolutions.get(res, {}))
                 add_meta.setdefault('height', int_or_none(res[:-1]))
             return [{

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -218,8 +218,8 @@ class TikTokBaseIE(InfoExtractor):
         def extract_addr(addr, add_meta={}):
             parsed_meta, res = parse_url_key(addr.get('url_key', ''))
             if res:
-                known_resolutions.setdefault(res, {}).setdefault('height', add_meta.get('height', addr.get('height')))
-                known_resolutions[res].setdefault('width', add_meta.get('width', addr.get('width')))
+                known_resolutions.setdefault(res, {}).setdefault('height', add_meta.get('height') or addr.get('height'))
+                known_resolutions[res].setdefault('width', add_meta.get('width') or addr.get('width'))
                 parsed_meta.update(known_resolutions.get(res, {}))
                 add_meta.setdefault('height', int_or_none(res[:-1]))
             return [{


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information
Resolution is not properly detected for >=720 clips.
The fix is to get the resolution out of `addr` instead of `add_meta`. However, I'm not 100% sure if there can be any cases where the resolution could be missing from `addr` and we should get it from `add_meta` as before. I've added a warning for that scenario.
The alternative would be to get the resolution like `addr.get('height', add_meta.get('height'))`

Before the fix:
```
[TikTok] Extracting URL: https://www.tiktok.com/@tatemcrae/video/7107337212743830830
[TikTok] 7107337212743830830: Downloading video feed
[debug] Sort order given by user: res, fps, quality
[debug] Sort order given by extractor: quality, codec, size, br
[debug] Formats sorted by: hasvid, ie_pref, res, fps, quality, vcodec, acodec, filesize, fs_approx, tbr, vbr, abr, lang, hdr:12(7), channels, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 7107337212743830830:
ID                     EXT RESOLUTION │  FILESIZE   TBR PROTO │ VCODEC   VBR ACODEC MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
download_addr-0        mp4 576x1024   │  20.23MiB       https │ h264         aac    Download video, watermarked (API)
download_addr-1        mp4 576x1024   │  20.23MiB       https │ h264         aac    Download video, watermarked
download_addr-2        mp4 576x1024   │  20.23MiB       https │ h264         aac    Download video, watermarked
bytevc1_720p_504085-0  mp4 unknown    │   9.03MiB  504k https │ h265    504k aac    Playback video (API)
bytevc1_720p_504085-1  mp4 unknown    │   9.03MiB  504k https │ h265    504k aac    Playback video
bytevc1_720p_504085-2  mp4 unknown    │   9.03MiB  504k https │ h265    504k aac    Playback video
bytevc1_1080p_808907-0 mp4 unknown    │  14.49MiB  808k https │ h265    808k aac    Playback video (API)
bytevc1_1080p_808907-1 mp4 unknown    │  14.49MiB  808k https │ h265    808k aac    Playback video
bytevc1_1080p_808907-2 mp4 unknown    │  14.49MiB  808k https │ h265    808k aac    Playback video
......
```

After the fix:
```
[TikTok] Extracting URL: https://www.tiktok.com/@tatemcrae/video/7107337212743830830
[TikTok] 7107337212743830830: Downloading video feed
[debug] Sort order given by user: res, fps, quality
[debug] Sort order given by extractor: quality, codec, size, br
[debug] Formats sorted by: hasvid, ie_pref, res, fps, quality, vcodec, acodec, filesize, fs_approx, tbr, vbr, abr, lang, hdr:12(7), channels, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 7107337212743830830:
ID                     EXT RESOLUTION │  FILESIZE   TBR PROTO │ VCODEC   VBR ACODEC MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
.....
bytevc1_540p_451303-0  mp4 576x1024   │   8.08MiB  451k https │ h265    451k aac    Direct video (API)
bytevc1_540p_451303-1  mp4 576x1024   │   8.08MiB  451k https │ h265    451k aac    Direct video
bytevc1_540p_451303-2  mp4 576x1024   │   8.08MiB  451k https │ h265    451k aac    Direct video
bytevc1_720p_504085-0  mp4 720x1280   │   9.03MiB  504k https │ h265    504k aac    Playback video (API)
bytevc1_720p_504085-1  mp4 720x1280   │   9.03MiB  504k https │ h265    504k aac    Playback video
bytevc1_720p_504085-2  mp4 720x1280   │   9.03MiB  504k https │ h265    504k aac    Playback video
bytevc1_1080p_808907-0 mp4 1080x1920  │  14.49MiB  808k https │ h265    808k aac    Playback video (API)
bytevc1_1080p_808907-1 mp4 1080x1920  │  14.49MiB  808k https │ h265    808k aac    Playback video
bytevc1_1080p_808907-2 mp4 1080x1920  │  14.49MiB  808k https │ h265    808k aac    Playback video
```
<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81560fd</samp>

### Summary
:warning::mag::bug:

<!--
1.  :warning: - This emoji conveys the idea of a warning message, which is added by this change to alert the user of a potential problem with the `addr` object.
2.  :mag: - This emoji conveys the idea of magnification or resolution, which is related to the `height` and `width` attributes that are used by this change to determine the video quality.
3.  :bug: - This emoji conveys the idea of a bug fix, which is the overall purpose of this change and the pull request it belongs to.
-->
Improve resolution detection and error handling for TikTok extractor. Use `addr.height` and `addr.width` instead of `add_meta` in `yt_dlp/extractor/tiktok.py`.

> _`addr` has no size_
> _Warn and use its attributes_
> _Fall leaves, TikTok fixed_

### Walkthrough
* Fix TikTok extractor for videos with missing or incorrect metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/7237/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59L219-R226),                             F0L246R



</details>
