### PR TITLE
[extractor/pbskids] Add support for pbskids.org videos

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1417,7 +1417,7 @@ from .patreon import (
     PatreonIE,
     PatreonCampaignIE
 )
-from .pbs import PBSIE
+from .pbs import PBSIE, PBSKidsIE
 from .pearvideo import PearVideoIE
 from .peekvids import PeekVidsIE, PlayVidsIE
 from .peertube import (

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -1,5 +1,4 @@
 import re
-import json
 
 from .common import InfoExtractor
 from ..compat import compat_str

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -747,7 +747,7 @@ class PBSKidsIE(InfoExtractor):
             'subtitles': subtitles,
             **traverse_obj(meta, {
                 'categories': ('video_obj', 'video_type', {str}, {lambda x: [x] if x else None}),
-                'channel': 'show_slug',
+                'channel': ('show_slug', {str}),
                 'description': ('video_obj', 'description', {str}),
                 'duration': ('video_obj', 'duration', {int_or_none}),
                 'series': ('video_obj', 'program_title', {str}),

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -701,7 +701,7 @@ class PBSIE(InfoExtractor):
 
 
 class PBSKidsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?pbskids\.org/video/(?P<channel>[a-zA-Z\-]+)/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?pbskids\.org/video/(?P<channel>[\w-]+)/(?P<id>\d+)'
     _TESTS = [
         {
             'url': 'https://pbskids.org/video/molly-of-denali/3030407927',

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -700,7 +700,7 @@ class PBSIE(InfoExtractor):
 
 
 class PBSKidsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?pbskids\.org/video/(?P<channel>[\w-]+)/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?pbskids\.org/video/[\w-]+/(?P<id>\d+)'
     _TESTS = [
         {
             'url': 'https://pbskids.org/video/molly-of-denali/3030407927',

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -701,7 +701,6 @@ class PBSIE(InfoExtractor):
 
 
 class PBSKidsIE(InfoExtractor):
-    # https://pbskids.org/video/molly-of-denali/3030407927
     _VALID_URL = r'https?://(?:www\.)?pbskids\.org/video/(?P<channel>[a-zA-Z\-]+)/(?P<id>[0-9]+)'
     _TESTS = [
         {

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -737,7 +737,7 @@ class PBSKidsIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        meta = self._search_json(r'window\._PBS_KIDS_DEEPLINK\s*=', webpage, video_id, 'video info')
+        meta = self._search_json(r'window\._PBS_KIDS_DEEPLINK\s*=', webpage, 'video info', video_id)
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
             traverse_obj(meta, ('video_obj', 'URI', {url_or_none})), video_id, ext='mp4')
 

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -737,7 +737,7 @@ class PBSKidsIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        meta = self._search_json(r'window\._PBS_KIDS_DEEPLINK\s*=', webpage, 'video info')
+        meta = self._search_json(r'window\._PBS_KIDS_DEEPLINK\s*=', webpage, video_id, 'video info')
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
             traverse_obj(meta, ('video_obj', 'URI', {url_or_none})), video_id, ext='mp4')
 
@@ -746,7 +746,7 @@ class PBSKidsIE(InfoExtractor):
             'formats': formats,
             'subtitles': subtitles,
             **traverse_obj(meta, {
-                'categories': ('video_obj', 'video_type', {str}, {lambda x: [x]}),
+                'categories': ('video_obj', 'video_type', {str}, {lambda x: [x] if x else None}),
                 'channel': 'show_slug',
                 'description': ('video_obj', 'description', {str}),
                 'duration': ('video_obj', 'duration', {int_or_none}),

--- a/yt_dlp/extractor/pbs.py
+++ b/yt_dlp/extractor/pbs.py
@@ -12,6 +12,7 @@ from ..utils import (
     orderedSet,
     strip_jsonp,
     strip_or_none,
+    traverse_obj,
     unified_strdate,
     url_or_none,
     US_RATINGS,
@@ -739,32 +740,31 @@ class PBSKidsIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
         # Grabbing JSON block linked to window._PBS_KIDS_DEEPLINK
-        # window._PBS_KIDS_DEEPLINK = {"show_slug":"molly-of-denali","video_id":"3030407927","video_obj":{"air_date":"2019-07-18T04:00:00-04:00","duration":1540,"expire_date":"2023-09-01T00:00:59-04:00","id":"3030407927","mezzanine":"https:\/\/image.pbs.org\/video-assets\/uTvFfmP-asset-kids-mezzanine1-16x9-zmxvNsR.jpg","mp4":"https:\/\/kids.video.cdn.pbs.org\/videos\/molly-of-denali\/edf8af19-c5f6-4d0a-b509-e6186ba7bf87\/2000236214\/hd-16x9-mezzanine-1080p\/mden105-ep-mp4-720p-3000k.mp4","title":"Bird in the Hand\/Bye-Bye Birdie","URI":"https:\/\/kids.video.cdn.pbs.org\/videos\/molly-of-denali\/edf8af19-c5f6-4d0a-b509-e6186ba7bf87\/2000236214\/hd-16x9-mezzanine-1080p\/mden105-ep-hls-16x9-720p_063.m3u8","drm":{"hls_uri":null,"hls_mm_profile":null,"fairplay_certificate":null,"fairplay_license":null,"dash_uri":null,"dash_mm_profile":null,"widevine_license":null,"playready_license":null},"video_type":"Episode","description":"Molly and Tooey think they\u2019ve discovered a ghost after a strange noise follows them from Spooky Hose all the way to the Trading Post\u2019s Bunkhouse. \/ Molly and Trini tag along with Nina on trip to Kenai National Park to see real, live puffins!","program_slug":"molly-of-denali","program_nola":"MDEN","program_title":"Molly of Denali"}};</script></body>
-        video_info = json.loads(self._search_regex(r'window\._PBS_KIDS_DEEPLINK = (?P<video_info>\{.*\})', webpage, 'video_info'))
+        meta = json.loads(self._search_regex(r'window\._PBS_KIDS_DEEPLINK = (?P<video_info>\{.*\})', webpage, 'video_info'))
 
-        title = video_info["video_obj"]["title"]
-        m3u8_playlist = video_info["video_obj"]["URI"]
-
-        description = (video_info["video_obj"]["description"])
-        duration = video_info["video_obj"]["duration"]
-        series = video_info["video_obj"]["program_title"]
+        # Extract relevant bits
+        air_date = traverse_obj(meta, ('video_obj', 'air_date'), expected_type=str)
+        channel = meta.get('show_slug')
+        description = traverse_obj(meta, ('video_obj', 'description'), expected_type=str)
+        duration = traverse_obj(meta, ('video_obj', 'duration'), expected_type=int_or_none)
+        m3u8_playlist = traverse_obj(meta, ('video_obj', 'URI'), expected_type=url_or_none)
+        series = traverse_obj(meta, ('video_obj', 'program_title'), expected_type=str)
+        title = traverse_obj(meta, ('video_obj', 'title'), expected_type=str)
         # Differentiate between clips and episodes
-        video_type = video_info["video_obj"]["video_type"]
+        video_type = traverse_obj(meta, ('video_obj', 'video_type'), expected_type=str)
         # expire_date = parse_iso8601(video_info["video_obj"]["expire_date"])
-        air_date = unified_strdate(video_info["video_obj"]["air_date"])
-        channel = video_info["show_slug"]
+        # Parse out formats
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_playlist, video_id, ext='mp4')
 
         return {
-            'id': video_id,
-            'title': title,
-            'description': description,
-            # TODO more properties (see yt_dlp/extractor/common.py)
-            'formats': formats,
-            'subtitles': subtitles,
-            'duration': duration,
-            'series': series,
-            'channel': channel,
-            'upload_date': air_date,
             'categories': [video_type],
+            'channel': channel,
+            'description': description,
+            'duration': duration,
+            'formats': formats,
+            'id': video_id,
+            'series': series,
+            'subtitles': subtitles,
+            'title': title,
+            'upload_date': unified_strdate(air_date),
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds support for videos on the pbskids.org site.  I added it as a second extractor to the existing `extractor/pbs.py`, but if that's not appropriate I can split it out to its own file, it doesn't share any code with the existing extractor.

I think I found all the proper convenience methods, passes flake8

Fixes #2440


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [X] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ec225c9</samp>

### Summary
🚚🧒📊

<!--
1.  🚚 - This emoji can be used to indicate that something was moved or imported from one place to another, such as the `PBSKidsIE` class from `pbs.py` to `_extractors.py`.
2.  🧒 - This emoji can be used to represent the target audience of PBS Kids, which is children, and to show that the new extractor supports videos for kids.
3.  📊 - This emoji can be used to represent the JSON data and the parsing and extraction of video formats and metadata, which are like data analysis tasks.
-->
Added a new extractor for PBS Kids videos. The `PBSKidsIE` class in `pbs.py` handles the JSON data from the PBS Kids website and extracts the video formats and metadata. The class is registered in `_extractors.py` as a supported extractor.

> _To support PBS Kids videos_
> _We imported `json` and `traverse_obj` modules_
> _And created a new class `PBSKidsIE`_
> _That parses the data and extracts the info we need_
> _To download and enjoy the shows_

### Walkthrough
* Add a new extractor class `PBSKidsIE` to handle PBS Kids videos ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R701-R770))
* Import `json` module and `traverse_obj` function to parse and access JSON data embedded in the webpage ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R2), [link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R15))
* Register `PBSKidsIE` as a supported extractor in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1420-R1420))
* Define the URL pattern, test cases, and extraction method for `PBSKidsIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R701-R770))
* Extract various metadata fields from the JSON data, such as title, description, duration, series, categories, upload_date, etc. ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R701-R770))
* Extract the m3u8 playlist URL and call `_extract_m3u8_formats_and_subtitles` to get the available formats and subtitles ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R701-R770))
* Return a dictionary with the extracted information ([link](https://github.com/yt-dlp/yt-dlp/pull/7602/files?diff=unified&w=0#diff-4da747e493d630cb8deb84a4b82fc49bcb0e788f61e0897db6b58c8815b04b77R701-R770))



</details>
