### PR TITLE
[extractor/zee5] Fix extraction of new content

### DIFF
--- a/yt_dlp/extractor/zee5.py
+++ b/yt_dlp/extractor/zee5.py
@@ -101,7 +101,7 @@ class Zee5IE(InfoExtractor):
     _LOGIN_HINT = 'Use "--username <mobile_number>" to login using otp or "--username token" and "--password <user_token>" to login using user token.'
     _NETRC_MACHINE = 'zee5'
     _GEO_COUNTRIES = ['IN']
-    _USER_COUNTRY = 'IN'
+    _USER_COUNTRY = None
 
     def _perform_login(self, username, password):
         if len(username) == 10 and username.isdigit() and self._USER_TOKEN is None:
@@ -128,7 +128,7 @@ class Zee5IE(InfoExtractor):
         token = jwt_decode_hs256(self._USER_TOKEN)
         if token.get('exp', 0) <= time.time():
             raise ExtractorError('User token has expired', expected=True)
-        self._USER_COUNTRY = token.get('current_country') or 'IN'
+        self._USER_COUNTRY = token.get('current_country')
 
     def _real_extract(self, url):
         video_id, display_id = self._match_valid_url(url).group('id', 'display_id')
@@ -148,7 +148,7 @@ class Zee5IE(InfoExtractor):
                 'content_id': video_id,
                 'device_id': self._DEVICE_ID,
                 'platform_name': 'desktop_web',
-                'country': self._USER_COUNTRY,
+                'country': self._USER_COUNTRY or self.get_param('geo_bypass_country') or 'IN',
                 'check_parental_control': False,
             }, headers={'content-type': 'application/json'}, data=json.dumps(data).encode('utf-8'))
         asset_data = json_data['assetDetails']

--- a/yt_dlp/extractor/zee5.py
+++ b/yt_dlp/extractor/zee5.py
@@ -1,14 +1,16 @@
 import json
-import random
-import string
+import time
+import uuid
 
 from .common import InfoExtractor
 from ..compat import compat_str
 from ..utils import (
     ExtractorError,
     int_or_none,
+    jwt_decode_hs256,
     parse_age_limit,
     str_or_none,
+    try_call,
     try_get,
     unified_strdate,
     unified_timestamp,
@@ -94,12 +96,12 @@ class Zee5IE(InfoExtractor):
         'url': 'https://www.zee5.com/music-videos/details/adhento-gaani-vunnapaatuga-jersey-nani-shraddha-srinath/0-0-56973',
         'only_matching': True
     }]
-    _DETAIL_API_URL = 'https://spapi.zee5.com/singlePlayback/getDetails/secure?content_id={}&device_id={}&platform_name=desktop_web&country=IN&check_parental_control=false'
-    _DEVICE_ID = ''.join(random.choices(string.ascii_letters + string.digits, k=20)).ljust(32, '0')
+    _DEVICE_ID = str(uuid.uuid4())
     _USER_TOKEN = None
     _LOGIN_HINT = 'Use "--username <mobile_number>" to login using otp or "--username token" and "--password <user_token>" to login using user token.'
     _NETRC_MACHINE = 'zee5'
     _GEO_COUNTRIES = ['IN']
+    _USER_COUNTRY = 'IN'
 
     def _perform_login(self, username, password):
         if len(username) == 10 and username.isdigit() and self._USER_TOKEN is None:
@@ -118,10 +120,15 @@ class Zee5IE(InfoExtractor):
             self._USER_TOKEN = otp_verify_json.get('token')
             if not self._USER_TOKEN:
                 raise ExtractorError(otp_request_json['message'], expected=True)
-        elif username.lower() == 'token' and len(password) > 1198:
+        elif username.lower() == 'token' and try_call(lambda: jwt_decode_hs256(password)):
             self._USER_TOKEN = password
         else:
             raise ExtractorError(self._LOGIN_HINT, expected=True)
+
+        token = jwt_decode_hs256(self._USER_TOKEN)
+        if token.get('exp', 0) <= time.time():
+            raise ExtractorError('User token has expired', expected=True)
+        self._USER_COUNTRY = token.get('current_country') or 'IN'
 
     def _real_extract(self, url):
         video_id, display_id = self._match_valid_url(url).group('id', 'display_id')
@@ -137,8 +144,13 @@ class Zee5IE(InfoExtractor):
             data['X-Z5-Guest-Token'] = self._DEVICE_ID
 
         json_data = self._download_json(
-            self._DETAIL_API_URL.format(video_id, self._DEVICE_ID),
-            video_id, headers={'content-type': 'application/json'}, data=json.dumps(data).encode('utf-8'))
+            'https://spapi.zee5.com/singlePlayback/getDetails/secure', video_id, query={
+                'content_id': video_id,
+                'device_id': self._DEVICE_ID,
+                'platform_name': 'desktop_web',
+                'country': self._USER_COUNTRY,
+                'check_parental_control': False,
+            }, headers={'content-type': 'application/json'}, data=json.dumps(data).encode('utf-8'))
         asset_data = json_data['assetDetails']
         show_data = json_data.get('showDetails', {})
         if 'premium' in asset_data['business_type']:

--- a/yt_dlp/extractor/zee5.py
+++ b/yt_dlp/extractor/zee5.py
@@ -126,7 +126,7 @@ class Zee5IE(InfoExtractor):
             raise ExtractorError(self._LOGIN_HINT, expected=True)
 
         token = jwt_decode_hs256(self._USER_TOKEN)
-        if token.get('exp', 0) <= time.time():
+        if token.get('exp', 0) <= int(time.time()):
             raise ExtractorError('User token has expired', expected=True)
         self._USER_COUNTRY = token.get('current_country')
 


### PR DESCRIPTION
A recent site API change requires that the `country` parameter in the API request's query matches the user's `current_country` value in their auth token. This seems to be enforced with all newly released content/episodes.

Previously, the extractor hardcoded `IN` as the API `country` param. This patch decodes the `_USER_TOKEN`, checks if it's expired, extracts the `_USER_COUNTRY`, and applies that value to the API request query.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e2461b7</samp>

### Summary
🔒🛠️🌐

<!--
1.  🔒 - This emoji represents security, as the changes involve using a more secure device ID generation method, validating and decoding the user token with a cryptographic algorithm, and checking the user token expiration time.
2.  🛠️ - This emoji represents reliability, as the changes fix some potential issues with the previous extractor, such as device ID collisions, user token tampering, and user token expiration errors.
3.  🌐 - This emoji represents compatibility, as the changes ensure that the extractor can handle different user countries and regions, by extracting the country from the user token and passing it to the detail API URL.
-->
Update Zee5 extractor to use more robust methods for device ID, user token, and country extraction. Fix detail API URL to include user country.

> _`Zee5` extractor_
> _enhanced with `uuid`, `jwt`_
> _autumn of bugs ends_

### Walkthrough
* Replace device ID generation with `uuid` and check user token expiration and country with `jwt_decode_hs256` and `time` ([link](https://github.com/yt-dlp/yt-dlp/pull/7280/files?diff=unified&w=0#diff-a558cbee737fe323389fe0bc41baf7a31165d4728e651f427aeb56d43aa3b131L2-R3), [link](https://github.com/yt-dlp/yt-dlp/pull/7280/files?diff=unified&w=0#diff-a558cbee737fe323389fe0bc41baf7a31165d4728e651f427aeb56d43aa3b131L10-R13), [link](https://github.com/yt-dlp/yt-dlp/pull/7280/files?diff=unified&w=0#diff-a558cbee737fe323389fe0bc41baf7a31165d4728e651f427aeb56d43aa3b131L97-R104), [link](https://github.com/yt-dlp/yt-dlp/pull/7280/files?diff=unified&w=0#diff-a558cbee737fe323389fe0bc41baf7a31165d4728e651f427aeb56d43aa3b131L121-R132))
* Change detail API URL to use query parameters and pass user country as a parameter ([link](https://github.com/yt-dlp/yt-dlp/pull/7280/files?diff=unified&w=0#diff-a558cbee737fe323389fe0bc41baf7a31165d4728e651f427aeb56d43aa3b131L140-R153))



</details>
