### PR TITLE
[extractor/Bilibili] Fixed bilibili bangumi extractors

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -214,7 +214,7 @@ from .bigo import BigoIE
 from .bild import BildIE
 from .bilibili import (
     BiliBiliIE,
-    BiliBiliBangumiEpisodeIE,
+    BiliBiliBangumiIE,
     BiliBiliBangumiSeasonIE,
     BiliBiliBangumiMediaIE,
     BiliBiliSearchIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -214,7 +214,8 @@ from .bigo import BigoIE
 from .bild import BildIE
 from .bilibili import (
     BiliBiliIE,
-    BiliBiliBangumiIE,
+    BiliBiliBangumiEpisodeIE,
+    BiliBiliBangumiSeasonIE,
     BiliBiliBangumiMediaIE,
     BiliBiliSearchIE,
     BilibiliCategoryIE,

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -415,7 +415,7 @@ class BiliBiliIE(BilibiliBaseIE):
 
 
 class BiliBiliBangumiIE(BilibiliBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?bilibili\.com/bangumi/play/(?P<id>ep\d+)'
+    _VALID_URL = r'https?://(?:www\.)?bilibili\.com/bangumi/play/(?P<id>ep\d+)/?(?:$|[#?])'
 
     _TESTS = [{
         'url': 'https://www.bilibili.com/bangumi/play/ep267851',
@@ -503,7 +503,7 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
 
 
 class BiliBiliBangumiMediaIE(BilibiliBaseIE):
-    _VALID_URL = r'https?://www\.bilibili\.com/bangumi/media/md(?P<id>\d+)'
+    _VALID_URL = r'https?://www\.bilibili\.com/bangumi/media/md(?P<id>\d+)/?(?:$|[#?])'
     _TESTS = [{
         'url': 'https://www.bilibili.com/bangumi/media/md24097891',
         'info_dict': {
@@ -522,7 +522,7 @@ class BiliBiliBangumiMediaIE(BilibiliBaseIE):
 
 
 class BiliBiliBangumiSeasonIE(BilibiliBaseIE):
-    _VALID_URL = r'(?x)https?://www\.bilibili\.com/bangumi/play/ss(?P<id>\d+)'
+    _VALID_URL = r'(?x)https?://www\.bilibili\.com/bangumi/play/ss(?P<id>\d+)/?(?:$|[#?])'
     _TESTS = [{
         'url': 'https://www.bilibili.com/bangumi/play/ss26801',
         'info_dict': {

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -451,11 +451,10 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
             'https://api.bilibili.com/pgc/view/web/season', video_id, 'Get episode details',
             query={'ep_id': episode_id}, headers=headers)['result']
 
-        episode_number, episode_info = 1, {}
-        for idx, ep in enumerate(traverse_obj(bangumi_info, ('episodes', ..., {dict})), 1):
-            if str_or_none(ep.get('id')) == episode_id:
-                episode_number, episode_info = idx, ep
-                break
+        episode_number, episode_info = next((
+            (idx, ep) for idx, ep in enumerate(traverse_obj(
+                bangumi_info, ('episodes', ..., {dict})), 1)
+            if str_or_none(ep.get('id')) == episode_id), (1, {}))
 
         season_id = bangumi_info.get('season_id')
         season_number = season_id and next((

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -18,6 +18,7 @@ from ..utils import (
     float_or_none,
     format_field,
     int_or_none,
+    join_nonempty,
     make_archive_id,
     merge_dicts,
     mimetype2ext,

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -488,7 +488,7 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
             'title': join_nonempty('title', 'long_title', delim=' ', from_dict=episode_info),
             'episode': episode_info.get('long_title'),
             'episode_id': episode_id,
-            'episode_number': episode_number,
+            'episode_number': int_or_none(episode_info.get('title')) or episode_number,
             'season_id': str_or_none(season_id),
             'season_number': season_number,
             'timestamp': int_or_none(episode_info.get('pub_time')),

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -415,7 +415,7 @@ class BiliBiliIE(BilibiliBaseIE):
 
 
 class BiliBiliBangumiIE(BilibiliBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?bilibili\.com/bangumi/play/(?P<id>ep\d+)/?(?:$|[#?])'
+    _VALID_URL = r'https?://(?:www\.)?bilibili\.com/bangumi/play/(?P<id>ep\d+)'
 
     _TESTS = [{
         'url': 'https://www.bilibili.com/bangumi/play/ep267851',
@@ -454,12 +454,11 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
             'https://api.bilibili.com/pgc/player/web/v2/playurl', video_id,
             'Extracting episode', query={'fnval': '4048', 'ep_id': episode_id},
             headers=headers)
-        if play_info['code'] == -10403:
-            self.raise_login_required('This video is for premium members only')
-        play_info = play_info['result']['video_info']
+        premium_only = play_info.get('code') == -10403
+        play_info = traverse_obj(play_info, ('result', 'video_info', {dict})) or {}
 
         formats = self.extract_formats(play_info)
-        if not formats and ('成为大会员抢先看' in webpage or '开通大会员观看' in webpage):
+        if not formats and (premium_only or '成为大会员抢先看' in webpage or '开通大会员观看' in webpage):
             self.raise_login_required('This video is for premium members only')
 
         bangumi_info = self._download_json(
@@ -503,7 +502,7 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
 
 
 class BiliBiliBangumiMediaIE(BilibiliBaseIE):
-    _VALID_URL = r'https?://www\.bilibili\.com/bangumi/media/md(?P<id>\d+)/?(?:$|[#?])'
+    _VALID_URL = r'https?://www\.bilibili\.com/bangumi/media/md(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.bilibili.com/bangumi/media/md24097891',
         'info_dict': {
@@ -522,7 +521,7 @@ class BiliBiliBangumiMediaIE(BilibiliBaseIE):
 
 
 class BiliBiliBangumiSeasonIE(BilibiliBaseIE):
-    _VALID_URL = r'(?x)https?://www\.bilibili\.com/bangumi/play/ss(?P<id>\d+)/?(?:$|[#?])'
+    _VALID_URL = r'(?x)https?://www\.bilibili\.com/bangumi/play/ss(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.bilibili.com/bangumi/play/ss26801',
         'info_dict': {

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -429,6 +429,7 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
+        episode_id = video_id[2:]
         webpage = self._download_webpage(url, video_id)
 
         if '您所在的地区无法观看本片' in webpage:
@@ -535,7 +536,7 @@ class BiliBiliBangumiSeasonIE(InfoExtractor):
             ('result', 'main_section', 'episodes'))
 
         return self.playlist_result((
-            self.url_result(entry['share_url'], BiliBiliBangumiEpisodeIE, entry['id'])
+            self.url_result(entry['share_url'], BiliBiliBangumiIE, entry['id'])
             for entry in episode_list), ss_id)
 
 

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -473,7 +473,7 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
                 'series_id': ('series', 'series_id', {str_or_none}),
                 'thumbnail': ('square_cover', {url_or_none}),
             }),
-            'title': join_nonempty('title', 'long_title', delim=' ', from_dict=episode_info)
+            'title': join_nonempty('title', 'long_title', delim=' ', from_dict=episode_info),
             'episode': episode_info.get('long_title'),
             'episode_id': episode_id,
             'episode_number': episode_number,

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -453,7 +453,10 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
         play_info = self._download_json(
             'https://api.bilibili.com/pgc/player/web/v2/playurl', video_id,
             'Extracting episode', query={'fnval': '4048', 'ep_id': episode_id},
-            headers=headers)['result']['video_info']
+            headers=headers)
+        if play_info['code'] == -10403:
+            self.raise_login_required('This video is for premium members only')
+        play_info = play_info['result']['video_info']
 
         formats = self.extract_formats(play_info)
         if not formats and ('成为大会员抢先看' in webpage or '开通大会员观看' in webpage):

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -435,9 +435,7 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
 
         if '您所在的地区无法观看本片' in webpage:
             raise GeoRestrictedError('This video is restricted')
-        elif ('成为大会员免费看' in webpage
-              or '正在观看预览，大会员免费看全片' in webpage
-              or '开通大会员观看' in webpage):
+        elif '正在观看预览，大会员免费看全片' in webpage:
             self.raise_login_required('This video is for premium members only')
 
         headers = {'Referer': url, **self.geo_verification_headers()}
@@ -447,6 +445,9 @@ class BiliBiliBangumiIE(BilibiliBaseIE):
             headers=headers)['result']['video_info']
 
         formats = self.extract_formats(play_info)
+        if not formats and (
+                '成为大会员抢先看' in webpage or '开通大会员观看' in webpage):
+            self.raise_login_required('This video is for premium members only')
 
         bangumi_info = self._download_json(
             'https://api.bilibili.com/pgc/view/web/season', video_id, 'Get episode details',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #6701, Fixes #7400
This bug was caused by changes to the source website's webpage, which resulted in the inability to locate playback information within the webpage. The issue has been resolved by utilizing the API from the source site.
The API reference is derived from: https://github.com/SocialSisterYi/bilibili-API-collect .

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d34de7</samp>

### Summary
:sparkles::recycle::bug:

<!--
1.  :sparkles: This emoji represents the addition of new features or classes, such as the `BiliBiliBangumiEpisodeIE` and `BiliBiliBangumiSeasonIE` classes.
2.  :recycle: This emoji represents the refactoring or improvement of existing code, such as the `BiliBiliBangumiIE` class and the use of new API endpoints.
3.  :bug: This emoji represents the fixing of bugs or errors, such as the error handling and the addition of more metadata fields.
-->
Refactor the Bilibili Bangumi extractor to use new API endpoints and support more URL types. Add new classes for extracting playlists of episodes from media and season URLs. Rename `BiliBiliBangumiIE` to `BiliBiliBangumiEpisodeIE`. Update the extractor imports in `_extractors.py`.

> _Bilibili Bangumi_
> _New classes and API calls_
> _Autumn of refactor_

### Walkthrough
*  Refactor Bilibili Bangumi extractor to support different types of URLs and use new API endpoints ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L217-R218), [link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L405-R427), [link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L436-R485), [link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L490-R541))
  * Import new classes `BiliBiliBangumiEpisodeIE` and `BiliBiliBangumiSeasonIE` from `bilibili.py` module and add them to `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L217-R218))
  * Rename `BiliBiliBangumiIE` to `BiliBiliBangumiEpisodeIE` and inherit from `BilibiliBaseIE` instead of `InfoExtractor` ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L405-R427))
  * Change `_VALID_URL` pattern of `BiliBiliBangumiEpisodeIE` to match only episode URLs that start with `ep` followed by a number ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L405-R427))
  * Update `_TESTS` list of `BiliBiliBangumiEpisodeIE` to include a new test case for an episode URL and change expected `id` and `title` fields ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L405-R427))
  * Modify `_real_extract` method of `BiliBiliBangumiEpisodeIE` to use new API endpoints for getting video and season information and extract more metadata fields ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L436-R485))
  * Add `episode_id`, `series_id`, `series`, and `subtitles` fields to the returned dictionary of `BiliBiliBangumiEpisodeIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L436-R485))
  * Change `title` field of `BiliBiliBangumiEpisodeIE` to include both episode title and long title ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L436-R485))
  * Handle region and premium restrictions and raise appropriate errors in `BiliBiliBangumiEpisodeIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L436-R485))
  * Modify `BiliBiliBangumiMediaIE` to inherit from `InfoExtractor` instead of `BilibiliSpaceBaseIE` and use `BiliBiliBangumiEpisodeIE` for generating playlist result ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L490-R541))
  * Add `geo_verification_headers` to API requests and use `traverse_obj` helper function in `BiliBiliBangumiMediaIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7337/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L490-R541))



</details>
