### PR TITLE
[extractor/wimbledon] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2360,6 +2360,7 @@ from .weyyak import WeyyakIE
 from .whyp import WhypIE
 from .wikimedia import WikimediaIE
 from .willow import WillowIE
+from .wimbledon import WimbledonIE
 from .wimtv import WimTVIE
 from .whowatch import WhoWatchIE
 from .wistia import (

--- a/yt_dlp/extractor/wimbledon.py
+++ b/yt_dlp/extractor/wimbledon.py
@@ -14,7 +14,7 @@ class WimbledonIE(InfoExtractor):
             'ext': 'mp4',
             'timestamp': 1687972186,
             'description': '',
-            'thumbnail': r're:^https://[\.\w-]+\.prod\.boltdns\.net/[^?#]+/image\.jpg',
+            'thumbnail': r're:^https://[\w.-]+\.prod\.boltdns\.net/[^?#]+/image\.jpg',
             'upload_date': '20230628',
             'title': 'Coco Gauff | My Wimbledon Inspiration',
             'tags': ['features', 'trending', 'homepage'],
@@ -26,7 +26,7 @@ class WimbledonIE(InfoExtractor):
         'info_dict': {
             'id': '6308703111112',
             'ext': 'mp4',
-            'thumbnail': r're:^https://[\.\w-]+\.prod\.boltdns\.net/[^?#]+/image\.jpg',
+            'thumbnail': r're:^https://[\w.-]+\.prod\.boltdns\.net/[^?#]+/image\.jpg',
             'description': 'null',
             'upload_date': '20220629',
             'uploader_id': '3506358525001',
@@ -45,11 +45,8 @@ class WimbledonIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         metadata = self._download_json(
-            f'https://www.wimbledon.com/relatedcontent/rest/v2/wim_v1/en/content/wim_v1_{video_id}_en',
-            video_id,
-        )
+            f'https://www.wimbledon.com/relatedcontent/rest/v2/wim_v1/en/content/wim_v1_{video_id}_en', video_id)
 
         return {
             '_type': 'url_transparent',

--- a/yt_dlp/extractor/wimbledon.py
+++ b/yt_dlp/extractor/wimbledon.py
@@ -6,9 +6,7 @@ from ..utils import (
 
 
 class WimbledonIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?wimbledon\.com/en_GB/video/media/(?P<id>[0-9]+).html'
-    BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/%s/default_default/index.html?videoId=%s'
-
+    _VALID_URL = r'https?://(?:www\.)?wimbledon\.com/\w+/video/media/(?P<id>\d+).html'
     _TESTS = [{
         'url': 'https://www.wimbledon.com/en_GB/video/media/6330247525112.html',
         'info_dict': {
@@ -16,7 +14,7 @@ class WimbledonIE(InfoExtractor):
             'ext': 'mp4',
             'timestamp': 1687972186,
             'description': '',
-            'thumbnail': 'https://cf-images.eu-west-1.prod.boltdns.net/v1/static/3506358525001/97312363-ba01-4158-8a45-1e51e518c0ff/806b5b8a-22dc-4618-aac9-f73bd6202715/1920x1080/match/image.jpg',
+            'thumbnail': r're:^https://[\.\w-]+\.prod\.boltdns\.net/[^?#]+/image\.jpg',
             'upload_date': '20230628',
             'title': 'Coco Gauff | My Wimbledon Inspiration',
             'tags': ['features', 'trending', 'homepage'],
@@ -28,7 +26,7 @@ class WimbledonIE(InfoExtractor):
         'info_dict': {
             'id': '6308703111112',
             'ext': 'mp4',
-            'thumbnail': 'https://cf-images.eu-west-1.prod.boltdns.net/v1/jit/3506358525001/3144a401-e6b3-4d49-9dfc-627866a2e2de/main/1920x1080/50s720ms/match/image.jpg',
+            'thumbnail': r're:^https://[\.\w-]+\.prod\.boltdns\.net/[^?#]+/image\.jpg',
             'description': 'null',
             'upload_date': '20220629',
             'uploader_id': '3506358525001',
@@ -37,11 +35,16 @@ class WimbledonIE(InfoExtractor):
             'tags': ['features', 'kids'],
             'timestamp': 1656500867,
         },
+    }, {
+        'url': 'https://www.wimbledon.com/en_US/video/media/6309327106112.html',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.wimbledon.com/es_Es/video/media/6308377909112.html',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        account = '3506358525001'
 
         metadata = self._download_json(
             f'https://www.wimbledon.com/relatedcontent/rest/v2/wim_v1/en/content/wim_v1_{video_id}_en',
@@ -50,11 +53,12 @@ class WimbledonIE(InfoExtractor):
 
         return {
             '_type': 'url_transparent',
-            'url': self.BRIGHTCOVE_URL_TEMPLATE % (account, video_id),
+            'url': f'http://players.brightcove.net/3506358525001/default_default/index.html?videoId={video_id}',
             'ie_key': 'BrightcoveNew',
             'id': video_id,
-            'title': metadata.get('title'),
-            'description': metadata.get('description'),
-            'language': metadata.get('language'),
-            'duration': parse_duration(traverse_obj(metadata, ('metadata', 'duration'))),
+            **traverse_obj(metadata, {
+                'title': 'title',
+                'description': 'description',
+                'duration': ('metadata', 'duration', {parse_duration}),
+            }),
         }

--- a/yt_dlp/extractor/wimbledon.py
+++ b/yt_dlp/extractor/wimbledon.py
@@ -1,0 +1,60 @@
+from .common import InfoExtractor
+from ..utils import (
+    parse_duration,
+    traverse_obj,
+)
+
+
+class WimbledonIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?wimbledon\.com/en_GB/video/media/(?P<id>[0-9]+).html'
+    BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/%s/default_default/index.html?videoId=%s'
+
+    _TESTS = [{
+        'url': 'https://www.wimbledon.com/en_GB/video/media/6330247525112.html',
+        'info_dict': {
+            'id': '6330247525112',
+            'ext': 'mp4',
+            'timestamp': 1687972186,
+            'description': '',
+            'thumbnail': 'https://cf-images.eu-west-1.prod.boltdns.net/v1/static/3506358525001/97312363-ba01-4158-8a45-1e51e518c0ff/806b5b8a-22dc-4618-aac9-f73bd6202715/1920x1080/match/image.jpg',
+            'upload_date': '20230628',
+            'title': 'Coco Gauff | My Wimbledon Inspiration',
+            'tags': ['features', 'trending', 'homepage'],
+            'uploader_id': '3506358525001',
+            'duration': 163072.0,
+        },
+    }, {
+        'url': 'https://www.wimbledon.com/en_GB/video/media/6308703111112.html',
+        'info_dict': {
+            'id': '6308703111112',
+            'ext': 'mp4',
+            'thumbnail': 'https://cf-images.eu-west-1.prod.boltdns.net/v1/jit/3506358525001/3144a401-e6b3-4d49-9dfc-627866a2e2de/main/1920x1080/50s720ms/match/image.jpg',
+            'description': 'null',
+            'upload_date': '20220629',
+            'uploader_id': '3506358525001',
+            'title': 'Roblox | WimbleWorld ',
+            'duration': 101440.0,
+            'tags': ['features', 'kids'],
+            'timestamp': 1656500867,
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        account = '3506358525001'
+
+        metadata = self._download_json(
+            f'https://www.wimbledon.com/relatedcontent/rest/v2/wim_v1/en/content/wim_v1_{video_id}_en',
+            video_id,
+        )
+
+        return {
+            '_type': 'url_transparent',
+            'url': self.BRIGHTCOVE_URL_TEMPLATE % (account, video_id),
+            'ie_key': 'BrightcoveNew',
+            'id': video_id,
+            'title': metadata.get('title'),
+            'description': metadata.get('description'),
+            'language': metadata.get('language'),
+            'duration': parse_duration(traverse_obj(metadata, ('metadata', 'duration'))),
+        }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The ID is extracted and passed to BrightcoveNewIE. Additional metadata is grabbed from the Wimbledon API using the same ID.

Fixes #7462 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b08218</samp>

### Summary
🎾🆕🎬

<!--
1.  🎾 - This emoji represents the sport of tennis, which is the main theme of the Wimbledon website and the videos that the extractor supports. It also conveys a sense of excitement and competition, as well as the British culture and tradition associated with the Wimbledon tournament.
2.  🆕 - This emoji represents the fact that this is a new extractor that adds support for a previously unsupported website. It also conveys a sense of novelty and innovation, as well as the potential for more video content and variety for the users of youtube-dl.
3.  🎬 - This emoji represents the fact that this extractor deals with video media, and specifically with the Brightcove player that hosts the videos on the Wimbledon website. It also conveys a sense of quality and professionalism, as well as the entertainment and enjoyment that the videos provide.
-->
Add support for extracting videos from the Wimbledon website. Define a new `WimbledonIE` class in `wimbledon.py` that uses the `BrightcoveNew` extractor and a JSON API.

> _`WimbledonIE` class_
> _Extracts videos and metadata_
> _From tennis website_

### Walkthrough
*  Add support for extracting videos from the Wimbledon website ([link](https://github.com/yt-dlp/yt-dlp/pull/7551/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R2363), [link](https://github.com/yt-dlp/yt-dlp/pull/7551/files?diff=unified&w=0#diff-a0b980dccc25875c2788812a28536c458b712206243c1968f0865ffaa7d69e73R1-R60))
   * Import the `WimbledonIE` class from the `wimbledon.py` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7551/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R2363))
   * Define the `WimbledonIE` class that inherits from the `InfoExtractor` base class ([link](https://github.com/yt-dlp/yt-dlp/pull/7551/files?diff=unified&w=0#diff-a0b980dccc25875c2788812a28536c458b712206243c1968f0865ffaa7d69e73R1-R60))



</details>
