### PR TITLE
[test] Fix `ssl_load_certs` tests

### DIFF
--- a/test/test_networking_utils.py
+++ b/test/test_networking_utils.py
@@ -98,7 +98,7 @@ class TestNetworkingUtils:
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         loaded_certifi_certs = False
 
-        # Monkey-Patch SSLContext to confirm it tries to load from certifi.where() location
+        # Monkey-patch SSLContext to confirm it tries to load from certifi.where()
         def load_verify_locations(cafile=None, capath=None, cadata=None):
             assert cafile == certifi.where() or cadata == certifi.contents()
             assert capath is None
@@ -121,7 +121,7 @@ class TestNetworkingUtils:
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         loaded_sys_certs = False
 
-        # set_default_verify_paths() should be called to get default system certs
+        # set_default_verify_paths() should be called to load default OpenSSL certs
         def set_default_verify_paths():
             context._set_default_verify_paths_real()
             nonlocal loaded_sys_certs


### PR DESCRIPTION
Some systems may default openssl certs be the same as certifi

https://github.com/yt-dlp/yt-dlp/commit/227bf1a33be7b89cd7d44ad046844c4ccba104f4#comments

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cae8f5d</samp>

### Summary
🐛🧪🔒

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of the pull request.
2.  🧪 - This emoji represents a test, which is the type of change made to the `test_load_certifi` function and the addition of the `test_load_default_certs` function.
3.  🔒 - This emoji represents security, which is the domain of the `ssl_load_certs` function and the HTTPS requests that depend on it.
-->
Improve tests for `ssl_load_certs` function in `test_networking_utils.py`. Add monkey-patching and a new test case to check certifi and default certificate loading.

> _`ssl_load_certs` -_
> _monkey-patch and test both paths_
> _autumn bug is fixed_

### Walkthrough
* Fix bug where certifi certificates were not loaded correctly on some platforms ([link](https://github.com/yt-dlp/yt-dlp/pull/7675/files?diff=unified&w=0#diff-2f2c7b37cf774a49156e51f008db9c510483e003d128de6e59b09f211a9f28f6L99-R134),   )



</details>
