### PR TITLE
[AdultSwim] fix ignoring subtitles warning

### DIFF
--- a/yt_dlp/extractor/adultswim.py
+++ b/yt_dlp/extractor/adultswim.py
@@ -170,8 +170,10 @@ class AdultSwimIE(TurnerBaseIE):
                         continue
                     ext = determine_ext(asset_url, mimetype2ext(asset.get('mime_type')))
                     if ext == 'm3u8':
-                        info['formats'].extend(self._extract_m3u8_formats(
-                            asset_url, video_id, 'mp4', m3u8_id='hls', fatal=False))
+                        fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                            asset_url, video_id, 'mp4', m3u8_id='hls', fatal=False)
+                        info['formats'].extend(fmts)
+                        self._merge_subtitles(subs, target=info['subtitles'])
                     elif ext == 'f4m':
                         continue
                         # info['formats'].extend(self._extract_f4m_formats(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->


Fixes [#6191](https://github.com/yt-dlp/yt-dlp/issues/6191)

This PR fixes a warning message stating "subtitle tracks found in the HLS manifest" are being ignored, following the change suggested in the issue.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 47fdc67</samp>

### Summary
🎞️🗣️🔀

<!--
1.  🎞️ - This emoji represents the extraction of m3u8 formats, which are video segments that can be streamed or downloaded. The emoji is also used for film or cinema in general, so it can convey the idea of video processing or manipulation.
2.  🗣️ - This emoji represents the extraction of subtitles, which are text or audio translations of the spoken dialogue in a video. The emoji is also used for speech or speaking in general, so it can convey the idea of language or communication.
3.  🔀 - This emoji represents the merging of subtitles, which is the process of combining two or more subtitle tracks into one. The emoji is also used for shuffle or randomize in general, so it can convey the idea of mixing or matching.
-->
Improve subtitle extraction and merging for `adultswim` extractor. Use m3u8 source to get subtitles and combine them with existing ones.

> _Extract m3u8 formats_
> _Subtitles join the info dict_
> _Autumn of merging_

### Walkthrough
* Extract subtitles from m3u8 formats and merge them with existing subtitles ([link](https://github.com/yt-dlp/yt-dlp/pull/7421/files?diff=unified&w=0#diff-7124b69d6e71e29ef6a1082f8239b8d19e3978118cdb49ce2b86c405a0d964cdL173-R176))



</details>
