### PR TITLE
[rh/urllib] Simplify gzip decoding

### DIFF
--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -154,7 +154,7 @@ class HTTPHandler(urllib.request.AbstractHTTPHandler):
     @staticmethod
     def gz(data):
         # There may be junk added the end of the file
-        # We ignore it by only decoding as much of the data we need
+        # We ignore it by only ever decoding a single gzip payload
         return zlib.decompress(data, wbits=zlib.MAX_WBITS | 16)
 
     def http_request(self, req):

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import gzip
 import http.client
 import io
 import socket
@@ -154,20 +153,9 @@ class HTTPHandler(urllib.request.AbstractHTTPHandler):
 
     @staticmethod
     def gz(data):
-        gz = gzip.GzipFile(fileobj=io.BytesIO(data), mode='rb')
-        try:
-            return gz.read()
-        except OSError as original_oserror:
-            # There may be junk add the end of the file
-            # See http://stackoverflow.com/q/4928560/35070 for details
-            for i in range(1, 1024):
-                try:
-                    gz = gzip.GzipFile(fileobj=io.BytesIO(data[:-i]), mode='rb')
-                    return gz.read()
-                except OSError:
-                    continue
-            else:
-                raise original_oserror
+        # There may be junk added the end of the file
+        # We ignore it by only decoding as much of the data we need
+        return zlib.decompress(data, wbits=zlib.MAX_WBITS | 16)
 
     def http_request(self, req):
         # According to RFC 3986, URLs can not contain non-ASCII characters, however this is not


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR removes the try and fail approach for decoding gzip compressed data. The old way tried to decode it using `GzipFile`, which however failed for trailing data since it tried to decode as a new file.

Instead we can use the `zlib.decompress` method, which will only ever try and decode a single data stream, ignoring the trailing data.

Refs:
- [`gzip.decompress`](https://docs.python.org/3/library/gzip.html#gzip.decompress)
    - When the data is certain to contain only one member the [zlib.decompress()](https://docs.python.org/3/library/zlib.html#zlib.decompress) function with *wbits* set to 31 is faster.
- [`zlib.decompress`](https://docs.python.org/3/library/zlib.html#zlib.decompress)
    - 16 + (8 to 15): Uses the low 4 bits of the value as the window size logarithm. The input must include a gzip header and trailer.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8fa9675</samp>

### Summary
🚀🔧🗜️

<!--
1.  🚀 This emoji conveys the idea of speeding up or improving performance, which is one of the main goals of the change.
2.  🔧 This emoji suggests fixing or tweaking something, which is another aspect of the change, as it simplifies the code and removes an unnecessary dependency.
3.  🗜️ This emoji depicts a compression tool, which is related to the topic of gzip decompression. It could also imply reducing the size or complexity of something, which is another effect of the change.
-->
Improve gzip decompression performance in `yt_dlp.networking._urllib` module. Replace `gzip` module with `zlib` module and simplify `gz` method.

> _Sing, O Muse, of the swift and skillful coder_
> _Who in his wisdom sought to improve the gz method_
> _And with the aid of zlib, the mighty compression tool_
> _He freed the code from gzip, the slow and needless import_

### Walkthrough
*  Simplify the `gz` method to use `zlib` instead of `gzip` for decompressing gzip responses ([link](https://github.com/yt-dlp/yt-dlp/pull/7611/files?diff=unified&w=0#diff-c7b2bfc3ad326c23db07694e9137f86e58e526681dab17e7680a968a7190e232L157-R158))
* Remove unused import of `gzip` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7611/files?diff=unified&w=0#diff-c7b2bfc3ad326c23db07694e9137f86e58e526681dab17e7680a968a7190e232L4))



</details>
