### PR TITLE
add funker530 extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -664,6 +664,7 @@ from .funimation import (
     FunimationShowIE,
 )
 from .funk import FunkIE
+from .funker530 import Funker530IE
 from .fusion import FusionIE
 from .fuyintv import FuyinTVIE
 from .gab import (

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import json
+import re
+
+from .common import InfoExtractor
+from ..utils import clean_html, unified_strdate
+
+
+class Funker530IE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?funker530\.com/video/(?P<id>[^/]+)'
+    _TEST = {
+        'url': 'https://funker530.com/video/azov-patrol-caught-in-open-under-automatic-grenade-launcher-fire/',
+        'md5': 'fcb1880a5703f5c17e9191bab27fb822',
+        'info_dict': {
+            'id': 'v2qbmu4',
+            'ext': 'mp4',
+            'title': 'Azov Patrol Caught In Open Under Automatic Grenade Launcher Fire',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'uploader': 'Funker530',
+            'width': 1280,
+            'height': 720,
+            'fps': 25,
+            'duration': 27,
+            'upload_date': '20230608',
+            'description': 'md5:e717a9120bccae558927dfd0bcbd07a0',
+        }
+    }
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
+
+        video_id = self._search_regex(
+            r'Rumble\("play",\s*\{video:\s*"([^"]+)"',
+            webpage, 'video_id')
+
+        metadata_url = f'https://rumble.com/embedJS/{video_id}.{video_id}/?url={url}&args=%5B%22play%22%2C%7B%22video%22%3A%22{video_id}%22%2C%22div%22%3A%22rumblePlayer%22%7D%5D'
+        metadata_js = self._download_webpage(metadata_url, video_id, 'Downloading metadata')
+
+        metadata = self.extract_video_metadata(metadata_js, video_id)
+
+        description = self._html_search_regex(
+            r'(?s)<div class="row video-desc-paragraph">.*?<p>(.*?)<div style="display: flex; flex-direction: column;',
+            webpage, 'description', fatal=False)
+        if description:
+            description = clean_html(description)
+
+        return {
+            'id': video_id,
+            'url': metadata['url'],
+            'title': metadata['title'],
+            'thumbnail': metadata['thumbnail'],
+            'uploader': metadata['author'],
+            'width': metadata['width'],
+            'height': metadata['height'],
+            'fps': metadata['fps'],
+            'duration': metadata['duration'],
+            'upload_date': unified_strdate(metadata['pubDate']),
+            'description': description,
+            'display_id': display_id,
+        }
+
+    @staticmethod
+    def clean_json_string(json_string):
+        cleaned_json = re.sub(r',\s*\w+:\w+\(\)', '', json_string)
+        return cleaned_json
+
+    def extract_video_metadata(self, js_file, video_id):
+        video_metadata = {}
+        metadata_match = re.search(rf'f\.f\["{video_id}"\]\s*=\s*(\{{.*?\}});', js_file)
+        if metadata_match:
+            metadata_json = self.clean_json_string(metadata_match.group(1))
+            metadata = json.loads(metadata_json)
+
+            # Extract relevant video metadata
+            video_metadata["fps"] = metadata.get("fps")
+            video_metadata["width"] = metadata.get("w")
+            video_metadata["height"] = metadata.get("h")
+            video_metadata["url"] = metadata.get("u", {}).get("mp4", {}).get("url")
+            video_metadata["thumbnail"] = metadata.get("i")
+            video_metadata["title"] = metadata.get("title")
+            video_metadata["author"] = metadata.get("author", {}).get("name")
+            video_metadata["duration"] = metadata.get("duration")
+            video_metadata["pubDate"] = metadata.get("pubDate")
+
+        return video_metadata

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -9,7 +9,7 @@ from ..utils import clean_html, unified_strdate
 
 
 class Funker530IE(InfoExtractor):
-    _VALID_URL = r'^https?:\/\/(?:www\.)?funker530\.com\/video\/(?P<id>[^\/]+)\/?$'
+    _VALID_URL = r'https?:\/\/(?:www\.)?funker530\.com\/video\/(?P<id>[^\/]+)\/?'
     _TEST = {
         'url': 'https://funker530.com/video/azov-patrol-caught-in-open-under-automatic-grenade-launcher-fire/',
         'md5': 'fcb1880a5703f5c17e9191bab27fb822',
@@ -42,7 +42,7 @@ class Funker530IE(InfoExtractor):
         metadata = self.extract_video_metadata(metadata_js, video_id)
 
         description = self._html_search_regex(
-            r'(?s)<div class="row video-desc-paragraph">.*?<p>(.*?)<div style="display: flex; flex-direction: column;',
+            r'(?s)<div class="row video-desc-paragraph">.*?<p>(.*?)<\/div>\n?<\/div>\n?<\/div>',
             webpage, 'description', fatal=False)
         if description:
             description = clean_html(description)

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -9,7 +9,7 @@ from ..utils import clean_html, unified_strdate
 
 
 class Funker530IE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?funker530\.com/video/(?P<id>[^/]+)'
+    _VALID_URL = r'^https?:\/\/(?:www\.)?funker530\.com\/video\/(?P<id>[^\/]+)\/?$'
     _TEST = {
         'url': 'https://funker530.com/video/azov-patrol-caught-in-open-under-automatic-grenade-launcher-fire/',
         'md5': 'fcb1880a5703f5c17e9191bab27fb822',

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -59,7 +59,7 @@ class Funker530IE(InfoExtractor):
             'duration': metadata['duration'],
             'upload_date': unified_strdate(metadata['pubDate']),
             'description': description,
-            'display_id': display_id,
+            # 'display_id': display_id,
         }
 
     @staticmethod

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -53,6 +53,7 @@ class Funker530IE(InfoExtractor):
             'availability': 'public',
             'upload_date': '20230608',
             'playable_in_embed': True,
+            'heatmap': 'count:100',
         }
     }]
 

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -59,14 +59,13 @@ class Funker530IE(InfoExtractor):
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
-        info = {}
-        rumble_urls = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
-        if rumble_urls:
-            info = {'url': rumble_urls[0], 'ie_key': RumbleEmbedIE.ie_key()}
+        rumble_url = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
+        if rumble_url:
+            info = {'url': rumble_url[0], 'ie_key': RumbleEmbedIE.ie_key()}
         else:
             youtube_url = list(YoutubeIE._extract_embed_urls(url, webpage))
             if youtube_url:
-                info = {'url': youtube_url, 'ie_key': YoutubeIE.ie_key()}
+                info = {'url': youtube_url[0], 'ie_key': YoutubeIE.ie_key()}
         if not info:
             raise ExtractorError('No videos found on webpage', expected=True)
 

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from .common import InfoExtractor
 from .rumble import RumbleEmbedIE
 from .youtube import YoutubeIE
@@ -62,11 +60,11 @@ class Funker530IE(InfoExtractor):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
         info = {}
-        rumble_urls = RumbleEmbedIE._extract_embed_urls(url, webpage)
+        rumble_urls = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
         if rumble_urls:
             info = {'url': rumble_urls[0], 'ie_key': RumbleEmbedIE.ie_key()}
         else:
-            youtube_url = next(YoutubeIE._extract_embed_urls(url, webpage), None)
+            youtube_url = list(YoutubeIE._extract_embed_urls(url, webpage))
             if youtube_url:
                 info = {'url': youtube_url, 'ie_key': YoutubeIE.ie_key()}
         if not info:

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -3,7 +3,7 @@
 from .common import InfoExtractor
 from .rumble import RumbleEmbedIE
 from .youtube import YoutubeIE
-from ..utils import clean_html, ExtractorError, strip_or_none, get_element_by_class
+from ..utils import ExtractorError, clean_html, get_element_by_class, strip_or_none
 
 
 class Funker530IE(InfoExtractor):
@@ -64,13 +64,13 @@ class Funker530IE(InfoExtractor):
         info = {}
         rumble_urls = RumbleEmbedIE._extract_embed_urls(url, webpage)
         if rumble_urls:
-            info.update({'url': rumble_urls[0], 'ie_key': RumbleEmbedIE.ie_key()})
+            info = {'url': rumble_urls[0], 'ie_key': RumbleEmbedIE.ie_key()}
         else:
             youtube_url = next(YoutubeIE._extract_embed_urls(url, webpage), None)
             if youtube_url:
-                info.update({'url': youtube_url, 'ie_key': YoutubeIE.ie_key()})
+                info = {'url': youtube_url, 'ie_key': YoutubeIE.ie_key()}
         if not info:
-            raise ExtractorError('No videos found on webpage')
+            raise ExtractorError('No videos found on webpage', expected=True)
 
         return {
             **info,

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -70,7 +70,4 @@ class Funker530IE(InfoExtractor):
             description = clean_html(re.sub(r'<style>(.|\s)*?<\/style>', '', description))
 
         embedded_video['description'] = description
-
-        print(embedded_video)
-
         return embedded_video

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -144,7 +144,7 @@ class RumbleEmbedIE(InfoExtractor):
         if embeds:
             return embeds
         return [f'https://rumble.com/embed/{mobj.group("id")}' for mobj in re.finditer(
-            r'<script>\s*Rumble\(\s*"play"\s*,\s*{\s*[\'"]video[\'"]\s*:\s*[\'"](?P<id>[0-9a-z]+)[\'"]', webpage)]
+            r'<script>[^<]*\bRumble\(\s*"play"\s*,\s*{\s*[\'"]?video[\'"]?\s*:\s*[\'"](?P<id>[0-9a-z]+)[\'"]', webpage)]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Added extractor for `funker530.com`. Extracts thumbnail, description, and metadata. Passes tests.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1177d8e</samp>

### Summary
🎥🆕🐝

<!--
1.  🎥 - This emoji represents the video-related nature of the changes, as well as the combat footage theme of Funker530.
2.  🆕 - This emoji represents the addition of a new module and class to support a new website.
3.  🐝 - This emoji represents the use of the Rumble video platform, which has a bee logo and is also a synonym for making a loud noise, like gunfire.
-->
Add support for Funker530 video extraction. Create a new `funker530.py` module with a `Funker530IE` class that handles the extraction logic and imports it in `_extractors.py`.

> _`Funker530IE`_
> _Extracts combat videos_
> _From Rumble platform_

### Walkthrough
* Add support for extracting videos from Funker530 website ([link](https://github.com/yt-dlp/yt-dlp/pull/7291/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R667), [link](https://github.com/yt-dlp/yt-dlp/pull/7291/files?diff=unified&w=0#diff-d0247fbe6e50e3bb2255d168c3dbc63ee7a551ea6ba67bec168766f1e9f19c25R1-R88))
  * Import `Funker530IE` class from `funker530.py` module in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7291/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R667))
  * Define `Funker530IE` class in `funker530.py` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7291/files?diff=unified&w=0#diff-d0247fbe6e50e3bb2255d168c3dbc63ee7a551ea6ba67bec168766f1e9f19c25R1-R88))



</details>
