### PR TITLE
[fd/external] Fix ffmpeg input from stdin

### DIFF
--- a/test/test_downloader_external.py
+++ b/test/test_downloader_external.py
@@ -129,6 +129,11 @@ class TestFFmpegFD(unittest.TestCase):
                 'ffmpeg', '-y', '-hide_banner', '-cookies', 'test=ytdlp; path=/; domain=.example.com;\r\n',
                 '-i', 'http://www.example.com/', '-c', 'copy', '-f', 'mp4', 'file:test'])
 
+            # Test with non-url input (ffmpeg reads from stdin '-' for websockets)
+            downloader._call_downloader('test', {'url': 'x', 'ext': 'mp4'})
+            self.assertEqual(self._args, [
+                'ffmpeg', '-y', '-hide_banner', '-i', 'x', '-c', 'copy', '-f', 'mp4', 'file:test'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -559,12 +559,13 @@ class FFmpegFD(ExternalFD):
 
         selected_formats = info_dict.get('requested_formats') or [info_dict]
         for i, fmt in enumerate(selected_formats):
-            cookies = self.ydl.cookiejar.get_cookies_for_url(fmt['url'])
+            is_http = re.match(r'^https?://', fmt['url'])
+            cookies = self.ydl.cookiejar.get_cookies_for_url(fmt['url']) if is_http else []
             if cookies:
                 args.extend(['-cookies', ''.join(
                     f'{cookie.name}={cookie.value}; path={cookie.path}; domain={cookie.domain};\r\n'
                     for cookie in cookies)])
-            if fmt.get('http_headers') and re.match(r'^https?://', fmt['url']):
+            if fmt.get('http_headers') and is_http:
                 # Trailing \r\n after each HTTP header is important to prevent warning from ffmpeg/avconv:
                 # [http @ 00000000003d2fa0] No trailing CRLF found in HTTP header.
                 args.extend(['-headers', ''.join(f'{key}: {val}\r\n' for key, val in fmt['http_headers'].items())])


### PR DESCRIPTION
The websockets downloader passes `-` to ffmpeg as input, and the new external FD cookies code was throwing

https://github.com/yt-dlp/yt-dlp/blob/42ded0a429c20ec13dc006825e1508d9a02f0ad4/yt_dlp/downloader/websocket.py#L12-L39

thanks to @JC-Chung for discovering the issue and providing this log:
```shell
[debug] Command-line config: ['-v', '-S', 'proto:ws', 'https://twitcasting.tv/msbsqn']
[debug] Encodings: locale cp950, fs utf-8, pref cp950, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.07.06 [b532a3481]
[debug] Lazy loading extractors is disabled
[debug] Python 3.9.6 (CPython AMD64 64bit) - Windows-10-10.0.19042-SP0 (OpenSSL 1.1.1k  25 Mar 2021)
[debug] exe versions: ffmpeg 2023-07-13-git-9a2335444b-full_build-www.gyan.dev (setts), ffprobe 2023-07-13-git-9a2335444b-full_build-www.gyan.dev
[debug] Optional libraries: Cryptodome-3.15.0, brotli-1.0.9, certifi-2022.12.07, mutagen-1.45.1, secretstorage-3.3.3, sqlite3-2.6.0, websockets-10.2
[debug] Proxy map: {}
[debug] Loaded 1857 extractors
[TwitCastingLive] Extracting URL: https://twitcasting.tv/msbsqn
[TwitCastingLive] msbsqn: Downloading webpage
[TwitCastingLive] msbsqn: Downloading live history
[TwitCasting] Extracting URL: https://twitcasting.tv/msbsqn/movie/772480442
[TwitCasting] 772480442: Downloading webpage
[TwitCasting] 772480442: Downloading live info
[TwitCasting] 772480442: Downloading m3u8 information
[TwitCasting] 772480442: Downloading source quality m3u8
[debug] Sort order given by user: proto:ws
[debug] Sort order given by extractor: source
[debug] Formats sorted by: hasvid, ie_pref, proto:ws(2), source, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, vext, aext, hasaud, id
[debug] Default format spec: best/bestvideo+bestaudio
[info] 772480442: Downloading 1 format(s): ws-main
[debug] Invoking web_socket_fragment downloader on "wss://115-69-195-19.twitcasting.tv/tc.edge/v1/streams/772480442.1008.96/fmp4/solid"
[download] Destination: 花声天使🌸 2023-07-21 19_08 [772480442].mp4
ERROR: unknown url type: '-'
Traceback (most recent call last):
  File "site-packages\yt_dlp\YoutubeDL.py", line 1576, in wrapper
    return func(self, *args, **kwargs)
  File "site-packages\yt_dlp\YoutubeDL.py", line 1732, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "site-packages\yt_dlp\YoutubeDL.py", line 1791, in process_ie_result
    ie_result = self.process_video_result(ie_result, download=download)
  File "site-packages\yt_dlp\YoutubeDL.py", line 2930, in process_video_result
    self.process_info(new_info)
  File "site-packages\yt_dlp\YoutubeDL.py", line 3396, in process_info
    success, real_download = self.dl(temp_filename, info_dict)
  File "site-packages\yt_dlp\YoutubeDL.py", line 3117, in dl
    return fd.download(name, new_info, subtitle)
  File "site-packages\yt_dlp\downloader\common.py", line 455, in download
    ret = self.real_download(filename, info_dict)
  File "site-packages\yt_dlp\downloader\websocket.py", line 39, in real_download
    return FFmpegStdinFD(self.ydl, self.params or {}).download(filename, info_copy)
  File "site-packages\yt_dlp\downloader\common.py", line 455, in download
    ret = self.real_download(filename, info_dict)
  File "site-packages\yt_dlp\downloader\external.py", line 50, in real_download
    retval = self._call_downloader(tmpfilename, info_dict)
  File "site-packages\yt_dlp\downloader\external.py", line 562, in _call_downloader
    cookies = self.ydl.cookiejar.get_cookies_for_url(fmt['url'])
  File "site-packages\yt_dlp\cookies.py", line 1320, in get_cookies_for_url
    return self._cookies_for_request(urllib.request.Request(escape_url(sanitize_url(url))))
  File "urllib\request.py", line 320, in __init__
    self.full_url = url
  File "urllib\request.py", line 346, in full_url
    self._parse()
  File "urllib\request.py", line 375, in _parse
    raise ValueError("unknown url type: %r" % self.full_url)
ValueError: unknown url type: '-'
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 35ee7b9</samp>

### Summary
🐛🧪🍪

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It also conveys that the bug was affecting some users and that the fix is important.
2.  🧪 - This emoji represents a test, which is the type of change made to the `test_make_cmd` function. It also conveys that the change is related to quality assurance and code coverage.
3.  🍪 - This emoji represents a cookie, which is the feature that was modified in the `_call_downloader` method. It also conveys that the change is related to web requests and authentication.
-->
Fix a bug where `yt-dlp` would fail to download some websocket streams using `ffmpeg`. Add a test case for `FFmpegFD` and modify its `_call_downloader` method to handle non-http urls correctly.

> _`yt-dlp` fixes_
> _websockets and cookies bugs_
> _autumn stream flows well_

### Walkthrough
* Fix a bug where yt-dlp would fail to download some websocket streams using ffmpeg ([link](https://github.com/yt-dlp/yt-dlp/pull/7655/files?diff=unified&w=0#diff-1a15a7f7535992074feca437a25701776e0ea29e5e9f481bb81cea64552eb21dL132-R137), [link](https://github.com/yt-dlp/yt-dlp/pull/7655/files?diff=unified&w=0#diff-045340cd706a52a49d1614a44d092c244144486fdd4101f4b56ae644ac9fdd04L562-R568))
  - Add a test case to `test_make_cmd` in `test/test_downloader_external.py` to check that non-url inputs are passed directly to ffmpeg ([link](https://github.com/yt-dlp/yt-dlp/pull/7655/files?diff=unified&w=0#diff-1a15a7f7535992074feca437a25701776e0ea29e5e9f481bb81cea64552eb21dL132-R137))
  - Modify `_call_downloader` in `yt_dlp/downloader/external.py` to only get and pass cookies for http or https urls ([link](https://github.com/yt-dlp/yt-dlp/pull/7655/files?diff=unified&w=0#diff-045340cd706a52a49d1614a44d092c244144486fdd4101f4b56ae644ac9fdd04L562-R568))



</details>
