### PR TITLE
[extractor/dropout] Dropout season pagination

### DIFF
--- a/yt_dlp/extractor/dropout.py
+++ b/yt_dlp/extractor/dropout.py
@@ -7,12 +7,10 @@ from ..utils import (
     ExtractorError,
     OnDemandPagedList,
     clean_html,
-    get_element_by_attribute,
     get_element_by_class,
     get_element_by_id,
     get_elements_by_class,
     int_or_none,
-    join_nonempty,
     unified_strdate,
     urlencode_postdata,
 )
@@ -223,11 +221,11 @@ class DropoutSeasonIE(InfoExtractor):
                     ie=DropoutIE.ie_key()
                 )
         except Exception as e:
-            if e.exc_info[0] == HTTPError and e.exc_info[1].code == 400: #Site returns 400 when you page past the end
+            if e.exc_info[0] == HTTPError and e.exc_info[1].code == 400:  # Site returns 400 when you page past the end
                 return
             else:
                 raise
-    
+
     def _real_extract(self, url):
         season_id = self._match_id(url)
         season_num = self._match_valid_url(url).group('season') or 1
@@ -235,5 +233,5 @@ class DropoutSeasonIE(InfoExtractor):
 
         entries = OnDemandPagedList(functools.partial(
             self._fetch_page, url, season_id), self._PAGE_SIZE)
-        
+	
         return self.playlist_result(entries, playlist_id=f'{season_id}-season-{season_num}', playlist_title=f'{season_title} - Season {season_num}')

--- a/yt_dlp/extractor/dropout.py
+++ b/yt_dlp/extractor/dropout.py
@@ -3,6 +3,7 @@ from .vimeo import VHXEmbedIE
 from ..utils import (
     ExtractorError,
     clean_html,
+    get_element_by_attribute,
     get_element_by_class,
     get_element_by_id,
     get_elements_by_class,

--- a/yt_dlp/extractor/dropout.py
+++ b/yt_dlp/extractor/dropout.py
@@ -168,7 +168,7 @@ class DropoutSeasonIE(InfoExtractor):
         {
             'url': 'https://www.dropout.tv/dimension-20-fantasy-high/season:1',
             'note': 'Multi-season series with the season in the url',
-            'playlist_count': 17,
+            'playlist_count': 24,
             'info_dict': {
                 'id': 'dimension-20-fantasy-high-season-1',
                 'title': 'Dimension 20 Fantasy High - Season 1'
@@ -177,7 +177,7 @@ class DropoutSeasonIE(InfoExtractor):
         {
             'url': 'https://www.dropout.tv/dimension-20-fantasy-high',
             'note': 'Multi-season series with the season not in the url',
-            'playlist_count': 17,
+            'playlist_count': 24,
             'info_dict': {
                 'id': 'dimension-20-fantasy-high-season-1',
                 'title': 'Dimension 20 Fantasy High - Season 1'
@@ -190,6 +190,15 @@ class DropoutSeasonIE(InfoExtractor):
             'info_dict': {
                 'id': 'dimension-20-shriek-week-season-1',
                 'title': 'Dimension 20 Shriek Week - Season 1'
+            }
+        },
+        {
+            'url': 'https://www.dropout.tv/breaking-news-no-laugh-newsroom/season:3',
+            'note': 'Multi-season series with season in the url that requires pagination',
+            'playlist_count': 25,
+            'info_dict': {
+                'id': 'breaking-news-no-laugh-newsroom-season-3',
+                'title': 'Breaking News No Laugh Newsroom - Season 3'
             }
         }
     ]

--- a/yt_dlp/extractor/dropout.py
+++ b/yt_dlp/extractor/dropout.py
@@ -233,5 +233,5 @@ class DropoutSeasonIE(InfoExtractor):
 
         entries = OnDemandPagedList(functools.partial(
             self._fetch_page, url, season_id), self._PAGE_SIZE)
-	
+
         return self.playlist_result(entries, playlist_id=f'{season_id}-season-{season_num}', playlist_title=f'{season_title} - Season {season_num}')

--- a/yt_dlp/extractor/dropout.py
+++ b/yt_dlp/extractor/dropout.py
@@ -210,7 +210,7 @@ class DropoutSeasonIE(InfoExtractor):
     def _fetch_page(self, url, season_id, page):
         page += 1
         webpage = self._download_webpage(
-            f'{url}?page={page}', season_id, note=f'Downloading page {page}')
+            f'{url}?page={page}', season_id, note=f'Downloading page {page}', expected_status={400})
         yield from [self.url_result(item_url, DropoutIE) for item_url in traverse_obj(
             get_elements_html_by_class('browse-item-link', webpage), (..., {extract_attributes}, 'href'))]
 

--- a/yt_dlp/extractor/dropout.py
+++ b/yt_dlp/extractor/dropout.py
@@ -208,7 +208,7 @@ class DropoutSeasonIE(InfoExtractor):
         season_title = season_id.replace('-', ' ').title()
         webpage = self._download_webpage(url, season_id)
         page_num = 1
-        
+
         entries = [
             self.url_result(
                 url=self._search_regex(r'<a href=["\'](.+?)["\'] class=["\']browse-item-link["\']',
@@ -216,7 +216,7 @@ class DropoutSeasonIE(InfoExtractor):
                 ie=DropoutIE.ie_key()
             ) for item in get_elements_by_class('js-collection-item', webpage)
         ]
-        
+
         next_page = False
         next_page = get_element_by_attribute('data-load-more-target', 'js-load-more-items-container', webpage)
         while next_page:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Handles pagination for seasons with more than 24 episodes. Also fixes test cases with accurate episode counts for seasons. 



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7d9739</samp>

### Summary
📄🔗🧪

<!--
1.  📄 This emoji can be used to represent the addition of pagination support, as it suggests the idea of multiple pages or documents being processed or accessed.
2.  🔗 This emoji can be used to represent the extraction and handling of the next page links, as it suggests the idea of connecting or following different URLs or resources.
3.  🧪 This emoji can be used to represent the updating of the test cases, as it suggests the idea of testing, experimenting, or verifying the functionality or quality of the code.
-->
Improved the `DropoutSeasonIE` extractor to handle multiple pages of episodes. Updated the tests and the `yt_dlp/extractor/dropout.py` file accordingly.

> _We're scraping the web for some videos to see_
> _We use `DropoutSeasonIE`_
> _But the pages are many and we need to fetch more_
> _So we add pagination with `get_element_by_attribute`_

### Walkthrough
* Import `get_element_by_attribute` function from `utils.py` to use for pagination ([link](https://github.com/yt-dlp/yt-dlp/pull/7304/files?diff=unified&w=0#diff-dbeadf033fee19b4cabd2dada23bc66943284f1b67ad8fb41c177c5cd7300467R6))
* Update `playlist_count` for `DropoutSeasonIE` extractor test cases to reflect current number of episodes for "Dimension 20: Fantasy High" ([link](https://github.com/yt-dlp/yt-dlp/pull/7304/files?diff=unified&w=0#diff-dbeadf033fee19b4cabd2dada23bc66943284f1b67ad8fb41c177c5cd7300467L170-R171), [link](https://github.com/yt-dlp/yt-dlp/pull/7304/files?diff=unified&w=0#diff-dbeadf033fee19b4cabd2dada23bc66943284f1b67ad8fb41c177c5cd7300467L179-R180))
* Add new test case for `DropoutSeasonIE` extractor to cover multi-season series with pagination, such as "Breaking News No Laugh Newsroom" ([link](https://github.com/yt-dlp/yt-dlp/pull/7304/files?diff=unified&w=0#diff-dbeadf033fee19b4cabd2dada23bc66943284f1b67ad8fb41c177c5cd7300467R194-R202))
* Initialize `page_num` variable to 1 in `_real_extract` method of `DropoutSeasonIE` extractor to keep track of current page number ([link](https://github.com/yt-dlp/yt-dlp/pull/7304/files?diff=unified&w=0#diff-dbeadf033fee19b4cabd2dada23bc66943284f1b67ad8fb41c177c5cd7300467R210))
* Add pagination logic to `_real_extract` method of `DropoutSeasonIE` extractor using `get_element_by_attribute`, `get_elements_by_class`, and `url_result` functions to download and extract all episodes of a paginated series ([link](https://github.com/yt-dlp/yt-dlp/pull/7304/files?diff=unified&w=0#diff-dbeadf033fee19b4cabd2dada23bc66943284f1b67ad8fb41c177c5cd7300467R220-R234))



</details>
