### PR TITLE
[ie/triller] Fix unlisted video extraction

### DIFF
--- a/yt_dlp/extractor/triller.py
+++ b/yt_dlp/extractor/triller.py
@@ -282,8 +282,7 @@ class TrillerUserIE(TrillerBaseIE):
             f'{self._API_BASE_URL}/api/users/by_username/{username}',
             username, note='Downloading user info', headers=self._API_HEADERS), ('user', {dict})) or {}
 
-        is_followed = user_info.get('followed_by_me')
-        if user_info.get('private') and not (is_followed == 'true' or is_followed is True):
+        if user_info.get('private') and user_info.get('followed_by_me') not in (True, 'true'):
             raise ExtractorError('This user profile is private', expected=True)
         elif traverse_obj(user_info, (('blocked_by_user', 'blocking_user'), {bool}), get_all=False):
             raise ExtractorError('The author of the video is blocked', expected=True)

--- a/yt_dlp/extractor/triller.py
+++ b/yt_dlp/extractor/triller.py
@@ -66,13 +66,6 @@ class TrillerBaseIE(InfoExtractor):
             'timestamp': ('timestamp', {unified_timestamp}),
         }))
 
-    def _check_user_info(self, user_info):
-        if user_info.get('private') and not user_info.get('followed_by_me'):
-            raise ExtractorError('This video is private', expected=True)
-        elif traverse_obj(user_info, 'blocked_by_user', 'blocking_user'):
-            raise ExtractorError('The author of the video is blocked', expected=True)
-        return user_info
-
     def _parse_video_info(self, video_info, username, user_id, display_id=None):
         video_id = str(video_info['id'])
         display_id = display_id or video_info.get('video_uuid')
@@ -231,8 +224,6 @@ class TrillerIE(TrillerBaseIE):
             f'{self._API_BASE_URL}/api/videos/{display_id}', display_id,
             headers=self._API_HEADERS)['videos'][0]
 
-        self._check_user_info(video_info.get('user') or {})
-
         return self._parse_video_info(video_info, username, None, display_id)
 
 
@@ -287,9 +278,15 @@ class TrillerUserIE(TrillerBaseIE):
     def _real_extract(self, url):
         username = self._match_id(url)
 
-        user_info = self._check_user_info(self._download_json(
+        user_info = traverse_obj(self._download_json(
             f'{self._API_BASE_URL}/api/users/by_username/{username}',
-            username, note='Downloading user info', headers=self._API_HEADERS)['user'])
+            username, note='Downloading user info', headers=self._API_HEADERS), ('user', {dict})) or {}
+
+        is_followed = user_info.get('followed_by_me')
+        if user_info.get('private') and not (is_followed == 'true' or is_followed is True):
+            raise ExtractorError('This user profile is private', expected=True)
+        elif traverse_obj(user_info, (('blocked_by_user', 'blocking_user'), {bool}), get_all=False):
+            raise ExtractorError('The author of the video is blocked', expected=True)
 
         user_id = str_or_none(user_info.get('user_id'))
         if not user_id:


### PR DESCRIPTION
Triller's brilliant API started returning a string (not boolean) value of `"true"`/`"false"` in the `followed_by_me` field, which made the error handling for private profiles useless.

This PR also removes the `private` check from video extraction, since apparently "private" actually means "unlisted", and private videos can be watched/downloaded as long as the video URL is known.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3d55bfe</samp>

### Summary
🔀🛡️🧰

<!--
1.  🔀 - This emoji can be used to indicate that some code was moved or refactored from one place to another, as in this case where the `_check_user_info` method was moved from the base class to the subclasses.
2.  🛡️ - This emoji can be used to indicate that some code was added or improved to enhance the security or privacy of the program, as in this case where the subclasses check the privacy and block status of videos and user profiles before extracting information.
3.  🧰 - This emoji can be used to indicate that some code was simplified or made more robust by using a utility function or a tool, as in this case where the `traverse_obj` function was used to safely access the user info from the API response.
-->
Refactored the Triller extractor to handle privacy and block checks in the specific subclasses. Simplified the user info extraction with `traverse_obj`.

> _Sing, O Muse, of the skillful coder who refined_
> _The Triller extractor, and from the base class removed_
> _The `_check_user_info` method, that no longer suited_
> _The subclasses, where the privacy and block status he proved._

### Walkthrough
*  Remove `_check_user_info` method from `TrillerBaseIE` class, as it is no longer used by subclasses ([link](https://github.com/yt-dlp/yt-dlp/pull/7670/files?diff=unified&w=0#diff-0db44320347e194248da5dcc8063abe5095d0cf3a175c7bf410ebf4f18d46c38L69-L75))
*  Simplify logic for checking user info in `_real_extract` method of `TrillerIE` class, using API response fields directly ([link](https://github.com/yt-dlp/yt-dlp/pull/7670/files?diff=unified&w=0#diff-0db44320347e194248da5dcc8063abe5095d0cf3a175c7bf410ebf4f18d46c38L234-L235))
*  Improve error handling and field parsing in `_real_extract` method of `TrillerUserIE` class, using `traverse_obj` utility function and converting string values to booleans ([link](https://github.com/yt-dlp/yt-dlp/pull/7670/files?diff=unified&w=0#diff-0db44320347e194248da5dcc8063abe5095d0cf3a175c7bf410ebf4f18d46c38L290-R290))



</details>
