### PR TITLE
[ie/LBRY] Fix original format extraction

### DIFF
--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import re
 import urllib.parse
 
 from .common import InfoExtractor
@@ -246,12 +247,13 @@ class LBRYIE(LBRYBaseIE):
             streaming_url = self._call_api_proxy(
                 'get', claim_id, {'uri': uri}, 'streaming url')['streaming_url']
 
-            # GET request returns original video/audio file if available
+            # GET request to v3 API returns original video/audio file if available
+            direct_url = re.sub(r'/api/v\d+/', '/api/v3/', streaming_url)
             ext = urlhandle_detect_ext(self._request_webpage(
-                streaming_url, display_id, 'Checking for original quality', headers=headers))
+                direct_url, display_id, 'Checking for original quality', headers=headers))
             if ext != 'm3u8':
                 formats.append({
-                    'url': streaming_url,
+                    'url': direct_url,
                     'format_id': 'original',
                     'quality': 1,
                     **traverse_obj(result, ('value', {

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -84,7 +84,7 @@ class LBRYIE(LBRYBaseIE):
     _TESTS = [{
         # Video
         'url': 'https://lbry.tv/@Mantega:1/First-day-LBRY:1',
-        'md5': 'fffd15d76062e9a985c22c7c7f2f4805',
+        'md5': '65bd7ec1f6744ada55da8e4c48a2edf9',
         'info_dict': {
             'id': '17f983b61f53091fb8ea58a9c56804e4ff8cff4d',
             'ext': 'mp4',
@@ -133,9 +133,8 @@ class LBRYIE(LBRYBaseIE):
             'license': 'None',
         }
     }, {
-        # HLS
         'url': 'https://odysee.com/@gardeningincanada:b/plants-i-will-never-grow-again.-the:e',
-        'md5': '25049011f3c8bc2f8b60ad88a031837e',
+        'md5': 'c35fac796f62a14274b4dc2addb5d0ba',
         'info_dict': {
             'id': 'e51671357333fe22ae88aad320bde2f6f96b1410',
             'ext': 'mp4',


### PR DESCRIPTION
The site migrated to v4 of its API and broke our extractor's "original" format extraction. This patch hardcodes the v3 API endpoint for the "original" format URLs, which is the same as the embed link found in the JSON LD block in the webpage.

Addresses https://github.com/yt-dlp/yt-dlp/issues/7251#issuecomment-1650204079


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dcf3973</samp>

### Summary
🆙🎥🛠️

<!--
1.  🆙 - This emoji can signify that the extractor was updated to use a newer version of the API, which is a positive and beneficial change.
2.  🎥 - This emoji can indicate that the extractor deals with video streaming, which is the main feature of the lbry platform and the extractor.
3.  🛠️ - This emoji can suggest that the extractor was fixed and the test checksums were adjusted, which is a maintenance and repair work.
-->
Improved lbry extractor by switching to v3 API and fixing tests.

> _`lbry` is the key to unlock the stream of doom_
> _We defy the old API and embrace the v3_
> _Our test checksums are fixed, no more errors in our way_
> _We download with quality and reliability_

### Walkthrough
* Change the streaming URL to use the v3 API and download the original file if available ([link](https://github.com/yt-dlp/yt-dlp/pull/7711/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8R3), [link](https://github.com/yt-dlp/yt-dlp/pull/7711/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L249-R255))
* Update the md5 checksums of the test videos to match the current files on the server ([link](https://github.com/yt-dlp/yt-dlp/pull/7711/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L86-R87), [link](https://github.com/yt-dlp/yt-dlp/pull/7711/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L135-R137))



</details>
