### PR TITLE
[ie/PicartoVod] Fix VOD download for picarto.tv

### DIFF
--- a/yt_dlp/extractor/picarto.py
+++ b/yt_dlp/extractor/picarto.py
@@ -107,6 +107,7 @@ class PicartoVodIE(InfoExtractor):
             'title': 'Art of Zod - Drawing and Painting',
             'thumbnail': r're:^https?://.*\.jpg',
             'channel': 'ArtofZod',
+            'age_limit': 18,
         }
     }, {
         'url': 'https://picarto.tv/videopopout/Plague',
@@ -122,6 +123,7 @@ class PicartoVodIE(InfoExtractor):
   video(id: "{video_id}") {{
     id
     title
+    adult
     file_name
     video_recording_image_url
     channel {{
@@ -144,6 +146,7 @@ class PicartoVodIE(InfoExtractor):
                 'title': ('title', {str}),
                 'thumbnail': 'video_recording_image_url',
                 'channel': ('channel', 'name', {str}),
+                'age_limit': ('adult', {lambda x: 18 if x else 0}),
             }),
             'formats': formats,
         }

--- a/yt_dlp/extractor/picarto.py
+++ b/yt_dlp/extractor/picarto.py
@@ -1,8 +1,7 @@
-from .common import InfoExtractor
-from ..utils import (
-    ExtractorError,
-)
 import urllib.parse
+
+from .common import InfoExtractor
+from ..utils import ExtractorError
 
 
 class PicartoIE(InfoExtractor):
@@ -96,9 +95,6 @@ class PicartoVodIE(InfoExtractor):
         },
         'skip': 'The VOD does not exist',
     }, {
-        'url': 'https://picarto.tv/videopopout/Plague',
-        'only_matching': True,
-    }, {
         'url': 'https://picarto.tv/ArtofZod/videos/772650',
         'md5': '00067a0889f1f6869cc512e3e79c521b',
         'info_dict': {
@@ -107,6 +103,9 @@ class PicartoVodIE(InfoExtractor):
             'title': 'govod+golive+ArtofZod_2023.06.12.23.28.30_nsfw.mkv',
             'thumbnail': r're:^https?://.*\.jpg'
         }
+    }, {
+        'url': 'https://picarto.tv/videopopout/Plague',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/picarto.py
+++ b/yt_dlp/extractor/picarto.py
@@ -3,8 +3,8 @@ import urllib.parse
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
-    traverse_obj,
     str_or_none,
+    traverse_obj,
 )
 
 


### PR DESCRIPTION
### Fix download of Picarto VODs

Fix broken Picarto VOD download, and also add regex to make VOD URLs like `https://picarto.tv/nikodart/videos/785794` to be valid. (Previously, they were treated as stream downloads.)

Fixes #2926.

#### Manual testing

```
$ python3 -m yt_dlp https://picarto.tv/nikodart/videos/785794
[PicartoVod] Extracting URL: https://picarto.tv/nikodart/videos/785794
[PicartoVod] 785794: Downloading JSON metadata                                                                                                                                                                                                                                  [PicartoVod] 785794: Downloading m3u8 information
[info] 785794: Downloading 1 format(s): hls-2656
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 1497
[download] Destination: commissions open! [785794].mp4                                                                                                                                                                                                                          [download]   0.0% of ~     0.00B at  378.67KiB/s ETA -1:59:55 (frag 0/1497)
```

Using `videopopout` URL:
```
$ python3 -m yt_dlp https://picarto.tv/videopopout/785794
[PicartoVod] Extracting URL: https://picarto.tv/videopopout/785794
[PicartoVod] 785794: Downloading JSON metadata                                                                                                                                                                                                                                  [PicartoVod] 785794: Downloading m3u8 information
[info] 785794: Downloading 1 format(s): hls-2656
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 1497
[download] Destination: commissions open! [785794].mp4                                                                                                                                                                                                                          [download]   0.0% of ~     0.00B at  408.40KiB/s ETA -1:59:55 (frag 0/1497)
```

Running the tests
```
$ python3 test/test_download.py TestDownload.test_PicartoVod_all                                                                                                                                                                          Skipping PicartoVod: The VOD does not exist                                                                                                                                                                                                                                     Skipped test_PicartoVod                                                                                                                                                                                                                                                         [debug] Loaded 1858 extractors                                                                                                                                                                                                                                                  [PicartoVod] Extracting URL: https://picarto.tv/ArtofZod/videos/772650                                                                                                                                                                                                          [PicartoVod] 772650: Downloading JSON metadata                                                                                                                                                                                                                                  [PicartoVod] 772650: Downloading m3u8 information                                                                                                                                                                                                                               [debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec,                                                                                                                                                             size, br, asr, proto, vext, aext, hasaud, source, id                                                                                                                                                                                                                            [info] 772650: Downloading 1 format(s): hls-2656                                                                                                                                                                                                                                [info] Writing video metadata as JSON to: test_PicartoVod_1_772650.info.json                                                                                                                                                                                                    [debug] Invoking hlsnative downloader on "https://recording-eu-1.picarto.tv/stream/hls/govod+golive+ArtofZod_2023.06                                                                                                                                                            .12.23.28.30_nsfw.mkv/1_0/index.m3u8?sessId=145051379"                                                                                                                                                                                                                          [hlsnative] Downloading m3u8 manifest                                                                                                                                                                                                                                           [hlsnative] Total fragments: 1244                                                                                                                                                                                                                                               [download] Destination: test_PicartoVod_1_772650.mp4
[download] 100% of    2.62MiB in 00:00:05 at 464.48KiB/s                                                                                                                                                                                                                        .                                                                                                                                                                                                                                                                               ----------------------------------------------------------------------                                                                                                                                                                                                          Ran 1 test in 10.245s

OK
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ea5f51</samp>

### Summary
🆕🔧🌐

<!--
1.  🆕 - This emoji signifies that a new feature or functionality was added, such as using a new API endpoint and supporting more VOD URL formats.
2.  🔧 - This emoji signifies that a bug or issue was fixed or improved, such as replacing `js_to_json` with `traverse_obj` for more robust and reliable parsing of JSON data.
3.  🌐 - This emoji signifies that a web-related or network-related component was involved or affected, such as using `urllib.parse` for data manipulation and handling different URL formats.
-->
Improved Picarto extractor by using a new API and handling more VOD URLs. Refactored some code to use `traverse_obj` and `urllib.parse`.

> _The Picarto extractor was old_
> _It needed a new API to hold_
> _So they used `urllib.parse`_
> _And `traverse_obj` was nice_
> _To handle more VODs as they're told_

### Walkthrough
*  Rewrite `_real_extract` method to use a different API endpoint and provide better metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/7727/files?diff=unified&w=0#diff-be325e078b6509e66cb0ce099f90d432f0a804804cd71a9fb51b367a207a0f87L105-R134))
*  Modify `_VALID_URL` regex to match another format of VOD URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/7727/files?diff=unified&w=0#diff-be325e078b6509e66cb0ce099f90d432f0a804804cd71a9fb51b367a207a0f87L87-R88))
*  Add a test case for the new URL format ([link](https://github.com/yt-dlp/yt-dlp/pull/7727/files?diff=unified&w=0#diff-be325e078b6509e66cb0ce099f90d432f0a804804cd71a9fb51b367a207a0f87R101-R103))
*  Replace `js_to_json` import with `traverse_obj` and add `urllib.parse` import ([link](https://github.com/yt-dlp/yt-dlp/pull/7727/files?diff=unified&w=0#diff-be325e078b6509e66cb0ce099f90d432f0a804804cd71a9fb51b367a207a0f87L4-R6))



</details>
