### PR TITLE
Update ffmpeg.py

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -251,7 +251,8 @@ class FFmpegPostProcessor(PostProcessor):
             cmd.append(encodeFilename(self._ffmpeg_filename_argument(path), True))
             self.write_debug(f'{self.basename} command line: {shell_quote(cmd)}')
             stdout, stderr, returncode = Popen.run(
-                cmd, text=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                cmd, text=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, creationflags=subprocess.CREATE_NO_WINDOW)
             if returncode != (0 if self.probe_available else 1):
                 return None
         except OSError:
@@ -292,7 +293,8 @@ class FFmpegPostProcessor(PostProcessor):
         cmd += opts
         cmd.append(self._ffmpeg_filename_argument(path))
         self.write_debug(f'ffprobe command line: {shell_quote(cmd)}')
-        stdout, _, _ = Popen.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        stdout, _, _ = Popen.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 stdin=subprocess.PIPE, creationflags=subprocess.CREATE_NO_WINDOW)
         return json.loads(stdout)
 
     def get_stream_number(self, path, keys, value):
@@ -361,7 +363,8 @@ class FFmpegPostProcessor(PostProcessor):
 
         self.write_debug('ffmpeg command line: %s' % shell_quote(cmd))
         _, stderr, returncode = Popen.run(
-            cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE, creationflags=subprocess.CREATE_NO_WINDOW)
         if returncode not in variadic(expected_retcodes):
             self.write_debug(stderr)
             raise FFmpegPostProcessorError(stderr.strip().splitlines()[-1])


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I created a yt-dlp GUI and I use ffmpeg to convert to audio often, recently I used pyinstaller to make a .exe for this GUI because I want to send it to friends who don't have python in their computers, also I don't like the console that appears with python so I just put the configuration to remove the console on pyinstaller, the program works fine, until it has to convert anything with ffmpeg, then because ffmpeg requires a console to open it the program crashes.

- All of this is on windows, I didn't test on linux or on mac
- This problem only happend to me when I compiled the program to .exe
- I tried this solution and it worked perfectly

Fixes #
Added 'creationflags=subprocess.CREATE_NO_WINDOW' so it doesn't try to create a terminal window, this fixes the crashing.



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9269931</samp>

### Summary
🐛🪟🎞️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the changes. The unwanted windows were a bug that affected the user experience and functionality of the program.
2.  🪟 - This emoji represents a window, which is the element that was affected by the changes. The windows were either suppressed or shown depending on the argument value.
3.  🎞️ - This emoji represents a film strip, which is related to the domain of the program. The program uses ffprobe and ffmpeg to manipulate video and audio files.
-->
Fix unwanted windows bug on Windows by adding an argument to suppress console windows in `ffmpeg.py` postprocessor.

> _When using the ffmpeg postprocessor_
> _Some windows would pop up and bother_
> _So a new argument_
> _Was added and sent_
> _To suppress them with `console_window_handler`_

### Walkthrough
*  Prevent console window from popping up on Windows when running ffprobe or ffmpeg by adding `creationflags=subprocess.CREATE_NO_WINDOW` argument to `Popen.run` calls in `ffmpeg.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7700/files?diff=unified&w=0#diff-3e3643b041e66907c439f5f74aca39c2ba6f86547ad4d05c9b1bd3701ce7fbdbL254-R255), [link](https://github.com/yt-dlp/yt-dlp/pull/7700/files?diff=unified&w=0#diff-3e3643b041e66907c439f5f74aca39c2ba6f86547ad4d05c9b1bd3701ce7fbdbL295-R297), [link](https://github.com/yt-dlp/yt-dlp/pull/7700/files?diff=unified&w=0#diff-3e3643b041e66907c439f5f74aca39c2ba6f86547ad4d05c9b1bd3701ce7fbdbL364-R367))



</details>
