### PR TITLE
[ie/hungama] Overhaul extractors

### DIFF
--- a/yt_dlp/extractor/hungama.py
+++ b/yt_dlp/extractor/hungama.py
@@ -118,7 +118,6 @@ class HungamaSongIE(InfoExtractor):
             'release_year': 2000,
             'thumbnail': 'https://stat2.hungama.ind.in/assets/images/default_images/da-200x200.png',
         },
-        'skip': 'Redirects to main page',
     }, {
         'url': 'https://un.hungama.com/song/tum-kya-mile-from-rocky-aur-rani-kii-prem-kahaani/103553672',
         'md5': '964f46828e8b250aa35e5fdcfdcac367',

--- a/yt_dlp/extractor/hungama.py
+++ b/yt_dlp/extractor/hungama.py
@@ -1,37 +1,65 @@
-import re
-
 from .common import InfoExtractor
 from ..utils import (
     int_or_none,
+    remove_end,
+    traverse_obj,
     try_get,
+    unified_timestamp,
+    url_or_none,
     urlencode_postdata,
 )
 
 
-class HungamaIE(InfoExtractor):
+class HungamaBaseIE(InfoExtractor):
+    def _call_api(self, path, content_id, fatal=False):
+        return traverse_obj(self._download_json(
+            f'https://cpage.api.hungama.com/v2/page/content/{content_id}/{path}/detail',
+            content_id, fatal=fatal, query={
+                'device': 'web',
+                'platform': 'a',
+                'storeId': '1',
+            }), ('data', {dict})) or {}
+
+
+class HungamaIE(HungamaBaseIE):
     _VALID_URL = r'''(?x)
                     https?://
                         (?:www\.|un\.)?hungama\.com/
                         (?:
-                            (?:video|movie)/[^/]+/|
+                            (?:video|movie|short-film)/[^/]+/|
                             tv-show/(?:[^/]+/){2}\d+/episode/[^/]+/
                         )
                         (?P<id>\d+)
                     '''
     _TESTS = [{
-        'url': 'http://un.hungama.com/video/krishna-chants/39349649/',
+        'url': 'http://www.hungama.com/video/krishna-chants/39349649/',
         'md5': '687c5f1e9f832f3b59f44ed0eb1f120a',
         'info_dict': {
             'id': '39349649',
             'ext': 'mp4',
             'title': 'Krishna Chants',
-            'description': 'Watch Krishna Chants video now. You can also watch other latest videos only at Hungama',
+            'description': ' ',
             'upload_date': '20180829',
             'duration': 264,
             'timestamp': 1535500800,
             'view_count': int,
-            'thumbnail': 'https://images.hungama.com/c/1/0dc/2ca/39349649/39349649_700x394.jpg',
-        }
+            'thumbnail': 'https://images1.hungama.com/tr:n-a_169_m/c/1/0dc/2ca/39349649/39349649_350x197.jpg?v=8',
+            'tags': 'count:6',
+        },
+    }, {
+        'url': 'https://un.hungama.com/short-film/adira/102524179/',
+        'md5': '2278463f5dc9db9054d0c02602d44666',
+        'info_dict': {
+            'id': '102524179',
+            'ext': 'mp4',
+            'title': 'Adira',
+            'description': 'md5:df20cd4d41eabb33634f06de1025a4b4',
+            'upload_date': '20230417',
+            'timestamp': 1681689600,
+            'view_count': int,
+            'thumbnail': 'https://images1.hungama.com/tr:n-a_23_m/c/1/197/ac9/102524179/102524179_350x525.jpg?v=1',
+            'tags': 'count:7',
+        },
     }, {
         'url': 'https://www.hungama.com/movie/kahaani-2/44129919/',
         'only_matching': True,
@@ -51,14 +79,19 @@ class HungamaIE(InfoExtractor):
                 'c': 'common',
                 'm': 'get_video_mdn_url',
             })
-
         formats = self._extract_m3u8_formats(video_json['stream_url'], video_id, ext='mp4', m3u8_id='hls')
-
-        json_ld = self._search_json_ld(
-            self._download_webpage(url, video_id, fatal=False) or '', video_id, fatal=False)
+        metadata = self._call_api('movie', video_id)
 
         return {
-            **json_ld,
+            **traverse_obj(metadata, ('head', 'data', {
+                'title': ('title', {str}),
+                'description': ('misc', 'description', {str}),
+                'duration': ('duration', {int}),  # duration in JSON is incorrect if string
+                'timestamp': ('releasedate', {unified_timestamp}),
+                'view_count': ('misc', 'playcount', {int_or_none}),
+                'thumbnail': ('image', {url_or_none}),
+                'tags': ('misc', 'keywords', ..., {str}),
+            })),
             'id': video_id,
             'formats': formats,
             'subtitles': {
@@ -72,9 +105,9 @@ class HungamaIE(InfoExtractor):
 
 class HungamaSongIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.|un\.)?hungama\.com/song/[^/]+/(?P<id>\d+)'
-    _TEST = {
-        'url': 'https://un.hungama.com/song/kitni-haseen-zindagi/2931166/',
-        'md5': 'd4a6a05a394ad0453a9bea3ca00e6024',
+    _TESTS = [{
+        'url': 'https://www.hungama.com/song/kitni-haseen-zindagi/2931166/',
+        'md5': '964f46828e8b250aa35e5fdcfdcac367',
         'info_dict': {
             'id': '2931166',
             'ext': 'mp3',
@@ -83,8 +116,23 @@ class HungamaSongIE(InfoExtractor):
             'artist': 'Lucky Ali',
             'album': None,
             'release_year': 2000,
-        }
-    }
+            'thumbnail': 'https://stat2.hungama.ind.in/assets/images/default_images/da-200x200.png',
+        },
+        'skip': 'Redirects to main page',
+    }, {
+        'url': 'https://un.hungama.com/song/tum-kya-mile-from-rocky-aur-rani-kii-prem-kahaani/103553672',
+        'md5': '964f46828e8b250aa35e5fdcfdcac367',
+        'info_dict': {
+            'id': '103553672',
+            'ext': 'mp3',
+            'title': 'md5:5ebeb1e10771b634ce5f700ce68ae5f4',
+            'track': 'Tum Kya Mile (From "Rocky Aur Rani Kii Prem Kahaani")',
+            'artist': 'Pritam Chakraborty, Arijit Singh, Shreya Ghoshal, Amitabh Bhattacharya',
+            'album': 'Tum Kya Mile (From "Rocky Aur Rani Kii Prem Kahaani")',
+            'release_year': 2023,
+            'thumbnail': 'https://images.hungama.com/c/1/7c2/c7b/103553671/103553671_200x200.jpg',
+        },
+    }]
 
     def _real_extract(self, url):
         audio_id = self._match_id(url)
@@ -122,26 +170,34 @@ class HungamaSongIE(InfoExtractor):
         }
 
 
-class HungamaAlbumPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.|un\.)?hungama\.com/(?:playlists|album)/[^/]+/(?P<id>\d+)'
+class HungamaAlbumPlaylistIE(HungamaBaseIE):
+    _VALID_URL = r'https?://(?:www\.|un\.)?hungama\.com/(?P<path>playlists|album)/[^/]+/(?P<id>\d+)'
     _TESTS = [{
-        'url': 'https://un.hungama.com/album/bhuj-the-pride-of-india/69481490/',
+        'url': 'https://www.hungama.com/album/bhuj-the-pride-of-india/69481490/',
         'playlist_mincount': 7,
         'info_dict': {
             'id': '69481490',
         },
     }, {
         'url': 'https://www.hungama.com/playlists/hindi-jan-to-june-2021/123063/',
-        'playlist_mincount': 50,
+        'playlist_mincount': 33,
         'info_dict': {
             'id': '123063',
+        },
+    }, {
+        'url': 'https://un.hungama.com/album/what-jhumka-%3F-from-rocky-aur-rani-kii-prem-kahaani/103891805/',
+        'playlist_mincount': 1,
+        'info_dict': {
+            'id': '103891805',
         },
     }]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id)
-        ptrn = r'<meta[^>]+?property=[\"\']?music:song:url[\"\']?[^>]+?content=[\"\']?([^\"\']+)'
-        items = re.findall(ptrn, webpage)
-        entries = [self.url_result(item, ie=HungamaSongIE.ie_key()) for item in items]
-        return self.playlist_result(entries, video_id)
+        playlist_id, path = self._match_valid_url(url).group('id', 'path')
+        data = self._call_api(remove_end(path, 's'), playlist_id, fatal=True)
+
+        def entries():
+            for song_url in traverse_obj(data, ('body', 'rows', ..., 'data', 'misc', 'share', {url_or_none})):
+                yield self.url_result(song_url, HungamaSongIE)
+
+        return self.playlist_result(entries(), playlist_id)

--- a/yt_dlp/extractor/hungama.py
+++ b/yt_dlp/extractor/hungama.py
@@ -11,7 +11,7 @@ from ..utils import (
 class HungamaIE(InfoExtractor):
     _VALID_URL = r'''(?x)
                     https?://
-                        (?:www\.)?hungama\.com/
+                        (?:www\.|un\.)?hungama\.com/
                         (?:
                             (?:video|movie)/[^/]+/|
                             tv-show/(?:[^/]+/){2}\d+/episode/[^/]+/
@@ -19,7 +19,7 @@ class HungamaIE(InfoExtractor):
                         (?P<id>\d+)
                     '''
     _TESTS = [{
-        'url': 'http://www.hungama.com/video/krishna-chants/39349649/',
+        'url': 'http://un.hungama.com/video/krishna-chants/39349649/',
         'md5': '687c5f1e9f832f3b59f44ed0eb1f120a',
         'info_dict': {
             'id': '39349649',
@@ -71,9 +71,9 @@ class HungamaIE(InfoExtractor):
 
 
 class HungamaSongIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?hungama\.com/song/[^/]+/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.|un\.)?hungama\.com/song/[^/]+/(?P<id>\d+)'
     _TEST = {
-        'url': 'https://www.hungama.com/song/kitni-haseen-zindagi/2931166/',
+        'url': 'https://un.hungama.com/song/kitni-haseen-zindagi/2931166/',
         'md5': 'd4a6a05a394ad0453a9bea3ca00e6024',
         'info_dict': {
             'id': '2931166',
@@ -123,9 +123,9 @@ class HungamaSongIE(InfoExtractor):
 
 
 class HungamaAlbumPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?hungama\.com/(?:playlists|album)/[^/]+/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.|un\.)?hungama\.com/(?:playlists|album)/[^/]+/(?P<id>\d+)'
     _TESTS = [{
-        'url': 'https://www.hungama.com/album/bhuj-the-pride-of-india/69481490/',
+        'url': 'https://un.hungama.com/album/bhuj-the-pride-of-india/69481490/',
         'playlist_mincount': 7,
         'info_dict': {
             'id': '69481490',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Added `un` subdomain to the extractor `hungama` by editing `_VALID_URL`

Fixes #7754 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a18dd41</samp>

### Summary
🎵🎬🛠️

<!--
1.  🎵 - This emoji represents music, which is relevant for the Hungama extractor that deals with songs and albums.
2.  🎬 - This emoji represents movies or videos, which is also relevant for the Hungama extractor that deals with videos and playlists.
3.  🛠️ - This emoji represents tools or fixing, which is suitable for the update that supports the `un.` subdomain.
-->
Improved the Hungama extractor to handle a new subdomain for various media types. Modified a test case accordingly.

> _We are the rebels of the `un.` domain_
> _We break the chains of the Hungama extractor_
> _We play the songs of doom and despair_
> _We make the playlists of the damned_

### Walkthrough
*  Update the `_VALID_URL` patterns for the `HungamaIE`, `HungamaSongIE`, and `HungamaAlbumPlaylistIE` classes to support the `un.` subdomain ([link](https://github.com/yt-dlp/yt-dlp/pull/7757/files?diff=unified&w=0#diff-63a9fca1d957910fc25b03441bf6b809f2a9c90711095a30e17547dcd0b43e84L14-R14), [link](https://github.com/yt-dlp/yt-dlp/pull/7757/files?diff=unified&w=0#diff-63a9fca1d957910fc25b03441bf6b809f2a9c90711095a30e17547dcd0b43e84L74-R76), [link](https://github.com/yt-dlp/yt-dlp/pull/7757/files?diff=unified&w=0#diff-63a9fca1d957910fc25b03441bf6b809f2a9c90711095a30e17547dcd0b43e84L126-R128))
*  Change the test URL for the `HungamaIE` class to use the `un.` subdomain and match the updated pattern ([link](https://github.com/yt-dlp/yt-dlp/pull/7757/files?diff=unified&w=0#diff-63a9fca1d957910fc25b03441bf6b809f2a9c90711095a30e17547dcd0b43e84L22-R22))



</details>
