### PR TITLE
[extractor/nhk] add NHK Radiru Live IE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1850,6 +1850,9 @@ The following extractors use this feature:
 #### twitchstream (Twitch)
 * `client_id`: Client ID value to be sent with GraphQL requests, e.g. `twitchstream:client_id=kimne78kx3ncx6brgo4mv6wki5h1ko`
 
+#### nhkradirulive (NHK らじる★らじる LIVE)
+* `area`: Which regional variation to extract. Valid areas are: `sapporo`, `sendai`, `tokyo`, `nagoya`, `osaka`, `hiroshima`, `matsuyama`, `fukuoka`. Defaults to `tokyo`.
+
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 
 <!-- MANPAGE: MOVE "INSTALLATION" SECTION HERE -->

--- a/README.md
+++ b/README.md
@@ -1851,7 +1851,7 @@ The following extractors use this feature:
 * `client_id`: Client ID value to be sent with GraphQL requests, e.g. `twitchstream:client_id=kimne78kx3ncx6brgo4mv6wki5h1ko`
 
 #### nhkradirulive (NHK らじる★らじる LIVE)
-* `area`: Which regional variation to extract. Valid areas are: `sapporo`, `sendai`, `tokyo`, `nagoya`, `osaka`, `hiroshima`, `matsuyama`, `fukuoka`. Defaults to `tokyo`.
+* `area`: Which regional variation to extract. Valid areas are: `sapporo`, `sendai`, `tokyo`, `nagoya`, `osaka`, `hiroshima`, `matsuyama`, `fukuoka`. Defaults to `tokyo`
 
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1260,6 +1260,7 @@ from .nhk import (
     NhkForSchoolProgramListIE,
     NhkRadioNewsPageIE,
     NhkRadiruIE,
+    NhkRadiruLiveIE,
 )
 from .nhl import NHLIE
 from .nick import (

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -535,7 +535,7 @@ class NhkRadiruLiveIE(InfoExtractor):
         }
     }]
 
-    _NOA_STATION_IDS = {'r1': 'n1', 'r2': 'n2', 'fm': 'n3'}  # lookup table is easier than working it out
+    _NOA_STATION_IDS = {'r1': 'n1', 'r2': 'n2', 'fm': 'n3'}
 
     def _real_extract(self, url):
         station = self._match_id(url)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds an extractor for NHK Radiru's live radio streams.
It supports the regional variations by letting them be specified as an extractor arg. For example, Radio 1 in Fukuoka would be `yt-dlp https://www.nhk.or.jp/radio/player/?ch=r1 --extractor-args nhkradirulive:area=fukuoka`.
If no area is specified, it defaults to tokyo. If an invalid area is specified, an error is thrown that lists the valid areas.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7232f9</samp>

### Summary
📻🇯🇵🆕

<!--
1.  📻 - This emoji represents radio, which is the main medium of NHK Radiru Live.
2.  🇯🇵 - This emoji represents Japan, which is the country where NHK Radiru Live operates and broadcasts.
3.  🆕 - This emoji represents something new, which is the addition of a new extractor class to the yt-dlp project.
-->
Add support for NHK Radiru Live, a Japanese radio streaming service, by creating a new extractor class `NhkRadiruLiveIE` and registering it in `_extractors.py`.

> _`NhkRadiruLiveIE`_
> _Extracts live radio streams_
> _Autumn leaves whisper_

### Walkthrough
*  Add `NhkRadiruLiveIE` extractor for NHK Radiru Live radio streaming service ([link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1263), [link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R498-R568))
   * Register the extractor in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1263))
   * Define the extractor class in `nhk.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R498-R568))
      * Import necessary modules and classes ([link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L10-R13))
      * Specify geo-restriction, URL pattern, and test cases ([link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R498-R568))
      * Implement `_real_extract` method to download and parse data from website and API ([link](https://github.com/yt-dlp/yt-dlp/pull/7332/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R498-R568))



</details>
