### PR TITLE
Save decrypted fragments to disk with `--keep-fragments`

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -515,7 +515,11 @@ class FragmentFD(FileDownloader):
                             'fragment_filename_sanitized': frag_filename,
                             'fragment_index': frag_index,
                         })
-                        if not append_fragment(decrypt_fragment(fragment, self._read_fragment(ctx)), frag_index, ctx):
+                        decrypted_fragment = decrypt_fragment(fragment, self._read_fragment(ctx))
+                        if self.params.get('keep_fragments', False):
+                            f, _ = self.sanitize_open(format(fragment['frag_index'], '05d') + '.ts', 'wb')
+                            f.write(decrypted_fragment)
+                        if not append_fragment(decrypted_fragment, frag_index, ctx):
                             return False
                 except KeyboardInterrupt:
                     self._finish_multiline_status()
@@ -529,8 +533,11 @@ class FragmentFD(FileDownloader):
                     break
                 try:
                     download_fragment(fragment, ctx)
-                    result = append_fragment(
-                        decrypt_fragment(fragment, self._read_fragment(ctx)), fragment['frag_index'], ctx)
+                    decrypted_fragment = decrypt_fragment(fragment, self._read_fragment(ctx))
+                    if self.params.get('keep_fragments', False):
+                        f, _ = self.sanitize_open(format(fragment['frag_index'], '05d') + '.ts', 'wb')
+                        f.write(decrypted_fragment)
+                    result = append_fragment(decrypted_fragment, fragment['frag_index'], ctx)
                 except KeyboardInterrupt:
                     if info_dict.get('is_live'):
                         break

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -517,7 +517,7 @@ class FragmentFD(FileDownloader):
                         })
                         decrypted_fragment = decrypt_fragment(fragment, self._read_fragment(ctx))
                         if self.params.get('keep_fragments', False):
-                            f, _ = self.sanitize_open(format(fragment['frag_index'], '05d') + '.ts', 'wb')
+                            f, _ = self.sanitize_open(ctx.get('fragment_filename_sanitized'), 'wb')
                             f.write(decrypted_fragment)
                         if not append_fragment(decrypted_fragment, frag_index, ctx):
                             return False
@@ -535,7 +535,7 @@ class FragmentFD(FileDownloader):
                     download_fragment(fragment, ctx)
                     decrypted_fragment = decrypt_fragment(fragment, self._read_fragment(ctx))
                     if self.params.get('keep_fragments', False):
-                        f, _ = self.sanitize_open(format(fragment['frag_index'], '05d') + '.ts', 'wb')
+                        f, _ = self.sanitize_open(ctx.get('fragment_filename_sanitized'), 'wb')
                         f.write(decrypted_fragment)
                     result = append_fragment(decrypted_fragment, fragment['frag_index'], ctx)
                 except KeyboardInterrupt:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

ADD DESCRIPTION HERE

This PR adds a feature I first requested in #5241. If `--keep-fragments` is enabled, the *decrypted* fragments are saved to disk, overwriting the raw (and possibly encrypted) fragments that were downloaded initially. If `--keep-fragments` is not passed, this preserves the default behavior of temporarily storing the original fragments on disk.

The only downside I see is that this increases disk writes, as each fragment is now written twice, once upon download, and once after decryption, even if there is no decryption to be done. However, this was the easiest solution to implement within the existing codebase.

If there is debate over whether this feature should be implemented at all, I doubt there are very many users that are relying on existing behavior by using `--keep-fragments` to preserve encrypted fragments, and I wanted to avoid adding an additional option. Even if the maintainers decide against merging this PR, I still leave it here for anyone else who could use #5241.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

copilot:all

</details>
