### PR TITLE
Update clean_podcast_url() in _utils.py

### DIFF
--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -5118,9 +5118,9 @@ def format_field(obj, field=None, template='%s', ignore=NO_DEFAULT, default='', 
 
 
 def clean_podcast_url(url):
-    url = re.sub(r'''(?x)
+    return re.sub(r'''(?x)
         (?:
-            (?:
+            (\w+://)(?:
                 chtbl\.com/track|
                 media\.blubrry\.com| # https://create.blubrry.com/resources/podcast-media-download-statistics/getting-started/
                 play\.podtrac\.com
@@ -5132,7 +5132,6 @@ def clean_podcast_url(url):
                 st\.fm # https://podsights.com/docs/
             )/e
         )/''', '', url)
-    return re.sub(r'^\w+://(\w+://)', r'\1', url)
 
 
 _HEX_TABLE = '0123456789abcdef'


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->


Fix for #7430 and #7544
Example URLs:
https://pdst.fm/e/2.gum.fm/chtbl.com/track/chrt.fm/track/34D33/pscrb.fm/rss/p/traffic.megaphone.fm/ITLLC7765286967.mp3?updated=1687282661

https://pdst.fm/e/https://mgln.ai/e/441/www.buzzsprout.com/1121972/13019085-ep-252-the-deep-life-stack.mp3


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 436c63c</samp>

### Summary
🐛🧹🎧

<!--
1.  🐛 Bug fix: This emoji is commonly used to indicate a bug fix or a patch for a software issue. In this case, the bug was that some podcast URLs had duplicate protocol prefixes, such as `http://http://example.com`.
2.  🧹 Clean up: This emoji is often used to signify code refactoring, simplification, or removal of unnecessary or redundant code. In this case, the code in the `clean_podcast_url` function was simplified by using a regex group to capture the protocol prefix and avoid appending it twice.
3.  🎧 Podcast: This emoji is relevant to the domain of the function, which is dealing with podcast URLs. It can also help to differentiate this change from other possible changes in the same project or repository.
-->
Fix and improve podcast URL cleaning in `yt_dlp/utils/_utils.py`. Use regex to avoid adding extra `http://` or `https://` to podcast URLs.

> _`clean_podcast_url` is the function of doom_
> _It strips away the noise and the gloom_
> _With a regex group it slays the duplicates_
> _No more protocol prefixes to confuse and frustrate_

### Walkthrough
* Fix duplicate protocol prefix bug in podcast URLs by capturing and reusing the first prefix in a regex group ([link](https://github.com/yt-dlp/yt-dlp/pull/7549/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL5121-R5123))
* Remove redundant line of code that was doing the same thing as the previous fix, but less efficiently and without a regex group ([link](https://github.com/yt-dlp/yt-dlp/pull/7549/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL5135))



</details>
