### PR TITLE
[extractor/youtube] Ignore incomplete data for comment threads by default

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3525,7 +3525,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     else:
                         raise ExtractorError(
                             'Incomplete data received for comment reply thread. '
-                            'Pass --ignore-errors to ignore and allow rest of comments to download',
+                            'Pass --ignore-errors to ignore and allow rest of comments to download.',
                             expected=True)
                 else:
                     raise

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3517,10 +3517,16 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 # Ignore incomplete data error for replies if retries didn't work.
                 # This is to allow any other parent comments and comment threads to be downloaded.
                 # See: https://github.com/yt-dlp/yt-dlp/issues/4669
-                if 'incomplete data' in str(e).lower() and parent and self.get_param('ignoreerrors') is True:
-                    self.report_warning(
-                        'Received incomplete data for a comment reply thread and retrying did not help. '
-                        'Ignoring to let other comments be downloaded.')
+                if 'incomplete data' in str(e).lower() and parent:
+                    if self.get_param('ignoreerrors') in (True, 'only_download'):
+                        self.report_warning(
+                            'Received incomplete data for a comment reply thread and retrying did not help. '
+                            'Ignoring to let other comments be downloaded. Pass --no-ignore-errors to not ignore.')
+                    else:
+                        raise ExtractorError(
+                            'Incomplete data received for comment reply thread. '
+                            'Pass --ignore-errors to ignore and allow rest of comments to download',
+                            expected=True)
                 else:
                     raise
             is_forced_continuation = False

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3426,7 +3426,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         # Pinned comments may appear a second time in newest first sort
                         # See: https://github.com/yt-dlp/yt-dlp/issues/6712
                         continue
-                    self.report_warning('Detected YouTube comments looping. Stopping comment extraction as we probably cannot get any more.')
+                    self.report_warning(
+                        'Detected YouTube comments looping. Stopping comment extraction '
+                        f'{"for this thread" if parent else ""} as we probably cannot get any more.')
                     yield
                 else:
                     tracker['seen_comment_ids'].add(comment['id'])
@@ -3522,13 +3524,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         self.report_warning(
                             'Received incomplete data for a comment reply thread and retrying did not help. '
                             'Ignoring to let other comments be downloaded. Pass --no-ignore-errors to not ignore.')
+                        return
                     else:
                         raise ExtractorError(
                             'Incomplete data received for comment reply thread. '
                             'Pass --ignore-errors to ignore and allow rest of comments to download.',
                             expected=True)
-                else:
-                    raise
+                raise
             is_forced_continuation = False
             continuation = None
             for continuation_items in traverse_obj(response, continuation_items_path, expected_type=list, default=[]):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Closes https://github.com/yt-dlp/yt-dlp/issues/7474

Allows comments to continue downloading if a reply thread gets an incomplete data error when `--ignore-errors only_download` is passed (default for CLI) in addition to `--ignore-errors`.

I have also added some help messages to the output to help users.

In the future it would be nice to have some exposed controls over how to handle the incomplete data error only, but this should do for now.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a3c8c65</samp>

### Summary
🐛🚨📝

<!--
1.  🐛 - This emoji represents a bug fix, as the change fixes the issue of missing comment reply threads due to incomplete data.
2.  🚨 - This emoji represents an error handling improvement, as the change distinguishes between different values for the `ignoreerrors` parameter and raises an ExtractorError for unexpected errors.
3.  📝 - This emoji represents a documentation update, as the change adds a suggestion to the error message to pass the `--ignore-errors` option to ignore the error and allow the rest of the comments to be downloaded.
-->
Modify error handling for comment reply threads in `yt_dlp/extractor/youtube.py`. Allow users to ignore errors without warnings or raise them as ExtractorError.

> _`ignoreerrors` splits_
> _comment errors handled well_
> _autumn leaves fall fast_

### Walkthrough
*  Modify error handling logic for comment reply threads ([link](https://github.com/yt-dlp/yt-dlp/pull/7475/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L3520-R3529))



</details>
