### PR TITLE
[extractor/stacommu] Add extractors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1855,7 +1855,7 @@ The following extractors use this feature:
 #### twitter
 * `legacy_api`: Force usage of the legacy Twitter API instead of the GraphQL API for tweet extraction. Has no effect if login cookies are passed
 
-#### wrestleuniverse
+#### stacommu, wrestleuniverse
 * `device_id`: UUID value assigned by the website and used to enforce device limits for paid livestream content. Can be found in browser local storage
 
 #### twitch

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1855,6 +1855,10 @@ from .srgssr import (
     SRGSSRPlayIE,
 )
 from .srmediathek import SRMediathekIE
+from .stacommu import (
+    StacommuLiveIE,
+    StacommuVODIE,
+)
 from .stanfordoc import StanfordOpenClassroomIE
 from .startv import StarTVIE
 from .steam import (

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -1,0 +1,300 @@
+import base64
+import binascii
+import json
+import time
+import uuid
+
+from .common import InfoExtractor
+from ..dependencies import Cryptodome
+from ..utils import (
+    ExtractorError,
+    int_or_none,
+    jwt_decode_hs256,
+    traverse_obj,
+    try_call,
+    url_or_none,
+    urlencode_postdata,
+)
+
+
+class WrestleUniverseBaseIE(InfoExtractor):
+    _NETRC_MACHINE = 'wrestleuniverse'
+    _VALID_URL_TMPL = r'https?://(?:www\.)?wrestle-universe\.com/(?:(?P<lang>\w{2})/)?%s/(?P<id>\w+)'
+    _API_PATH = None
+    _REAL_TOKEN = None
+    _TOKEN_EXPIRY = None
+    _REFRESH_TOKEN = None
+    _DEVICE_ID = None
+    _LOGIN_QUERY = {'key': 'AIzaSyCaRPBsDQYVDUWWBXjsTrHESi2r_F3RAdA'}
+    _LOGIN_HEADERS = {
+        'Accept': '*/*',
+        'Content-Type': 'application/json',
+        'X-Client-Version': 'Chrome/JsCore/9.9.4/FirebaseCore-web',
+        'X-Firebase-gmpid': '1:307308870738:web:820f38fe5150c8976e338b',
+        'Referer': 'https://www.wrestle-universe.com/',
+        'Origin': 'https://www.wrestle-universe.com',
+    }
+
+    @property
+    def _TOKEN(self):
+        if not self._REAL_TOKEN or not self._TOKEN_EXPIRY:
+            token = try_call(lambda: self._get_cookies('https://www.wrestle-universe.com/')['token'].value)
+            if not token and not self._REFRESH_TOKEN:
+                self.raise_login_required()
+            self._REAL_TOKEN = token
+
+        if not self._REAL_TOKEN or self._TOKEN_EXPIRY <= int(time.time()):
+            if not self._REFRESH_TOKEN:
+                raise ExtractorError(
+                    'Expired token. Refresh your cookies in browser and try again', expected=True)
+            self._refresh_token()
+
+        return self._REAL_TOKEN
+
+    @_TOKEN.setter
+    def _TOKEN(self, value):
+        self._REAL_TOKEN = value
+
+        expiry = traverse_obj(value, ({jwt_decode_hs256}, 'exp', {int_or_none}))
+        if not expiry:
+            raise ExtractorError('There was a problem with the auth token')
+        self._TOKEN_EXPIRY = expiry
+
+    def _perform_login(self, username, password):
+        login = self._download_json(
+            'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword', None,
+            'Logging in', query=self._LOGIN_QUERY, headers=self._LOGIN_HEADERS, data=json.dumps({
+                'returnSecureToken': True,
+                'email': username,
+                'password': password,
+            }, separators=(',', ':')).encode())
+        self._REFRESH_TOKEN = traverse_obj(login, ('refreshToken', {str}))
+        if not self._REFRESH_TOKEN:
+            self.report_warning('No refresh token was granted')
+        self._TOKEN = traverse_obj(login, ('idToken', {str}))
+
+    def _real_initialize(self):
+        if WrestleUniverseBaseIE._DEVICE_ID:
+            return
+
+        WrestleUniverseBaseIE._DEVICE_ID = self._configuration_arg('device_id', [None], ie_key='WrestleUniverse')[0]
+        if not WrestleUniverseBaseIE._DEVICE_ID:
+            WrestleUniverseBaseIE._DEVICE_ID = self.cache.load(self._NETRC_MACHINE, 'device_id')
+            if WrestleUniverseBaseIE._DEVICE_ID:
+                return
+            WrestleUniverseBaseIE._DEVICE_ID = str(uuid.uuid4())
+
+        self.cache.store(self._NETRC_MACHINE, 'device_id', WrestleUniverseBaseIE._DEVICE_ID)
+
+    def _refresh_token(self):
+        refresh = self._download_json(
+            'https://securetoken.googleapis.com/v1/token', None, 'Refreshing token',
+            query=self._LOGIN_QUERY, data=urlencode_postdata({
+                'grant_type': 'refresh_token',
+                'refresh_token': self._REFRESH_TOKEN,
+            }), headers={
+                **self._LOGIN_HEADERS,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            })
+        if traverse_obj(refresh, ('refresh_token', {str})):
+            self._REFRESH_TOKEN = refresh['refresh_token']
+        token = traverse_obj(refresh, 'access_token', 'id_token', expected_type=str)
+        if not token:
+            raise ExtractorError('No auth token returned from refresh request')
+        self._TOKEN = token
+
+    def _call_api(self, video_id, param='', msg='API', auth=True, data=None, query={}, fatal=True):
+        headers = {'CA-CID': ''}
+        if data:
+            headers['Content-Type'] = 'application/json;charset=utf-8'
+            data = json.dumps(data, separators=(',', ':')).encode()
+        if auth:
+            headers['Authorization'] = f'Bearer {self._TOKEN}'
+        return self._download_json(
+            f'https://api.wrestle-universe.com/v1/{self._API_PATH}/{video_id}{param}', video_id,
+            note=f'Downloading {msg} JSON', errnote=f'Failed to download {msg} JSON',
+            data=data, headers=headers, query=query, fatal=fatal)
+
+    def _call_encrypted_api(self, video_id, param='', msg='API', data={}, query={}, fatal=True):
+        if not Cryptodome.RSA:
+            raise ExtractorError('pycryptodomex not found. Please install', expected=True)
+        private_key = Cryptodome.RSA.generate(2048)
+        cipher = Cryptodome.PKCS1_OAEP.new(private_key, hashAlgo=Cryptodome.SHA1)
+
+        def decrypt(data):
+            if not data:
+                return None
+            try:
+                return cipher.decrypt(base64.b64decode(data)).decode()
+            except (ValueError, binascii.Error) as e:
+                raise ExtractorError(f'Could not decrypt data: {e}')
+
+        token = base64.b64encode(private_key.public_key().export_key('DER')).decode()
+        api_json = self._call_api(video_id, param, msg, data={
+            'deviceId': self._DEVICE_ID,
+            'token': token,
+            **data,
+        }, query=query, fatal=fatal)
+        return api_json, decrypt
+
+    def _download_metadata(self, url, video_id, lang, props_key):
+        metadata = self._call_api(video_id, msg='metadata', query={'al': lang or 'ja'}, auth=False, fatal=False)
+        if not metadata:
+            webpage = self._download_webpage(url, video_id)
+            nextjs_data = self._search_nextjs_data(webpage, video_id)
+            metadata = traverse_obj(nextjs_data, ('props', 'pageProps', props_key, {dict})) or {}
+        return metadata
+
+    def _get_formats(self, data, path, video_id=None):
+        hls_url = traverse_obj(data, path, get_all=False)
+        if not hls_url and not data.get('canWatch'):
+            self.raise_no_formats(
+                'This account does not have access to the requested content', expected=True)
+        elif not hls_url:
+            self.raise_no_formats('No supported formats found')
+        return self._extract_m3u8_formats(hls_url, video_id, 'mp4', m3u8_id='hls', live=True)
+
+
+class WrestleUniverseVODIE(WrestleUniverseBaseIE):
+    _VALID_URL = WrestleUniverseBaseIE._VALID_URL_TMPL % 'videos'
+    _TESTS = [{
+        'url': 'https://www.wrestle-universe.com/en/videos/dp8mpjmcKfxzUhEHM2uFws',
+        'info_dict': {
+            'id': 'dp8mpjmcKfxzUhEHM2uFws',
+            'ext': 'mp4',
+            'title': 'The 3rd “Futari wa Princess” Max Heart Tournament',
+            'description': 'md5:318d5061e944797fbbb81d5c7dd00bf5',
+            'location': '埼玉・春日部ふれあいキューブ',
+            'channel': 'tjpw',
+            'duration': 7119,
+            'timestamp': 1674979200,
+            'upload_date': '20230129',
+            'thumbnail': 'https://image.asset.wrestle-universe.com/8FjD67P8rZc446RBQs5RBN/8FjD67P8rZc446RBQs5RBN',
+            'chapters': 'count:7',
+            'cast': 'count:21',
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }]
+
+    _API_PATH = 'videoEpisodes'
+
+    def _real_extract(self, url):
+        lang, video_id = self._match_valid_url(url).group('lang', 'id')
+        metadata = self._download_metadata(url, video_id, lang, 'videoEpisodeFallbackData')
+        video_data = self._call_api(video_id, ':watch', 'watch', data={
+            # 'deviceId' is required if ignoreDeviceRestriction is False
+            'ignoreDeviceRestriction': True,
+        })
+
+        return {
+            'id': video_id,
+            'formats': self._get_formats(video_data, (
+                (('protocolHls', 'url'), ('chromecastUrls', ...)), {url_or_none}), video_id),
+            **traverse_obj(metadata, {
+                'title': ('displayName', {str}),
+                'description': ('description', {str}),
+                'channel': ('labels', 'group', {str}),
+                'location': ('labels', 'venue', {str}),
+                'timestamp': ('watchStartTime', {int_or_none}),
+                'thumbnail': ('keyVisualUrl', {url_or_none}),
+                'cast': ('casts', ..., 'displayName', {str}),
+                'duration': ('duration', {int}),
+                'chapters': ('videoChapters', lambda _, v: isinstance(v.get('start'), int), {
+                    'title': ('displayName', {str}),
+                    'start_time': ('start', {int}),
+                    'end_time': ('end', {int}),
+                }),
+            }),
+        }
+
+
+class WrestleUniversePPVIE(WrestleUniverseBaseIE):
+    _VALID_URL = WrestleUniverseBaseIE._VALID_URL_TMPL % 'lives'
+    _TESTS = [{
+        'note': 'HLS AES-128 key obtained via API',
+        'url': 'https://www.wrestle-universe.com/en/lives/buH9ibbfhdJAY4GKZcEuJX',
+        'info_dict': {
+            'id': 'buH9ibbfhdJAY4GKZcEuJX',
+            'ext': 'mp4',
+            'title': '【PPV】Beyond the origins, into the future',
+            'description': 'md5:9a872db68cd09be4a1e35a3ee8b0bdfc',
+            'channel': 'tjpw',
+            'location': '東京・Twin Box AKIHABARA',
+            'duration': 10098,
+            'timestamp': 1675076400,
+            'upload_date': '20230130',
+            'thumbnail': 'https://image.asset.wrestle-universe.com/rJs2m7cBaLXrwCcxMdQGRM/rJs2m7cBaLXrwCcxMdQGRM',
+            'thumbnails': 'count:3',
+            'hls_aes': {
+                'key': '5633184acd6e43f1f1ac71c6447a4186',
+                'iv': '5bac71beb33197d5600337ce86de7862',
+            },
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+        'skip': 'No longer available',
+    }, {
+        'note': 'unencrypted HLS',
+        'url': 'https://www.wrestle-universe.com/en/lives/wUG8hP5iApC63jbtQzhVVx',
+        'info_dict': {
+            'id': 'wUG8hP5iApC63jbtQzhVVx',
+            'ext': 'mp4',
+            'title': 'GRAND PRINCESS \'22',
+            'description': 'md5:e4f43d0d4262de3952ff34831bc99858',
+            'channel': 'tjpw',
+            'location': '東京・両国国技館',
+            'duration': 18044,
+            'timestamp': 1647665400,
+            'upload_date': '20220319',
+            'thumbnail': 'https://image.asset.wrestle-universe.com/i8jxSTCHPfdAKD4zN41Psx/i8jxSTCHPfdAKD4zN41Psx',
+            'thumbnails': 'count:3',
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }]
+
+    _API_PATH = 'events'
+
+    def _real_extract(self, url):
+        lang, video_id = self._match_valid_url(url).group('lang', 'id')
+        metadata = self._download_metadata(url, video_id, lang, 'eventFallbackData')
+
+        info = {
+            'id': video_id,
+            **traverse_obj(metadata, {
+                'title': ('displayName', {str}),
+                'description': ('description', {str}),
+                'channel': ('labels', 'group', {str}),
+                'location': ('labels', 'venue', {str}),
+                'timestamp': ('startTime', {int_or_none}),
+                'thumbnails': (('keyVisualUrl', 'alterKeyVisualUrl', 'heroKeyVisualUrl'), {'url': {url_or_none}}),
+            }),
+        }
+
+        ended_time = traverse_obj(metadata, ('endedTime', {int_or_none}))
+        if info.get('timestamp') and ended_time:
+            info['duration'] = ended_time - info['timestamp']
+
+        video_data, decrypt = self._call_encrypted_api(
+            video_id, ':watchArchive', 'watch archive', data={'method': 1})
+        info['formats'] = self._get_formats(video_data, (
+            ('hls', None), ('urls', 'chromecastUrls'), ..., {url_or_none}), video_id)
+        for f in info['formats']:
+            # bitrates are exaggerated in PPV playlists, so avoid wrong/huge filesize_approx values
+            if f.get('tbr'):
+                f['tbr'] = int(f['tbr'] / 2.5)
+
+        hls_aes_key = traverse_obj(video_data, ('hls', 'key', {decrypt}))
+        if hls_aes_key:
+            info['hls_aes'] = {
+                'key': hls_aes_key,
+                'iv': traverse_obj(video_data, ('hls', 'iv', {decrypt})),
+            },
+        elif traverse_obj(video_data, ('hls', 'encryptType', {int})):
+            self.report_warning('HLS AES-128 key was not found in API response')
+
+        return info

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -80,14 +80,8 @@ class StacommuVODIE(StacommuBaseIE):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        video_info = self._call_api(video_id, msg='video information', auth=False, fatal=False)
-        if not video_info:
-            webpage = self._download_webpage(url, video_id)
-            nextjs_data = self._search_nextjs_data(webpage, video_id)
-            video_info = traverse_obj(
-                nextjs_data,
-                ('props', 'pageProps', 'dehydratedState', 'queries', 0, 'state', 'data', {dict})
-            ) or {}
+        video_info = self._download_metadata(
+            url, video_id, 'ja', ('dehydratedState', 'queries', 0, 'state', 'data'))
         hls_info, decrypt = self._call_encrypted_api(
             video_id, ':watch', 'stream information', data={'method': 1})
 

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -11,11 +11,6 @@ from ..utils import (
 class StacommuBaseIE(WrestleUniverseBaseIE):
     _NETRC_MACHINE = 'stacommu'
     _API_HOST = 'api.stacommu.jp'
-    _API_PATH = None
-    _REAL_TOKEN = None
-    _TOKEN_EXPIRY = None
-    _REFRESH_TOKEN = None
-    _DEVICE_ID = None
     _LOGIN_QUERY = {'key': 'AIzaSyCR9czxhH2eWuijEhTNWBZ5MCcOYEUTAhg'}
     _LOGIN_HEADERS = {
         'Accept': '*/*',

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -126,7 +126,7 @@ class StacommuLiveIE(StacommuBaseIE):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        video_info = self._call_api(video_id, msg='video information', auth=False)
+        video_info = self._call_api(video_id, msg='video information', query={'al': 'ja'}, auth=False)
         hls_info, decrypt = self._call_encrypted_api(
             video_id, ':watchArchive', 'stream information', data={'method': 1})
 

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -1,24 +1,16 @@
-import base64
-import binascii
-import json
 import time
-import uuid
 
-from .common import InfoExtractor
-from ..compat import compat_HTTPError
-from ..dependencies import Cryptodome
+from .wrestleuniverse import WrestleUniverseBaseIE
 from ..utils import (
-    ExtractorError,
     int_or_none,
-    jwt_decode_hs256,
     traverse_obj,
     url_or_none,
-    urlencode_postdata,
 )
 
 
-class StacommuBaseIE(InfoExtractor):
+class StacommuBaseIE(WrestleUniverseBaseIE):
     _NETRC_MACHINE = 'stacommu'
+    _API_HOST = 'api.stacommu.jp'
     _API_PATH = None
     _REAL_TOKEN = None
     _TOKEN_EXPIRY = None
@@ -33,124 +25,12 @@ class StacommuBaseIE(InfoExtractor):
         'Origin': 'https://www.stacommu.jp',
     }
 
-    @property
+    @WrestleUniverseBaseIE._TOKEN.getter
     def _TOKEN(self):
         if self._REAL_TOKEN and self._TOKEN_EXPIRY <= int(time.time()):
             self._refresh_token()
 
         return self._REAL_TOKEN
-
-    @_TOKEN.setter
-    def _TOKEN(self, value):
-        self._REAL_TOKEN = value
-
-        expiry = traverse_obj(value, ({jwt_decode_hs256}, 'exp', {int_or_none}))
-        if not expiry:
-            raise ExtractorError('There was a problem with the auth token')
-        self._TOKEN_EXPIRY = expiry
-
-    def _perform_login(self, username, password):
-        try:
-            login = self._download_json(
-                'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword', None,
-                'Logging in', query=self._LOGIN_QUERY, headers=self._LOGIN_HEADERS, data=json.dumps({
-                    'returnSecureToken': True,
-                    'email': username,
-                    'password': password,
-                }, separators=(',', ':')).encode())
-        except ExtractorError as e:
-            if isinstance(e.cause, compat_HTTPError) and e.cause.code == 400:
-                message = traverse_obj(
-                    self._parse_json(e.cause.read().decode(), None), ('error', 'message', {str}))
-                self.report_warning(f'Unable to log in: {message}')
-            else:
-                raise
-        else:
-            self._REFRESH_TOKEN = traverse_obj(login, ('refreshToken', {str}))
-            if not self._REFRESH_TOKEN:
-                self.report_warning('No refresh token was granted')
-            self._TOKEN = traverse_obj(login, ('idToken', {str}))
-
-    def _real_initialize(self):
-        if StacommuBaseIE._DEVICE_ID:
-            return
-
-        StacommuBaseIE._DEVICE_ID = self._configuration_arg('device_id', [None], ie_key='Stacommu')[0]
-        if not StacommuBaseIE._DEVICE_ID:
-            StacommuBaseIE._DEVICE_ID = self.cache.load(self._NETRC_MACHINE, 'device_id')
-            if StacommuBaseIE._DEVICE_ID:
-                return
-            StacommuBaseIE._DEVICE_ID = str(uuid.uuid4())
-
-        self.cache.store(self._NETRC_MACHINE, 'device_id', StacommuBaseIE._DEVICE_ID)
-
-    def _refresh_token(self):
-        refresh = self._download_json(
-            'https://securetoken.googleapis.com/v1/token', None, 'Refreshing token',
-            query=self._LOGIN_QUERY, data=urlencode_postdata({
-                'grant_type': 'refresh_token',
-                'refresh_token': self._REFRESH_TOKEN,
-            }), headers={
-                **self._LOGIN_HEADERS,
-                'Content-Type': 'application/x-www-form-urlencoded',
-            })
-        if traverse_obj(refresh, ('refresh_token', {str})):
-            self._REFRESH_TOKEN = refresh['refresh_token']
-        token = traverse_obj(refresh, 'access_token', 'id_token', expected_type=str)
-        if not token:
-            raise ExtractorError('No auth token returned from refresh request')
-        self._TOKEN = token
-
-    def _call_api(self, video_id, param='', msg='API', auth=True, data=None, query={}, fatal=True):
-        headers = {'CA-CID': ''}
-        if data:
-            headers['Content-Type'] = 'application/json;charset=utf-8'
-            data = json.dumps(data, separators=(',', ':')).encode()
-        if auth and self._TOKEN:
-            headers['Authorization'] = f'Bearer {self._TOKEN}'
-        return self._download_json(
-            f'https://api.stacommu.jp/v1/{self._API_PATH}/{video_id}{param}', video_id,
-            note=f'Downloading {msg} JSON', errnote=f'Failed to download {msg} JSON',
-            data=data, headers=headers, query=query, fatal=fatal)
-
-    def _call_encrypted_api(self, video_id, param='', msg='API', data={}, query={}, fatal=True):
-        if not Cryptodome.RSA:
-            raise ExtractorError('pycryptodomex not found. Please install', expected=True)
-        private_key = Cryptodome.RSA.generate(2048)
-        cipher = Cryptodome.PKCS1_OAEP.new(private_key, hashAlgo=Cryptodome.SHA1)
-
-        def decrypt(data):
-            if not data:
-                return None
-            try:
-                return cipher.decrypt(base64.b64decode(data)).decode()
-            except (ValueError, binascii.Error) as e:
-                raise ExtractorError(f'Could not decrypt data: {e}')
-
-        token = base64.b64encode(private_key.public_key().export_key('DER')).decode()
-        api_json = self._call_api(video_id, param, msg, data={
-            'deviceId': self._DEVICE_ID,
-            'token': token,
-            **data,
-        }, query=query, fatal=fatal)
-        return api_json, decrypt
-
-    def _download_metadata(self, url, video_id, lang, props_key):
-        metadata = self._call_api(video_id, msg='metadata', query={'al': 'ja'}, auth=False, fatal=False)
-        if not metadata:
-            webpage = self._download_webpage(url, video_id)
-            nextjs_data = self._search_nextjs_data(webpage, video_id)
-            metadata = traverse_obj(nextjs_data, ('props', 'pageProps', props_key, {dict})) or {}
-        return metadata
-
-    def _get_formats(self, data, path, video_id=None):
-        hls_url = traverse_obj(data, path, get_all=False)
-        if not hls_url and not data.get('canWatch'):
-            self.raise_no_formats(
-                'This account does not have access to the requested content', expected=True)
-        elif not hls_url:
-            self.raise_no_formats('No supported formats found')
-        return self._extract_m3u8_formats(hls_url, video_id, 'mp4', m3u8_id='hls', live=True)
 
     def _extract_hls_key(self, data, path, decrypt):
         encryption_data = traverse_obj(data, path)

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -27,6 +27,11 @@ class StacommuBaseIE(WrestleUniverseBaseIE):
 
         return self._REAL_TOKEN
 
+    def _get_formats(self, data, path, video_id=None):
+        if not traverse_obj(data, path) and not data.get('canWatch') and not self._TOKEN:
+            self.raise_login_required(method='password')
+        return super()._get_formats(data, path, video_id)
+
     def _extract_hls_key(self, data, path, decrypt):
         encryption_data = traverse_obj(data, path)
         if traverse_obj(encryption_data, ('encryptType', {int})) == 0:

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -5,48 +5,37 @@ import time
 import uuid
 
 from .common import InfoExtractor
+from ..compat import compat_HTTPError
 from ..dependencies import Cryptodome
 from ..utils import (
     ExtractorError,
     int_or_none,
     jwt_decode_hs256,
     traverse_obj,
-    try_call,
     url_or_none,
     urlencode_postdata,
 )
 
 
-class WrestleUniverseBaseIE(InfoExtractor):
-    _NETRC_MACHINE = 'wrestleuniverse'
-    _VALID_URL_TMPL = r'https?://(?:www\.)?wrestle-universe\.com/(?:(?P<lang>\w{2})/)?%s/(?P<id>\w+)'
+class StacommuBaseIE(InfoExtractor):
+    _NETRC_MACHINE = 'stacommu'
     _API_PATH = None
     _REAL_TOKEN = None
     _TOKEN_EXPIRY = None
     _REFRESH_TOKEN = None
     _DEVICE_ID = None
-    _LOGIN_QUERY = {'key': 'AIzaSyCaRPBsDQYVDUWWBXjsTrHESi2r_F3RAdA'}
+    _LOGIN_QUERY = {'key': 'AIzaSyCR9czxhH2eWuijEhTNWBZ5MCcOYEUTAhg'}
     _LOGIN_HEADERS = {
         'Accept': '*/*',
         'Content-Type': 'application/json',
         'X-Client-Version': 'Chrome/JsCore/9.9.4/FirebaseCore-web',
-        'X-Firebase-gmpid': '1:307308870738:web:820f38fe5150c8976e338b',
-        'Referer': 'https://www.wrestle-universe.com/',
-        'Origin': 'https://www.wrestle-universe.com',
+        'Referer': 'https://www.stacommu.jp/',
+        'Origin': 'https://www.stacommu.jp',
     }
 
     @property
     def _TOKEN(self):
-        if not self._REAL_TOKEN or not self._TOKEN_EXPIRY:
-            token = try_call(lambda: self._get_cookies('https://www.wrestle-universe.com/')['token'].value)
-            if not token and not self._REFRESH_TOKEN:
-                self.raise_login_required()
-            self._REAL_TOKEN = token
-
-        if not self._REAL_TOKEN or self._TOKEN_EXPIRY <= int(time.time()):
-            if not self._REFRESH_TOKEN:
-                raise ExtractorError(
-                    'Expired token. Refresh your cookies in browser and try again', expected=True)
+        if self._REAL_TOKEN and self._TOKEN_EXPIRY <= int(time.time()):
             self._refresh_token()
 
         return self._REAL_TOKEN
@@ -61,30 +50,39 @@ class WrestleUniverseBaseIE(InfoExtractor):
         self._TOKEN_EXPIRY = expiry
 
     def _perform_login(self, username, password):
-        login = self._download_json(
-            'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword', None,
-            'Logging in', query=self._LOGIN_QUERY, headers=self._LOGIN_HEADERS, data=json.dumps({
-                'returnSecureToken': True,
-                'email': username,
-                'password': password,
-            }, separators=(',', ':')).encode())
-        self._REFRESH_TOKEN = traverse_obj(login, ('refreshToken', {str}))
-        if not self._REFRESH_TOKEN:
-            self.report_warning('No refresh token was granted')
-        self._TOKEN = traverse_obj(login, ('idToken', {str}))
+        try:
+            login = self._download_json(
+                'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword', None,
+                'Logging in', query=self._LOGIN_QUERY, headers=self._LOGIN_HEADERS, data=json.dumps({
+                    'returnSecureToken': True,
+                    'email': username,
+                    'password': password,
+                }, separators=(',', ':')).encode())
+        except ExtractorError as e:
+            if isinstance(e.cause, compat_HTTPError) and e.cause.code == 400:
+                message = traverse_obj(
+                    self._parse_json(e.cause.read().decode(), None), ('error', 'message', {str}))
+                self.report_warning(f'Unable to log in: {message}')
+            else:
+                raise
+        else:
+            self._REFRESH_TOKEN = traverse_obj(login, ('refreshToken', {str}))
+            if not self._REFRESH_TOKEN:
+                self.report_warning('No refresh token was granted')
+            self._TOKEN = traverse_obj(login, ('idToken', {str}))
 
     def _real_initialize(self):
-        if WrestleUniverseBaseIE._DEVICE_ID:
+        if StacommuBaseIE._DEVICE_ID:
             return
 
-        WrestleUniverseBaseIE._DEVICE_ID = self._configuration_arg('device_id', [None], ie_key='WrestleUniverse')[0]
-        if not WrestleUniverseBaseIE._DEVICE_ID:
-            WrestleUniverseBaseIE._DEVICE_ID = self.cache.load(self._NETRC_MACHINE, 'device_id')
-            if WrestleUniverseBaseIE._DEVICE_ID:
+        StacommuBaseIE._DEVICE_ID = self._configuration_arg('device_id', [None], ie_key='Stacommu')[0]
+        if not StacommuBaseIE._DEVICE_ID:
+            StacommuBaseIE._DEVICE_ID = self.cache.load(self._NETRC_MACHINE, 'device_id')
+            if StacommuBaseIE._DEVICE_ID:
                 return
-            WrestleUniverseBaseIE._DEVICE_ID = str(uuid.uuid4())
+            StacommuBaseIE._DEVICE_ID = str(uuid.uuid4())
 
-        self.cache.store(self._NETRC_MACHINE, 'device_id', WrestleUniverseBaseIE._DEVICE_ID)
+        self.cache.store(self._NETRC_MACHINE, 'device_id', StacommuBaseIE._DEVICE_ID)
 
     def _refresh_token(self):
         refresh = self._download_json(
@@ -108,10 +106,10 @@ class WrestleUniverseBaseIE(InfoExtractor):
         if data:
             headers['Content-Type'] = 'application/json;charset=utf-8'
             data = json.dumps(data, separators=(',', ':')).encode()
-        if auth:
+        if auth and self._TOKEN:
             headers['Authorization'] = f'Bearer {self._TOKEN}'
         return self._download_json(
-            f'https://api.wrestle-universe.com/v1/{self._API_PATH}/{video_id}{param}', video_id,
+            f'https://api.stacommu.jp/v1/{self._API_PATH}/{video_id}{param}', video_id,
             note=f'Downloading {msg} JSON', errnote=f'Failed to download {msg} JSON',
             data=data, headers=headers, query=query, fatal=fatal)
 
@@ -138,7 +136,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
         return api_json, decrypt
 
     def _download_metadata(self, url, video_id, lang, props_key):
-        metadata = self._call_api(video_id, msg='metadata', query={'al': lang or 'ja'}, auth=False, fatal=False)
+        metadata = self._call_api(video_id, msg='metadata', query={'al': 'ja'}, auth=False, fatal=False)
         if not metadata:
             webpage = self._download_webpage(url, video_id)
             nextjs_data = self._search_nextjs_data(webpage, video_id)
@@ -154,24 +152,49 @@ class WrestleUniverseBaseIE(InfoExtractor):
             self.raise_no_formats('No supported formats found')
         return self._extract_m3u8_formats(hls_url, video_id, 'mp4', m3u8_id='hls', live=True)
 
+    def _extract_hls_key(self, data, path, decrypt):
+        encryption_data = traverse_obj(data, path)
+        if traverse_obj(encryption_data, ('encryptType', {int})) == 0:
+            return None
+        return traverse_obj(encryption_data, {'key': ('key', {decrypt}), 'iv': ('iv', {decrypt})})
 
-class WrestleUniverseVODIE(WrestleUniverseBaseIE):
-    _VALID_URL = WrestleUniverseBaseIE._VALID_URL_TMPL % 'videos'
+
+class StacommuVODIE(StacommuBaseIE):
+    _VALID_URL = r'https?://www\.stacommu\.jp/videos/episodes/(?P<id>[\da-zA-Z]+)'
     _TESTS = [{
-        'url': 'https://www.wrestle-universe.com/en/videos/dp8mpjmcKfxzUhEHM2uFws',
+        # not encrypted
+        'url': 'https://www.stacommu.jp/videos/episodes/aXcVKjHyAENEjard61soZZ',
         'info_dict': {
-            'id': 'dp8mpjmcKfxzUhEHM2uFws',
+            'id': 'aXcVKjHyAENEjard61soZZ',
             'ext': 'mp4',
-            'title': 'The 3rd “Futari wa Princess” Max Heart Tournament',
-            'description': 'md5:318d5061e944797fbbb81d5c7dd00bf5',
-            'location': '埼玉・春日部ふれあいキューブ',
-            'channel': 'tjpw',
-            'duration': 7119,
-            'timestamp': 1674979200,
-            'upload_date': '20230129',
-            'thumbnail': 'https://image.asset.wrestle-universe.com/8FjD67P8rZc446RBQs5RBN/8FjD67P8rZc446RBQs5RBN',
-            'chapters': 'count:7',
-            'cast': 'count:21',
+            'title': 'スタコミュAWARDの裏側、ほぼ全部見せます！〜晴れ舞台の直前ドキドキ編〜',
+            'description': 'md5:6400275c57ae75c06da36b06f96beb1c',
+            'timestamp': 1679652000,
+            'upload_date': '20230324',
+            'thumbnail': 'https://image.stacommu.jp/6eLobQan8PFtBoU4RL4uGg/6eLobQan8PFtBoU4RL4uGg',
+            'cast': 'count:11',
+            'duration': 250,
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }, {
+        # encrypted; requires a premium account
+        'url': 'https://www.stacommu.jp/videos/episodes/3hybMByUvzMEqndSeu5LpD',
+        'info_dict': {
+            'id': '3hybMByUvzMEqndSeu5LpD',
+            'ext': 'mp4',
+            'title': 'スタプラフェス2023〜裏側ほぼ全部見せます〜＃10',
+            'description': 'md5:85494488ccf1dfa1934accdeadd7b340',
+            'timestamp': 1682506800,
+            'upload_date': '20230426',
+            'thumbnail': 'https://image.stacommu.jp/eMdXtEefR4kEyJJMpAFi7x/eMdXtEefR4kEyJJMpAFi7x',
+            'cast': 'count:55',
+            'duration': 312,
+            'hls_aes': {
+                'key': '6bbaf241b8e1fd9f59ecf546a70e4ae7',
+                'iv': '1fc9002a23166c3bb1d240b953d09de9',
+            },
         },
         'params': {
             'skip_download': 'm3u8',
@@ -181,76 +204,49 @@ class WrestleUniverseVODIE(WrestleUniverseBaseIE):
     _API_PATH = 'videoEpisodes'
 
     def _real_extract(self, url):
-        lang, video_id = self._match_valid_url(url).group('lang', 'id')
-        metadata = self._download_metadata(url, video_id, lang, 'videoEpisodeFallbackData')
-        video_data = self._call_api(video_id, ':watch', 'watch', data={
-            # 'deviceId' is required if ignoreDeviceRestriction is False
-            'ignoreDeviceRestriction': True,
-        })
+        video_id = self._match_id(url)
+        video_info = self._call_api(video_id, msg='video information', auth=False, fatal=False)
+        if not video_info:
+            webpage = self._download_webpage(url, video_id)
+            nextjs_data = self._search_nextjs_data(webpage, video_id)
+            video_info = traverse_obj(
+                nextjs_data,
+                ('props', 'pageProps', 'dehydratedState', 'queries', 0, 'state', 'data', {dict})
+            ) or {}
+        hls_info, decrypt = self._call_encrypted_api(
+            video_id, ':watch', 'stream information', data={'method': 1})
 
         return {
             'id': video_id,
-            'formats': self._get_formats(video_data, (
-                (('protocolHls', 'url'), ('chromecastUrls', ...)), {url_or_none}), video_id),
-            **traverse_obj(metadata, {
+            'formats': self._get_formats(hls_info, ('protocolHls', 'url', {url_or_none}), video_id),
+            'hls_aes': self._extract_hls_key(hls_info, 'protocolHls', decrypt),
+            **traverse_obj(video_info, {
                 'title': ('displayName', {str}),
                 'description': ('description', {str}),
-                'channel': ('labels', 'group', {str}),
-                'location': ('labels', 'venue', {str}),
                 'timestamp': ('watchStartTime', {int_or_none}),
                 'thumbnail': ('keyVisualUrl', {url_or_none}),
                 'cast': ('casts', ..., 'displayName', {str}),
                 'duration': ('duration', {int}),
-                'chapters': ('videoChapters', lambda _, v: isinstance(v.get('start'), int), {
-                    'title': ('displayName', {str}),
-                    'start_time': ('start', {int}),
-                    'end_time': ('end', {int}),
-                }),
             }),
         }
 
 
-class WrestleUniversePPVIE(WrestleUniverseBaseIE):
-    _VALID_URL = WrestleUniverseBaseIE._VALID_URL_TMPL % 'lives'
+class StacommuLiveIE(StacommuBaseIE):
+    _VALID_URL = r'https?://www\.stacommu\.jp/live/(?P<id>[\da-zA-Z]+)'
     _TESTS = [{
-        'note': 'HLS AES-128 key obtained via API',
-        'url': 'https://www.wrestle-universe.com/en/lives/buH9ibbfhdJAY4GKZcEuJX',
+        'url': 'https://www.stacommu.jp/live/d2FJ3zLnndegZJCAEzGM3m',
         'info_dict': {
-            'id': 'buH9ibbfhdJAY4GKZcEuJX',
+            'id': 'd2FJ3zLnndegZJCAEzGM3m',
             'ext': 'mp4',
-            'title': '【PPV】Beyond the origins, into the future',
-            'description': 'md5:9a872db68cd09be4a1e35a3ee8b0bdfc',
-            'channel': 'tjpw',
-            'location': '東京・Twin Box AKIHABARA',
-            'duration': 10098,
-            'timestamp': 1675076400,
-            'upload_date': '20230130',
-            'thumbnail': 'https://image.asset.wrestle-universe.com/rJs2m7cBaLXrwCcxMdQGRM/rJs2m7cBaLXrwCcxMdQGRM',
-            'thumbnails': 'count:3',
+            'title': '仲村悠菜 2023/05/04',
+            'timestamp': 1683195647,
+            'upload_date': '20230504',
+            'thumbnail': 'https://image.stacommu.jp/pHGF57SPEHE2ke83FS92FN/pHGF57SPEHE2ke83FS92FN',
+            'duration': 5322,
             'hls_aes': {
-                'key': '5633184acd6e43f1f1ac71c6447a4186',
-                'iv': '5bac71beb33197d5600337ce86de7862',
+                'key': 'efbb3ec0b8246f61adf1764c5a51213a',
+                'iv': '80621d19a1f19167b64cedb415b05d1c',
             },
-        },
-        'params': {
-            'skip_download': 'm3u8',
-        },
-        'skip': 'No longer available',
-    }, {
-        'note': 'unencrypted HLS',
-        'url': 'https://www.wrestle-universe.com/en/lives/wUG8hP5iApC63jbtQzhVVx',
-        'info_dict': {
-            'id': 'wUG8hP5iApC63jbtQzhVVx',
-            'ext': 'mp4',
-            'title': 'GRAND PRINCESS \'22',
-            'description': 'md5:e4f43d0d4262de3952ff34831bc99858',
-            'channel': 'tjpw',
-            'location': '東京・両国国技館',
-            'duration': 18044,
-            'timestamp': 1647665400,
-            'upload_date': '20220319',
-            'thumbnail': 'https://image.asset.wrestle-universe.com/i8jxSTCHPfdAKD4zN41Psx/i8jxSTCHPfdAKD4zN41Psx',
-            'thumbnails': 'count:3',
         },
         'params': {
             'skip_download': 'm3u8',
@@ -260,41 +256,19 @@ class WrestleUniversePPVIE(WrestleUniverseBaseIE):
     _API_PATH = 'events'
 
     def _real_extract(self, url):
-        lang, video_id = self._match_valid_url(url).group('lang', 'id')
-        metadata = self._download_metadata(url, video_id, lang, 'eventFallbackData')
+        video_id = self._match_id(url)
+        video_info = self._call_api(video_id, msg='video information', auth=False)
+        hls_info, decrypt = self._call_encrypted_api(
+            video_id, ':watchArchive', 'stream information', data={'method': 1})
 
-        info = {
+        return {
             'id': video_id,
-            **traverse_obj(metadata, {
+            'formats': self._get_formats(hls_info, ('hls', 'urls', ..., {url_or_none}), video_id),
+            'hls_aes': self._extract_hls_key(hls_info, 'hls', decrypt),
+            **traverse_obj(video_info, {
                 'title': ('displayName', {str}),
-                'description': ('description', {str}),
-                'channel': ('labels', 'group', {str}),
-                'location': ('labels', 'venue', {str}),
                 'timestamp': ('startTime', {int_or_none}),
-                'thumbnails': (('keyVisualUrl', 'alterKeyVisualUrl', 'heroKeyVisualUrl'), {'url': {url_or_none}}),
+                'thumbnail': ('keyVisualUrl', {url_or_none}),
+                'duration': ('duration', {int_or_none}),
             }),
         }
-
-        ended_time = traverse_obj(metadata, ('endedTime', {int_or_none}))
-        if info.get('timestamp') and ended_time:
-            info['duration'] = ended_time - info['timestamp']
-
-        video_data, decrypt = self._call_encrypted_api(
-            video_id, ':watchArchive', 'watch archive', data={'method': 1})
-        info['formats'] = self._get_formats(video_data, (
-            ('hls', None), ('urls', 'chromecastUrls'), ..., {url_or_none}), video_id)
-        for f in info['formats']:
-            # bitrates are exaggerated in PPV playlists, so avoid wrong/huge filesize_approx values
-            if f.get('tbr'):
-                f['tbr'] = int(f['tbr'] / 2.5)
-
-        hls_aes_key = traverse_obj(video_data, ('hls', 'key', {decrypt}))
-        if hls_aes_key:
-            info['hls_aes'] = {
-                'key': hls_aes_key,
-                'iv': traverse_obj(video_data, ('hls', 'iv', {decrypt})),
-            },
-        elif traverse_obj(video_data, ('hls', 'encryptType', {int})):
-            self.report_warning('HLS AES-128 key was not found in API response')
-
-        return info

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -114,7 +114,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
         if data:
             headers['Content-Type'] = 'application/json;charset=utf-8'
             data = json.dumps(data, separators=(',', ':')).encode()
-        if auth:
+        if auth and self._TOKEN:
             headers['Authorization'] = f'Bearer {self._TOKEN}'
         return self._download_json(
             f'https://{self._API_HOST}/v1/{self._API_PATH}/{video_id}{param}', video_id,

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -113,7 +113,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
         if data:
             headers['Content-Type'] = 'application/json;charset=utf-8'
             data = json.dumps(data, separators=(',', ':')).encode()
-        if auth and self._TOKEN:
+        if auth:
             headers['Authorization'] = f'Bearer {self._TOKEN}'
         return self._download_json(
             f'https://{self._API_HOST}/v1/{self._API_PATH}/{video_id}{param}', video_id,
@@ -143,7 +143,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
         return api_json, decrypt
 
     def _download_metadata(self, url, video_id, lang, props_keys):
-        metadata = self._call_api(video_id, msg='video information', query={'al': lang or 'ja'}, auth=False, fatal=False)
+        metadata = self._call_api(video_id, msg='metadata', query={'al': lang or 'ja'}, auth=False, fatal=False)
         if not metadata:
             webpage = self._download_webpage(url, video_id)
             nextjs_data = self._search_nextjs_data(webpage, video_id)

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -142,12 +142,12 @@ class WrestleUniverseBaseIE(InfoExtractor):
         }, query=query, fatal=fatal)
         return api_json, decrypt
 
-    def _download_metadata(self, url, video_id, lang, props_key):
+    def _download_metadata(self, url, video_id, lang, props_keys):
         metadata = self._call_api(video_id, msg='metadata', query={'al': lang or 'ja'}, auth=False, fatal=False)
         if not metadata:
             webpage = self._download_webpage(url, video_id)
             nextjs_data = self._search_nextjs_data(webpage, video_id)
-            metadata = traverse_obj(nextjs_data, ('props', 'pageProps', props_key, {dict})) or {}
+            metadata = traverse_obj(nextjs_data, ('props', 'pageProps', *props_keys, {dict})) or {}
         return metadata
 
     def _get_formats(self, data, path, video_id=None):
@@ -187,7 +187,7 @@ class WrestleUniverseVODIE(WrestleUniverseBaseIE):
 
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
-        metadata = self._download_metadata(url, video_id, lang, 'videoEpisodeFallbackData')
+        metadata = self._download_metadata(url, video_id, lang, ('videoEpisodeFallbackData',))
         video_data = self._call_api(video_id, ':watch', 'watch', data={
             # 'deviceId' is required if ignoreDeviceRestriction is False
             'ignoreDeviceRestriction': True,
@@ -266,7 +266,7 @@ class WrestleUniversePPVIE(WrestleUniverseBaseIE):
 
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
-        metadata = self._download_metadata(url, video_id, lang, 'eventFallbackData')
+        metadata = self._download_metadata(url, video_id, lang, ('eventFallbackData',))
 
         info = {
             'id': video_id,

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -75,7 +75,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
             if isinstance(e.cause, compat_HTTPError) and e.cause.code == 400:
                 message = traverse_obj(
                     self._parse_json(e.cause.read().decode(), None), ('error', 'message', {str}))
-                self.report_warning(f'Unable to log in: {message}')
+                raise ExtractorError(f'Unable to log in: {message}', expected=True)
             else:
                 raise
         else:

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -148,10 +148,8 @@ class WrestleUniverseBaseIE(InfoExtractor):
         if not metadata:
             webpage = self._download_webpage(url, video_id)
             nextjs_data = self._search_nextjs_data(webpage, video_id)
-            metadata = traverse_obj(
-                nextjs_data,
-                ('props', 'pageProps', *variadic(props_keys, (str, bytes, dict, set)), {dict})
-            ) or {}
+            metadata = traverse_obj(nextjs_data, (
+                'props', 'pageProps', *variadic(props_keys, (str, bytes, dict, set)), {dict})) or {}
         return metadata
 
     def _get_formats(self, data, path, video_id=None):

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -143,7 +143,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
         return api_json, decrypt
 
     def _download_metadata(self, url, video_id, lang, props_keys):
-        metadata = self._call_api(video_id, msg='metadata', query={'al': lang or 'ja'}, auth=False, fatal=False)
+        metadata = self._call_api(video_id, msg='video information', query={'al': lang or 'ja'}, auth=False, fatal=False)
         if not metadata:
             webpage = self._download_webpage(url, video_id)
             nextjs_data = self._search_nextjs_data(webpage, video_id)

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -113,7 +113,7 @@ class WrestleUniverseBaseIE(InfoExtractor):
         if data:
             headers['Content-Type'] = 'application/json;charset=utf-8'
             data = json.dumps(data, separators=(',', ':')).encode()
-        if auth:
+        if auth and self._TOKEN:
             headers['Authorization'] = f'Bearer {self._TOKEN}'
         return self._download_json(
             f'https://{self._API_HOST}/v1/{self._API_PATH}/{video_id}{param}', video_id,

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -14,6 +14,7 @@ from ..utils import (
     try_call,
     url_or_none,
     urlencode_postdata,
+    variadic,
 )
 
 
@@ -147,7 +148,10 @@ class WrestleUniverseBaseIE(InfoExtractor):
         if not metadata:
             webpage = self._download_webpage(url, video_id)
             nextjs_data = self._search_nextjs_data(webpage, video_id)
-            metadata = traverse_obj(nextjs_data, ('props', 'pageProps', *props_keys, {dict})) or {}
+            metadata = traverse_obj(
+                nextjs_data,
+                ('props', 'pageProps', *variadic(props_keys, (str, bytes, dict, set)), {dict})
+            ) or {}
         return metadata
 
     def _get_formats(self, data, path, video_id=None):
@@ -187,7 +191,7 @@ class WrestleUniverseVODIE(WrestleUniverseBaseIE):
 
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
-        metadata = self._download_metadata(url, video_id, lang, ('videoEpisodeFallbackData',))
+        metadata = self._download_metadata(url, video_id, lang, 'videoEpisodeFallbackData')
         video_data = self._call_api(video_id, ':watch', 'watch', data={
             # 'deviceId' is required if ignoreDeviceRestriction is False
             'ignoreDeviceRestriction': True,
@@ -266,7 +270,7 @@ class WrestleUniversePPVIE(WrestleUniverseBaseIE):
 
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
-        metadata = self._download_metadata(url, video_id, lang, ('eventFallbackData',))
+        metadata = self._download_metadata(url, video_id, lang, 'eventFallbackData')
 
         info = {
             'id': video_id,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Adds support for stacommu, a video platform of Stardust Promotion, a Japanese talent agency. Its backend system seems to be identical to wrestleuniverse's, so I reused many parts of code from the existing extractor implementation.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at da6f41b</samp>

### Summary
📝🚀🆕

<!--
1.  📝 for the change in the `README.md` file, since it is a documentation update.
2.  🚀 for the change in the `_extractors.py` file, since it is a new feature addition.
3.  🆕 for the change in the `stacommu.py` module, since it is a new file creation.
-->
This pull request adds a new extractor for the `stacommu` website, which is a Japanese streaming platform that requires a device ID for some content. The extractor consists of a new module `stacommu.py` that defines two classes for live and VOD videos, and a documentation update in the `README.md` file. The extractor also handles authentication, encryption, and format extraction for the `stacommu` videos.

> _`stacommu` extractor_
> _New feature for Japan's streams_
> _Winter's device ID_

### Walkthrough
*  Add `stacommu` extractor module `stacommu.py` that supports downloading videos from a Japanese streaming platform ([link](https://github.com/yt-dlp/yt-dlp/pull/7432/files?diff=unified&w=0#diff-94b8992ff07a35dde39e76f8f14191afa898e2802527664a84b40ad48cef8fd5R1-R274))
*  Define two extractor classes `StacommuLiveIE` and `StacommuVODIE` that handle live events and video on demand episodes respectively, inheriting from a common base class `StacommuBaseIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7432/files?diff=unified&w=0#diff-94b8992ff07a35dde39e76f8f14191afa898e2802527664a84b40ad48cef8fd5R1-R274))
*  Implement authentication, encryption, metadata extraction, and format extraction logic for `stacommu` videos in `StacommuBaseIE` and its subclasses ([link](https://github.com/yt-dlp/yt-dlp/pull/7432/files?diff=unified&w=0#diff-94b8992ff07a35dde39e76f8f14191afa898e2802527664a84b40ad48cef8fd5R1-R274))
*  Register the new extractor classes in `_extractors.py` by importing them from `stacommu.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7432/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1858-R1861))
*  Document the new extractor and its `device_id` option in `README.md` ([link](https://github.com/yt-dlp/yt-dlp/pull/7432/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1858-R1858))



</details>
