### PR TITLE
[WebVTT] Allow spaces before newlines for CueBlock

### DIFF
--- a/yt_dlp/webvtt.py
+++ b/yt_dlp/webvtt.py
@@ -95,6 +95,7 @@ _REGEX_TS = re.compile(r'''(?x)
 _REGEX_EOF = re.compile(r'\Z')
 _REGEX_NL = re.compile(r'(?:\r\n|[\r\n]|$)')
 _REGEX_BLANK = re.compile(r'(?:\r\n|[\r\n])+')
+_REGEX_OPTIONAL_WHITESPACE = re.compile(r'[ \t]*')
 
 
 def _parse_ts(ts):
@@ -285,6 +286,7 @@ class CueBlock(Block):
         m1 = parser.consume(_REGEX_TS)
         if not m1:
             return None
+        parser.consume(_REGEX_OPTIONAL_WHITESPACE)
         m2 = parser.consume(cls._REGEX_SETTINGS)
         if not parser.consume(_REGEX_NL):
             return None


### PR DESCRIPTION
### Description

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fixes the `CueBlock` parser for WebVTT to allow optional spaces or tabs in front of the settings list.

See: https://www.w3.org/TR/webvtt1/#webvtt-cue-block

In particular:
> 3. Optionally, one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters followed by a [WebVTT cue settings list](https://www.w3.org/TR/webvtt1/#webvtt-cue-settings-list).

And this part of the WebVTT cue settings list definition:
> A WebVTT cue settings list consist of a sequence of zero or more WebVTT cue settings

This PR came to be when I recently encountered a vtt file that included one space before the newline in the WebVTT cue block, which caused the parser to fail like this:

```
ERROR: Parse error at position 57 (near '1\n00:00:00.634 --> 0')
```

The actual error doesn't occur at position 57 (which is the 1), but rather at position 88 (which is right at the end of the last timestamp) because no newline character can be matched.

https://github.com/yt-dlp/yt-dlp/blob/86aea0d3a213da3be1da638b9b828e6f0ee1d59f/yt_dlp/webvtt.py#L289-L290

Returning null here then causes the `parse_fragment` method to raise the `ParserError` as seen in the error snippet.

https://github.com/yt-dlp/yt-dlp/blob/86aea0d3a213da3be1da638b9b828e6f0ee1d59f/yt_dlp/webvtt.py#L392-L397

Fixes #7453

Replaces #7454, as it doesn't adhere to the WebVTT spec.

---

### Template notes

<details open><summary>Comments about some template items</summary>

I have a few issues with some of the template items, but didn't know where to add my comments, so I'm doing that here:

> - [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

There is another open PR for this (see above), but it doesn't adhere to the WebVTT spec and would break vtt files without a space at the end of the cue timings.

> - [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

Running flake8 results in the following error:
```
yt_dlp/webvtt.py:80:26: BLK100 Black would make changes.
```

This is not code that I changed and can't actually be resolved by running black.
Black changes a few more things in that file and also causes another issue for flake8:

```
yt_dlp/webvtt.py:82:53: E203 whitespace before ':'
```

The code in question was reformatted like that:
```py
class ParseError(Exception):
    def __init__(self, parser):
        super().__init__(
            "Parse error at position %u (near %r)"
            % (parser._pos, parser._data[parser._pos : parser._pos + 20])
        )
``` 

Removing the whitespace after `parser._pos` then causes this flake8 error:
```
yt_dlp/webvtt.py:82:53: BLK100 Black would make changes.
```

No idea what I'm supposed to do here, so I ignored BLK100 instead and completed the flake8 run successfully.

As for the tests, I couldn't find any WebVTT tests to run, so I executed the normal testsuite as explained by the developer instructions.

</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 28ccfe9</samp>

### Summary
🛠️📝🎞️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it could be used to indicate that the changes improve or repair the cue parsing functionality.
2.  📝 - This emoji represents a document or a note, and it could be used to indicate that the changes involve modifying or adding text or regex patterns.
3.  🎞️ - This emoji represents a film strip or a video, and it could be used to indicate that the changes are related to WebVTT cues, which are used for subtitles or captions in video content.
-->
Improve WebVTT cue parsing by using a regex to handle whitespace. This affects the file `yt_dlp/webvtt.py`.

> _Sing, O Muse, of the skillful coder who improved the WebVTT cue parsing_
> _By adding support for optional whitespace, a subtle and cunning task_
> _He wielded the mighty regex, like Hephaestus forging his tools of fire_
> _And matched and consumed the spaces, as a lion devours a hapless stag_

### Walkthrough
* Allow optional whitespace in WebVTT cue blocks by defining a regex for zero or more spaces or tabs ([link](https://github.com/yt-dlp/yt-dlp/pull/7681/files?diff=unified&w=0#diff-17d03f1700281e69bedbd6a9b82f9e59a82b68fbd1c35f84db8cafb020b3a362R98)) and using it to consume any whitespace before parsing the cue components in the `parse` method of the `CueBlock` class ([link](https://github.com/yt-dlp/yt-dlp/pull/7681/files?diff=unified&w=0#diff-17d03f1700281e69bedbd6a9b82f9e59a82b68fbd1c35f84db8cafb020b3a362R289)) in `yt_dlp/webvtt.py`



</details>
