### PR TITLE
[networking/rh] Add strict extension checking

### DIFF
--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -951,8 +951,8 @@ class FakeResponse(Response):
 
 class FakeRH(RequestHandler):
 
-    def validate(self, request):
-        assert isinstance(request, Request)
+    def _validate(self, request):
+        return
 
     def _send(self, request: Request):
         if request.url.startswith('ssl://'):

--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -872,10 +872,10 @@ class TestRequestHandlerValidation:
 
     EXTENSION_TESTS = [
         ('Urllib', [
-            ({'cookiejar': 'notacookiejar'}, TypeError),
+            ({'cookiejar': 'notacookiejar'}, AssertionError),
             ({'cookiejar': CookieJar()}, False),
             ({'timeout': 1}, False),
-            ({'timeout': 'notatimeout'}, TypeError),
+            ({'timeout': 'notatimeout'}, AssertionError),
             ({'unsupported': 'value'}, UnsupportedRequest),
         ]),
         (NoCheckRH, [

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -28,7 +28,7 @@ from ._helper import (
     make_socks_proxy_opts,
     select_proxy,
 )
-from .common import Features, RequestHandler, Response, register
+from .common import Features, RequestHandler, Response, register_rh
 from .exceptions import (
     CertificateVerifyError,
     HTTPError,
@@ -372,7 +372,7 @@ def handle_response_read_exceptions(e):
         raise TransportError(cause=e) from e
 
 
-@register
+@register_rh
 class UrllibRH(RequestHandler, InstanceStoreMixin):
     _SUPPORTED_URL_SCHEMES = ('http', 'https', 'data', 'ftp')
     _SUPPORTED_PROXY_SCHEMES = ('http', 'socks4', 'socks4a', 'socks5', 'socks5h')

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -28,7 +28,7 @@ from ._helper import (
     make_socks_proxy_opts,
     select_proxy,
 )
-from .common import Features, RequestHandler, Response, register_rh
+from .common import Features, RequestHandler, Response, register
 from .exceptions import (
     CertificateVerifyError,
     HTTPError,
@@ -372,7 +372,7 @@ def handle_response_read_exceptions(e):
         raise TransportError(cause=e) from e
 
 
-@register_rh
+@register
 class UrllibRH(RequestHandler, InstanceStoreMixin):
     _SUPPORTED_URL_SCHEMES = ('http', 'https', 'data', 'ftp')
     _SUPPORTED_PROXY_SCHEMES = ('http', 'socks4', 'socks4a', 'socks5', 'socks5h')

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -386,8 +386,9 @@ class UrllibRH(RequestHandler, InstanceStoreMixin):
             self._SUPPORTED_URL_SCHEMES = (*self._SUPPORTED_URL_SCHEMES, 'file')
 
     def _check_extensions(self, extensions):
-        self._check_timeout_extension(extensions)
-        self._check_cookiejar_extension(extensions)
+        super()._check_extensions(extensions)
+        extensions.pop('cookiejar', None)
+        extensions.pop('timeout', None)
 
     def _create_instance(self, proxies, cookiejar):
         opener = urllib.request.OpenerDirector()

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -377,7 +377,6 @@ class UrllibRH(RequestHandler, InstanceStoreMixin):
     _SUPPORTED_URL_SCHEMES = ('http', 'https', 'data', 'ftp')
     _SUPPORTED_PROXY_SCHEMES = ('http', 'socks4', 'socks4a', 'socks5', 'socks5h')
     _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
-    _SUPPORTED_EXTENSIONS = ('cookiejar', 'timeout')
     RH_NAME = 'urllib'
 
     def __init__(self, *, enable_file_urls: bool = False, **kwargs):
@@ -385,6 +384,10 @@ class UrllibRH(RequestHandler, InstanceStoreMixin):
         self.enable_file_urls = enable_file_urls
         if self.enable_file_urls:
             self._SUPPORTED_URL_SCHEMES = (*self._SUPPORTED_URL_SCHEMES, 'file')
+
+    def _check_extensions(self, extensions):
+        self._check_timeout_extension(extensions)
+        self._check_cookiejar_extension(extensions)
 
     def _create_instance(self, proxies, cookiejar):
         opener = urllib.request.OpenerDirector()

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -377,6 +377,7 @@ class UrllibRH(RequestHandler, InstanceStoreMixin):
     _SUPPORTED_URL_SCHEMES = ('http', 'https', 'data', 'ftp')
     _SUPPORTED_PROXY_SCHEMES = ('http', 'socks4', 'socks4a', 'socks5', 'socks5h')
     _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
+    _SUPPORTED_EXTENSIONS = ('cookiejar', 'timeout')
     RH_NAME = 'urllib'
 
     def __init__(self, *, enable_file_urls: bool = False, **kwargs):

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -106,7 +106,7 @@ class RequestDirector:
 _REQUEST_HANDLERS = {}
 
 
-def register_rh(handler):
+def register(handler):
     """Register a RequestHandler class"""
     assert issubclass(handler, RequestHandler), f'{handler} must be a subclass of RequestHandler'
     assert handler.RH_KEY not in _REQUEST_HANDLERS, f'RequestHandler {handler.RH_KEY} already registered'

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -280,7 +280,7 @@ class RequestHandler(abc.ABC):
         extensions = request.extensions.copy()
         self._check_extensions(extensions)
         if extensions:
-            # XXX: add support for optional extensions
+            # TODO(future): add support for optional extensions
             raise UnsupportedRequest(f'Unsupported extensions: {", ".join(extensions.keys())}')
 
     @wrap_request_errors

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -147,6 +147,11 @@ class RequestHandler(abc.ABC):
         a proxy url with an url scheme not in this list will raise an UnsupportedRequest.
 
     - `_SUPPORTED_FEATURES`: a tuple of supported features, as defined in Features enum.
+
+    - `_SUPPORTED_EXTENSIONS`: a tuple of supported request extensions keys. Any Request that contains
+        an extension not in this list will raise an UnsupportedRequest. Extensions that start
+        with an underscore (_) are excluded from this check.
+
     The above may be set to None to disable the checks.
 
     Parameters:
@@ -183,6 +188,7 @@ class RequestHandler(abc.ABC):
     _SUPPORTED_URL_SCHEMES = ()
     _SUPPORTED_PROXY_SCHEMES = ()
     _SUPPORTED_FEATURES = ()
+    _SUPPORTED_EXTENSIONS = ()
 
     def __init__(
         self, *,
@@ -276,6 +282,10 @@ class RequestHandler(abc.ABC):
             raise UnsupportedRequest('timeout is not a float or int')
 
     def _check_extensions(self, extensions):
+        if self._SUPPORTED_EXTENSIONS is not None:
+            for extension in extensions:
+                if extension not in self._SUPPORTED_EXTENSIONS and not extension.startswith('_'):
+                    raise UnsupportedRequest(f'Unsupported request extension: "{extension}"')
         self._check_cookiejar_extension(extensions)
         self._check_timeout_extension(extensions)
 

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -13,7 +13,6 @@ from collections.abc import Iterable, Mapping
 from email.message import Message
 from http import HTTPStatus
 from http.cookiejar import CookieJar
-from types import NoneType
 
 from ._helper import make_ssl_context, wrap_request_errors
 from .exceptions import (
@@ -22,6 +21,7 @@ from .exceptions import (
     TransportError,
     UnsupportedRequest,
 )
+from ..compat.types import NoneType
 from ..utils import (
     bug_reports_message,
     classproperty,

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -21,7 +21,7 @@ from .exceptions import (
     TransportError,
     UnsupportedRequest,
 )
-from ..compat.types import NoneType
+from ..compat import types
 from ..utils import (
     bug_reports_message,
     classproperty,
@@ -272,8 +272,8 @@ class RequestHandler(abc.ABC):
 
     def _check_extensions(self, extensions):
         """Check extensions for unsupported extensions. Subclasses should extend this."""
-        assert isinstance(extensions.get('cookiejar'), (CookieJar, NoneType))
-        assert isinstance(extensions.get('timeout'), (float, int, NoneType))
+        assert isinstance(extensions.get('cookiejar'), (CookieJar, types.NoneType))
+        assert isinstance(extensions.get('timeout'), (float, int, types.NoneType))
 
     @wrap_request_errors
     def validate(self, request: Request):

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -13,7 +13,6 @@ from collections.abc import Iterable, Mapping
 from email.message import Message
 from http import HTTPStatus
 from http.cookiejar import CookieJar
-from types import NoneType
 
 from ._helper import make_ssl_context, wrap_request_errors
 from .exceptions import (
@@ -271,11 +270,11 @@ class RequestHandler(abc.ABC):
                 raise UnsupportedRequest(f'Unsupported proxy type: "{scheme}"')
 
     def _check_timeout_extension(self, extensions):
-        if not isinstance(extensions.pop('timeout', None), (float, int, NoneType)):
+        if not isinstance(extensions.pop('timeout', None), (float, int, type(None))):
             raise TypeError('timeout extension is not a float or int')
 
     def _check_cookiejar_extension(self, extensions):
-        if not isinstance(extensions.pop('cookiejar', None), (CookieJar, NoneType)):
+        if not isinstance(extensions.pop('cookiejar', None), (CookieJar, type(None))):
             raise TypeError('cookiejar extension is not a CookieJar')
 
     def _check_extensions(self, extensions):

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -173,11 +173,11 @@ class RequestHandler(abc.ABC):
     If an extension is supported, subclasses should override _check_extensions(extensions)
     to pop and validate the extension.
     - Extensions left in `extensions` are treated as unsupported and UnsupportedRequest will be raised.
-    - If an extension validation fails due to wrong type passed, TypeError should be raised.
 
     The following extensions are defined for RequestHandler:
-    - `cookiejar`: Cookiejar to use for this request. To enable, use self._check_cookiejar_extension.
-    - `timeout`: socket timeout to use for this request. To enable, use self._check_timeout_extension.
+    - `cookiejar`: Cookiejar to use for this request.
+    - `timeout`: socket timeout to use for this request.
+    To enable these, add extensions.pop('<extension>', None) to _check_extensions
 
     Apart from the url protocol, proxies dict may contain the following keys:
     - `all`: proxy to use for all protocols. Used as a fallback if no proxy is set for a specific protocol.
@@ -269,16 +269,10 @@ class RequestHandler(abc.ABC):
             if scheme not in self._SUPPORTED_PROXY_SCHEMES:
                 raise UnsupportedRequest(f'Unsupported proxy type: "{scheme}"')
 
-    def _check_timeout_extension(self, extensions):
-        if not isinstance(extensions.pop('timeout', None), (float, int, type(None))):
-            raise TypeError('timeout extension is not a float or int')
-
-    def _check_cookiejar_extension(self, extensions):
-        if not isinstance(extensions.pop('cookiejar', None), (CookieJar, type(None))):
-            raise TypeError('cookiejar extension is not a CookieJar')
-
     def _check_extensions(self, extensions):
-        """Check extensions for unsupported extensions. To be implemented by subclasses."""
+        """Check extensions for unsupported extensions. Subclasses should override this."""
+        assert isinstance(extensions.get('cookiejar'), (CookieJar, type(None)))
+        assert isinstance(extensions.get('timeout'), (float, int, type(None)))
 
     def _validate(self, request):
         self._check_url_scheme(request)

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -21,6 +21,7 @@ from .exceptions import (
     TransportError,
     UnsupportedRequest,
 )
+from ..compat.types import NoneType
 from ..utils import (
     bug_reports_message,
     classproperty,
@@ -271,8 +272,8 @@ class RequestHandler(abc.ABC):
 
     def _check_extensions(self, extensions):
         """Check extensions for unsupported extensions. Subclasses should extend this."""
-        assert isinstance(extensions.get('cookiejar'), (CookieJar, type(None)))
-        assert isinstance(extensions.get('timeout'), (float, int, type(None)))
+        assert isinstance(extensions.get('cookiejar'), (CookieJar, NoneType))
+        assert isinstance(extensions.get('timeout'), (float, int, NoneType))
 
     def _validate(self, request):
         self._check_url_scheme(request)


### PR DESCRIPTION
This adds strict checks for extensions in RequestHandlers.

Previously the logic meant any extension received was optional to support. However, this causes issues if an extension is required to be supported for the request.

This PR changes it so RequestHandlers have to specify what extensions they support. If they don't support an extension then the request is marked as unsupported by the handler. This is done through removing extensions from a copy of the extensions dict when checking.

Since the architecture is very new, compat is not a concern yet.

I won't do it as part of this PR, but if we need the support for optional extensions there is lots of ways we can go about adding it if need be, such as :
- extensions starting with underscore
- `__optional__` extension containing list of optional extensions to ignore


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [X] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8265877</samp>

### Summary
🌐🧪🔧

<!--
1.  🌐 - This emoji represents the `urllib` module and the network requests that the `UrllibRH` class handles. It also suggests the global scope of the networking functionality.
2.  🧪 - This emoji represents the testing and refactoring of the extension validation logic in `test_networking.py`. It also suggests the experimental and scientific nature of the tests.
3.  🔧 - This emoji represents the support and processing of request extensions in the `RequestHandler` class and its subclasses. It also suggests the tool-like and customizable nature of the extensions.
-->
This pull request adds support for request extensions to the `RequestHandler` class and its subclasses, which are used to perform network requests in `yt-dlp`. It also refactors the extension validation tests in `test_networking.py` to use a parametrized method.

> _Oh we are the coders of the sea_
> _We write our `RequestHandler`s with glee_
> _We check our extensions on the count of three_
> _And raise an `UnsupportedRequest` if we disagree_

### Walkthrough
*  Add and document `_SUPPORTED_EXTENSIONS` attribute to `RequestHandler` and its subclasses to validate request extensions ([link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78R826), [link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-c7b2bfc3ad326c23db07694e9137f86e58e526681dab17e7680a968a7190e232R380), [link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-ead7fca4af365bb8c89c1a0257a027147d0533eb2e0dfb395d08a9a12e58d4abR150-R154), [link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-ead7fca4af365bb8c89c1a0257a027147d0533eb2e0dfb395d08a9a12e58d4abR191))
*  Implement core extension check in `_check_timeout_extension` method of `RequestHandler` to raise `UnsupportedRequest` exception for unsupported extensions ([link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-ead7fca4af365bb8c89c1a0257a027147d0533eb2e0dfb395d08a9a12e58d4abR285-R288))
*  Refactor and parametrize extension tests in `test_networking.py` using `EXTENSION_TESTS` attribute and `test_extension` method ([link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78R871-R885), [link](https://github.com/yt-dlp/yt-dlp/pull/7604/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L912-R935))



</details>
