### PR TITLE
[ie/youtube] Fix consent cookie

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -498,9 +498,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             return
         socs = cookies.get('SOCS')
         if socs and not socs.value.startswith('CAA'):  # not consented
-            self.to_screen("consented")
             return
-        self.to_screen("setting consent cookie")
         self._set_cookie('.youtube.com', 'SOCS', 'CAI', secure=True)  # accept all (required for mixes)
 
     def _initialize_pref(self):

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -496,16 +496,10 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         cookies = self._get_cookies('https://www.youtube.com/')
         if cookies.get('__Secure-3PSID'):
             return
-        consent_id = None
-        consent = cookies.get('CONSENT')
-        if consent:
-            if 'YES' in consent.value:
-                return
-            consent_id = self._search_regex(
-                r'PENDING\+(\d+)', consent.value, 'consent', default=None)
-        if not consent_id:
-            consent_id = random.randint(100, 999)
-        self._set_cookie('.youtube.com', 'CONSENT', 'YES+cb.20210328-17-p0.en+FX+%s' % consent_id)
+        socs = cookies.get('SOCS')
+        if socs and not socs.value.startswith('CAA'):  # not consented
+            return
+        self._set_cookie('.youtube.com', 'SOCS', 'CAE', secure=True)  # reject all
 
     def _initialize_pref(self):
         cookies = self._get_cookies('https://www.youtube.com/')

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -498,8 +498,10 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             return
         socs = cookies.get('SOCS')
         if socs and not socs.value.startswith('CAA'):  # not consented
+            self.to_screen("consented")
             return
-        self._set_cookie('.youtube.com', 'SOCS', 'CAE', secure=True)  # reject all
+        self.to_screen("setting consent cookie")
+        self._set_cookie('.youtube.com', 'SOCS', 'CAI', secure=True)  # accept all (required for mixes)
 
     def _initialize_pref(self):
         cookies = self._get_cookies('https://www.youtube.com/')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Fixes https://github.com/yt-dlp/yt-dlp/issues/7594

CONSENT cookie no longer appears to be used.

YouTube now sets the SOCS cookie based on if you accept/reject all. 

This sets the bare minimum SOCS cookie with a value of "accept all". We can't use reject all by default as some things don't work such as mixes. If a user wants to reject all then they can manually pass the cookie.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e7be2f3</samp>

### Summary
🍪🎵🔒

<!--
1.  🍪 - This emoji represents the cookie, which is the main subject of the change. It can also imply consent, as cookies are often used to store user preferences and consent choices.
2.  🎵 - This emoji represents the music, which is the purpose of the change. The change is meant to fix the extraction of YouTube mixes, which are playlists of music videos based on a seed video or topic.
3.  🔒 - This emoji represents the security, which is an aspect of the change. The change adds the secure flag to the SOCS cookie, which means that it can only be transmitted over HTTPS connections. This can help protect the user's privacy and consent choices.
-->
Replace consent cookie with SOCS cookie for YouTube extraction. Fix YouTube mix extraction by setting SOCS cookie to 'CAI'. Add secure flag to SOCS cookie.

> _`SOCS` cookie set_
> _YouTube mixes now working_
> _Winter of consent_

### Walkthrough
* Replace the consent cookie code with a simpler SOCS cookie code for YouTube extraction ([link](https://github.com/yt-dlp/yt-dlp/pull/7774/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506L499-R502))



</details>
