### PR TITLE
[extractor/bilibili] add format_id

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -69,7 +69,9 @@ class BilibiliBaseIE(InfoExtractor):
             'tbr': float_or_none(video.get('bandwidth'), scale=1000),
             'filesize': int_or_none(video.get('size')),
             'quality': int_or_none(video.get('id')),
-            'format_id': self._search_regex(r'-(\d+)\.m4s\?', traverse_obj(video, 'baseUrl', 'base_url'), 'video:format_id', fatal=False) or str_or_none(video.get('id')),
+            'format_id': traverse_obj(
+                video, (('baseUrl', 'base_url'), {self._FORMAT_ID_RE.search}, 1),
+                ('id', {str_or_none}), get_all=False),
             'format': format_names.get(video.get('id')),
         } for video in traverse_obj(play_info, ('dash', 'video', ...)))
 

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -3,6 +3,7 @@ import functools
 import hashlib
 import itertools
 import math
+import re
 import time
 import urllib.error
 import urllib.parse
@@ -38,6 +39,8 @@ from ..utils import (
 
 
 class BilibiliBaseIE(InfoExtractor):
+    _FORMAT_ID_RE = re.compile(r'-(\d+)\.m4s\?')
+
     def extract_formats(self, play_info):
         format_names = {
             r['quality']: traverse_obj(r, 'new_description', 'display_desc')

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -54,7 +54,8 @@ class BilibiliBaseIE(InfoExtractor):
             'acodec': audio.get('codecs'),
             'vcodec': 'none',
             'tbr': float_or_none(audio.get('bandwidth'), scale=1000),
-            'filesize': int_or_none(audio.get('size'))
+            'filesize': int_or_none(audio.get('size')),
+            'format_id': str_or_none(audio.get('id')),
         } for audio in audios]
 
         formats.extend({
@@ -68,6 +69,7 @@ class BilibiliBaseIE(InfoExtractor):
             'tbr': float_or_none(video.get('bandwidth'), scale=1000),
             'filesize': int_or_none(video.get('size')),
             'quality': int_or_none(video.get('id')),
+            'format_id': self._search_regex(r'-(\d+)\.m4s\?', traverse_obj(video, 'baseUrl', 'base_url'), 'video:format_id', fatal=False) or str_or_none(video.get('id')),
             'format': format_names.get(video.get('id')),
         } for video in traverse_obj(play_info, ('dash', 'video', ...)))
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Currently `BilibiliBaseIE` extractor use automatically generated ordinary `format_id` for video/audio formats. However, bilibili also has a certain form of `format_id`, which works in a similar way as Youtube.
This PR adds `format_id` for different video/audio formats, providing a consistent `format_id` for a given quality+codec combination.

Before:
```CMD
> py.exe -m yt_dlp -F https://www.bilibili.com/video/BV1GB4y1J7f2/ --cookies-from-browser chrome

[Cookies] Extracting cookies from chrome 
[Cookies] Extracted 2965 cookies from chrome 
[BiliBili] Extracting URL: https://www.bilibili.com/video/BV1GB4y1J7f2/ 
[BiliBili] 1GB4y1J7f2: Downloading webpage 
[BiliBili] BV1GB4y1J7f2: Extracting videos in anthology
[BiliBili] 603352756: Extracting chapters
[info] Available formats for BV1GB4y1J7f2:
ID EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC      ABR 
──────────────────────────────────────────────────────────────────────────────────
0  m4a audio only     │ ≈122.10MiB   67k https │ audio only        mp4a.40.2   67k
1  m4a audio only     │ ≈241.09MiB  133k https │ audio only        mp4a.40.2  133k
2  m4a audio only     │ ≈565.11MiB  311k https │ audio only        mp4a.40.2  311k
3  mp4 640x360     29 │ ≈623.05MiB  343k https │ avc1.64001E  343k video only
4  mp4 852x480     29 │ ≈954.46MiB  526k https │ avc1.64001F  526k video only
5  mp4 1280x720    29 │ ≈  1.65GiB  928k https │ avc1.640028  928k video only
6  mp4 1920x1080   29 │ ≈  3.57GiB 2013k https │ avc1.640032 2013k video only
7  mp4 1920x1080   29 │ ≈  5.16GiB 2909k https │ avc1.640032 2909k video only


> py.exe -m yt_dlp -F https://www.bilibili.com/video/BV1wN411S7x2/ --cookies-from-browser chrome

[Cookies] Extracting cookies from chrome 
[Cookies] Extracted 2969 cookies from chrome 
[BiliBili] Extracting URL: https://www.bilibili.com/video/BV1wN411S7x2/ 
[BiliBili] 1wN411S7x2: Downloading webpage 
[BiliBili] BV1wN411S7x2: Extracting videos in anthology 
[BiliBili] 487968052: Extracting chapters 
[info] Available formats for BV1wN411S7x2: 
ID EXT RESOLUTION FPS │   FILESIZE    TBR PROTO │ VCODEC           VBR ACODEC      ABR 
──────────────────────────────────────────────────────────────────────────────────────
0  m4a audio only     │ ≈  6.38MiB    44k https │ audio only           mp4a.40.5   44k
1  m4a audio only     │ ≈ 15.34MiB   107k https │ audio only           mp4a.40.2  107k
2  m4a audio only     │ ≈ 26.60MiB   185k https │ audio only           mp4a.40.2  185k
3  mp4 640x360     29 │ ≈ 24.74MiB   172k https │ avc1.64001E     172k video only
4  mp4 640x360     30 │ ≈ 15.69MiB   109k https │ av01.0.08M.08   109k video only
5  mp4 640x360     30 │ ≈ 19.63MiB   137k https │ hev1.1.6.L120   137k video only
6  mp4 852x480     29 │ ≈ 45.89MiB   319k https │ avc1.64001F     319k video only
7  mp4 852x480     30 │ ≈ 21.06MiB   147k https │ av01.0.08M.08   147k video only
8  mp4 852x480     30 │ ≈ 29.25MiB   204k https │ hev1.1.6.L120   204k video only
9  mp4 1280x720    29 │ ≈ 93.64MiB   652k https │ avc1.640028     652k video only
10 mp4 1280x720    30 │ ≈ 46.98MiB   327k https │ av01.0.08M.08   327k video only
11 mp4 1280x720    30 │ ≈ 49.38MiB   344k https │ hev1.1.6.L120   344k video only
12 mp4 1920x1080   29 │ ≈160.96MiB  1120k https │ avc1.640032    1120k video only
13 mp4 1920x1080   30 │ ≈128.19MiB   892k https │ av01.0.08M.08   892k video only
14 mp4 1920x1080   30 │ ≈100.28MiB   698k https │ hev1.1.6.L150   698k video only
15 mp4 1920x1080   59 │ ≈149.32MiB  1039k https │ hev1.1.6.L150  1039k video only
16 mp4 1920x1080   60 │ ≈146.94MiB  1023k https │ av01.0.09M.08  1023k video only
17 mp4 1920x1080   62 │ ≈510.89MiB  3556k https │ avc1.640032    3556k video only
18 mp4 3840x2160   62 │ ≈  1.95GiB 13921k https │ avc1.640034   13921k video only
19 mp4 3840x2160   62 │ ≈  1.06GiB  7587k https │ hev1.1.6.L153  7587k video only
```

After:
```CMD
>py.exe -m yt_dlp -F https://www.bilibili.com/video/BV1GB4y1J7f2/ --cookies-from-browser chrome

[Cookies] Extracting cookies from chrome 
[Cookies] Extracted 2961 cookies from chrome 
[BiliBili] Extracting URL: https://www.bilibili.com/video/BV1GB4y1J7f2/ 
[BiliBili] 1GB4y1J7f2: Downloading webpage 
[BiliBili] BV1GB4y1J7f2: Extracting videos in anthology
[BiliBili] 603352756: Extracting chapters
[info] Available formats for BV1GB4y1J7f2:
ID    EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC      ABR
─────────────────────────────────────────────────────────────────────────────────────
30216 m4a audio only     │ ≈122.10MiB   67k https │ audio only        mp4a.40.2   67k
30232 m4a audio only     │ ≈241.09MiB  133k https │ audio only        mp4a.40.2  133k
30280 m4a audio only     │ ≈565.11MiB  311k https │ audio only        mp4a.40.2  311k
30016 mp4 640x360     29 │ ≈623.05MiB  343k https │ avc1.64001E  343k video only
30032 mp4 852x480     29 │ ≈954.46MiB  526k https │ avc1.64001F  526k video only
30064 mp4 1280x720    29 │ ≈  1.65GiB  928k https │ avc1.640028  928k video only
30080 mp4 1920x1080   29 │ ≈  3.57GiB 2013k https │ avc1.640032 2013k video only
30112 mp4 1920x1080   29 │ ≈  5.16GiB 2909k https │ avc1.640032 2909k video only


> py.exe -m yt_dlp -F https://www.bilibili.com/video/BV1wN411S7x2/ --cookies-from-browser chrome

[Cookies] Extracting cookies from chrome 
[Cookies] Extracted 2961 cookies from chrome 
[BiliBili] Extracting URL: https://www.bilibili.com/video/BV1wN411S7x2/ 
[BiliBili] 1wN411S7x2: Downloading webpage 
[BiliBili] BV1wN411S7x2: Extracting videos in anthology 
[BiliBili] 487968052: Extracting chapters 
[info] Available formats for BV1wN411S7x2: 
ID     EXT RESOLUTION FPS │   FILESIZE    TBR PROTO │ VCODEC           VBR ACODEC      ABR 
──────────────────────────────────────────────────────────────────────────────────────────
30216  m4a audio only     │ ≈  6.38MiB    44k https │ audio only           mp4a.40.5   44k
30232  m4a audio only     │ ≈ 15.34MiB   107k https │ audio only           mp4a.40.2  107k
30280  m4a audio only     │ ≈ 26.60MiB   185k https │ audio only           mp4a.40.2  185k
30016  mp4 640x360     29 │ ≈ 24.74MiB   172k https │ avc1.64001E     172k video only
100022 mp4 640x360     30 │ ≈ 15.69MiB   109k https │ av01.0.08M.08   109k video only
100109 mp4 640x360     30 │ ≈ 19.63MiB   137k https │ hev1.1.6.L120   137k video only
30032  mp4 852x480     29 │ ≈ 45.89MiB   319k https │ avc1.64001F     319k video only
100023 mp4 852x480     30 │ ≈ 21.06MiB   147k https │ av01.0.08M.08   147k video only
100110 mp4 852x480     30 │ ≈ 29.25MiB   204k https │ hev1.1.6.L120   204k video only
30064  mp4 1280x720    29 │ ≈ 93.64MiB   652k https │ avc1.640028     652k video only
100024 mp4 1280x720    30 │ ≈ 46.98MiB   327k https │ av01.0.08M.08   327k video only
100111 mp4 1280x720    30 │ ≈ 49.38MiB   344k https │ hev1.1.6.L120   344k video only
30080  mp4 1920x1080   29 │ ≈160.96MiB  1120k https │ avc1.640032    1120k video only
100026 mp4 1920x1080   30 │ ≈128.19MiB   892k https │ av01.0.08M.08   892k video only
100113 mp4 1920x1080   30 │ ≈100.28MiB   698k https │ hev1.1.6.L150   698k video only
100144 mp4 1920x1080   59 │ ≈149.32MiB  1039k https │ hev1.1.6.L150  1039k video only
100028 mp4 1920x1080   60 │ ≈146.94MiB  1023k https │ av01.0.09M.08  1023k video only
30116  mp4 1920x1080   62 │ ≈510.89MiB  3556k https │ avc1.640032    3556k video only
100035 mp4 3840x2160   62 │ ≈  1.95GiB 13921k https │ avc1.640034   13921k video only
100036 mp4 3840x2160   62 │ ≈  1.06GiB  7587k https │ hev1.1.6.L153  7587k video only
```



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5065a2a</samp>

### Summary
🆕🔊🎥

<!--
1.  🆕 - This emoji conveys the idea of adding something new, such as a new field or feature.
2.  🔊 - This emoji represents audio, which is one of the formats affected by the change.
3.  🎥 - This emoji represents video, which is the other format affected by the change.
-->
Improve format handling for Bilibili extractor. Add `format_id` fields to `yt_dlp/extractor/bilibili.py` to distinguish audio and video formats.

> _Bilibili formats_
> _`format_id` fields added_
> _Codec, quality cut_

### Walkthrough
* Add `format_id` field to audio and video formats extracted from Bilibili API response ([link](https://github.com/yt-dlp/yt-dlp/pull/7555/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L57-R58), [link](https://github.com/yt-dlp/yt-dlp/pull/7555/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39R72))



</details>
