### PR TITLE
ignore whitespace at the end of cue timings

### DIFF
--- a/yt_dlp/webvtt.py
+++ b/yt_dlp/webvtt.py
@@ -95,6 +95,7 @@ _REGEX_TS = re.compile(r'''(?x)
 _REGEX_EOF = re.compile(r'\Z')
 _REGEX_NL = re.compile(r'(?:\r\n|[\r\n]|$)')
 _REGEX_BLANK = re.compile(r'(?:\r\n|[\r\n])+')
+_REGEX_SPACE = re.compile(r'(?: )+')
 
 
 def _parse_ts(ts):
@@ -286,6 +287,7 @@ class CueBlock(Block):
         if not m1:
             return None
         m2 = parser.consume(cls._REGEX_SETTINGS)
+        parser.consume(_REGEX_SPACE)
         if not parser.consume(_REGEX_NL):
             return None
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This adds a call to conusme any whitespace at the end of a cue timing line in a VTT fragment, which happens at least with some videos from srf.ch.

Fixes #7453


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c45a68d</samp>

### Summary
🕵️‍♂️🎞️⏩

<!--
1.  🕵️‍♂️ - This emoji could represent the improvement of parsing by using a regular expression, which is a way of finding and matching patterns in text. The detective emoji could suggest the idea of searching and solving a problem.
2.  🎞️ - This emoji could represent the WebVTT subtitles, which are a format for displaying text and cues on video. The film frames emoji could suggest the idea of video and media content.
3.  ⏩ - This emoji could represent the skipping of spaces before cue identifiers and timings, which are the parts of the WebVTT format that indicate when and how the subtitles should appear. The fast-forward emoji could suggest the idea of speeding up and skipping unnecessary parts.
-->
Improved WebVTT subtitle parsing in `yt_dlp/webvtt.py`. Used regex for spaces and skipped them before cue identifiers and timings.

> _Sing, O Muse, of the skillful coder who improved_
> _The parsing of WebVTT, the format of subtitles,_
> _By using a `regex` for spaces, like a sieve_
> _That filters out the chaff before the cue `identifiers` and `timings`._

### Walkthrough
*  Add a global variable `SPACES_RE` to match one or more spaces in WebVTT subtitles ([link](https://github.com/yt-dlp/yt-dlp/pull/7454/files?diff=unified&w=0#diff-17d03f1700281e69bedbd6a9b82f9e59a82b68fbd1c35f84db8cafb020b3a362R98))
*  Use `SPACES_RE` to skip any spaces before the cue identifier or the cue timings in the `parse` method of the `CueBlock` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7454/files?diff=unified&w=0#diff-17d03f1700281e69bedbd6a9b82f9e59a82b68fbd1c35f84db8cafb020b3a362R290))



</details>
