### PR TITLE
[ie] Extract subtitles from SMIL manifests

### DIFF
--- a/yt_dlp/extractor/livestream.py
+++ b/yt_dlp/extractor/livestream.py
@@ -81,7 +81,7 @@ class LivestreamIE(InfoExtractor):
     _API_URL_TEMPLATE = 'http://livestream.com/api/accounts/%s/events/%s'
 
     def _parse_smil_formats_and_subtitles(
-            self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None, *, parse_subs=True):
+            self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None):
         base_ele = find_xpath_attr(
             smil, self._xpath_ns('.//meta', namespace), 'name', 'httpBase')
         base = base_ele.get('content') if base_ele is not None else 'http://livestreamvod-f.akamaihd.net/'

--- a/yt_dlp/extractor/livestream.py
+++ b/yt_dlp/extractor/livestream.py
@@ -80,7 +80,8 @@ class LivestreamIE(InfoExtractor):
     }]
     _API_URL_TEMPLATE = 'http://livestream.com/api/accounts/%s/events/%s'
 
-    def _parse_smil_formats(self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None):
+    def _parse_smil_formats_and_subtitles(
+            self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None, *, parse_subs=True):
         base_ele = find_xpath_attr(
             smil, self._xpath_ns('.//meta', namespace), 'name', 'httpBase')
         base = base_ele.get('content') if base_ele is not None else 'http://livestreamvod-f.akamaihd.net/'
@@ -104,7 +105,7 @@ class LivestreamIE(InfoExtractor):
                 'tbr': tbr,
                 'preference': -1000,  # Strictly inferior than all other formats?
             })
-        return formats
+        return formats, {}
 
     def _extract_video_info(self, video_data):
         video_id = compat_str(video_data['id'])

--- a/yt_dlp/extractor/mediaset.py
+++ b/yt_dlp/extractor/mediaset.py
@@ -155,11 +155,11 @@ class MediasetIE(ThePlatformBaseIE):
     }]
 
     def _parse_smil_formats_and_subtitles(
-            self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None, *, parse_subs=True):
+            self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None):
         for video in smil.findall(self._xpath_ns('.//video', namespace)):
             video.attrib['src'] = re.sub(r'(https?://vod05)t(-mediaset-it\.akamaized\.net/.+?.mpd)\?.+', r'\1\2', video.attrib['src'])
         return super(MediasetIE, self)._parse_smil_formats_and_subtitles(
-            smil, smil_url, video_id, namespace, f4m_params, transform_rtmp_url, parse_subs=parse_subs)
+            smil, smil_url, video_id, namespace, f4m_params, transform_rtmp_url)
 
     def _check_drm_formats(self, tp_formats, video_id):
         has_nondrm, drm_manifest = False, ''

--- a/yt_dlp/extractor/mediaset.py
+++ b/yt_dlp/extractor/mediaset.py
@@ -154,10 +154,12 @@ class MediasetIE(ThePlatformBaseIE):
         }
     }]
 
-    def _parse_smil_formats(self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None):
+    def _parse_smil_formats_and_subtitles(
+            self, smil, smil_url, video_id, namespace=None, f4m_params=None, transform_rtmp_url=None, *, parse_subs=True):
         for video in smil.findall(self._xpath_ns('.//video', namespace)):
             video.attrib['src'] = re.sub(r'(https?://vod05)t(-mediaset-it\.akamaized\.net/.+?.mpd)\?.+', r'\1\2', video.attrib['src'])
-        return super(MediasetIE, self)._parse_smil_formats(smil, smil_url, video_id, namespace, f4m_params, transform_rtmp_url)
+        return super(MediasetIE, self)._parse_smil_formats_and_subtitles(
+            smil, smil_url, video_id, namespace, f4m_params, transform_rtmp_url, parse_subs=parse_subs)
 
     def _check_drm_formats(self, tp_formats, video_id):
         has_nondrm, drm_manifest = False, ''

--- a/yt_dlp/extractor/nbc.py
+++ b/yt_dlp/extractor/nbc.py
@@ -131,7 +131,6 @@ class NBCIE(ThePlatformIE):  # XXX: Do not subclass from concrete IE
                 'age_limit': 0,
                 'thumbnail': r're:https?://.+\.jpg',
             },
-            'expected_warnings': ['Ignoring subtitle tracks'],
             'params': {
                 'skip_download': 'm3u8',
             },

--- a/yt_dlp/extractor/theplatform.py
+++ b/yt_dlp/extractor/theplatform.py
@@ -45,7 +45,7 @@ class ThePlatformBaseIE(OnceIE):
                     raise ExtractorError(
                         error_element.attrib['abstract'], expected=True)
 
-        smil_formats, smil_subs = self._parse_smil_formats_and_subtitles(
+        smil_formats, subtitles = self._parse_smil_formats_and_subtitles(
             meta, smil_url, video_id, namespace=default_ns,
             # the parameters are from syfy.com, other sites may use others,
             # they also work for nbc.com
@@ -64,9 +64,6 @@ class ThePlatformBaseIE(OnceIE):
                         _format['url'] = update_url_query(media_url, {'hdnea3': hdnea2.value})
 
                 formats.append(_format)
-
-        subtitles = self._parse_smil_subtitles(meta, default_ns)
-        self._merge_subtitles(smil_subs, target=subtitles)
 
         return formats, subtitles
 

--- a/yt_dlp/extractor/theplatform.py
+++ b/yt_dlp/extractor/theplatform.py
@@ -45,7 +45,7 @@ class ThePlatformBaseIE(OnceIE):
                     raise ExtractorError(
                         error_element.attrib['abstract'], expected=True)
 
-        smil_formats = self._parse_smil_formats(
+        smil_formats, smil_subs = self._parse_smil_formats_and_subtitles(
             meta, smil_url, video_id, namespace=default_ns,
             # the parameters are from syfy.com, other sites may use others,
             # they also work for nbc.com
@@ -66,6 +66,7 @@ class ThePlatformBaseIE(OnceIE):
                 formats.append(_format)
 
         subtitles = self._parse_smil_subtitles(meta, default_ns)
+        self._merge_subtitles(smil_subs, target=subtitles)
 
         return formats, subtitles
 


### PR DESCRIPTION
`_extract_smil_formats_and_subtitles` and `_parse_smil_subtitles` only extract subtitles from the SMIL itself; `_parse_smil_formats` was ignoring all of the HLS/DASH/ISM manifest subtitles

Extractors that are directly impacted by this change:

- **`MediasetIE`**
   - it had redefined `_parse_smil_formats`, so PR needed to adapt it to redefine `_parse_smil_formats_and_subtitles`instead
   
- **`LivestreamIE`**
   - it had redefined `_parse_smil_formats`, so PR needed to adapt it to redefine `_parse_smil_formats_and_subtitles`instead
   
- **`SBSIE`**
   - no fix needed
   
- **`ThePlatformIE`**
   - PR adapts `_extract_theplatform_smil` to use `_parse_smil_formats_and_subtitles` instead of `_parse_smil_formats`
   - **indirectly impacted** are all extractors subclassed from `ThePlatformIE` or any extractor returning `url_result`s to it


Related #7484


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 075e3ce</samp>

### Summary
🎞️🗣️🛠️

<!--
1.  🎞️ This emoji represents the SMIL format, which is a multimedia synchronization language that can be used to describe the temporal and spatial relationships between media objects. It is often used to create interactive presentations or animations. This emoji is relevant for the first, third, and fifth changes, which involve parsing and extracting subtitles from SMIL files.
2. 🗣️ This emoji represents the subtitles or captions that are added to videos to provide additional information or translation for the viewers. It is relevant for all the changes, which enhance the subtitle extraction and merging capabilities of the extractors.
3. 🛠️ This emoji represents the tools or modifications that are made to the code to improve its functionality or performance. It is relevant for the second and fourth changes, which remove or disable some features that are no longer needed or desired.
-->
This pull request improves the subtitle extraction and merging for various `InfoExtractor` subclasses that handle SMIL, M3U8, MPD, and ISM files. It adds a new parameter `extract_subs` to the superclass and overrides or modifies some functions in the subclasses. It also updates the test cases to match the new behavior.

> _`InfoExtractor`_
> _Enhances subtitles in spring_
> _`parse_subs` is new_

### Walkthrough
*  Add a new parameter `extract_subs` to the function `_extract_smil_formats_and_subtitles` in `common.py` to control whether to extract subtitles from SMIL files or not ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2243-R2244))
*  Pass the `extract_subs` parameter to the function `_parse_smil_formats_and_subtitles` and receive the subtitles returned by that function in `common.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2257-R2269))
*  Rename the function `_parse_smil_formats` to `_parse_smil_formats_and_subtitles` in `common.py` to reflect its new functionality ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2329-R2337))
*  Add a new variable `subtitles` to the function `_parse_smil_formats_and_subtitles` in `common.py` to store the subtitles extracted from the SMIL file ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2337-R2345))
*  Use the functions `_extract_m3u8_formats_and_subtitles`, `_extract_mpd_formats_and_subtitles`, and `_extract_ism_formats_and_subtitles` instead of their counterparts without subtitles in `common.py` to enable the extraction and merging of subtitles from M3U8, MPD, and ISM files ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2385-R2397), [link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2407-R2430))
*  Return both the formats and the subtitles extracted from the SMIL file in the function `_parse_smil_formats_and_subtitles` in `common.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2442-R2461))
*  Override the function `_parse_smil_formats_and_subtitles` in `livestream.py` and `mediaset.py` to return an empty dictionary for subtitles, since these subclasses do not extract subtitles from the SMIL file ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-de759949ea8a712263ea95214b4c24064f314128d2bcffbad76eca9e07073560L83-R84), [link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-de759949ea8a712263ea95214b4c24064f314128d2bcffbad76eca9e07073560L107-R108), [link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-b8ea51677c6dbdff3872a4ce0de126407a6f12dc5d4541e32371fb3364765ca5L157-R162))
*  Use the function `_parse_smil_formats_and_subtitles` and merge the subtitles from the SMIL file with the subtitles from the metadata in the function `_extract_theplatform_smil` in `theplatform.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-665418b61f97d16d95c134f49e50b95c175a7b154685876b26f468916710e43aL48-R48), [link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-665418b61f97d16d95c134f49e50b95c175a7b154685876b26f468916710e43aR69))
*  Remove the expected warning `Ignoring subtitle tracks` from the test case of the `NBCIE` class in `nbc.py`, since this subclass no longer ignores subtitles from the SMIL file ([link](https://github.com/yt-dlp/yt-dlp/pull/7667/files?diff=unified&w=0#diff-db8d06cca3b41f67d5615e9bcf4c7f22a052e1d5a408d90a53c6579c7972ff9bL134))



</details>
