### PR TITLE
[googledrive] Fix missing "source" format

### DIFF
--- a/yt_dlp/extractor/googledrive.py
+++ b/yt_dlp/extractor/googledrive.py
@@ -5,7 +5,9 @@ from ..compat import compat_parse_qs
 from ..utils import (
     ExtractorError,
     determine_ext,
+    extract_attributes,
     get_element_by_class,
+    get_element_html_by_id,
     int_or_none,
     lowercase_escape,
     try_get,
@@ -238,9 +240,8 @@ class GoogleDriveIE(InfoExtractor):
                     urlh, url, video_id, note='Downloading confirmation page',
                     errnote='Unable to confirm download', fatal=False)
                 if confirmation_webpage:
-                    confirmed_source_url = self._html_search_regex(
-                        r'action="(.+?)"', confirmation_webpage,
-                        'confirmation code', default=None)
+                    confirmed_source_url = extract_attributes(
+                        get_element_html_by_id('download-form', confirmation_webpage) or '').get('action')
                     if confirmed_source_url:
                         urlh = request_source_file(confirmed_source_url, 'confirmed source', b'')
                         if urlh and urlh.headers.get('Content-Disposition'):

--- a/yt_dlp/extractor/googledrive.py
+++ b/yt_dlp/extractor/googledrive.py
@@ -34,6 +34,7 @@ class GoogleDriveIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'Big Buck Bunny.mp4',
             'duration': 45,
+            'thumbnail': 'https://drive.google.com/thumbnail?id=0ByeS4oOUV-49Zzh4R1J6R09zazQ',
         }
     }, {
         # video can't be watched anonymously due to view count limit reached,

--- a/yt_dlp/extractor/googledrive.py
+++ b/yt_dlp/extractor/googledrive.py
@@ -207,10 +207,10 @@ class GoogleDriveIE(InfoExtractor):
                 'export': 'download',
             })
 
-        def request_source_file(source_url, kind):
+        def request_source_file(source_url, kind, data=None):
             return self._request_webpage(
                 source_url, video_id, note='Requesting %s file' % kind,
-                errnote='Unable to request %s file' % kind, fatal=False)
+                errnote='Unable to request %s file' % kind, fatal=False, data=data)
         urlh = request_source_file(source_url, 'source')
         if urlh:
             def add_source_format(urlh):
@@ -237,14 +237,11 @@ class GoogleDriveIE(InfoExtractor):
                     urlh, url, video_id, note='Downloading confirmation page',
                     errnote='Unable to confirm download', fatal=False)
                 if confirmation_webpage:
-                    confirm = self._search_regex(
-                        r'confirm=([^&"\']+)', confirmation_webpage,
+                    confirmed_source_url = self._html_search_regex(
+                        r'action="(.+?)"', confirmation_webpage,
                         'confirmation code', default=None)
-                    if confirm:
-                        confirmed_source_url = update_url_query(source_url, {
-                            'confirm': confirm,
-                        })
-                        urlh = request_source_file(confirmed_source_url, 'confirmed source')
+                    if confirmed_source_url:
+                        urlh = request_source_file(confirmed_source_url, 'confirmed source', b'')
                         if urlh and urlh.headers.get('Content-Disposition'):
                             add_source_format(urlh)
                     else:

--- a/yt_dlp/extractor/googledrive.py
+++ b/yt_dlp/extractor/googledrive.py
@@ -243,7 +243,7 @@ class GoogleDriveIE(InfoExtractor):
                     confirmed_source_url = extract_attributes(
                         get_element_html_by_id('download-form', confirmation_webpage) or '').get('action')
                     if confirmed_source_url:
-                        urlh = request_source_file(confirmed_source_url, 'confirmed source', b'')
+                        urlh = request_source_file(confirmed_source_url, 'confirmed source', data=b'')
                         if urlh and urlh.headers.get('Content-Disposition'):
                             add_source_format(urlh)
                     else:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This pull request addresses an issue where the "source" format was missing when a video was still being processed.

The problem occurred when attempting to extract video information from a source that was not yet fully processed. In such cases, the "source" format was not included in the extracted information, leading to "Video is still being processed" error even though the source is available.

To resolve this issue, the code has been modified to ensure that the "source" format is included even when the video is still undergoing processing by changing confirm regex to the whole url including uuid & at param. This ensures that all available formats are captured, providing a comprehensive set of video options for users.

Additionally, the pull request includes necessary updates to the relevant test cases to ensure proper functionality so that the test cases is marked as passed because the thumbnail key is available.

Overall, this fix enhances the reliability and completeness of video extraction from the given source, improving the overall user experience.

Fix #7344 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 44f5ec9</samp>

### Summary
🖼️📮🔗

<!--
1.  🖼️ for thumbnail extraction, since this emoji depicts a framed picture or image.
2.  📮 for supporting POST requests for source files, since this emoji depicts a mailbox with a letter, which could symbolize sending or receiving data via HTTP methods.
3.  🔗 for simplifying confirmation URL extraction, since this emoji depicts a link or chain, which could symbolize a URL or a connection.
-->
Enhance GoogleDriveIE extractor with thumbnail, POST, and confirmation URL features.

> _Sing, O Muse, of the skillful coder who improved the extractor_
> _Of GoogleDriveIE, the mighty tool that fetches videos online_
> _He added thumbnail extraction, a splendid feature for the users_
> _And made it support POST requests, `source_file` to refine_

### Walkthrough
* Add thumbnail URL extraction to GoogleDriveIE extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/7395/files?diff=unified&w=0#diff-f000a5dd6f0f7231185a73c67cd0b3599e4a48f119391e7a7f00f702e7b17ee0R37))
* Modify `request_source_file` function to accept optional `data` parameter for POST requests ([link](https://github.com/yt-dlp/yt-dlp/pull/7395/files?diff=unified&w=0#diff-f000a5dd6f0f7231185a73c67cd0b3599e4a48f119391e7a7f00f702e7b17ee0L210-R214))
* Use HTML-based extraction of confirmation URL instead of regex-based extraction of confirmation code ([link](https://github.com/yt-dlp/yt-dlp/pull/7395/files?diff=unified&w=0#diff-f000a5dd6f0f7231185a73c67cd0b3599e4a48f119391e7a7f00f702e7b17ee0L240-R245))



</details>
