### PR TITLE
--download-sections "*from_urls" extracting sections from embedded YT URLS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,14 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     Needs ffmpeg. This option can be used
                                     multiple times to download multiple
                                     sections, e.g. --download-sections
-                                    "*10:15-inf" --download-sections "intro"
+                                    "*10:15-inf" --download-sections "intro".
+				    --download-sections "*from_url" can be set
+				    to extract sections automaticall from urls 
+				    like www.youtube.com/embed/VID?start=6&end=10
+				    If output template is not set *from_url would
+				    automatically add timestamps to the file name
+				    "%(title)s-%(id)s-%(section_start)s-
+				    %(section_end)s.%(ext)s"
     --downloader [PROTO:]NAME       Name or path of the external downloader to
                                     use (optionally) prefixed by the protocols
                                     (http, ftp, m3u8, dash, rstp, rtmp, mms) to

--- a/README.md
+++ b/README.md
@@ -619,9 +619,21 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     "*10:15-inf" --download-sections "intro".
 				    --download-sections "*from_url" can be set
 				    to extract sections automaticall from urls 
-				    like www.youtube.com/embed/VID?start=6&end=10
-				    If output template is not set *from_url would
-				    automatically add timestamps to the file name
+				    www.youtube.com/embed/VID?start=6&end=10
+				    youtu.be/VID?t=552
+				    www.youtube.com/watch?v=VID&t=552s
+				    www.youtube.com/watch?v=VID&t=1h9m10s
+				    If the end value is not specified the s
+				    ection is calculated to be until the end
+				    of the video. Alternatively "*from_url+999"
+				    can be specified, where 999 is the duration
+				    in seconds which is added to the start time
+				    for all URLS where the start or t value is 
+				    specified. If both end value and duration 
+				    are specified the end value takes precedence.
+				    If output template is not set, *from_url 
+				    would automatically add timestamps to the 
+				    output file name
 				    "%(title)s-%(id)s-%(section_start)s-
 				    %(section_end)s.%(ext)s"
     --downloader [PROTO:]NAME       Name or path of the external downloader to

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -353,7 +353,7 @@ def validate_options(opts):
                 chapters.append(re.compile(regex))
             except re.error as err:
                 raise ValueError(f'invalid {name} regex "{regex}" - {err}')
-        return chapters, ranges, behavior_flag,set_duration
+        return chapters, ranges, behavior_flag, set_duration
 
     opts.remove_chapters, opts.remove_ranges, flag, set_duration = parse_chapters('--remove-chapters', opts.remove_chapters)
     opts.download_ranges = download_range_func(*parse_chapters('--download-sections', opts.download_ranges))

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -3768,7 +3768,7 @@ class download_range_func:
         local_ranges = []
 
         if (self.flag & self.Flags.EXTRACT_RANGE_FROM_URL) > 0:
-            local_ranges = self.extract_ranges_from_url(info_dict.get('original_url'),self.set_duration)
+            local_ranges = self.extract_ranges_from_url(info_dict.get('original_url'), self.set_duration)
 
         # yield with nothing if no ranges are present
         if not self.ranges and not self.chapters and not local_ranges:
@@ -3809,17 +3809,17 @@ class download_range_func:
         # Check if 'h' is present in the time string
         if 'h' in time_str:
             hours, time_str = time_str.split('h')
-            total_seconds += float_or_none(hours,default=0.0) * 3600
+            total_seconds += float_or_none(hours, default=0.0) * 3600
 
         # Check if 'm' is present in the remaining time string
         if 'm' in time_str:
             minutes, time_str = time_str.split('m')
-            total_seconds += float_or_none(minutes,default=0.0) * 60
+            total_seconds += float_or_none(minutes, default=0.0) * 60
 
         # Remove 's' if present and add the remaining seconds
         if 's' in time_str:
             seconds = time_str.rstrip('s')
-            total_seconds += float_or_none(seconds,default=0.0)
+            total_seconds += float_or_none(seconds, default=0.0)
 
         # yes, it's silly to convert float to string and then convert it back, but the alternative was an extra loop
         # in extract_ranges_from_url
@@ -3838,11 +3838,11 @@ class download_range_func:
     # that have a start value,if set_duration is not set and the end value is not specified, the end value
     # is set to inf. If both set_duration and end value are set, the end value specified in the URL takes precedence.
     @staticmethod
-    def extract_ranges_from_url(url,set_duration):
+    def extract_ranges_from_url(url, set_duration):
         produced_ranges = []
         parsed_url = urllib.parse.urlparse(url)
         query_params = urllib.parse.parse_qs(parsed_url.query)
-        start_array=[]
+        start_array = []
 
         # Get the values of "t" parameters, treated the same as start parameter after conversion to seconds
         t_array = query_params.get('t', [])
@@ -3856,14 +3856,14 @@ class download_range_func:
 
         for i in range(max_pairs):
             start = start_array[i] if i < len(start_array) else '0'  # default is 0
-            start_float=float_or_none(start,default=0.0)
+            start_float = float_or_none(start, default=0.0)
 
             end_float = float('inf')  # if end_float is not set anywhere else, it remains inf
-            if i < len(end_array): #if end is set it takes precedence over set_duration
-                end_float=float_or_none(end_array[i],default=float('inf'))
+            if i < len(end_array):  # if end is set it takes precedence over set_duration
+                end_float = float_or_none(end_array[i], default=float('inf'))
             else:
                 if set_duration is not None:
-                    end_float=start_float+set_duration
+                    end_float = start_float + set_duration
 
             produced_ranges.append((start_float, end_float,))
 


### PR DESCRIPTION

A new option was added to --download-sections  - *from_urls - to generate sections automatically from the URL itself.

When --download-sections "*from_urls" is specified, for any URLS of the form https://www.youtube.com/embed/VIDEOID?start=6&end=10

The start and end values are parsed and an additional download section is generated. The default value for start is 0, the default value for end is inf (end of video). If neither start nor end is present in the URL the old behavior remains unchanged, even if *from_urls is specified.

Multiple start and end values are supported per URL, these are paired and multiple sections are generated.
If multiple --download-sections are specified they are combined with the newly generated sections, for each video.

When the *from_urls option is specified the default output template is changed to "%(title)s-%(id)s-%(section_start)s-%(section_end)s.%(ext)s". This is done in order to produce different files when there are multiple sections from the same video are specified or different sections are already present in the directory, otherwise the default behavior is to skip the download.

Updated documentation for --download-sections "*from_url", added explanation and URL example.

Execution example: 

py -bb -Werror -Xdev ".\yt_dlp\__main__.py" "https://www.youtube.com/embed/djzX3fXnIFs?start=6&end=10"  --download-sections "*from_urls"  -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
  
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 93f8056</samp>

### Summary
📝🎞️🔗

<!--
1.  📝 - This emoji represents documentation, writing, or editing, and can be used for the first change that updates the README.md file.
2.  🎞️ - This emoji represents video, film, or cinema, and can be used for the second change that adds support for downloading video sections based on the URL.
3.  🔗 - This emoji represents link, connection, or relation, and can be used for the third change that adds a new feature to the `download_range_func` class that extracts start and end times from the video URL query parameters.
-->
This pull request adds a new feature to yt-dlp that allows downloading sections of videos based on the URL. It modifies `yt_dlp/__init__.py`, `yt_dlp/utils/_utils.py`, and `README.md` to implement and document the `--download-sections` option and the `*from_url` value. It also changes the default output template to include the section start and end times in the file name.

> _If you want to download a section_
> _Of a video without much inspection_
> _Use `--download-sections`_
> _With `*from_url` selections_
> _And enjoy the automatic detection_

### Walkthrough
*  Add a new feature to download sections of videos based on the URL parameters ([link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L619-R626), [link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-368601fd75cc1f1f9a4427938fe6381ffbab2ed89434cabb25d9346b43f037b0L326-R341), [link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-368601fd75cc1f1f9a4427938fe6381ffbab2ed89434cabb25d9346b43f037b0L339-R361), [link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL3751-R3772), [link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL3768-R3817))
  * Update the documentation of the `--download-sections` option in `README.md` to explain the new value `*from_url` and the default output template ([link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L619-R626))
  * Modify the `parse_chapters` function in `yt_dlp/__init__.py` to accept a flag parameter that indicates whether to extract ranges from the URL or not, and return the flag along with the chapters and ranges ([link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-368601fd75cc1f1f9a4427938fe6381ffbab2ed89434cabb25d9346b43f037b0L326-R341))
  * Modify the `validate_options` function in `yt_dlp/__init__.py` to pass the flag to the `download_range_func` constructor, and update the default output template if the flag is set ([link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-368601fd75cc1f1f9a4427938fe6381ffbab2ed89434cabb25d9346b43f037b0L339-R361))
  * Modify the `download_range_func` class in `yt_dlp/utils/_utils.py` to store the flag as an attribute, and add a static method to extract ranges from the URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL3751-R3772))
  * Modify the `__call__` method of the `download_range_func` class in `yt_dlp/utils/_utils.py` to combine the ranges from the URL with the existing ranges, and yield from the combined list ([link](https://github.com/yt-dlp/yt-dlp/pull/7248/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL3768-R3817))



</details>
