### PR TITLE
Add `globals` module

### DIFF
--- a/devscripts/make_changelog.py
+++ b/devscripts/make_changelog.py
@@ -53,6 +53,7 @@ class CommitGroup(enum.Enum):
                     'cookies',
                     'core',
                     'dependencies',
+                    'globals',
                     'jsinterp',
                     'outtmpl',
                     'plugins',

--- a/devscripts/make_lazy_extractors.py
+++ b/devscripts/make_lazy_extractors.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from inspect import getsource
 
 from devscripts.utils import get_filename_args, read_file, write_file
+from yt_dlp.globals import ALL_IES
 
 NO_ATTR = object()
 STATIC_CLASS_PROPERTIES = [
@@ -65,11 +66,11 @@ def get_all_ies():
         # os.rename cannot be used, e.g. in Docker. See https://github.com/yt-dlp/yt-dlp/pull/4958
         shutil.move(PLUGINS_DIRNAME, BLOCKED_DIRNAME)
     try:
-        from yt_dlp.extractor.extractors import _ALL_CLASSES
+        from yt_dlp.extractor import extractors  # noqa: F401
     finally:
         if os.path.exists(BLOCKED_DIRNAME):
             shutil.move(BLOCKED_DIRNAME, PLUGINS_DIRNAME)
-    return _ALL_CLASSES
+    return list(ALL_IES.get().values())
 
 
 def extra_ie_code(ie, base=None):

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -20,11 +20,11 @@ from .cookies import SUPPORTED_BROWSERS, SUPPORTED_KEYRINGS
 from .downloader.external import get_external_downloader
 from .extractor import list_extractor_classes
 from .extractor.adobepass import MSO_INFO
+from .globals import _IN_CLI, ffmpeg_location
 from .options import parseOpts
 from .postprocessor import (
     FFmpegExtractAudioPP,
     FFmpegMergerPP,
-    FFmpegPostProcessor,
     FFmpegSubtitlesConvertorPP,
     FFmpegThumbnailsConvertorPP,
     FFmpegVideoConvertorPP,
@@ -63,8 +63,6 @@ from .utils import (
     write_string,
 )
 from .YoutubeDL import YoutubeDL
-
-_IN_CLI = False
 
 
 def _exit(status=0, *args):
@@ -957,7 +955,7 @@ def _real_main(argv=None):
     # We may need ffmpeg_location without having access to the YoutubeDL instance
     # See https://github.com/yt-dlp/yt-dlp/issues/2191
     if opts.ffmpeg_location:
-        FFmpegPostProcessor._ffmpeg_location.set(opts.ffmpeg_location)
+        ffmpeg_location.set(opts.ffmpeg_location)
 
     with YoutubeDL(ydl_opts) as ydl:
         pre_process = opts.update_self or opts.rm_cachedir
@@ -1002,8 +1000,7 @@ def _real_main(argv=None):
 
 
 def main(argv=None):
-    global _IN_CLI
-    _IN_CLI = True
+    _IN_CLI.set(True)
     try:
         _exit(*variadic(_real_main(argv)))
     except DownloadError:

--- a/yt_dlp/extractor/__init__.py
+++ b/yt_dlp/extractor/__init__.py
@@ -1,16 +1,16 @@
 from ..compat.compat_utils import passthrough_module
+from ..globals import ALL_IES
 
 passthrough_module(__name__, '.extractors')
 del passthrough_module
 
 
 def gen_extractor_classes():
-    """ Return a list of supported extractors.
+    """ Return an iterable of supported extractors.
     The order does matter; the first extractor matched is the one handling the URL.
     """
-    from .extractors import _ALL_CLASSES
-
-    return _ALL_CLASSES
+    from . import extractors  # noqa: F401
+    return ALL_IES.get().values()
 
 
 def gen_extractors():
@@ -21,7 +21,7 @@ def gen_extractors():
 
 
 def list_extractor_classes(age_limit=None):
-    """Return a list of extractors that are suitable for the given age, sorted by extractor name"""
+    """Return an iterable of extractors that are suitable for the given age, sorted by extractor name"""
     from .generic import GenericIE
 
     yield from sorted(filter(
@@ -37,6 +37,5 @@ def list_extractors(age_limit=None):
 
 def get_info_extractor(ie_name):
     """Returns the info extractor class with the given ie_name"""
-    from . import extractors
-
-    return getattr(extractors, f'{ie_name}IE')
+    from . import extractors  # noqa: F401
+    return ALL_IES.get()[f'{ie_name}IE']

--- a/yt_dlp/extractor/extractors.py
+++ b/yt_dlp/extractor/extractors.py
@@ -1,28 +1,32 @@
-import contextlib
 import os
 
+from ..globals import ALL_IES, LAZY_EXTRACTORS, PLUGIN_IES
 from ..plugins import load_plugins
 
 # NB: Must be before other imports so that plugins can be correctly injected
-_PLUGIN_CLASSES = load_plugins('extractor', 'IE')
-
-_LAZY_LOADER = False
-if not os.environ.get('YTDLP_NO_LAZY_EXTRACTORS'):
-    with contextlib.suppress(ImportError):
-        from .lazy_extractors import *  # noqa: F403
-        from .lazy_extractors import _ALL_CLASSES
-        _LAZY_LOADER = True
-
-if not _LAZY_LOADER:
-    from ._extractors import *  # noqa: F403
-    _ALL_CLASSES = [  # noqa: F811
-        klass
-        for name, klass in globals().items()
-        if name.endswith('IE') and name != 'GenericIE'
-    ]
-    _ALL_CLASSES.append(GenericIE)  # noqa: F405
-
-globals().update(_PLUGIN_CLASSES)
-_ALL_CLASSES[:0] = _PLUGIN_CLASSES.values()
+PLUGIN_IES.set(load_plugins('extractor', 'IE'))
+del load_plugins
+ALL_IES.set(PLUGIN_IES.get().copy())
 
 from .common import _PLUGIN_OVERRIDES  # noqa: F401
+
+if os.environ.get('YTDLP_NO_LAZY_EXTRACTORS'):
+    LAZY_EXTRACTORS.set(False)
+else:
+    try:
+        from .lazy_extractors import _ALL_CLASSES
+    except ImportError:
+        LAZY_EXTRACTORS.set(None)
+    else:
+        LAZY_EXTRACTORS.set(True)
+        ALL_IES.get().update({ie.__name__: ie for ie in _ALL_CLASSES})
+
+if not LAZY_EXTRACTORS.get():
+    from . import _extractors
+    ALL_IES.get().update(
+        (name, ie) for name, ie in vars(_extractors).items()
+        if name.endswith('IE') and name != 'GenericIE'
+    )
+    ALL_IES.get()['GenericIE'] = _extractors.GenericIE
+
+globals().update(ALL_IES.get())

--- a/yt_dlp/globals.py
+++ b/yt_dlp/globals.py
@@ -1,0 +1,38 @@
+from contextvars import ContextVar
+
+
+class UNSET:
+    pass
+
+
+class GlobalVar:
+    def __init__(self, name, default=UNSET):
+        self.name, self.value = name, default
+
+    def __repr__(self):
+        if self.value is UNSET:
+            return f'{type(self).__name__}({self.name!r})'
+        return f'{type(self).__name__}({self.name!r}, {self.value!r})'
+
+    def get(self):
+        if self.value is UNSET:
+            raise ValueError(f'{self} is unset')
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+_IN_CLI = GlobalVar('_IN_CLI', default=False)
+
+# `True`=enabled, `None`=disabled, `False`=force disabled
+LAZY_EXTRACTORS = GlobalVar('LAZY_EXTRACTORS')
+ALL_IES = GlobalVar('ALL_IES')
+PLUGIN_IES = GlobalVar('PLUGIN_IES')
+
+ALL_PPS = GlobalVar('ALL_PPS')
+PLUGIN_PPS = GlobalVar('PLUGIN_PPS')
+
+
+# Intended to be changed by users
+ffmpeg_location = ContextVar('ffmpeg_location', default=None)

--- a/yt_dlp/postprocessor/__init__.py
+++ b/yt_dlp/postprocessor/__init__.py
@@ -1,47 +1,10 @@
-# flake8: noqa: F401
+from ..compat.compat_utils import passthrough_module
+from ..globals import ALL_PPS
 
-from .common import PostProcessor
-from .embedthumbnail import EmbedThumbnailPP
-from .exec import ExecAfterDownloadPP, ExecPP
-from .ffmpeg import (
-    FFmpegConcatPP,
-    FFmpegCopyStreamPP,
-    FFmpegEmbedSubtitlePP,
-    FFmpegExtractAudioPP,
-    FFmpegFixupDuplicateMoovPP,
-    FFmpegFixupDurationPP,
-    FFmpegFixupM3u8PP,
-    FFmpegFixupM4aPP,
-    FFmpegFixupStretchedPP,
-    FFmpegFixupTimestampPP,
-    FFmpegMergerPP,
-    FFmpegMetadataPP,
-    FFmpegPostProcessor,
-    FFmpegSplitChaptersPP,
-    FFmpegSubtitlesConvertorPP,
-    FFmpegThumbnailsConvertorPP,
-    FFmpegVideoConvertorPP,
-    FFmpegVideoRemuxerPP,
-)
-from .metadataparser import (
-    MetadataFromFieldPP,
-    MetadataFromTitlePP,
-    MetadataParserPP,
-)
-from .modify_chapters import ModifyChaptersPP
-from .movefilesafterdownload import MoveFilesAfterDownloadPP
-from .sponskrub import SponSkrubPP
-from .sponsorblock import SponsorBlockPP
-from .xattrpp import XAttrMetadataPP
-from ..plugins import load_plugins
-
-_PLUGIN_CLASSES = load_plugins('postprocessor', 'PP')
+passthrough_module(__name__, '.postprocessors', (..., '__all__'))
+del passthrough_module
 
 
 def get_postprocessor(key):
-    return globals()[key + 'PP']
-
-
-globals().update(_PLUGIN_CLASSES)
-__all__ = [name for name in globals().keys() if name.endswith('PP')]
-__all__.extend(('PostProcessor', 'FFmpegPostProcessor'))
+    from . import postprocessors  # noqa: F401
+    return ALL_PPS.get()[f'{key}PP']

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -1,5 +1,4 @@
 import collections
-import contextvars
 import itertools
 import json
 import os
@@ -84,7 +83,7 @@ class FFmpegPostProcessorError(PostProcessingError):
 
 
 class FFmpegPostProcessor(PostProcessor):
-    _ffmpeg_location = contextvars.ContextVar('ffmpeg_location', default=None)
+    from ..globals import ffmpeg_location as _ffmpeg_location
 
     def __init__(self, downloader=None):
         PostProcessor.__init__(self, downloader)

--- a/yt_dlp/postprocessor/postprocessors.py
+++ b/yt_dlp/postprocessor/postprocessors.py
@@ -1,0 +1,45 @@
+# flake8: noqa: F401
+from ..globals import ALL_PPS, PLUGIN_PPS
+from ..plugins import load_plugins
+
+PLUGIN_PPS.set(load_plugins('postprocessor', 'PP'))
+del load_plugins
+globals().update(PLUGIN_PPS.get())
+
+from .common import PostProcessor
+from .embedthumbnail import EmbedThumbnailPP
+from .exec import ExecAfterDownloadPP, ExecPP
+from .ffmpeg import (
+    FFmpegConcatPP,
+    FFmpegCopyStreamPP,
+    FFmpegEmbedSubtitlePP,
+    FFmpegExtractAudioPP,
+    FFmpegFixupDuplicateMoovPP,
+    FFmpegFixupDurationPP,
+    FFmpegFixupM3u8PP,
+    FFmpegFixupM4aPP,
+    FFmpegFixupStretchedPP,
+    FFmpegFixupTimestampPP,
+    FFmpegMergerPP,
+    FFmpegMetadataPP,
+    FFmpegPostProcessor,
+    FFmpegSplitChaptersPP,
+    FFmpegSubtitlesConvertorPP,
+    FFmpegThumbnailsConvertorPP,
+    FFmpegVideoConvertorPP,
+    FFmpegVideoRemuxerPP,
+)
+from .metadataparser import (
+    MetadataFromFieldPP,
+    MetadataFromTitlePP,
+    MetadataParserPP,
+)
+from .modify_chapters import ModifyChaptersPP
+from .movefilesafterdownload import MoveFilesAfterDownloadPP
+from .sponskrub import SponSkrubPP
+from .sponsorblock import SponsorBlockPP
+from .xattrpp import XAttrMetadataPP
+
+
+ALL_PPS.set({name: klass for name, klass in globals().items() if name.endswith('PP')})
+__all__ = ['PostProcessor', 'FFmpegPostProcessor', *ALL_PPS.get().keys()]

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -59,6 +59,7 @@ from ..compat import (
     compat_shlex_quote,
 )
 from ..dependencies import brotli, certifi, websockets, xattr
+from ..globals import _IN_CLI
 from ..socks import ProxyType, sockssocket
 
 __name__ = __name__.rsplit('.', 1)[0]  # Pretend to be the parent module
@@ -1882,8 +1883,7 @@ def write_string(s, out=None, encoding=None):
 
 
 def deprecation_warning(msg, *, printer=None, stacklevel=0, **kwargs):
-    from .. import _IN_CLI
-    if _IN_CLI:
+    if _IN_CLI.get():
         if msg in deprecation_warning._cache:
             return
         deprecation_warning._cache.add(msg)


### PR DESCRIPTION
Needed for #5680, #2861, `--plugin-dir`

`GlobalVar` for `IN_CLI`/`LAZY_EXTRACTORS` allow us to import it globally and still get the current value accurately. Mutable values like `ALL_IES` etc could just be their actual value, but I decided to wrap it in `GlobalVar` anyway so everything in the module is accessed in the same manner.