### PR TITLE
[extractor/zaiko] Add support for eticket links on zaiko.io

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2444,7 +2444,10 @@ from .younow import (
 from .youporn import YouPornIE
 from .yourporn import YourPornIE
 from .yourupload import YourUploadIE
-from .zaiko import ZaikoIE, ZaikoETicketIE
+from .zaiko import (
+    ZaikoIE,
+    ZaikoETicketIE,
+)
 from .zapiks import ZapiksIE
 from .zattoo import (
     BBVTVIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2444,7 +2444,7 @@ from .younow import (
 from .youporn import YouPornIE
 from .yourporn import YourPornIE
 from .yourupload import YourUploadIE
-from .zaiko import ZaikoIE
+from .zaiko import ZaikoIE, ZaikoETicketIE
 from .zapiks import ZapiksIE
 from .zattoo import (
     BBVTVIE,

--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -99,7 +99,7 @@ class ZaikoIE(ZaikoBaseIE):
 
 
 class ZaikoETicketIE(ZaikoBaseIE):
-    _VALID_URL = r'https?://(?:www.)?zaiko\.io/account/eticket/(?P<id>\w{48}=)'
+    _VALID_URL = r'https?://(?:www.)?zaiko\.io/account/eticket/(?P<id>[\w=-]{49})'
     _TESTS = [{
         'url': 'https://zaiko.io/account/eticket/000000000000000000000000000000000000000000000000=',
         'only_matching': True,
@@ -110,6 +110,7 @@ class ZaikoETicketIE(ZaikoBaseIE):
 
         webpage = self._download_real_webpage(url, ticket_id)
         eticket = self._parse_vue_element_attr('eticket', webpage, ticket_id)
+
         return self.playlist_result(
             [self.url_result(stream, ZaikoIE) for stream in traverse_obj(eticket, ('streams', ..., 'url'))],
             ticket_id, **traverse_obj(eticket, ('ticket-details', {

--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -109,11 +109,10 @@ class ZaikoETicketIE(ZaikoBaseIE):
         ticket_id = self._match_id(url)
 
         webpage = self._download_real_webpage(url, ticket_id)
-        eticket_meta = self._parse_vue_element_attr('eticket', webpage, ticket_id)
-
-        ticket_details = eticket_meta.get('ticket-details')
-        streams = eticket_meta.get('streams') or []
-
+        eticket = self._parse_vue_element_attr('eticket', webpage, ticket_id)
         return self.playlist_result(
-            [self.url_result(stream.get('url'), ZaikoIE) for stream in streams], ticket_id,
-            ticket_details.get('event_name'), thumbnail=ticket_details.get('event_img_url'))
+            [self.url_result(stream, ZaikoIE) for stream in traverse_obj(eticket, ('streams', ..., 'url'))],
+            ticket_id, **traverse_obj(eticket, ('ticket-details', {
+                'title': 'event_name',
+                'thumbnail': 'event_img_url',
+            })))

--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -95,7 +95,7 @@ class ZaikoIE(ZaikoBaseIE):
 
 
 class ZaikoETicketIE(ZaikoBaseIE):
-    _VALID_URL = r'https?://zaiko\.io/account/eticket/(?P<id>\w{48}=)'
+    _VALID_URL = r'https?://(?:www.)?zaiko\.io/account/eticket/(?P<id>\w{48}=)'
     _TESTS = [{
         'url': 'https://zaiko.io/account/eticket/000000000000000000000000000000000000000000000000=',
         'only_matching': True,

--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -104,8 +104,14 @@ class ZaikoIE(ZaikoBaseIE):
 class ZaikoETicketIE(ZaikoBaseIE):
     _VALID_URL = r'https?://(?:www.)?zaiko\.io/account/eticket/(?P<id>[\w=-]{49})'
     _TESTS = [{
-        'url': 'https://zaiko.io/account/eticket/000000000000000000000000000000000000000000000000=',
-        'only_matching': True,
+        'url': 'https://zaiko.io/account/eticket/TZjMwMzQ2Y2EzMXwyMDIzMDYwNzEyMTMyNXw1MDViOWU2Mw==',
+        'playlist_count': 1,
+        'info_dict': {
+            'id': 'f30346ca31-20230607121325-505b9e63',
+            'title': 'ZAIKO STREAMING TEST',
+            'thumbnail': 'https://media.zkocdn.net/pf_1/1_3wdyjcjyupseatkwid34u',
+        },
+        'skip': 'Only available with the ticketholding account',
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -1,3 +1,5 @@
+import base64
+
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
@@ -5,6 +7,7 @@ from ..utils import (
     int_or_none,
     str_or_none,
     traverse_obj,
+    try_call,
     unescapeHTML,
     url_or_none,
 )
@@ -107,6 +110,8 @@ class ZaikoETicketIE(ZaikoBaseIE):
 
     def _real_extract(self, url):
         ticket_id = self._match_id(url)
+        ticket_id = try_call(
+            lambda: base64.urlsafe_b64decode(ticket_id[1:]).decode().replace('|', '-')) or ticket_id
 
         webpage = self._download_real_webpage(url, ticket_id)
         eticket = self._parse_vue_element_attr('eticket', webpage, ticket_id)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Hello!

This PR improves #7254.

The eticket link can be found in the email from Zaiko after purchasing tickets, or the account page on the website (https://zaiko.io/account).

The added test is "only_matching" since the link is unique for each audience. Posting a real URL might give Zaiko a chance to find the user who shared their ticket.

At last, I have to say, the code quality of #7254 is good. The "```live_status, msg, expected```" map looks beautiful.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d0dd5a1</samp>

### Summary
🎟️🎥🔧

<!--
1.  🎟️ - This emoji represents the concept of e-tickets, which are the main feature of the new extractor.
2.  🎥 - This emoji represents the concept of video streaming, which is the type of content that the extractor handles.
3.  🔧 - This emoji represents the concept of refactoring, which is the process of improving the structure and readability of the code.
-->
Add support for Zaiko e-ticket URLs and refactor Zaiko extractor. This pull request introduces a new extractor `ZaikoETicketIE` for extracting videos from e-ticket URLs, and shares common logic with the existing `ZaikoIE` extractor in a base class `ZaikoBaseIE`.

> _We're sailing on the web with our `Zaiko` crew_
> _We've got a new extractor for the e-ticket view_
> _So heave away, me hearties, on the count of three_
> _And we'll stream the finest events from across the sea_

### Walkthrough
* Create a new base class `ZaikoBaseIE` with a common method `_parse_vue_element_attr` for parsing HTML elements with Vue.js attributes ([link](https://github.com/yt-dlp/yt-dlp/pull/7347/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854L13-R24))
* Remove the `_parse_vue_element_attr` method from the `ZaikoIE` class and make it inherit from `ZaikoBaseIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7347/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854L33-L41))
* Add a new extractor class `ZaikoETicketIE` that handles Zaiko e-ticket URLs, requires logging in, and redirects to the event URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7347/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854R95-R118), [link](https://github.com/yt-dlp/yt-dlp/pull/7347/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L2447-R2447))
* Import the `ZaikoETicketIE` class in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7347/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L2447-R2447))



</details>
