### PR TITLE
[extractor/ccc] Handle subtitles and automatic captions

### DIFF
--- a/yt_dlp/extractor/ccc.py
+++ b/yt_dlp/extractor/ccc.py
@@ -16,6 +16,7 @@ class CCCIE(InfoExtractor):
         'md5': '3a1eda8f3a29515d27f5adb967d7e740',
         'info_dict': {
             'id': '1839',
+            'display_id': '30C3_-_5443_-_en_-_saal_g_-_201312281830_-_introduction_to_processor_design_-_byterazor',
             'ext': 'mp4',
             'title': 'Introduction to Processor Design',
             'creator': 'byterazor',
@@ -24,6 +25,7 @@ class CCCIE(InfoExtractor):
             'upload_date': '20131228',
             'timestamp': 1388188800,
             'duration': 3710,
+            'view_count': int,
             'tags': list,
         }
     }, {


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Previously subtitles and automatic captions were not detected and fetched from media.ccc.de. This change makes them extractable.

The change is fairly trivial, so I did not open an issue for discussions. I hope that is okay.

I tried adding subtitle information to the test, but they seem to get filterd. Assert always claims it got `None`, but I can write-subs and write-auto-subs just fine via the yt-dlp cli tool. If I missed something, please let me know an I am happy to add a test for this.

On master the test failed, so I also fixed them before applying my changes.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c97fd11</samp>

### Summary

No summary available (An error occurred while summarizing these changes: Gave up after 3 retries: Failed to read error response)



### Walkthrough
*  Add `display_id` and `view_count` fields to the CCC extractor test case ([link](https://github.com/yt-dlp/yt-dlp/pull/7525/files?diff=unified&w=0#diff-f51824075dfb87d4a82e37e0fcf75eee34a78c52a265cceb6f9fd2f2b3fdb05cR19), [link](https://github.com/yt-dlp/yt-dlp/pull/7525/files?diff=unified&w=0#diff-f51824075dfb87d4a82e37e0fcf75eee34a78c52a265cceb6f9fd2f2b3fdb05cR28))
*  Initialize `automatic_captions` and `subtitles` dictionaries to store subtitle URLs for different languages and states ([link](https://github.com/yt-dlp/yt-dlp/pull/7525/files?diff=unified&w=0#diff-f51824075dfb87d4a82e37e0fcf75eee34a78c52a265cceb6f9fd2f2b3fdb05cR42-R43))
*  Append subtitle URLs to the corresponding dictionaries based on the mime type and state of the recording ([link](https://github.com/yt-dlp/yt-dlp/pull/7525/files?diff=unified&w=0#diff-f51824075dfb87d4a82e37e0fcf75eee34a78c52a265cceb6f9fd2f2b3fdb05cR71-R75))
*  Return `subtitles` and `automatic_captions` dictionaries as part of the video information dictionary in the `_real_extract` method of `yt_dlp/extractor/ccc.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7525/files?diff=unified&w=0#diff-f51824075dfb87d4a82e37e0fcf75eee34a78c52a265cceb6f9fd2f2b3fdb05cR89-R90))



</details>
