### PR TITLE
[extractor/sohu] Fix for unsupported base64-encoded url

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1787,7 +1787,10 @@ from .slideslive import SlidesLiveIE
 from .slutload import SlutloadIE
 from .smotrim import SmotrimIE
 from .snotr import SnotrIE
-from .sohu import SohuIE
+from .sohu import (
+    SohuIE,
+    SohuVIE,
+)
 from .sonyliv import (
     SonyLIVIE,
     SonyLIVSeriesIE,

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -288,7 +288,5 @@ class SohuVIE(InfoExtractor):
     def _real_extract(self, url):
         encoded_id = self._match_id(url)
         path = base64.urlsafe_b64decode(encoded_id).decode()
-        if re.match(r'\d+/n\d+\.shtml', path):
-            return self.url_result(urljoin('http://tv.sohu.com/', path), SohuIE)
-        else:
-            return self.url_result(urljoin('http://my.tv.sohu.com/', path), SohuIE)
+        subdomain = 'tv' if re.match(r'\d+/n\d+\.shtml', path) else 'my.tv'
+        return self.url_result(urljoin(f'http://{subdomain}.sohu.com/', path), SohuIE)

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -157,6 +157,8 @@ class SohuIE(InfoExtractor):
 
                 data = format_data['data']
                 clip_url = traverse_obj(data, (('clipsURL', 'mp4PlayUrl'), i, {url_or_none}), get_all=False)
+                if not clip_url:
+                    raise ExtractorError(f'Unable to extract url for clip {i}')
                 su = data['su']
 
                 video_url = 'newflv.sohu.ccgslb.net'

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -223,7 +223,7 @@ class SohuIE(InfoExtractor):
 
         if mytv:
             publish_time = unified_timestamp(self._search_regex(
-                r"publishTime: '(\d+-\d+-\d+ \d+:\d+)'", webpage, 'publish time', fatal=False))
+                r'publishTime:\s*["\'](\d+-\d+-\d+ \d+:\d+)["\']', webpage, 'publish time', fatal=False))
         else:
             publish_time = unified_timestamp(traverse_obj(vid_data, ('tv_application_time', {str_or_none})))
 

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -233,7 +233,7 @@ class SohuIE(InfoExtractor):
                 'alt_title': ('data', 'subName', {str_or_none}),
                 'uploader': ('wm_data', 'wm_username', {str_or_none}),
                 'thumbnail': ('data', 'coverImg', {url_or_none}),
-                'tags': ('data', 'tag', {str_or_none}, {lambda i: i.split() if i else None}),
+                'tags': ('data', 'tag', {str.split}),
             }),
             **info,
         }

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -225,7 +225,7 @@ class SohuIE(InfoExtractor):
             publish_time = unified_timestamp(self._search_regex(
                 r'publishTime:\s*["\'](\d+-\d+-\d+ \d+:\d+)["\']', webpage, 'publish time', fatal=False))
         else:
-            publish_time = unified_timestamp(traverse_obj(vid_data, ('tv_application_time', {str_or_none})))
+            publish_time = traverse_obj(vid_data, ('tv_application_time', {unified_timestamp}))
 
         return {
             'timestamp': publish_time - 8 * 3600 if publish_time else None,

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -10,7 +10,6 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     float_or_none,
-    str_or_none,
     url_or_none,
     unified_timestamp,
     try_get,

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -230,8 +230,8 @@ class SohuIE(InfoExtractor):
         return {
             'timestamp': publish_time - 8 * 3600 if publish_time else None,
             **traverse_obj(vid_data, {
-                'alt_title': ('data', 'subName', {str_or_none}),
-                'uploader': ('wm_data', 'wm_username', {str_or_none}),
+                'alt_title': ('data', 'subName', {str}),
+                'uploader': ('wm_data', 'wm_username', {str}),
                 'thumbnail': ('data', 'coverImg', {url_or_none}),
                 'tags': ('data', 'tag', {str.split}),
             }),

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -150,7 +150,7 @@ class SohuIE(InfoExtractor):
                         'prot': 9,
                         'file': clip_url,
                         'new': su[i],
-                        'prod': 'flash',
+                        'prod': 'h5n',
                         'rb': 1,
                     }
 

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -12,6 +12,7 @@ from ..utils import (
     float_or_none,
     str_or_none,
     url_or_none,
+    unified_timestamp,
     try_get,
     urljoin,
     traverse_obj,
@@ -204,7 +205,14 @@ class SohuIE(InfoExtractor):
                 'duration': traverse_obj(vid_data, ('data', 'totalDuration', {float_or_none})),
             }
 
+        if mytv:
+            release_time = unified_timestamp(self._search_regex(
+                r"publishTime: '(\d+-\d+-\d+ \d+:\d+)'", webpage, 'upload time', fatal=False))
+        else:
+            release_time = unified_timestamp(traverse_obj(vid_data, ('tv_application_time', {str_or_none})))
+
         return {
+            'timestamp': release_time - 8 * 3600 if release_time else None,
             **traverse_obj(vid_data, {
                 'uploader': ('wm_data', 'wm_username', {str_or_none}),
                 'thumbnail': ('data', 'coverImg', {url_or_none}),

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -9,6 +9,8 @@ from ..compat import (
 from ..utils import (
     ExtractorError,
     int_or_none,
+    float_or_none,
+    str_or_none,
     url_or_none,
     try_get,
     urljoin,
@@ -106,7 +108,7 @@ class SohuIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id)
 
-        title = re.sub(r' - 搜狐视频$', '', self._og_search_title(webpage))
+        title = re.sub(r'( - 高清正版在线观看)? - 搜狐视频$', '', self._og_search_title(webpage))
 
         vid = self._html_search_regex(
             r'var vid ?= ?["\'](\d+)["\']',
@@ -199,9 +201,18 @@ class SohuIE(InfoExtractor):
                 'entries': playlist,
                 'id': video_id,
                 'title': title,
+                'duration': traverse_obj(vid_data, ('data', 'totalDuration', {float_or_none})),
             }
 
-        return info
+        return {
+            **traverse_obj(vid_data, {
+                'uploader': ('wm_data', 'wm_username', {str_or_none}),
+                'thumbnail': ('data', 'coverImg', {url_or_none}),
+                'alt_title': ('data', 'subName', {str_or_none}),
+                'tags': ('data', 'tag', {str_or_none}, {lambda i: i.split() if i else None}),
+            }),
+            **info,
+        }
 
 
 class SohuVIE(InfoExtractor):
@@ -212,7 +223,7 @@ class SohuVIE(InfoExtractor):
         'url': 'https://tv.sohu.com/v/MjAyMzA2MTQvbjYwMTMxNTE5Mi5zaHRtbA==.html',
         'info_dict': {
             'id': '601315192',
-            'title': '《淬火丹心》第1集 - 高清正版在线观看',
+            'title': '《淬火丹心》第1集',
         },
         'playlist_mincount': 9,
         'skip': 'Only available in China',

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -208,6 +208,15 @@ class SohuVIE(InfoExtractor):
     _VALID_URL = r'https?://tv\.sohu\.com/v/(?P<id>[\w=-]+)\.html(?:$|[#?])'
 
     _TESTS = [{
+        'note': 'Multipart video',
+        'url': 'https://tv.sohu.com/v/MjAyMzA2MTQvbjYwMTMxNTE5Mi5zaHRtbA==.html',
+        'info_dict': {
+            'id': '601315192',
+            'title': '《淬火丹心》第1集 - 高清正版在线观看',
+        },
+        'playlist_mincount': 9,
+        'skip': 'Only available in China',
+    }, {
         'url': 'https://tv.sohu.com/v/dXMvMjMyNzk5ODg5Lzc4NjkzNDY0LnNodG1s.html',
         'info_dict': {
             'id': '78693464',
@@ -215,6 +224,14 @@ class SohuVIE(InfoExtractor):
             'title': '【爱范品】第31期：MWC见不到的奇葩手机',
             'duration': 213,
         }
+    }, {
+        'note': 'Multipart video',
+        'url': 'https://tv.sohu.com/v/dXMvMjQyNTYyMTYzLzc4OTEwMzM5LnNodG1s.html?src=pl',
+        'info_dict': {
+            'id': '78910339',
+            'title': '【神探苍实战秘籍】第13期 战争之影 赫卡里姆',
+        },
+        'playlist_mincount': 3,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -1,3 +1,4 @@
+import base64
 import re
 
 from .common import InfoExtractor
@@ -9,6 +10,7 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     try_get,
+    urljoin,
 )
 
 
@@ -31,13 +33,15 @@ class SohuIE(InfoExtractor):
             'id': '409385080',
             'ext': 'mp4',
             'title': '《2015湖南卫视羊年元宵晚会》唐嫣《花好月圆》',
-        }
+        },
+        'skip': 'no longer available',
     }, {
         'url': 'http://my.tv.sohu.com/us/232799889/78693464.shtml',
         'info_dict': {
             'id': '78693464',
             'ext': 'mp4',
             'title': '【爱范品】第31期：MWC见不到的奇葩手机',
+            'duration': 213,
         }
     }, {
         'note': 'Multipart video',
@@ -196,3 +200,25 @@ class SohuIE(InfoExtractor):
             }
 
         return info
+
+
+class SohuVIE(InfoExtractor):
+    _VALID_URL = r'https?://tv\.sohu\.com/v/(?P<id>[\w=-]+)\.html(?:$|[#?])'
+
+    _TESTS = [{
+        'url': 'https://tv.sohu.com/v/dXMvMjMyNzk5ODg5Lzc4NjkzNDY0LnNodG1s.html',
+        'info_dict': {
+            'id': '78693464',
+            'ext': 'mp4',
+            'title': '【爱范品】第31期：MWC见不到的奇葩手机',
+            'duration': 213,
+        }
+    }]
+
+    def _real_extract(self, url):
+        encoded_id = self._match_id(url)
+        path = base64.urlsafe_b64decode(encoded_id).decode()
+        if re.match(r'\d+/n\d+\.shtml', path):
+            return self.url_result(urljoin('http://tv.sohu.com/', path), SohuIE)
+        else:
+            return self.url_result(urljoin('http://my.tv.sohu.com/', path), SohuIE)

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -9,8 +9,10 @@ from ..compat import (
 from ..utils import (
     ExtractorError,
     int_or_none,
+    url_or_none,
     try_get,
     urljoin,
+    traverse_obj,
 )
 
 
@@ -136,7 +138,7 @@ class SohuIE(InfoExtractor):
                 allot = format_data['allot']
 
                 data = format_data['data']
-                clips_url = data['clipsURL']
+                clip_url = traverse_obj(data, (('clipsURL', 'mp4PlayUrl'), i, {url_or_none}), get_all=False)
                 su = data['su']
 
                 video_url = 'newflv.sohu.ccgslb.net'
@@ -146,7 +148,7 @@ class SohuIE(InfoExtractor):
                 while 'newflv.sohu.ccgslb.net' in video_url:
                     params = {
                         'prot': 9,
-                        'file': clips_url[i],
+                        'file': clip_url,
                         'new': su[i],
                         'prod': 'flash',
                         'rb': 1,

--- a/yt_dlp/extractor/sohu.py
+++ b/yt_dlp/extractor/sohu.py
@@ -46,7 +46,12 @@ class SohuIE(InfoExtractor):
             'id': '78693464',
             'ext': 'mp4',
             'title': '【爱范品】第31期：MWC见不到的奇葩手机',
+            'uploader': '爱范儿视频',
             'duration': 213,
+            'timestamp': 1425519600,
+            'upload_date': '20150305',
+            'thumbnail': 'http://e3f49eaa46b57.cdn.sohucs.com//group1/M10/83/FA/MTAuMTAuODguODA=/6_14cbccdde5eg104SysCutcloud_78693464_7_0b.jpg',
+            'tags': ['爱范儿', '爱范品', 'MWC', '手机'],
         }
     }, {
         'note': 'Multipart video',
@@ -54,6 +59,12 @@ class SohuIE(InfoExtractor):
         'info_dict': {
             'id': '78910339',
             'title': '【神探苍实战秘籍】第13期 战争之影 赫卡里姆',
+            'uploader': '小苍cany',
+            'duration': 744.0,
+            'timestamp': 1426269360,
+            'upload_date': '20150313',
+            'thumbnail': 'http://e3f49eaa46b57.cdn.sohucs.com//group1/M11/89/57/MTAuMTAuODguODA=/6_14cea022a1dg102SysCutcloud_78910339_8_0b.jpg',
+            'tags': ['小苍MM', '英雄联盟', '实战秘籍'],
         },
         'playlist': [{
             'info_dict': {
@@ -84,6 +95,11 @@ class SohuIE(InfoExtractor):
             'id': '78932792',
             'ext': 'mp4',
             'title': 'youtube-dl testing video',
+            'duration': 360,
+            'timestamp': 1426348620,
+            'upload_date': '20150314',
+            'thumbnail': 'http://e3f49eaa46b57.cdn.sohucs.com//group1/M02/8A/00/MTAuMTAuODguNzk=/6_14cee1be192g102SysCutcloud_78932792_7_7b.jpg',
+            'tags': [],
         },
         'params': {
             'skip_download': True
@@ -206,17 +222,17 @@ class SohuIE(InfoExtractor):
             }
 
         if mytv:
-            release_time = unified_timestamp(self._search_regex(
-                r"publishTime: '(\d+-\d+-\d+ \d+:\d+)'", webpage, 'upload time', fatal=False))
+            publish_time = unified_timestamp(self._search_regex(
+                r"publishTime: '(\d+-\d+-\d+ \d+:\d+)'", webpage, 'publish time', fatal=False))
         else:
-            release_time = unified_timestamp(traverse_obj(vid_data, ('tv_application_time', {str_or_none})))
+            publish_time = unified_timestamp(traverse_obj(vid_data, ('tv_application_time', {str_or_none})))
 
         return {
-            'timestamp': release_time - 8 * 3600 if release_time else None,
+            'timestamp': publish_time - 8 * 3600 if publish_time else None,
             **traverse_obj(vid_data, {
+                'alt_title': ('data', 'subName', {str_or_none}),
                 'uploader': ('wm_data', 'wm_username', {str_or_none}),
                 'thumbnail': ('data', 'coverImg', {url_or_none}),
-                'alt_title': ('data', 'subName', {str_or_none}),
                 'tags': ('data', 'tag', {str_or_none}, {lambda i: i.split() if i else None}),
             }),
             **info,
@@ -232,6 +248,11 @@ class SohuVIE(InfoExtractor):
         'info_dict': {
             'id': '601315192',
             'title': '《淬火丹心》第1集',
+            'alt_title': '“点天灯”发生事故',
+            'duration': 2701.692,
+            'timestamp': 1686758040,
+            'upload_date': '20230614',
+            'thumbnail': 'http://photocdn.tv.sohu.com/img/20230614/vrsa_hor_1686738763256_454010551.jpg',
         },
         'playlist_mincount': 9,
         'skip': 'Only available in China',
@@ -241,7 +262,12 @@ class SohuVIE(InfoExtractor):
             'id': '78693464',
             'ext': 'mp4',
             'title': '【爱范品】第31期：MWC见不到的奇葩手机',
+            'uploader': '爱范儿视频',
             'duration': 213,
+            'timestamp': 1425519600,
+            'upload_date': '20150305',
+            'thumbnail': 'http://e3f49eaa46b57.cdn.sohucs.com//group1/M10/83/FA/MTAuMTAuODguODA=/6_14cbccdde5eg104SysCutcloud_78693464_7_0b.jpg',
+            'tags': ['爱范儿', '爱范品', 'MWC', '手机'],
         }
     }, {
         'note': 'Multipart video',
@@ -249,6 +275,12 @@ class SohuVIE(InfoExtractor):
         'info_dict': {
             'id': '78910339',
             'title': '【神探苍实战秘籍】第13期 战争之影 赫卡里姆',
+            'uploader': '小苍cany',
+            'duration': 744.0,
+            'timestamp': 1426269360,
+            'upload_date': '20150313',
+            'thumbnail': 'http://e3f49eaa46b57.cdn.sohucs.com//group1/M11/89/57/MTAuMTAuODguODA=/6_14cea022a1dg102SysCutcloud_78910339_8_0b.jpg',
+            'tags': ['小苍MM', '英雄联盟', '实战秘籍'],
         },
         'playlist_mincount': 3,
     }]


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Applied patch by bashonly for new URL format and fixed URL extraction for multipart video.

Fixes #1667 and #7463


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fcdb87e</samp>

### Summary
🆕🛠️🧪

<!--
1.  🆕 - This emoji conveys the idea of adding a new feature or class to the program, which is the `SohuVIE` extractor that can handle more video formats from Sohu.
2.  🛠️ - This emoji suggests the idea of fixing or improving something, which is the `SohuIE` extractor that can now handle different URL and data structures more robustly.
3.  🧪 - This emoji implies the idea of testing or experimenting, which is the updated and skipped tests for the Sohu extractors.
-->
Add support for more Sohu video formats and improve extraction logic. Create a new `SohuVIE` extractor class and update the existing `SohuIE` class in `sohu.py`. Register the new extractor in `_extractors.py`.

> _Sing, O Muse, of the skillful hackers who devised_
> _A cunning way to fetch the videos of Sohu, the rich and vast_
> _They imported a new class, `SohuVIE`, with parentheses and line_
> _To join the mighty host of extractors in the `_extractors.py` module_

### Walkthrough
*  Add support for a new type of Sohu video URL format ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR205-R243),[link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1790-R1793))
  - Define a new `SohuVIE` class in `sohu.py` that inherits from `InfoExtractor` and matches the new URL pattern ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR205-R243))
  - Implement a `_real_extract` method that decodes the video ID from the URL, validates it, and delegates the extraction to either `SohuIE` or `SohuIE` depending on the path ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR205-R243))
  - Import the new class in `_extractors.py` to register it as an extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1790-R1793))
  - Provide some test cases for the new class in `sohu.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR205-R243))
* Improve the robustness and accuracy of the existing `SohuIE` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL34-R39),[link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR46),[link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL135-R141),[link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL145-R151))
  - Add a `skip` key to the first test case to indicate that the video is no longer available ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL34-R39))
  - Add a `duration` key to the second test case to provide the expected video length ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR46))
  - Modify the extraction of the clip URL from the data dictionary to use the `traverse_obj` function and look for alternative keys ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL135-R141))
  - Update the request parameters to use the extracted clip URL instead of the list of clips ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL145-R151))
* Add some utility functions and modules to the `sohu.py` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR1),[link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL11-R15))
  - Import the `base64` module to decode the video IDs in the new URL format ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dR1))
  - Import the `url_or_none`, `urljoin`, and `traverse_obj` functions from the `utils` module to process the video URLs and metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/7628/files?diff=unified&w=0#diff-0d6925801fe3cc574d3942348fe99b5e7f6dd6c75063fbbf0c8e9ff0df6a912dL11-R15))



</details>
