### PR TITLE
[extractor/ximalaya] use the normal sort order

### DIFF
--- a/yt_dlp/extractor/ximalaya.py
+++ b/yt_dlp/extractor/ximalaya.py
@@ -158,7 +158,7 @@ class XimalayaAlbumIE(XimalayaBaseIE):
         return self._download_json(
             'https://www.ximalaya.com/revision/album/v1/getTracksList',
             playlist_id, note=f'Downloading tracks list page {page_idx}',
-            query={'albumId': playlist_id, 'pageNum': page_idx, 'sort': 1})['data']
+            query={'albumId': playlist_id, 'pageNum': page_idx})['data']
 
     def _get_entries(self, page_data):
         for e in page_data['tracks']:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible


-->

ADD DESCRIPTION HERE

The `sort=1` reverses the sort order of the playlist so that the last track is downloaded first. I don't know why this was added but the user has to download all tracks to get the first one.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7b3e24d</samp>

### Summary
🐛🚫🎵

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of this change. Removing the `sort` parameter solved the problem of missing or duplicated tracks in some albums.
2.  🚫 - This emoji represents a removal or deletion, which is the effect of this change. The `sort` parameter was removed from the query of the tracks list request, simplifying the code and the request.
3.  🎵 - This emoji represents music, which is the domain of this change. The change affects the tracks list request, which is used to fetch the music tracks of an album.
-->
Removed `sort` parameter from `ximalaya.py` extractor to fix missing tracks issue. This parameter caused some tracks to be skipped or duplicated in some albums.

> _`sort` parameter_
> _gone from tracks list query_
> _no more missing songs_

### Walkthrough
* Remove `sort` parameter from tracks list query to fix missing tracks issue ([link](https://github.com/yt-dlp/yt-dlp/pull/7292/files?diff=unified&w=0#diff-0b49e0118c7ef46255bc0d36cc6cf3b6c6472ba0fa3296994444014c5d6fa909L161-R161))



</details>
