### PR TITLE
[EmbedThumbnail] Support m4v Extention

### DIFF
--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -114,7 +114,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             self._report_run('ffmpeg', filename)
             self.run_ffmpeg(filename, temp_filename, options)
 
-        elif info['ext'] in ['m4a', 'mp4', 'mov']:
+        elif info['ext'] in ['m4a', 'mp4', 'm4v', 'mov']:
             prefer_atomicparsley = 'embed-thumbnail-atomicparsley' in self.get_param('compat_opts', [])
             # Method 1: Use mutagen
             if not mutagen or prefer_atomicparsley:
@@ -213,7 +213,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             temp_filename = filename
 
         else:
-            raise EmbedThumbnailPPError('Supported filetypes for thumbnail embedding are: mp3, mkv/mka, ogg/opus/flac, m4a/mp4/mov')
+            raise EmbedThumbnailPPError('Supported filetypes for thumbnail embedding are: mp3, mkv/mka, ogg/opus/flac, m4a/mp4/m4v/mov')
 
         if success and temp_filename != filename:
             os.replace(temp_filename, filename)


### PR DESCRIPTION
### Support m4v Extention

Some platforms can serve m4v for mpeg video, this commit simply adds support for embedding thumbnails into m4v files.

Tested with both AtomicParsley and Mutagen. It is possible that m4v files could include DRM, but I don't have any DRM m4v files to test on. The existing error handling should probably be fine in those cases.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1bbf619</samp>

### Summary
🎞️🆕🛠️

<!--
1.  🎞️ - This emoji represents film strips or videos, and can be used to indicate the addition of a new video-related feature or format.
2.  🆕 - This emoji represents something new or updated, and can be used to indicate the support for a new variant of an existing format or the improvement of an error message.
3.  🛠️ - This emoji represents tools or fixing, and can be used to indicate the enhancement of a functionality or the resolution of a bug.
-->
Add thumbnail embedding for `m4v` files and improve error message. This allows users to embed thumbnails in more video formats and get clearer feedback on unsupported ones.

> _Sing, O Muse, of the skillful coder who devised_
> _A way to adorn the `m4v` files with fair thumbnails_
> _Like the cunning Hephaestus who forged the shield of Achilles_
> _With many a splendid image of gods and men in battle._

### Walkthrough
* Add support for embedding thumbnails in m4v files by modifying the file extension check ([link](https://github.com/yt-dlp/yt-dlp/pull/7583/files?diff=unified&w=0#diff-e80ed3bd1dc6da9b03b2f29524eb5989b94e7ecc814543b78b2ba4f1f76578aaL117-R117))
* Update the error message for unsupported filetypes to include m4v ([link](https://github.com/yt-dlp/yt-dlp/pull/7583/files?diff=unified&w=0#diff-e80ed3bd1dc6da9b03b2f29524eb5989b94e7ecc814543b78b2ba4f1f76578aaL216-R216))



</details>
