### PR TITLE
[ie/crunchyroll] Remove initial state scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,7 +1826,6 @@ The following extractors use this feature:
 #### crunchyrollbeta (Crunchyroll)
 * `format`: Which stream type(s) to extract (default: `adaptive_hls`). Potentially useful values include `adaptive_hls`, `adaptive_dash`, `vo_adaptive_hls`, `vo_adaptive_dash`, `download_hls`, `download_dash`, `multitrack_adaptive_hls_v2`
 * `hardsub`: Preference order for which hardsub versions to extract, or `all` (default: `None` = no hardsubs), e.g. `crunchyrollbeta:hardsub=en-US,None`
-* `ua_workaround`: Enables the legacy 403 workaround of passing your browser's User-Agent (with `--user-agent`) and fresh cookies (with `--cookies-from-browser` or `--cookies`)
 
 #### vikichannel
 * `video_types`: Types of videos to download - one or more of `episodes`, `movies`, `clips`, `trailers`

--- a/README.md
+++ b/README.md
@@ -1826,6 +1826,7 @@ The following extractors use this feature:
 #### crunchyrollbeta (Crunchyroll)
 * `format`: Which stream type(s) to extract (default: `adaptive_hls`). Potentially useful values include `adaptive_hls`, `adaptive_dash`, `vo_adaptive_hls`, `vo_adaptive_dash`, `download_hls`, `download_dash`, `multitrack_adaptive_hls_v2`
 * `hardsub`: Preference order for which hardsub versions to extract, or `all` (default: `None` = no hardsubs), e.g. `crunchyrollbeta:hardsub=en-US,None`
+* `ua_workaround`: Enables the legacy 403 workaround of passing your browser's User-Agent (with `--user-agent`) and fresh cookies (with `--cookies-from-browser` or `--cookies`)
 
 #### vikichannel
 * `video_types`: Types of videos to download - one or more of `episodes`, `movies`, `clips`, `trailers`

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -27,11 +27,24 @@ class CrunchyrollBaseIE(InfoExtractor):
     _AUTH_HEADERS = None
     _API_ENDPOINT = None
     _BASIC_AUTH = None
-    _QUERY = {}
+    _CLIENT_ID = ('cr_web', 'noaihdevm_6iyg0a8l0q')
+    _LOCALE_LOOKUP = {
+        'ar': 'ar-SA',
+        'de': 'de-DE',
+        '': 'en-US',
+        'es': 'es-419',
+        'es-es': 'es-ES',
+        'fr': 'fr-FR',
+        'it': 'it-IT',
+        'pt-br': 'pt-BR',
+        'pt-pt': 'pt-PT',
+        'ru': 'ru-RU',
+        'hi': 'hi-IN',
+    }
 
     @property
     def is_logged_in(self):
-        return self._get_cookies(self._BASE_URL).get('etp_rt')
+        return bool(self._get_cookies(self._BASE_URL).get('etp_rt'))
 
     def _perform_login(self, username, password):
         if self.is_logged_in:
@@ -62,31 +75,15 @@ class CrunchyrollBaseIE(InfoExtractor):
         if not self.is_logged_in:
             raise ExtractorError('Login succeeded but did not set etp_rt cookie')
 
-    def _update_query(self, lang):
-        if lang in CrunchyrollBaseIE._QUERY:
-            return
-
-        webpage = self._download_webpage(
-            f'{self._BASE_URL}/{lang}', None, note=f'Retrieving main page (lang={lang or None})')
-
-        initial_state = self._search_json(r'__INITIAL_STATE__\s*=', webpage, 'initial state', None)
-        CrunchyrollBaseIE._QUERY[lang] = traverse_obj(initial_state, {
-            'locale': ('localization', 'locale'),
-        }) or None
-
-        if CrunchyrollBaseIE._BASIC_AUTH:
-            return
-
-        app_config = self._search_json(r'__APP_CONFIG__\s*=', webpage, 'app config', None)
-        cx_api_param = app_config['cxApiParams']['accountAuthClientId' if self.is_logged_in else 'anonClientId']
-        self.write_debug(f'Using cxApiParam={cx_api_param}')
-        CrunchyrollBaseIE._BASIC_AUTH = 'Basic ' + base64.b64encode(f'{cx_api_param}:'.encode()).decode()
-
     def _update_auth(self):
         if CrunchyrollBaseIE._AUTH_HEADERS and CrunchyrollBaseIE._AUTH_REFRESH > time_seconds():
             return
 
-        assert CrunchyrollBaseIE._BASIC_AUTH, '_update_query needs to be called at least one time beforehand'
+        if not CrunchyrollBaseIE._BASIC_AUTH:
+            cx_api_param = self._CLIENT_ID[self.is_logged_in]
+            self.write_debug(f'Using cxApiParam={cx_api_param}')
+            CrunchyrollBaseIE._BASIC_AUTH = 'Basic ' + base64.b64encode(f'{cx_api_param}:'.encode()).decode()
+
         grant_type = 'etp_rt_cookie' if self.is_logged_in else 'client_id'
         auth_response = self._download_json(
             f'{self._BASE_URL}/auth/v1/token', None, note=f'Authenticating with grant_type={grant_type}',
@@ -95,16 +92,24 @@ class CrunchyrollBaseIE(InfoExtractor):
         CrunchyrollBaseIE._AUTH_HEADERS = {'Authorization': auth_response['token_type'] + ' ' + auth_response['access_token']}
         CrunchyrollBaseIE._AUTH_REFRESH = time_seconds(seconds=traverse_obj(auth_response, ('expires_in', {float_or_none}), default=300) - 10)
 
+    def _locale_from_language(self, language):
+        config_locale = self._configuration_arg('metadata', ie_key=CrunchyrollBetaIE, casesense=True)
+        return config_locale[0] if config_locale else self._LOCALE_LOOKUP.get(language)
+
     def _call_base_api(self, endpoint, internal_id, lang, note=None, query={}):
-        self._update_query(lang)
         self._update_auth()
 
         if not endpoint.startswith('/'):
             endpoint = f'/{endpoint}'
 
+        query = query.copy()
+        locale = self._locale_from_language(lang)
+        if locale:
+            query['locale'] = locale
+
         return self._download_json(
             f'{self._BASE_URL}{endpoint}', internal_id, note or f'Calling API: {endpoint}',
-            headers=CrunchyrollBaseIE._AUTH_HEADERS, query={**CrunchyrollBaseIE._QUERY[lang], **query})
+            headers=CrunchyrollBaseIE._AUTH_HEADERS, query=query)
 
     def _call_api(self, path, internal_id, lang, note='api', query={}):
         if not path.startswith(f'/content/v2/{self._API_ENDPOINT}/'):
@@ -206,7 +211,7 @@ class CrunchyrollBetaIE(CrunchyrollCmsBaseIE):
     IE_NAME = 'crunchyroll'
     _VALID_URL = r'''(?x)
         https?://(?:beta\.|www\.)?crunchyroll\.com/
-        (?P<lang>(?:\w{2}(?:-\w{2})?/)?)
+        (?:(?P<lang>\w{2}(?:-\w{2})?)/)?
         watch/(?!concert|musicvideo)(?P<id>\w+)'''
     _TESTS = [{
         # Premium only
@@ -304,7 +309,7 @@ class CrunchyrollBetaIE(CrunchyrollCmsBaseIE):
         },
         'playlist_mincount': 5,
     }, {
-        'url': 'https://www.crunchyroll.com/watch/GY2P1Q98Y',
+        'url': 'https://www.crunchyroll.com/de/watch/GY2P1Q98Y',
         'only_matching': True,
     }, {
         'url': 'https://beta.crunchyroll.com/pt-br/watch/G8WUN8VKP/the-ruler-of-conspiracy',

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -92,8 +92,9 @@ class CrunchyrollBaseIE(InfoExtractor):
         except ExtractorError as error:
             if isinstance(error.cause, HTTPError) and error.cause.status == 403:
                 raise ExtractorError(
-                    'Please open a crunchyroll page in the browser and pass cookies as well as '
-                    'the browsers User-Agent to work around cloudflare blocking', expected=True)
+                    'Request blocked by Cloudflare; navigate to Crunchyroll in your browser, '
+                    'and pass fresh cookies (with --cookies-from-browser or --cookies) '
+                    'as well as your browser\'s User-Agent with --user-agent', expected=True)
             raise
 
         CrunchyrollBaseIE._AUTH_HEADERS = {'Authorization': auth_response['token_type'] + ' ' + auth_response['access_token']}

--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -46,15 +46,6 @@ class CrunchyrollBaseIE(InfoExtractor):
     def is_logged_in(self):
         return bool(self._get_cookies(self._BASE_URL).get('etp_rt'))
 
-    def _initialize_pre_login(self):
-        if self._configuration_arg('ua_workaround', ie_key=CrunchyrollBetaIE):
-            return
-
-        self.cookiejar.clear(domain='.crunchyroll.com', path='/', name='__cf_bm')
-        self.cookiejar.clear(domain='.crunchyroll.com', path='/', name='cf_clearance')
-        self._request_webpage(
-            f'{self._BASE_URL}/robots.txt', None, 'Setting up session', expected_status=403, fatal=False)
-
     def _perform_login(self, username, password):
         if self.is_logged_in:
             return
@@ -99,13 +90,11 @@ class CrunchyrollBaseIE(InfoExtractor):
                 f'{self._BASE_URL}/auth/v1/token', None, note=f'Authenticating with grant_type={grant_type}',
                 headers={'Authorization': CrunchyrollBaseIE._BASIC_AUTH}, data=f'grant_type={grant_type}'.encode())
         except ExtractorError as error:
-            if (isinstance(error.cause, HTTPError) and error.cause.status == 403
-                    and not self._configuration_arg('ua_workaround', ie_key=CrunchyrollBetaIE)):
+            if isinstance(error.cause, HTTPError) and error.cause.status == 403:
                 raise ExtractorError(
                     'Request blocked by Cloudflare; navigate to Crunchyroll in your browser, '
-                    'enable the legacy 403 workaround using  --extractor-arg crunchyrollbeta:ua_workaround , '
-                    'passing your browser\'s User-Agent (with --user-agent) '
-                    'and fresh cookies (with --cookies-from-browser or --cookies)', expected=True)
+                    'then pass the fresh cookies (with --cookies-from-browser or --cookies) '
+                    'and your browser\'s User-Agent (with --user-agent)', expected=True)
             raise
 
         CrunchyrollBaseIE._AUTH_HEADERS = {'Authorization': auth_response['token_type'] + ' ' + auth_response['access_token']}


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR removes the initial state scraping, saving one request. The initial state payload was removed from the webpage, and so we hardcode these values instead.

It also tries to adds a more helpful message for 403 workaround (#7442).

Fixes #7624


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06d280f</samp>

### Summary
🛠️🌐✅

<!--
1.  🛠️ for fixing a regex bug
2.  🌐 for using locale codes and handling Cloudflare errors
3.  ✅ for adding a test case
-->
Improve Crunchyroll extraction by using better API parameters, handling errors, and fixing a bug.

> _`Crunchyroll` extracts_
> _With client IDs, locale_
> _Cloudflare cut off_

### Walkthrough
* Add and use class attributes for client IDs and locale codes ([link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L30-R47), [link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L65-R107), [link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L105-R120))
* Refactor and improve base extractor methods ([link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L65-R107), [link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L105-R120))
* Fix minor bug in beta extractor URL regex ([link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L209-R222))
* Add test case for beta extractor with German language URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7632/files?diff=unified&w=0#diff-e2aa04216cc9a5b0a2e020fa6201e0403ed0a820ba38d084b4da5dac2c10d7f2L307-R320))



</details>
