### PR TITLE
[N1] Fix extractor for new player

### DIFF
--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -33,7 +33,7 @@ class N1InfoAssetIE(InfoExtractor):
 
 class N1InfoIIE(InfoExtractor):
     IE_NAME = 'N1Info:article'
-    _VALID_URL = r'https?://(?:(?:\w+\.)?n1info\.\w+|nova\.rs)/(?:[^/]+/){1,2}(?P<id>[^/]+)'
+    _VALID_URL = r'https?://(?:(?:\w+\.)?n1info\.\w+|nova\.rs)/(?:[^/?#]+/){1,2}(?P<id>[^/?#]+)'
     _TESTS = [{
         # Youtube embedded
         'url': 'https://rs.n1info.com/sport-klub/tenis/kako-je-djokovic-propustio-istorijsku-priliku-video/',
@@ -127,7 +127,8 @@ class N1InfoIIE(InfoExtractor):
                     'timestamp': timestamp,
                     'thumbnail': self._html_search_meta('thumbnailURL', webpage),
                     'formats': self._extract_m3u8_formats(
-                        f'https://cdn-uc.brid.tv/live/partners/{site_id}/streaming/{video_id}/{video_id}.m3u8', video_id),
+                        f'https://cdn-uc.brid.tv/live/partners/{site_id}/streaming/{video_id}/{video_id}.m3u8',
+                        video_id, fatal=False),
                 })
         else:
             # Old player still present in older articles
@@ -141,8 +142,8 @@ class N1InfoIIE(InfoExtractor):
                     'title': title,
                     'thumbnail': video_data.get('data-thumbnail'),
                     'timestamp': timestamp,
-                    'ie_key': 'N1InfoAsset'}
-                )
+                    'ie_key': 'N1InfoAsset',
+                })
 
         embedded_videos = re.findall(r'(<iframe[^>]+>)', webpage)
         for embedded_video in embedded_videos:

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -118,7 +118,7 @@ class N1InfoIIE(InfoExtractor):
         plugin_data = self._html_search_meta('BridPlugin', webpage)
         entries = []
         if plugin_data:
-            site_id = re.search(r'site:(\d+)', webpage).group(1)
+            site_id = self._html_search_regex(r'site:(\d+)', webpage, 'site id')
             for video_data in re.findall(r'\$bp\("Brid_\d+", (.+)\);', webpage):
                 video_id = self._parse_json(video_data, title)['video']
                 entries.append({

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -120,8 +120,7 @@ class N1InfoIIE(InfoExtractor):
         if plugin_data:
             site_id = re.search(r'site:(\d+)', webpage).group(1)
             for video_data in re.findall(r'\$bp\("Brid_\d+", (.+)\);', webpage):
-                video_data = self._parse_json(video_data, title)
-                video_id = video_data['video']
+                video_id = self._parse_json(video_data, title)['video']
                 entries.append({
                     'id': video_id,
                     'title': title,

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -95,6 +95,16 @@ class N1InfoIIE(InfoExtractor):
             'timestamp': 1635861677,
         },
     }, {
+        'url': 'https://n1info.rs/vesti/cuta-biti-u-kosovskoj-mitrovici-znaci-da-te-docekaju-eksplozivnim-napravama/',
+        'info_dict': {
+            'id': '1332368',
+            'ext': 'mp4',
+            'title': 'Ćuta: Biti u Kosovskoj Mitrovici znači da te dočekaju eksplozivnim napravama',
+            'upload_date': '20230620',
+            'timestamp': 1687290536,
+            'thumbnail': 'https://cdn.brid.tv/live/partners/26827/snapshot/1332368_th_6492013a8356f_1687290170.jpg'
+        },
+    }, {
         'url': 'https://hr.n1info.com/vijesti/pravobraniteljica-o-ubojstvu-u-zagrebu-radi-se-o-doista-nezapamcenoj-situaciji/',
         'only_matching': True,
     }]

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -123,14 +123,13 @@ class N1InfoIIE(InfoExtractor):
             for video_data in brid_data:
                 video_data = self._parse_json(video_data, title)
                 video_id = video_data['video']
-                thumbnail = self._html_search_meta('thumbnailURL', webpage)
-                formats = self._extract_m3u8_formats(f'https://cdn-uc.brid.tv/live/partners/{site_id}/streaming/{video_id}/{video_id}.m3u8', video_id)
                 entries.append({
-                    'formats': formats,
                     'id': video_id,
                     'title': title,
-                    'thumbnail': thumbnail,
                     'timestamp': timestamp,
+                    'thumbnail': self._html_search_meta('thumbnailURL', webpage),
+                    'formats': self._extract_m3u8_formats(
+                        f'https://cdn-uc.brid.tv/live/partners/{site_id}/streaming/{video_id}/{video_id}.m3u8', video_id),
                 })
         else:
             # Old player still present in older articles

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -131,8 +131,7 @@ class N1InfoIIE(InfoExtractor):
                     'title': title,
                     'thumbnail': thumbnail,
                     'timestamp': timestamp,
-                    }
-                )
+                })
         else:
             # Old player still present in older articles
             videos = re.findall(r'(?m)(<video[^>]+>)', webpage)

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -33,7 +33,7 @@ class N1InfoAssetIE(InfoExtractor):
 
 class N1InfoIIE(InfoExtractor):
     IE_NAME = 'N1Info:article'
-    _VALID_URL = r'https?://(?:(?:(?:ba|rs|hr)\.)?n1info\.(?:com|si|rs|hr|ba)|nova\.rs)/(?:[^/]+/){1,2}(?P<id>[^/]+)'
+    _VALID_URL = r'https?://(?:(?:\w+\.)?n1info\.\w+|nova\.rs)/(?:[^/]+/){1,2}(?P<id>[^/]+)'
     _TESTS = [{
         # Youtube embedded
         'url': 'https://rs.n1info.com/sport-klub/tenis/kako-je-djokovic-propustio-istorijsku-priliku-video/',

--- a/yt_dlp/extractor/n1.py
+++ b/yt_dlp/extractor/n1.py
@@ -118,9 +118,8 @@ class N1InfoIIE(InfoExtractor):
         plugin_data = self._html_search_meta('BridPlugin', webpage)
         entries = []
         if plugin_data:
-            brid_data = re.findall(r'\$bp\("Brid_\d+", (.+)\);', webpage)
             site_id = re.search(r'site:(\d+)', webpage).group(1)
-            for video_data in brid_data:
+            for video_data in re.findall(r'\$bp\("Brid_\d+", (.+)\);', webpage):
                 video_data = self._parse_json(video_data, title)
                 video_id = video_data['video']
                 entries.append({


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes N1 extractor for new player on newer articles.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe10f99</samp>

### Summary
🌐🎬🐛

<!--
1.  🌐 - This emoji can represent the support for more domains, as it is often used to symbolize the internet, web, or global reach.
2.  🎬 - This emoji can represent the new player, as it is often used to symbolize movies, videos, or media production.
3.  🐛 - This emoji can represent the fix for thumbnail extraction, as it is often used to symbolize bugs, errors, or issues.
-->
Improve N1Info extractor to handle different domains and player, and fix thumbnail issue. Add `yt_dlp/extractor/n1.py` test.

> _`N1Info` expands_
> _Domains and player updated_
> _Thumbnail fixed - fall_

### Walkthrough
* Updated the URL regex to support more domains for N1Info ([link](https://github.com/yt-dlp/yt-dlp/pull/7373/files?diff=unified&w=0#diff-0b22d856bfc66e8a7d4ee056866735af7753ca69a137c49a02fa9268ea9af830L36-R36))
* Added extraction logic for the new Brid player, which uses JSON data and m3u8 formats ([link](https://github.com/yt-dlp/yt-dlp/pull/7373/files?diff=unified&w=0#diff-0b22d856bfc66e8a7d4ee056866735af7753ca69a137c49a02fa9268ea9af830L108-R149))
* Fixed thumbnail extraction by using the correct meta tag ([link](https://github.com/yt-dlp/yt-dlp/pull/7373/files?diff=unified&w=0#diff-0b22d856bfc66e8a7d4ee056866735af7753ca69a137c49a02fa9268ea9af830L108-R149))
* Kept the old extraction logic for the video tag for backward compatibility ([link](https://github.com/yt-dlp/yt-dlp/pull/7373/files?diff=unified&w=0#diff-0b22d856bfc66e8a7d4ee056866735af7753ca69a137c49a02fa9268ea9af830L108-R149))
* Added a test case for a URL that uses the new Brid player (`yt_dlp/extractor/n1.py`) ([link](https://github.com/yt-dlp/yt-dlp/pull/7373/files?diff=unified&w=0#diff-0b22d856bfc66e8a7d4ee056866735af7753ca69a137c49a02fa9268ea9af830R98-R107))



</details>
