### PR TITLE
[extractor/antenna] Improvements

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1699,7 +1699,6 @@ from .megatvcom import (
     MegaTVComEmbedIE,
 )
 from .antenna import (
-    AntennaGrWatchIE,
     Ant1NewsGrWatchIE,
     Ant1NewsGrArticleIE,
     Ant1NewsGrEmbedIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1698,7 +1698,8 @@ from .megatvcom import (
     MegaTVComIE,
     MegaTVComEmbedIE,
 )
-from .ant1newsgr import (
+from .antenna import (
+    AntennaGrWatchIE,
     Ant1NewsGrWatchIE,
     Ant1NewsGrArticleIE,
     Ant1NewsGrEmbedIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1699,7 +1699,7 @@ from .megatvcom import (
     MegaTVComEmbedIE,
 )
 from .antenna import (
-    Ant1NewsGrWatchIE,
+    AntennaGrWatchIE,
     Ant1NewsGrArticleIE,
     Ant1NewsGrEmbedIE,
 )

--- a/yt_dlp/extractor/antenna.py
+++ b/yt_dlp/extractor/antenna.py
@@ -31,7 +31,6 @@ class AntennaBaseIE(InfoExtractor):
             'thumbnails': thumbnails,
             'formats': formats,
             'subtitles': subs,
-            '_old_archive_ids': [make_archive_id('Ant1NewsGrWatch', video_id)],
         }
 
 
@@ -68,6 +67,7 @@ class AntennaGrWatchIE(AntennaBaseIE):
         webpage = self._download_webpage(url, video_id)
         info = self._download_and_extract_api_data(video_id, netloc)
         info['description'] = self._og_search_description(webpage, default=None)
+        info['_old_archive_ids'] = [make_archive_id('Ant1NewsGrWatch', video_id)],
         return info
 
 

--- a/yt_dlp/extractor/antenna.py
+++ b/yt_dlp/extractor/antenna.py
@@ -5,6 +5,7 @@ from ..networking import HEADRequest
 from ..utils import (
     ExtractorError,
     determine_ext,
+    make_archive_id,
     scale_thumbnails_to_max_format_width,
 )
 
@@ -30,6 +31,7 @@ class AntennaBaseIE(InfoExtractor):
             'thumbnails': thumbnails,
             'formats': formats,
             'subtitles': subs,
+            '_old_archive_ids': [make_archive_id('Ant1NewsGrWatch', video_id)],
         }
 
 

--- a/yt_dlp/extractor/antenna.py
+++ b/yt_dlp/extractor/antenna.py
@@ -17,8 +17,13 @@ class AntennaBaseIE(InfoExtractor):
             source = info['url']
         except KeyError:
             raise ExtractorError('no source found for %s' % video_id)
-        formats, subs = (self._extract_m3u8_formats_and_subtitles(source, video_id, 'mp4')
-                         if determine_ext(source) == 'm3u8' else ([{'url': source}], {}))
+
+        ext = determine_ext(source)
+        formats = [{'url': source, 'ext': ext, 'format': ext, 'format_id': ext}]
+        subs = {}
+        if ext == 'm3u8':
+            formats, subs = self._extract_m3u8_formats_and_subtitles(source, video_id, 'mp4')
+
         thumbnails = scale_thumbnails_to_max_format_width(
             formats, [{'url': info['thumb']}], r'(?<=/imgHandler/)\d+')
         return {
@@ -30,7 +35,7 @@ class AntennaBaseIE(InfoExtractor):
         }
 
 
-class Ant1NewsGrWatchIE(AntennaBaseIE):
+class AntennaGrWatchIE(AntennaBaseIE):
     IE_NAME = 'antenna:watch'
     IE_DESC = 'antenna.gr and ant1news.gr videos'
     _VALID_URL = r'https?://(?P<netloc>(?:www\.)?(?:antenna|ant1news)\.gr)/watch/(?P<id>\d+)/'
@@ -51,6 +56,8 @@ class Ant1NewsGrWatchIE(AntennaBaseIE):
         'info_dict': {
             'id': '1643812',
             'ext': 'mp4',
+            'format': 'mp4',
+            'format_id': 'mp4',
             'title': 'ΟΙ ΠΡΟΔΟΤΕΣ – ΕΠΕΙΣΟΔΙΟ 01',
             'thumbnail': 'https://ant1media.azureedge.net/imgHandler/1000/b3d63096-e72d-43c4-87a0-00d4363d242f.jpg',
         },

--- a/yt_dlp/extractor/antenna.py
+++ b/yt_dlp/extractor/antenna.py
@@ -41,7 +41,7 @@ class AntennaGrWatchIE(AntennaBaseIE):
 
     _TESTS = [{
         'url': 'https://www.ant1news.gr/watch/1506168/ant1-news-09112021-stis-18-45',
-        'md5': '95925e6b32106754235f2417e0d2dfab',
+        'md5': 'c472d9dd7cd233c63aff2ea42201cda6',
         'info_dict': {
             'id': '1506168',
             'ext': 'mp4',
@@ -51,6 +51,7 @@ class AntennaGrWatchIE(AntennaBaseIE):
         },
     }, {
         'url': 'https://www.antenna.gr/watch/1643812/oi-prodotes-epeisodio-01',
+        'md5': '8f6f7dd3b1dba4d835ba990e25f31243',
         'info_dict': {
             'id': '1643812',
             'ext': 'mp4',


### PR DESCRIPTION
* Rename base extractor as Antenna, as that's the top-level name
* Modernize extractor code, including
  * Avoid `_og_search_description` warning
  * Set `format` to `mp4` (or equivalent, instead of 0)
* Update tests for bigger images
* Support extracting also antenna.gr websites (+ add a test)

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b2d77b</samp>

### Summary
:truck::sparkles::recycle:

<!--
1.  :truck: This emoji represents the renaming and moving of the ant1newsgr.py file to antenna.py. It is often used to indicate file or code relocation or refactoring.
2.  :sparkles: This emoji represents the creation of the new AntennaGrWatchIE class and the AntennaWatchGrBaseIE abstract base class. It is often used to indicate new features or enhancements.
3.  :recycle: This emoji represents the simplification and reuse of the format and subtitle extraction logic. It is often used to indicate code optimization or refactoring.
-->
Renamed and refactored the `ant1newsgr.py` extractor to `antenna.py` to support both ant1news.gr and antenna.gr websites. Added a new extractor class for antenna.gr watch pages and a base class for common logic. Updated the import statement in `_extractors.py`.

> _`ant1newsgr.py`_
> _Renamed to `antenna.py`_
> _Snowflakes of refactor_

### Walkthrough
*  Rename `ant1newsgr.py` to `antenna.py` and update import statement in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1699-R1700))
*  Create abstract base class `AntennaWatchGrBaseIE` with abstract property `_API_PATH` and simplify format and subtitle extraction logic ([link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-f8c6192d7cfbe152927c9da52a805884976ec492ab8d42f1804786b74bd70190R2), [link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-f8c6192d7cfbe152927c9da52a805884976ec492ab8d42f1804786b74bd70190L12-R18), [link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-f8c6192d7cfbe152927c9da52a805884976ec492ab8d42f1804786b74bd70190L20-R31))
*  Modify `Ant1NewsGrWatchIE` to inherit from `AntennaWatchGrBaseIE` and implement `_API_PATH` ([link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-f8c6192d7cfbe152927c9da52a805884976ec492ab8d42f1804786b74bd70190L33-R43))
*  Add new subclass `AntennaGrWatchIE` to handle videos from antenna.gr and provide test case ([link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-f8c6192d7cfbe152927c9da52a805884976ec492ab8d42f1804786b74bd70190L59-R86))
*  Modify `Ant1NewsGrEmbedIE` to inherit from `AntennaWatchGrBaseIE` and implement `_API_PATH` ([link](https://github.com/yt-dlp/yt-dlp/pull/7584/files?diff=unified&w=0#diff-f8c6192d7cfbe152927c9da52a805884976ec492ab8d42f1804786b74bd70190L99-R126))



</details>
