### PR TITLE
Modify the regular expression so that it allows downloading videos wi…

### DIFF
--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -490,18 +490,18 @@ class CrunchyrollMusicIE(CrunchyrollBaseIE):
     _VALID_URL = r'''(?x)
         https?://(?:www\.)?crunchyroll\.com/
         (?P<lang>(?:\w{2}(?:-\w{2})?/)?)
-        watch/(?P<type>concert|musicvideo)/(?P<id>\w{10})'''
+        watch/(?P<type>concert|musicvideo)/(?P<id>\w+)'''
     _TESTS = [{
-        'url': 'https://www.crunchyroll.com/watch/musicvideo/MV88BB7F2C',
+        'url': 'https://www.crunchyroll.com/de/watch/musicvideo/MV5B02C79',
         'info_dict': {
             'ext': 'mp4',
-            'id': 'MV88BB7F2C',
-            'display_id': 'crossing-field',
-            'title': 'Crossing Field',
-            'track': 'Crossing Field',
-            'artist': 'LiSA',
+            'id': 'MV5B02C79',
+            'display_id': 'egaono-hana',
+            'title': 'Egaono Hana',
+            'track': 'Egaono Hana',
+            'artist': 'Goose house',
             'thumbnail': r're:(?i)^https://www.crunchyroll.com/imgsrv/.*\.jpeg?$',
-            'genre': ['Anime'],
+            'genre': ['j pop'],
         },
         'params': {'skip_download': 'm3u8'},
     }, {
@@ -519,7 +519,7 @@ class CrunchyrollMusicIE(CrunchyrollBaseIE):
         },
         'params': {'skip_download': 'm3u8'},
     }, {
-        'url': 'https://www.crunchyroll.com/watch/musicvideo/MV88BB7F2C/crossing-field',
+        'url': 'https://www.crunchyroll.com/de/watch/musicvideo/MV5B02C79/egaono-hana',
         'only_matching': True,
     }, {
         'url': 'https://www.crunchyroll.com/watch/concert/MC2E2AC135/live-is-smile-always-364joker-at-yokohama-arena',

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -504,7 +504,7 @@ class CrunchyrollMusicIE(CrunchyrollBaseIE):
             'genre': ['J-Pop'],
         },
         'params': {'skip_download': 'm3u8'},
-    },{
+    }, {
         'url': 'https://www.crunchyroll.com/watch/musicvideo/MV88BB7F2C',
         'info_dict': {
             'ext': 'mp4',
@@ -537,7 +537,7 @@ class CrunchyrollMusicIE(CrunchyrollBaseIE):
     }, {
         'url': 'https://www.crunchyroll.com/watch/concert/MC2E2AC135/live-is-smile-always-364joker-at-yokohama-arena',
         'only_matching': True,
-    },{
+    }, {
         'url': 'https://www.crunchyroll.com/watch/musicvideo/MV88BB7F2C/crossing-field',
         'only_matching': True,
     }]

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -501,7 +501,20 @@ class CrunchyrollMusicIE(CrunchyrollBaseIE):
             'track': 'Egaono Hana',
             'artist': 'Goose house',
             'thumbnail': r're:(?i)^https://www.crunchyroll.com/imgsrv/.*\.jpeg?$',
-            'genre': ['j pop'],
+            'genre': ['J-Pop'],
+        },
+        'params': {'skip_download': 'm3u8'},
+    },{
+        'url': 'https://www.crunchyroll.com/watch/musicvideo/MV88BB7F2C',
+        'info_dict': {
+            'ext': 'mp4',
+            'id': 'MV88BB7F2C',
+            'display_id': 'crossing-field',
+            'title': 'Crossing Field',
+            'track': 'Crossing Field',
+            'artist': 'LiSA',
+            'thumbnail': r're:(?i)^https://www.crunchyroll.com/imgsrv/.*\.jpeg?$',
+            'genre': ['Anime'],
         },
         'params': {'skip_download': 'm3u8'},
     }, {
@@ -523,6 +536,9 @@ class CrunchyrollMusicIE(CrunchyrollBaseIE):
         'only_matching': True,
     }, {
         'url': 'https://www.crunchyroll.com/watch/concert/MC2E2AC135/live-is-smile-always-364joker-at-yokohama-arena',
+        'only_matching': True,
+    },{
+        'url': 'https://www.crunchyroll.com/watch/musicvideo/MV88BB7F2C/crossing-field',
         'only_matching': True,
     }]
     _API_ENDPOINT = 'music'


### PR DESCRIPTION



### Description of your *pull request* and other information



Previously, only videos with a video ID length of exactly 10 characters were allowed to be downloaded. This restriction made it impossible to download videos with IDs of less than 10 characters in length. To address this issue, I have modified the regex expression to make it compatible with videos of varying lengths, enabling the download of all videos. Additionally, I have added a test case specifically for videos with IDs shorter than 10 characters to ensure proper functionality





Fixes #7419


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5716d0c</samp>

### Summary
🎵🛠️✅

<!--
1.  🎵 - This emoji represents music and can be used to indicate that the changes are related to the music video ID extraction for Crunchyroll.
2.  🛠️ - This emoji represents a tool or a fix and can be used to indicate that the changes improved the existing functionality of the extractor by using a more flexible regex.
3.  ✅ - This emoji represents a check mark or a test and can be used to indicate that the changes added a new test case and URL for the extractor.
-->
Improved music video support for `crunchyroll.py` extractor. Used a better regex and added a test.

> _`Crunchyroll` videos_
> _Better ID extraction_
> _With flexible `regex`_

### Walkthrough
* Allow for music video IDs with different lengths in Crunchyroll extractor by changing the regex from `\w{10}` to `\w+` ([link](https://github.com/yt-dlp/yt-dlp/pull/7439/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L493-R504))
* Add a new test case with a different ID and language code to `only_matching` in `yt_dlp/extractor/crunchyroll.py` to demonstrate the regex change ([link](https://github.com/yt-dlp/yt-dlp/pull/7439/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L522-R522))



</details>
