### PR TITLE
[ie/PatreonCampaign] Fix extraction

### DIFF
--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -404,8 +404,8 @@ class PatreonCampaignIE(PatreonBaseIE):
             posts_json = self._call_api('posts', campaign_id, query=params, note='Downloading posts page %d' % page)
 
             cursor = traverse_obj(posts_json, ('meta', 'pagination', 'cursors', 'next'))
-            for post in traverse_obj(posts_json, ('data', lambda _, v: v['attributes']['patreon_url'])):
-                yield self.url_result(urljoin('https://www.patreon.com/', post['attributes']['patreon_url']), PatreonIE)
+            for post_url in traverse_obj(posts_json, ('data', ..., 'attributes', 'patreon_url')):
+                yield self.url_result(urljoin('https://www.patreon.com/', post_url), PatreonIE)
 
             if cursor is None:
                 break

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -2,21 +2,21 @@ import itertools
 
 from .common import InfoExtractor
 from .vimeo import VimeoIE
-
 from ..compat import compat_urllib_parse_unquote
 from ..networking.exceptions import HTTPError
 from ..utils import (
+    KNOWN_EXTENSIONS,
+    ExtractorError,
     clean_html,
     determine_ext,
-    ExtractorError,
     int_or_none,
-    KNOWN_EXTENSIONS,
     mimetype2ext,
     parse_iso8601,
     str_or_none,
     traverse_obj,
     try_get,
     url_or_none,
+    urljoin,
 )
 
 
@@ -404,8 +404,8 @@ class PatreonCampaignIE(PatreonBaseIE):
             posts_json = self._call_api('posts', campaign_id, query=params, note='Downloading posts page %d' % page)
 
             cursor = traverse_obj(posts_json, ('meta', 'pagination', 'cursors', 'next'))
-            for post in posts_json.get('data') or []:
-                yield self.url_result(url_or_none(traverse_obj(post, ('attributes', 'patreon_url'))), 'Patreon')
+            for post in traverse_obj(posts_json, ('data', lambda _, v: v['attributes']['patreon_url'])):
+                yield self.url_result(urljoin('https://www.patreon.com/', post['attributes']['patreon_url']), PatreonIE)
 
             if cursor is None:
                 break


### PR DESCRIPTION
`PatreonCampaign._entries()` was yielding `url_result(None, ...)` because of path-only URLs in API response

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9d13b8a</samp>

### Summary
🗂️🔗🧑‍💻

<!--
1.  🗂️ - This emoji can be used to represent sorting imports, as it suggests organizing files or data in a logical way. Alternatively, one could use 📇 (card index) or 📑 (bookmark tabs) for the same purpose.
2.  🔗 - This emoji can be used to represent improving post extraction by using `urljoin` to make post URLs absolute, as it suggests linking or connecting different parts of a web page or a network. Alternatively, one could use 🌐 (globe with meridians) or 🖇️ (linked paperclips) for the same purpose.
3.  🧑‍💻 - This emoji can be used to represent delegating post URLs to `PatreonIE` for more comprehensive extraction, as it suggests coding or programming a solution or a feature. Alternatively, one could use 🤖 (robot) or 💻 (laptop) for the same purpose.
-->
Improve Patreon post extraction and code quality. Use `PatreonIE` to handle post URLs from `patreon.py` and sort imports.

> _To improve `patreon.py`'s extraction_
> _We sorted imports and took action_
> _We used `urljoin` to fix_
> _The post URLs in the mix_
> _And delegated them to `PatreonIE` for satisfaction_

### Walkthrough
* Sort imports alphabetically in `patreon.py` to follow PEP 8 and improve readability ([link](https://github.com/yt-dlp/yt-dlp/pull/7664/files?diff=unified&w=0#diff-43c8ea3c27066a4e6c79e187fe0933e811ab4812d1f3584420f835e401b66af4L5-R12))
* Import `urljoin` function from `urllib.parse` to join relative URLs with base URL in `PatreonCampaignIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/7664/files?diff=unified&w=0#diff-43c8ea3c27066a4e6c79e187fe0933e811ab4812d1f3584420f835e401b66af4R19))
* Modify `_entries` method in `PatreonCampaignIE` extractor to use `urljoin` and `PatreonIE` for each post URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7664/files?diff=unified&w=0#diff-43c8ea3c27066a4e6c79e187fe0933e811ab4812d1f3584420f835e401b66af4L407-R408))



</details>
