### PR TITLE
[youtube] approximate description metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,7 +1811,7 @@ The following extractors use this feature:
 
 #### youtubetab (YouTube playlists, channels, feeds, etc.)
 * `skip`: One or more of `webpage` (skip initial webpage download), `authcheck` (allow the download of playlists requiring authentication when no initial webpage is downloaded. This may cause unwanted behavior, see [#1122](https://github.com/yt-dlp/yt-dlp/pull/1122) for more details)
-* `approximate_metadata`: Extract approximate `upload_date`, `timestamp`, and `description` in flat-playlist. This may cause date-based filters to be slightly off and descriptions to be incomplete
+* `approximate_metadata`: Extract approximate `upload_date`, `timestamp`, and `description` metadata. Note that this may cause date-based filters to be slightly off, descriptions to be incomplete and metadata to be inconsistent with full video metadata.
 
 #### generic
 * `fragment_query`: Passthrough any query in mpd/m3u8 manifest URLs to their fragments if no value is provided, or else apply the query string given as `fragment_query=VALUE`. Does not apply to ffmpeg

--- a/README.md
+++ b/README.md
@@ -1811,7 +1811,7 @@ The following extractors use this feature:
 
 #### youtubetab (YouTube playlists, channels, feeds, etc.)
 * `skip`: One or more of `webpage` (skip initial webpage download), `authcheck` (allow the download of playlists requiring authentication when no initial webpage is downloaded. This may cause unwanted behavior, see [#1122](https://github.com/yt-dlp/yt-dlp/pull/1122) for more details)
-* `approximate_date`: Extract approximate `upload_date` and `timestamp` in flat-playlist. This may cause date-based filters to be slightly off
+* `approximate_metadata`: Extract approximate `upload_date`, `timestamp`, and `description` in flat-playlist. This may cause date-based filters to be slightly off and descriptions to be incomplete
 
 #### generic
 * `fragment_query`: Passthrough any query in mpd/m3u8 manifest URLs to their fragments if no value is provided, or else apply the query string given as `fragment_query=VALUE`. Does not apply to ffmpeg

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -106,7 +106,7 @@ def generator(test_case, tname):
             params = tc.get('params', {})
             if not info_dict.get('id'):
                 raise Exception(f'Test {tname} definition incorrect - "id" key is not present')
-            elif not info_dict.get('ext') and info_dict.get('_type', 'video') == 'video':
+            elif 'ext' not in info_dict and info_dict.get('_type', 'video') == 'video':
                 if params.get('skip_download') and params.get('ignore_no_formats_error'):
                     continue
                 raise Exception(f'Test {tname} definition incorrect - "ext" key must be present to define the output file')

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -106,7 +106,7 @@ def generator(test_case, tname):
             params = tc.get('params', {})
             if not info_dict.get('id'):
                 raise Exception(f'Test {tname} definition incorrect - "id" key is not present')
-            elif 'ext' not in info_dict and info_dict.get('_type', 'video') == 'video':
+            elif not info_dict.get('ext') and info_dict.get('_type', 'video') == 'video':
                 if params.get('skip_download') and params.get('ignore_no_formats_error'):
                     continue
                 raise Exception(f'Test {tname} definition incorrect - "ext" key must be present to define the output file')

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -6941,7 +6941,7 @@ class YoutubeSearchURLIE(YoutubeTabBaseInfoExtractor):
             'title': 'youtube-dl test video',
         }
     }, {
-        'url': 'https://www.youtube.com/results?baz=bar&search_query=IaSGqQa5O-M&filters=video&lclk=video',
+        'url': 'https://www.youtube.com/results?search_query=IaSGqQa5O-M&sp=EgIQAUICCAE%253D',
         'playlist_mincount': 1,
         'info_dict': {
             'id': 'IaSGqQa5O-M',
@@ -6949,8 +6949,8 @@ class YoutubeSearchURLIE(YoutubeTabBaseInfoExtractor):
         },
         'playlist': [{
             'info_dict': {
+                '_type': 'url',
                 'id': 'IaSGqQa5O-M',
-                'ext': None,
                 'title': 'Convolutions and adding random variables, visually explained',
                 'description': 'Adding random variables, with connections to the central limit theorem. Help fund future projects:\xa0...',
                 'channel_url': 'https://www.youtube.com/channel/UCYO_jab_esuFRV4b17AJtAw',

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -928,6 +928,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def _parse_time_text(self, text):
         if not text:
             return
+
+        if self._configuration_arg('approximate_date', ie_key=YoutubeTabIE):
+            self._downloader.deprecated_feature('[youtube] approximate_date extractor argument is deprecated. '
+                                                'Use approximate_metadata instead')
+
         dt = self.extract_relative_time(text)
         timestamp = None
         if isinstance(dt, datetime.datetime):
@@ -1086,6 +1091,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             'thumbnails': self._extract_thumbnails(renderer, 'thumbnail'),
             'timestamp': (self._parse_time_text(time_text)
                           if self._configuration_arg('approximate_metadata', ie_key=YoutubeTabIE)
+                          or self._configuration_arg('approximate_date', ie_key=YoutubeTabIE)
                           else None),
             'release_timestamp': scheduled_timestamp,
             'availability':

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1018,7 +1018,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
             snippet_text = []
             for snippet in metadata_snippets:
-                runs = snippet.get('snippetText').get('runs')
+                runs = snippet.get('snippetText', {}).get('runs', [])
                 for run in runs:
                     snippet_text.append(run['text'])
             if snippet_text:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -6955,7 +6955,7 @@ class YoutubeSearchURLIE(YoutubeTabBaseInfoExtractor):
                 'url': 'https://www.youtube.com/watch?v=IaSGqQa5O-M',
                 'channel_id': 'UCYO_jab_esuFRV4b17AJtAw',
                 'duration': 1645.0,
-                'timestamp': 1687910400,
+                'timestamp': int,
             }
         }],
         'params': {

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1056,8 +1056,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             url = f'https://www.youtube.com/shorts/{video_id}'
 
         time_text = (self._get_text(renderer, 'publishedTimeText', 'videoInfo')
-                     or self._get_text(reel_header_renderer, 'timestampText')
-                     or self._get_text(renderer, 'publishedTimeText', 'simpleText') or '')
+                     or self._get_text(reel_header_renderer, 'timestampText') or '')
         scheduled_timestamp = str_to_int(traverse_obj(renderer, ('upcomingEventData', 'startTime'), get_all=False))
 
         live_status = (

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1011,7 +1011,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         title = self._get_text(renderer, 'title', 'headline') or self._get_text(reel_header_renderer, 'reelTitleText')
         description = self._get_text(renderer, 'descriptionSnippet')
         if not description and self._configuration_arg(
-                'approximate_description', ie_key=YoutubeTabIE):
+                'approximate_metadata', ie_key=YoutubeTabIE):
             description = join_nonempty(*(self._get_text(x, 'snippetText') for x in traverse_obj(
                 renderer, ('detailedMetadataSnippets',))), delim='') or None
 
@@ -1085,7 +1085,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             'uploader_url': format_field(channel_handle, None, 'https://www.youtube.com/%s', default=None),
             'thumbnails': self._extract_thumbnails(renderer, 'thumbnail'),
             'timestamp': (self._parse_time_text(time_text)
-                          if self._configuration_arg('approximate_date', ie_key=YoutubeTabIE)
+                          if self._configuration_arg('approximate_metadata', ie_key=YoutubeTabIE)
                           else None),
             'release_timestamp': scheduled_timestamp,
             'availability':
@@ -6854,7 +6854,7 @@ class YoutubeNotificationsIE(YoutubeTabBaseInfoExtractor):
             rf'{re.escape(channel or "")}[^:]+: (.+)', notification_title,
             'video title', default=None)
         timestamp = (self._parse_time_text(self._get_text(notification, 'sentTimeText'))
-                     if self._configuration_arg('approximate_date', ie_key=YoutubeTabIE)
+                     if self._configuration_arg('approximate_metadata', ie_key=YoutubeTabIE)
                      else None)
         return {
             '_type': 'url',
@@ -6955,10 +6955,11 @@ class YoutubeSearchURLIE(YoutubeTabBaseInfoExtractor):
                 'url': 'https://www.youtube.com/watch?v=IaSGqQa5O-M',
                 'channel_id': 'UCYO_jab_esuFRV4b17AJtAw',
                 'duration': 1645.0,
+                'timestamp': 1687910400,
             }
         }],
         'params': {
-            'extractor_args': {'youtubetab': {'approximate_description': ['1']}},
+            'extractor_args': {'youtubetab': {'approximate_metadata': ['1']}},
             'extract_flat': True,
             'playlist_items': '1'
         }

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -6942,6 +6942,37 @@ class YoutubeSearchURLIE(YoutubeTabBaseInfoExtractor):
             'title': 'youtube-dl test video',
         }
     }, {
+        'url': 'https://www.youtube.com/results?baz=bar&search_query=IaSGqQa5O-M&filters=video&lclk=video',
+        'playlist_mincount': 1,
+        'info_dict': {
+            'id': 'IaSGqQa5O-M',
+            'title': 'IaSGqQa5O-M'
+        },
+        'playlist': [{
+            'info_dict': {
+                'id': 'IaSGqQa5O-M',
+                'ext': None,
+                'title': 'Convolutions and adding random variables, visually explained',
+                'description': 'Adding random variables, with connections to the central limit theorem. Help fund future projects:\xa0...',
+                'channel_url': 'https://www.youtube.com/channel/UCYO_jab_esuFRV4b17AJtAw',
+                'uploader_url': 'https://www.youtube.com/@3blue1brown',
+                'channel_is_verified': True,
+                'view_count': int,
+                'uploader': '3Blue1Brown',
+                'ie_key': 'Youtube',
+                'uploader_id': '@3blue1brown',
+                'channel': '3Blue1Brown',
+                'url': 'https://www.youtube.com/watch?v=IaSGqQa5O-M',
+                'channel_id': 'UCYO_jab_esuFRV4b17AJtAw',
+                'duration': 1645.0,
+            }
+        }],
+        'params': {
+            'extractor_args': {'youtubetab': {'approximate_description': ['1']}},
+            'extract_flat': True,
+            'playlist_items': '1'
+        }
+    }, {
         'url': 'https://www.youtube.com/results?search_query=python&sp=EgIQAg%253D%253D',
         'playlist_mincount': 5,
         'info_dict': {

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1010,19 +1010,10 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         title = self._get_text(renderer, 'title', 'headline') or self._get_text(reel_header_renderer, 'reelTitleText')
         description = self._get_text(renderer, 'descriptionSnippet')
-        metadata_snippets = renderer.get('detailedMetadataSnippets')
-        wants_approximate_description = self._configuration_arg('approximate_description', ie_key=YoutubeTabIE)
-        if description is None and metadata_snippets is not None and wants_approximate_description:
-            # use metadata snippets to construct a description
-            # it won't be a full one, but should be usable for --flat-playlist
-
-            snippet_text = []
-            for snippet in metadata_snippets:
-                runs = snippet.get('snippetText', {}).get('runs', [])
-                for run in runs:
-                    snippet_text.append(run['text'])
-            if snippet_text:
-                description = ''.join(snippet_text)
+        if not description and self._configuration_arg(
+                'approximate_description', ie_key=YoutubeTabIE):
+            description = join_nonempty(*(self._get_text(x, 'snippetText') for x in traverse_obj(
+                renderer, ('detailedMetadataSnippets',))), delim='') or None
 
         duration = int_or_none(renderer.get('lengthSeconds'))
         if duration is None:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1056,7 +1056,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             url = f'https://www.youtube.com/shorts/{video_id}'
 
         time_text = (self._get_text(renderer, 'publishedTimeText', 'videoInfo')
-                     or self._get_text(reel_header_renderer, 'timestampText') or '')
+                     or self._get_text(reel_header_renderer, 'timestampText')
+                     or self._get_text(renderer, 'publishedTimeText', 'simpleText') or '')
         scheduled_timestamp = str_to_int(traverse_obj(renderer, ('upcomingEventData', 'startTime'), get_all=False))
 
         live_status = (

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -6943,7 +6943,7 @@ class YoutubeSearchURLIE(YoutubeTabBaseInfoExtractor):
                 '_type': 'url',
                 'id': 'IaSGqQa5O-M',
                 'title': 'Convolutions and adding random variables, visually explained',
-                'description': 'Adding random variables, with connections to the central limit theorem. Help fund future projects:\xa0...',
+                'description': '0:00 - Intro quiz 2:24 - Discrete case, diagonal slices 6:49 - Discrete case, flip-and-slide 8:41 - The discrete formula 10:58\xa0...',
                 'channel_url': 'https://www.youtube.com/channel/UCYO_jab_esuFRV4b17AJtAw',
                 'uploader_url': 'https://www.youtube.com/@3blue1brown',
                 'channel_is_verified': True,

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1010,6 +1010,19 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         title = self._get_text(renderer, 'title', 'headline') or self._get_text(reel_header_renderer, 'reelTitleText')
         description = self._get_text(renderer, 'descriptionSnippet')
+        metadata_snippets = renderer.get('detailedMetadataSnippets')
+        wants_approximate_description = self._configuration_arg('approximate_description', ie_key=YoutubeTabIE)
+        if description is None and metadata_snippets is not None and wants_approximate_description:
+            # use metadata snippets to construct a description
+            # it won't be a full one, but should be usable for --flat-playlist
+
+            snippet_text = []
+            for snippet in metadata_snippets:
+                runs = snippet.get('snippetText').get('runs')
+                for run in runs:
+                    snippet_text.append(run['text'])
+            if snippet_text:
+                description = ''.join(snippet_text)
 
         duration = int_or_none(renderer.get('lengthSeconds'))
         if duration is None:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1012,8 +1012,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         description = self._get_text(renderer, 'descriptionSnippet')
         if not description and self._configuration_arg(
                 'approximate_metadata', ie_key=YoutubeTabIE):
-            description = join_nonempty(*(self._get_text(x, 'snippetText') for x in traverse_obj(
-                renderer, ('detailedMetadataSnippets',))), delim='') or None
+            snippets = traverse_obj(renderer, ('detailedMetadataSnippets',)) or []
+            description = join_nonempty(*(self._get_text(x, 'snippetText') for x in snippets), delim='') or None
 
         duration = int_or_none(renderer.get('lengthSeconds'))
         if duration is None:


### PR DESCRIPTION
### Description of your *pull request* and other information

I have started to develop a separate search interface for YouTube on VRChat powered by yt-dlp, while the base features work, we wish to replicate parts of the existing Youtube search UI while still maintaining low latency searches (AKA using `--flat-playlist`), while that does give what we need to make it work, there are two things missing at the moment:
 - Descriptions, the same that appear in the website's search results.
 - Video timestamps, the same that appear in the website's search results.

This PR implements both:
 - An `youtubetab:approximate_description` option is added, akin to `youtubetab:approximate_date`, which extracts as much description as possible from `detailedMetadataSnippets`.
 - Adding a separate query for `time_text`, `publishedTimeText.simpleText`, which lets the JSON given by yt-dlp to contain something that isn't `null`.

So, `yt-dlp 'ytsearch1:test' --dump-json --flat-playlist --extractor-args "youtubetab:approximate_date;approximate_description"` would give more data than what is currently provided without extractor args.

This is related to https://github.com/yt-dlp/yt-dlp/issues/6717#issuecomment-1498603054, an open question of this PR would be if `approximate_metadata` would be more useful. I'm of the opinion that the user should choose which parts of the video should be approximated, and which are exact.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)
  - Note: The youtube tests were failing before this PR's changes (on master branch). The set of failing tests did not change with this PR.

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
  - I had to edit the info_dict's `'ext'` requirement so that `'ext': None` can work as a valid test case (as that's what you get from a flat playlist)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at edd3dab</samp>

### Summary
:recycle::sparkles::bug:

<!--
1.  :recycle: for the code simplification and refactoring.
2.  :sparkles: for the new feature of approximate_description.
3.  :bug: for the bugfix of time_text.
-->
Improve YouTube metadata extraction and simplify test code. Add `approximate_description` feature and `time_text` bugfix to `yt_dlp/extractor/youtube.py`, and use `in` operator for 'ext' key check in `test/test_download.py`.

> _Sing, O Muse, of the skillful coder who refined the code_
> _Of the extractor, that cunning tool that plucks from YouTube_
> _The precious metadata and descriptions of the videos,_
> _Like Hermes stealing Apollo's cattle in the ancient days._

### Walkthrough
*  Add feature to extract approximate description from metadata snippets when regular description is missing ([link](https://github.com/yt-dlp/yt-dlp/pull/7445/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L1013-R1026)). This feature is controlled by a new argument 'approximate_description' for the `YoutubeBaseInfoExtractor` class in `yt_dlp/extractor/youtube.py`.



</details>
