### PR TITLE
[extractor/youtube] Better detect DRM

### DIFF
--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -93,10 +93,12 @@ class HlsFD(FragmentFD):
                            f'please {install_ffmpeg}add "--downloader ffmpeg --hls-use-mpegts" to your command')
         if not can_download:
             if self._has_drm(s) and not self.params.get('allow_unplayable_formats'):
-                hint = ('' if info_dict.get('has_drm') and self.params.get('test') else
-                        '; Try selecting another format with --format or '
-                        'add --check-formats to automatically fallback to the next best format')
-                self.report_error(f'This stream is DRM protected{hint}', tb=False)
+                if info_dict.get('has_drm') and self.params.get('test'):
+                    self.to_screen(f'[{self.FD_NAME}] This format is DRM protected', skip_eol=True)
+                else:
+                    self.report_error(
+                        'This format is DRM protected; Try selecting another format with --format or '
+                        'add --check-formats to automatically fallback to the next best format', tb=False)
                 return False
             message = message or 'Unsupported features have been detected'
             fd = FFmpegFD(self.ydl, self.params)

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -28,7 +28,16 @@ class HlsFD(FragmentFD):
     FD_NAME = 'hlsnative'
 
     @staticmethod
-    def can_download(manifest, info_dict, allow_unplayable_formats=False):
+    def _has_drm(manifest):  # TODO: https://github.com/yt-dlp/yt-dlp/pull/5039
+        return bool(re.search('|'.join((
+            r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
+            r'#EXT-X-(?:SESSION-)?KEY:.*?KEYFORMAT="com\.apple\.streamingkeydelivery"',  # Apple FairPlay
+            r'#EXT-X-(?:SESSION-)?KEY:.*?KEYFORMAT="com\.microsoft\.playready"',  # Microsoft PlayReady
+            r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
+        )), manifest))
+
+    @classmethod
+    def can_download(cls, manifest, info_dict, allow_unplayable_formats=False):
         UNSUPPORTED_FEATURES = [
             # r'#EXT-X-BYTERANGE',  # playlists composed of byte ranges of media files [2]
 
@@ -50,13 +59,15 @@ class HlsFD(FragmentFD):
         ]
         if not allow_unplayable_formats:
             UNSUPPORTED_FEATURES += [
-                r'#EXT-X-KEY:METHOD=(?!NONE|AES-128)',  # encrypted streams [1]
+                r'#EXT-X-KEY:METHOD=(?!NONE|AES-128)',  # encrypted streams [1], but not necessarily DRM
             ]
 
         def check_results():
             yield not info_dict.get('is_live')
             for feature in UNSUPPORTED_FEATURES:
                 yield not re.search(feature, manifest)
+            if not allow_unplayable_formats:
+                yield not cls._has_drm(manifest)
         return all(check_results())
 
     def real_download(self, filename, info_dict):
@@ -81,14 +92,11 @@ class HlsFD(FragmentFD):
                 message = ('Live HLS streams are not supported by the native downloader. If this is a livestream, '
                            f'please {install_ffmpeg}add "--downloader ffmpeg --hls-use-mpegts" to your command')
         if not can_download:
-            has_drm = re.search('|'.join([
-                r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
-                r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
-            ]), s)
-            if has_drm and not self.params.get('allow_unplayable_formats'):
-                self.report_error(
-                    'This video is DRM protected; Try selecting another format with --format or '
-                    'add --check-formats to automatically fallback to the next best format')
+            if self._has_drm(s) and not self.params.get('allow_unplayable_formats'):
+                hint = ('' if info_dict.get('has_drm') and self.params.get('test') else
+                        '; Try selecting another format with --format or '
+                        'add --check-formats to automatically fallback to the next best format')
+                self.report_error(f'This video is DRM protected{hint}', tb=False)
                 return False
             message = message or 'Unsupported features have been detected'
             fd = FFmpegFD(self.ydl, self.params)

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -96,7 +96,7 @@ class HlsFD(FragmentFD):
                 hint = ('' if info_dict.get('has_drm') and self.params.get('test') else
                         '; Try selecting another format with --format or '
                         'add --check-formats to automatically fallback to the next best format')
-                self.report_error(f'This video is DRM protected{hint}', tb=False)
+                self.report_error(f'This stream is DRM protected{hint}', tb=False)
                 return False
             message = message or 'Unsupported features have been detected'
             fd = FFmpegFD(self.ydl, self.params)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -25,6 +25,7 @@ import xml.etree.ElementTree
 from ..compat import functools  # isort: split
 from ..compat import compat_etree_fromstring, compat_expanduser, compat_os_name
 from ..cookies import LenientSimpleCookie
+from ..downloader.hls import HlsFD
 from ..downloader.f4m import get_base_url, remove_encrypted_media
 from ..utils import (
     IDENTITY,
@@ -224,7 +225,8 @@ class InfoExtractor:
                                  width : height ratio as float.
                     * no_resume  The server does not support resuming the
                                  (HTTP or RTMP) download. Boolean.
-                    * has_drm    The format has DRM and cannot be downloaded. Boolean
+                    * has_drm    True if the format has DRM and cannot be downloaded.
+                                 'maybe' if the format may have DRM and has to be tested before download.
                     * extra_param_to_segment_url  A query string to append to each
                                  fragment's URL, or to update each existing query string
                                  with. Only applied by the native HLS/DASH downloaders.
@@ -1979,11 +1981,7 @@ class InfoExtractor:
             errnote=None, fatal=True, data=None, headers={}, query={},
             video_id=None):
         formats, subtitles = [], {}
-
-        has_drm = re.search('|'.join([
-            r'#EXT-X-FAXS-CM:',  # Adobe Flash Access
-            r'#EXT-X-(?:SESSION-)?KEY:.*?URI="skd://',  # Apple FairPlay
-        ]), m3u8_doc)
+        has_drm = HlsFD._has_drm(m3u8_doc)
 
         def format_url(url):
             return url if re.match(r'^https?://', url) else urllib.parse.urljoin(m3u8_url, url)

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -4052,7 +4052,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         streaming_data = traverse_obj(player_responses, (..., 'streamingData'))
         *formats, subtitles = self._extract_formats_and_subtitles(streaming_data, video_id, player_url, live_status, duration)
         if all(f.get('has_drm') for f in formats):
-            # If these are no formats that defenitely don't have DRM, all have DRM
+            # If there are no formats that definitely don't have DRM, all have DRM
             for f in formats:
                 f['has_drm'] = True
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3932,9 +3932,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             elif itag:
                 f['format_id'] = itag
 
+            if f.get('source_preference') is None:
+                f['source_preference'] = -1
+
             if itag in ('616', '235'):
                 f['format_note'] = join_nonempty(f.get('format_note'), 'Premium', delim=' ')
-                f['source_preference'] = (f.get('source_preference') or -1) + 100
+                f['source_preference'] += 100
 
             f['quality'] = q(itag_qualities.get(try_get(f, lambda f: f['format_id'].split('-')[0]), -1))
             if f['quality'] == -1 and f.get('height'):
@@ -3943,6 +3946,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 f['format_note'] = join_nonempty(f.get('format_note'), client_name, delim=', ')
             if f.get('fps') and f['fps'] <= 1:
                 del f['fps']
+
+            if proto == 'hls' and f.get('has_drm'):
+                f['has_drm'] = 'maybe'
+                f['source_preference'] -= 5
             return True
 
         subtitles = {}
@@ -4044,6 +4051,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                        else None)
         streaming_data = traverse_obj(player_responses, (..., 'streamingData'))
         *formats, subtitles = self._extract_formats_and_subtitles(streaming_data, video_id, player_url, live_status, duration)
+        if all(f.get('has_drm') for f in formats):
+            # If these are no formats that defenitely don't have DRM, all have DRM
+            for f in formats:
+                f['has_drm'] = True
 
         return live_broadcast_details, live_status, streaming_data, formats, subtitles
 


### PR DESCRIPTION


### Description of your *pull request* and other information

Some YouTube videos like `Uk1hv6h7O1Y` has non-DRM m3u8 formats which yt-dlp wrongly detects as DRM. This happens because DRM and non-DRM formats are available in the same master manifest and it is impossible to determine which is which without downloading the child manifest.

But downloading child manifest for all these format will be slow and undesired for most. So we will instead enable all these formats and label them as potentially containing DRM in `-F`.

Just before the format is to get selected for download, it will be tested for DRM and will be discarded. This uses the `--check-formats` mechanism but is enabled by default.

Since this check is enabled by default, I am not de-prioritizing these formats in sorting unless everything else is equal. For example, a potentially DRMed `616` (Premium) format will remain prioritized.

In theory, it is possible for these types of master manifests to be used by other sites as well. But changing the DRM detection in core code directly will cause all DRM manifests to only be detected as "Maybe DRM", which is undesirable. So unless we find such cases in the wild, I am opting to make this change only for youtube and leave the general parsing as-is.

```
❯ yt-dlp Uk1hv6h7O1Y -vf 281/616 -F --no-sim
[debug] Command-line config: ['--ignore-config', 'Uk1hv6h7O1Y', '-vf', '281/616', '-F', '--no-sim']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.06.22 [812cdfa06] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: ee384ef6c
[debug] Python 3.11.0 (CPython AMD64 64bit) - Windows-10-10.0.22000-SP0 (OpenSSL 1.1.1q  5 Jul 2022)
[debug] exe versions: ffmpeg n5.1.2-8-g5746987bad-20221204 (fdk,setts), ffprobe N-109332-g45ab5307a6-20221201, phantomjs 2.1.1
[debug] Optional libraries: Cryptodome-3.18.0, brotli-1.0.9, certifi-2022.12.07, mutagen-1.46.0, sqlite3-2.6.0, websockets-10.4
[debug] Proxy map: {}
[debug] Loaded 1851 extractors
[youtube] Extracting URL: Uk1hv6h7O1Y
[youtube] Uk1hv6h7O1Y: Downloading webpage
[youtube] Uk1hv6h7O1Y: Downloading ios player API JSON
[youtube] Uk1hv6h7O1Y: Downloading android player API JSON
[youtube] Uk1hv6h7O1Y: Downloading m3u8 information
[debug] Sort order given by extractor: quality, res, fps, hdr:12, source, vcodec:vp9.2, channels, acodec, lang, proto
[debug] Formats sorted by: hasvid, ie_pref, quality, res, fps, hdr:12(7), source, vcodec:vp9.2(10), channels, acodec, lang, proto, size, br, asr, vext, aext, hasaud, id
[info] Available formats for Uk1hv6h7O1Y:
ID  EXT   RESOLUTION FPS CH │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC      ABR ASR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
sb2 mhtml 48x27        1    │                  mhtml │ images                                  storyboard
sb1 mhtml 80x45        1    │                  mhtml │ images                                  storyboard
sb0 mhtml 160x90       1    │                  mhtml │ images                                  storyboard
233 mp4   audio only        │                  m3u8  │ audio only          unknown             [en] Maybe DRM, Default, IOS
234 mp4   audio only        │                  m3u8  │ audio only          unknown             [en] Maybe DRM, Default, IOS
293 mp4   audio only        │                  m3u8  │ audio only          unknown             [en] Maybe DRM, Default, IOS
294 mp4   audio only        │                  m3u8  │ audio only          unknown             [en] Maybe DRM, Default, IOS
295 mp4   audio only        │                  m3u8  │ audio only          unknown             [en] Maybe DRM, Default, IOS
599 m4a   audio only      2 │  733.79KiB   31k https │ audio only          mp4a.40.5   31k 22k [en] ultralow, ANDR, m4a_dash
600 webm  audio only      2 │  854.77KiB   36k https │ audio only          opus        36k 48k [en] ultralow, ANDR, webm_dash
139 m4a   audio only      2 │    1.13MiB   49k https │ audio only          mp4a.40.5   49k 22k [en] low, IOS, m4a_dash
249 webm  audio only      2 │    1.23MiB   53k https │ audio only          opus        53k 48k [en] low, ANDR, webm_dash
250 webm  audio only      2 │    1.62MiB   70k https │ audio only          opus        70k 48k [en] low, ANDR, webm_dash
140 m4a   audio only      2 │    3.01MiB  130k https │ audio only          mp4a.40.2  130k 44k [en] medium, IOS, m4a_dash
251 webm  audio only      2 │    3.15MiB  136k https │ audio only          opus       136k 48k [en] medium, ANDR, webm_dash
17  3gp   176x144     12  1 │    1.86MiB   80k https │ mp4v.20.3           mp4a.40.2       22k [en] 144p, ANDR
602 mp4   256x144     12    │ ~  1.94MiB   81k m3u8  │ vp09.00.10.08   81k video only          Maybe DRM, IOS
597 mp4   256x144     12    │  762.70KiB   32k https │ avc1.4d400b     32k video only          144p, ANDR, mp4_dash
598 webm  256x144     12    │  560.69KiB   24k https │ vp9             24k video only          144p, ANDR, webm_dash
269 mp4   256x144     24    │ ~  3.67MiB  154k m3u8  │ avc1.4D400C    154k video only          Maybe DRM, IOS
281 mp4   256x144     24    │ ~  4.09MiB  172k m3u8  │ avc1.4D400C    172k video only          Maybe DRM, IOS
603 mp4   256x144     24    │ ~  3.70MiB  155k m3u8  │ vp09.00.11.08  155k video only          Maybe DRM, IOS
394 mp4   256x144     24    │    1.47MiB   63k https │ av01.0.00M.08   63k video only          144p, ANDR, mp4_dash
160 mp4   256x144     24    │    1.06MiB   46k https │ avc1.4D400C     46k video only          144p, IOS, mp4_dash
278 webm  256x144     24    │    1.94MiB   83k https │ vp09.00.11.08   83k video only          144p, IOS, webm_dash
229 mp4   426x240     24    │ ~  6.24MiB  262k m3u8  │ avc1.4D4015    262k video only          Maybe DRM, IOS
282 mp4   426x240     24    │ ~  6.56MiB  276k m3u8  │ avc1.4D4015    276k video only          Maybe DRM, IOS
604 mp4   426x240     24    │ ~  5.40MiB  227k m3u8  │ vp09.00.20.08  227k video only          Maybe DRM, IOS
395 mp4   426x240     24    │    1.88MiB   81k https │ av01.0.00M.08   81k video only          240p, ANDR, mp4_dash
133 mp4   426x240     24    │    2.11MiB   91k https │ avc1.4D4015     91k video only          240p, IOS, mp4_dash
242 webm  426x240     24    │    1.83MiB   79k https │ vp09.00.20.08   79k video only          240p, IOS, webm_dash
230 mp4   640x360     24    │ ~ 11.83MiB  497k m3u8  │ avc1.4D401E    497k video only          Maybe DRM, IOS
283 mp4   640x360     24    │ ~ 12.06MiB  507k m3u8  │ avc1.4D401E    507k video only          Maybe DRM, IOS
605 mp4   640x360     24    │ ~ 10.23MiB  430k m3u8  │ vp09.00.21.08  430k video only          Maybe DRM, IOS
396 mp4   640x360     24    │    3.34MiB  144k https │ av01.0.01M.08  144k video only          360p, ANDR, mp4_dash
134 mp4   640x360     24    │    3.26MiB  140k https │ avc1.4D401E    140k video only          360p, IOS, mp4_dash
18  mp4   640x360     24  2 │ ≈  6.41MiB  269k https │ avc1.42001E         mp4a.40.2       44k [en] 360p, ANDR
243 webm  640x360     24    │    3.12MiB  134k https │ vp09.00.21.08  134k video only          360p, IOS, webm_dash
231 mp4   854x480     24    │ ~ 14.93MiB  627k m3u8  │ avc1.4D401E    627k video only          Maybe DRM, IOS
284 mp4   854x480     24    │ ~ 19.50MiB  819k m3u8  │ avc1.4D401E    819k video only          Maybe DRM, IOS
606 mp4   854x480     24    │ ~ 12.92MiB  543k m3u8  │ vp09.00.30.08  543k video only          Maybe DRM, IOS
397 mp4   854x480     24    │    5.63MiB  242k https │ av01.0.04M.08  242k video only          480p, ANDR, mp4_dash
135 mp4   854x480     24    │    4.44MiB  191k https │ avc1.4D401E    191k video only          480p, IOS, mp4_dash
244 webm  854x480     24    │    4.41MiB  190k https │ vp09.00.30.08  190k video only          480p, IOS, webm_dash
232 mp4   1280x720    24    │ ~ 20.22MiB  850k m3u8  │ avc1.4D401F    850k video only          Maybe DRM, IOS
287 mp4   1280x720    24    │ ~ 24.63MiB 1035k m3u8  │ avc1.4D401F   1035k video only          Maybe DRM, IOS
288 mp4   1280x720    24    │ ~ 71.01MiB 2983k m3u8  │ avc1.4D401F   2983k video only          Maybe DRM, IOS
609 mp4   1280x720    24    │ ~ 19.14MiB  804k m3u8  │ vp09.00.31.08  804k video only          Maybe DRM, IOS
22  mp4   1280x720    24  2 │ ≈ 10.86MiB  456k https │ avc1.64001F         mp4a.40.2       44k [en] 720p, ANDR
398 mp4   1280x720    24    │    9.88MiB  425k https │ av01.0.05M.08  425k video only          720p, ANDR, mp4_dash
136 mp4   1280x720    24    │    7.60MiB  327k https │ avc1.4D401F    327k video only          720p, IOS, mp4_dash
247 webm  1280x720    24    │    7.01MiB  302k https │ vp09.00.31.08  302k video only          720p, IOS, webm_dash
270 mp4   1920x1080   24    │ ~ 57.69MiB 2424k m3u8  │ avc1.640028   2424k video only          Maybe DRM, IOS
290 mp4   1920x1080   24    │ ~ 61.10MiB 2567k m3u8  │ avc1.640028   2567k video only          Maybe DRM, IOS
614 mp4   1920x1080   24    │ ~ 45.28MiB 1902k m3u8  │ vp09.00.40.08 1902k video only          Maybe DRM, IOS
399 mp4   1920x1080   24    │   16.31MiB  702k https │ av01.0.08M.08  702k video only          1080p, ANDR, mp4_dash
137 mp4   1920x1080   24    │   26.90MiB 1158k https │ avc1.640028   1158k video only          1080p, IOS, mp4_dash
248 webm  1920x1080   24    │   19.09MiB  822k https │ vp09.00.40.08  822k video only          1080p, IOS, webm_dash
616 mp4   1920x1080   24    │ ~ 63.45MiB 2665k m3u8  │ vp09.00.40.08 2665k video only          Maybe DRM, Premium, IOS
[info] Testing format 281
[hlsnative] Downloading m3u8 manifest
ERROR: This video is DRM protected

[info] Unable to download format 281. Skipping...
[info] Testing format 616
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 39
[download] Destination: D:\Programs\Source\yt-dlp\yt-dlp\tmpaukdw5ab.tmp
[debug] File locking is not supported. Proceeding without locking
[download] 100% of    712.00B in 00:00:00 at 6.41KiB/s
[info] Uk1hv6h7O1Y: Downloading 1 format(s): 616
[debug] Invoking hlsnative downloader on "https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/1687539821/ei/DXyVZPVt7aeO4w-T6LjQDA/ip/49.37.227.147/id/524d61bfa87b3b56/itag/616/source/youtube/requiressl/yes/ratebypass/yes/pfa/1/wft/1/sgovp/clen%3D29885879%3Bdur%3D194.903%3Bgir%3Dyes%3Bitag%3D356%3Blmt%3D1665804274901572/hls_chunk_host/rr1---sn-gwpa-jjwe.googlevideo.com/mh/3q/mm/31,29/mn/sn-gwpa-jjwe,sn-gwpa-h55z/ms/au,rdu/mv/m/mvi/1/pcm2cms/yes/pl/20/initcwndbps/720000/vprv/1/playlist_type/DVR/dover/13/txp/5532434/mt/1687517828/fvip/4/short_key/1/keepalive/yes/fexp/24007246,24363392/beids/24350017/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,pfa,wft,sgovp,vprv,playlist_type/sig/AOq0QJ8wRQIhAJlDYkjC6ibVpc3WSSmZ4wATjK_cRzi4vXzy2ln201LDAiA1PZRufZZMMirVfxZghQNqMnM9ObJsL3nAla00ubkdhA%3D%3D/lsparams/hls_chunk_host,mh,mm,mn,ms,mv,mvi,pcm2cms,pl,initcwndbps/lsig/AG3C_xAwRQIhAOph83Cgt_XlIx6T0UtNioRkdewKFmuzSVGbkqvowDGkAiAs1zfz_hImQo56IgCnKc3sbTQn1C4nEMItC0DCu3hpXQ%3D%3D/playlist/index.m3u8"
[download] Bazzi feat. Camila Cabello - Beautiful [Official Music Video] [Uk1hv6h7O1Y].mp4 has already been downloaded
[download] 100% of   15.12MiB
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ee384ef</samp>

### Summary
🔒🎞️🚫

<!--
1.  🔒 - This emoji represents the concept of DRM protection, encryption, or security, and can be used to indicate the changes related to DRM detection and handling.
2.  🎞️ - This emoji represents the concept of video formats, streams, or media, and can be used to indicate the changes related to HLS, YouTube, and manifest formats.
3.  🚫 - This emoji represents the concept of rejection, exclusion, or error, and can be used to indicate the changes related to filtering out unplayable formats and showing better error messages.
-->
This pull request enhances the support and user experience for DRM-protected and unsupported formats in `yt_dlp`. It adds a new method to detect DRM in `HlsFD`, uses it in `InfoExtractor` and `youtube.py`, and improves the format selection and output in `YoutubeDL.py`.

> _Oh we are the coders of `yt_dlp`_
> _We handle the formats with skill and pep_
> _We filter out the DRM and show the best_
> _And we sing as we work on the pull request_

### Walkthrough
*  Add a new static method `_has_drm` to the `HlsFD` class to detect DRM in HLS manifests using a regular expression ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b52feb4b242a6e7d828ecdcab6e5ed8b6bb6f94ec5f5dffa7ae52299946d02b1L31-R38))
*  Refactor the `can_download` and `real_download` methods of the `HlsFD` class to use the `_has_drm` method and improve the DRM error handling ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b52feb4b242a6e7d828ecdcab6e5ed8b6bb6f94ec5f5dffa7ae52299946d02b1L53-R60), [link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b52feb4b242a6e7d828ecdcab6e5ed8b6bb6f94ec5f5dffa7ae52299946d02b1R67-R68), [link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b52feb4b242a6e7d828ecdcab6e5ed8b6bb6f94ec5f5dffa7ae52299946d02b1L84-R97))
*  Import the `HlsFD` class in the `common.py` module to use the `_has_drm` method in the `InfoExtractor` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6R28))
*  Update the documentation and the implementation of the `has_drm` field in the `InfoExtractor` class to support a new possible value of `'maybe'`, which indicates uncertain DRM status ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L227-R229), [link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L1982-R1985))
*  Adjust the `source_preference` and the `has_drm` fields of the YouTube formats in the `YoutubeIE` class to handle the `'maybe'` case and prioritize playable formats ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3935-R3940), [link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506R3949-R3952))
*  Add a new style attribute `BAD_FORMAT` to the `YoutubeDL` class to color the output of DRM-protected or unsupported formats ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR986))
*  Remove the `check_formats` parameter from the `build_format_selector` function and replace it with a more granular logic in the `_check_formats` function, which checks and filters formats based on the `check_formats` and `allow_unplayable_formats` parameters ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL2089-L2090), [link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL2263-R2275))
*  Modify the `process_video_result` function to handle the `'maybe'` case and set the `_has_drm` field of the `info_dict` accordingly ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL2618-R2629))
*  Modify the `render_formats_table` function to use the `BAD_FORMAT` style and distinguish between different DRM cases in the format output ([link](https://github.com/yt-dlp/yt-dlp/pull/7396/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL3726-R3740))



</details>
