### PR TITLE
[ie/tiktok] Fix audio-only format extraction

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -206,11 +206,11 @@ class TikTokBaseIE(InfoExtractor):
         known_resolutions = {}
 
         def audio_meta(url):
-            ext = determine_ext(url)
+            ext = determine_ext(url, default_ext='m4a')
             return {
                 'format_note': 'Music track',
-                'ext': 'm4a' if ext != 'mp3' else ext,
-                'acodec': 'aac' if ext != 'mp3' else ext,
+                'ext': ext,
+                'acodec': 'aac' if ext == 'm4a' else ext,
                 'vcodec': 'none',
                 'width': None,
                 'height': None,

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -528,7 +528,7 @@ class TikTokIE(TikTokBaseIE):
             'repost_count': int,
             'comment_count': int,
         },
-        'skip': 'unable to download video data: HTTP Error 403: Forbidden',
+        'params': {'skip_download': True},  # XXX: unable to download video data: HTTP Error 403: Forbidden
     }, {
         # Video without title and description
         'url': 'https://www.tiktok.com/@pokemonlife22/video/7059698374567611694',

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -528,6 +528,7 @@ class TikTokIE(TikTokBaseIE):
             'repost_count': int,
             'comment_count': int,
         },
+        'skip': 'unable to download video data: HTTP Error 403: Forbidden',
     }, {
         # Video without title and description
         'url': 'https://www.tiktok.com/@pokemonlife22/video/7059698374567611694',
@@ -601,7 +602,7 @@ class TikTokIE(TikTokBaseIE):
     }, {
         # only available via web
         'url': 'https://www.tiktok.com/@moxypatch/video/7206382937372134662',
-        'md5': '8d8c0be14127020cd9f5def4a2e6b411',
+        'md5': '6aba7fad816e8709ff2c149679ace165',
         'info_dict': {
             'id': '7206382937372134662',
             'ext': 'mp4',
@@ -638,8 +639,8 @@ class TikTokIE(TikTokBaseIE):
             'uploader_id': '86328792343818240',
             'uploader_url': 'https://www.tiktok.com/@MS4wLjABAAAA-0bQT0CqebTRr6I4IkYvMDMKSRSJHLNPBo5HrSklJwyA2psXLSZG5FP-LMNpHnJd',
             'channel_id': 'MS4wLjABAAAA-0bQT0CqebTRr6I4IkYvMDMKSRSJHLNPBo5HrSklJwyA2psXLSZG5FP-LMNpHnJd',
-            'creator': 't8',
-            'artist': 't8',
+            'creator': 'tate mcrae',
+            'artist': 'tate mcrae',
             'track': 'original sound',
             'upload_date': '20220609',
             'timestamp': 1654805899,
@@ -651,6 +652,31 @@ class TikTokIE(TikTokBaseIE):
             'thumbnail': r're:^https://.+\.webp',
         },
         'params': {'format': 'bytevc1_1080p_808907-0'},
+    }, {
+        # Slideshow, audio-only m4a format
+        'url': 'https://www.tiktok.com/@hara_yoimiya/video/7253412088251534594',
+        'md5': '2ff8fe0174db2dbf49c597a7bef4e47d',
+        'info_dict': {
+            'id': '7253412088251534594',
+            'ext': 'm4a',
+            'title': 'я ред флаг простите #переписка #щитпост #тревожныйтиппривязанности #рекомендации ',
+            'description': 'я ред флаг простите #переписка #щитпост #тревожныйтиппривязанности #рекомендации ',
+            'uploader': 'hara_yoimiya',
+            'uploader_id': '6582536342634676230',
+            'uploader_url': 'https://www.tiktok.com/@MS4wLjABAAAAIAlDxriiPWLE-p8p1R_0Bx8qWKfi-7zwmGhzU8Mv25W8sNxjfIKrol31qTczzuLB',
+            'channel_id': 'MS4wLjABAAAAIAlDxriiPWLE-p8p1R_0Bx8qWKfi-7zwmGhzU8Mv25W8sNxjfIKrol31qTczzuLB',
+            'creator': 'лампочка',
+            'artist': 'Øneheart',
+            'album': 'watching the stars',
+            'track': 'watching the stars',
+            'upload_date': '20230708',
+            'timestamp': 1688816612,
+            'view_count': int,
+            'like_count': int,
+            'comment_count': int,
+            'repost_count': int,
+            'thumbnail': r're:^https://.+\.webp',
+        },
     }, {
         # Auto-captions available
         'url': 'https://www.tiktok.com/@hankgreen1/video/7047596209028074758',

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -205,15 +205,16 @@ class TikTokBaseIE(InfoExtractor):
 
         known_resolutions = {}
 
-        def mp3_meta(url):
+        def audio_meta(url):
+            ext = determine_ext(url)
             return {
                 'format_note': 'Music track',
-                'ext': 'mp3',
-                'acodec': 'mp3',
+                'ext': 'm4a' if ext != 'mp3' else ext,
+                'acodec': 'aac' if ext != 'mp3' else ext,
                 'vcodec': 'none',
                 'width': None,
                 'height': None,
-            } if determine_ext(url) == 'mp3' else {}
+            } if ext == 'mp3' or '-music-' in url else {}
 
         def extract_addr(addr, add_meta={}):
             parsed_meta, res = parse_url_key(addr.get('url_key', ''))
@@ -231,7 +232,7 @@ class TikTokBaseIE(InfoExtractor):
                 **add_meta, **parsed_meta,
                 'format_note': join_nonempty(
                     add_meta.get('format_note'), '(API)' if 'aweme/v1' in url else None, delim=' '),
-                **mp3_meta(url),
+                **audio_meta(url),
             } for url in addr.get('url_list') or []]
 
         # Hack: Add direct video links first to prioritize them when removing duplicate formats


### PR DESCRIPTION
The original patch only fixed slideshows w/ mp3 audio, not m4a formats. mb

Closes #6608


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd4d4b1</samp>

### Summary
🎵🔄🎞️

<!--
1.  🎵 This emoji represents the improvement of the `mp3_meta` function to handle more audio formats and metadata, as well as the update of the test cases to match current TikTok video data. It conveys the idea of music and sound, which are relevant to the audio processing and testing aspects of the changes.
2.  🔄 This emoji represents the renaming of the `mp3_meta` function, which implies a change or update in the code. It also conveys the idea of compatibility and adaptability, which are relevant to the handling of more audio formats and metadata.
3.  🎞️ This emoji represents the addition of a new test case for slideshow videos, which are a type of TikTok video that consists of multiple images with audio. It conveys the idea of video and media, which are relevant to the TikTok platform and the testing aspect of the changes.
-->
Improved TikTok extractor to support more audio formats and metadata, and added tests for slideshow videos. Renamed `mp3_meta` to `audio_meta` in `yt_dlp/extractor/tiktok.py` and updated references.

> _`mp3_meta` grows_
> _more formats and metadata_
> _autumn tests updated_

### Walkthrough
*  Rename and modify `mp3_meta` function to `audio_meta` to support more audio formats and metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/7712/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59L208-R217), [link](https://github.com/yt-dlp/yt-dlp/pull/7712/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59L234-R235))
*  Add `skip` key to test case for unavailable video in `tiktok.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7712/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59R531))
*  Update `md5`, `creator`, `artist` and `track` fields of test case for video with mp3 format in `tiktok.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7712/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59L603-R605), [link](https://github.com/yt-dlp/yt-dlp/pull/7712/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59L640-R643))
*  Add new test case for video with m4a format and slideshow in `tiktok.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7712/files?diff=unified&w=0#diff-74b94c3c4e7ceb887dc0ea639744a410e1782f46b6855856df71cc21b1b87a59R656-R680))



</details>
