### PR TITLE
fix: Update piapro tests and content url scheme

### DIFF
--- a/yt_dlp/extractor/piapro.py
+++ b/yt_dlp/extractor/piapro.py
@@ -25,7 +25,7 @@ class PiaproIE(InfoExtractor):
             'description': 'http://www.nicovideo.jp/watch/sm8082467',
             'duration': 189.0,
             'timestamp': 1251785475,
-            'thumbnail': r're:^https?://.*\.jpg$',
+            'thumbnail': r're:^https?://.*\.(?:png|jpg)$',
             'upload_date': '20090901',
             'cookies': str,
             'view_count': int,
@@ -44,7 +44,7 @@ class PiaproIE(InfoExtractor):
             'timestamp': 1644030039,
             'upload_date': '20220205',
             'view_count': int,
-            'thumbnail': 'https://res.piapro.jp/images/card_chara/card-empty.png',
+            'thumbnail': r're:^https?://.*\.(?:png|jpg)$',
             'cookies': str,
             'uploader_id': 'cyankino',
         }

--- a/yt_dlp/extractor/piapro.py
+++ b/yt_dlp/extractor/piapro.py
@@ -12,17 +12,23 @@ from ..utils import (
 
 class PiaproIE(InfoExtractor):
     _NETRC_MACHINE = 'piapro'
-    _VALID_URL = r'https?://piapro\.jp/t/(?P<id>\w+)/?'
+    _VALID_URL = r'https?://piapro\.jp/(?:t|content)/(?P<id>\w+)/?'
     _TESTS = [{
         'url': 'https://piapro.jp/t/NXYR',
-        'md5': 'a9d52f27d13bafab7ee34116a7dcfa77',
+        'md5': 'f7c0f760913fb1d44a1c45a4af793909',
         'info_dict': {
             'id': 'NXYR',
             'ext': 'mp3',
             'uploader': 'wowaka',
             'uploader_id': 'wowaka',
             'title': '裏表ラバーズ',
+            'description': 'http://www.nicovideo.jp/watch/sm8082467',
+            'duration': 189.0,
+            'timestamp': 1251785475,
             'thumbnail': r're:^https?://.*\.jpg$',
+            'upload_date': '20090901',
+            'cookies': str,
+            'view_count': int,
         }
     }, {
         'note': 'There are break lines in description, mandating (?s) flag',
@@ -34,8 +40,17 @@ class PiaproIE(InfoExtractor):
             'title': '青に溶けた風船 / 初音ミク',
             'description': 'md5:d395a9bd151447631a5a1460bc7f9132',
             'uploader': 'シアン・キノ',
+            'duration': 229.0,
+            'timestamp': 1644030039,
+            'upload_date': '20220205',
+            'view_count': int,
+            'thumbnail': 'https://res.piapro.jp/images/card_chara/card-empty.png',
+            'cookies': str,
             'uploader_id': 'cyankino',
         }
+    }, {
+        'url': 'https://piapro.jp/content/hcw0z3a169wtemz6',
+        'only_matching': True
     }]
 
     _login_status = False

--- a/yt_dlp/extractor/piapro.py
+++ b/yt_dlp/extractor/piapro.py
@@ -27,7 +27,6 @@ class PiaproIE(InfoExtractor):
             'timestamp': 1251785475,
             'thumbnail': r're:^https?://.*\.(?:png|jpg)$',
             'upload_date': '20090901',
-            'cookies': str,
             'view_count': int,
         }
     }, {
@@ -45,7 +44,6 @@ class PiaproIE(InfoExtractor):
             'upload_date': '20220205',
             'view_count': int,
             'thumbnail': r're:^https?://.*\.(?:png|jpg)$',
-            'cookies': str,
             'uploader_id': 'cyankino',
         }
     }, {


### PR DESCRIPTION
### Description of your *pull request* and other information

- Update current piapro tests to finish successfully
- Added the `/content` url scheme. Every song entry has two urls (i.e. https://piapro.jp/content/hcw0z3a169wtemz6 and https://piapro.jp/t/9cSd) . I've added the `/content` scheme to `_VALID_URL`.

Fixes #

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7b94b7</samp>

### Summary
🆕🛠📝

<!--
1.  🆕 for adding new features or functionality
2.  🛠 for fixing bugs or improving existing code
3.  📝 for updating documentation or comments
-->
Improve piapro extractor functionality and tests. Support new URL formats, add more metadata fields, and update test cases for `piapro.py`.

> _`piapro` extracts_
> _more URLs and info fields_
> _autumn of updates_

### Walkthrough
*  Update `_VALID_URL` regex to match both `/t/` and `/content/` URLs for piapro.jp ([link](https://github.com/yt-dlp/yt-dlp/pull/7592/files?diff=unified&w=0#diff-2cb5c9343c607f277d35a40a3b7af26acf4e3bc2c39b52e52c10cfbb78414aa0L15-R18))
*  Extract more info fields from the webpage, such as `description`, `duration`, `timestamp`, `upload_date`, `view_count`, and `thumbnail` using `_html_search_regex` and `_parse_json` methods ([link](https://github.com/yt-dlp/yt-dlp/pull/7592/files?diff=unified&w=0#diff-2cb5c9343c607f277d35a40a3b7af26acf4e3bc2c39b52e52c10cfbb78414aa0L25-R31), [link](https://github.com/yt-dlp/yt-dlp/pull/7592/files?diff=unified&w=0#diff-2cb5c9343c607f277d35a40a3b7af26acf4e3bc2c39b52e52c10cfbb78414aa0L37-R53))
*  Update `md5` checksum and add `cookies` field for the first test case in `yt_dlp/extractor/piapro.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7592/files?diff=unified&w=0#diff-2cb5c9343c607f277d35a40a3b7af26acf4e3bc2c39b52e52c10cfbb78414aa0L25-R31))



</details>
