### PR TITLE
[refactor] Refactor cookies.py and _utils.py related to isatty().

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -65,10 +65,9 @@ class YDLLogger(_YDLLogger):
         if not self._ydl or self._ydl.params.get('noprogress') or self._ydl.params.get('logger'):
             return
         file = self._ydl._out_files.error
-        try:
-            if not file.isatty():
-                return
-        except BaseException:
+        if not hasattr(file, "isatty"):
+            return
+        if not file.isatty():
             return
         return self.ProgressBar(file, preserve_output=False)
 

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4698,10 +4698,7 @@ def supports_terminal_sequences(stream):
             return False
     elif not os.getenv('TERM'):
         return False
-    try:
-        return stream.isatty()
-    except BaseException:
-        return False
+    return stream.isatty() if hasattr(stream, "isatty") else False
 
 
 def windows_enable_vt_mode():


### PR DESCRIPTION
…

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Without try-except statements, `hasattr()` will improve speed slightly when no such `isatty()` method exists.

According to [the answer](https://stackoverflow.com/a/50732230/20307768),
Exception `AttributeError: object has no attribute 'isatty'` is related to `isatty()`  may occur when running the method with mocked object or GUI environment(See [here](https://github.com/sphinx-doc/sphinx/issues/159)) which may not have the method.

Because of that, I didn't change any `isatty()` in test files.

It's related to a function or a method called `progress_bar`, `supports_terminal_sequences`. But there is no test in the directory for or related to them. So I didn't run tests.

Related external commits.
1. https://github.com/tornadoweb/tornado/issues/920
2. https://github.com/ytdl-org/youtube-dl/issues/16659
3. https://github.com/sphinx-doc/sphinx/issues/159, https://github.com/sphinx-doc/sphinx/commit/64d2c2c795e9e47474689fbf39ab0afc647a8397

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 76869ff</samp>

### Summary
🐛🚀♻️

<!--
1.  🐛 for bug fix
2.  🚀 for performance improvement
3.  ♻️ for code refactoring
-->
Fix progress bar issue with `--cookies-from-browser` and `StringIO` cookie jar. Refactor and simplify `supports_terminal_sequences` function.

> _`isatty` check_
> _avoids exception in file_
> _progress bar fixed - spring_

### Walkthrough
* Add a check for `isatty` attribute of `file` object to avoid exception when using `--cookies-from-browser` with `StringIO` object ([link](https://github.com/yt-dlp/yt-dlp/pull/7656/files?diff=unified&w=0#diff-c042473d560a04c6fd504c3cb3ae2c9a56a27e42458132a265a3ffda0d60a5c7L68-R71) in `yt_dlp/cookies.py`)



</details>
