### PR TITLE
S4C extractor:Add subtitles, thumbnail, and ability to download a series. 

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1709,7 +1709,10 @@ from .ruv import (
     RuvIE,
     RuvSpilaIE
 )
-from .s4c import S4CIE
+from .s4c import (
+    S4CIE,
+    S4CSeriesIE
+)
 from .safari import (
     SafariIE,
     SafariApiIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1709,6 +1709,9 @@ from .ruv import (
     RuvIE,
     RuvSpilaIE
 )
+from .s4c import (
+    S4CIE
+)
 from .safari import (
     SafariIE,
     SafariApiIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1709,9 +1709,7 @@ from .ruv import (
     RuvIE,
     RuvSpilaIE
 )
-from .s4c import (
-    S4CIE
-)
+from .s4c import S4CIE
 from .safari import (
     SafariIE,
     SafariApiIE,

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from ..utils import traverse_obj
+from ..utils import traverse_obj, url_or_none
 
 
 class S4CIE(InfoExtractor):

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -1,36 +1,61 @@
 from .common import InfoExtractor
 
+from ..utils import (
+    traverse_obj
+)
+
 
 class S4CIE(InfoExtractor):
-    
-    _VALID_URL = r'https?://(?:www\.)?yourextractor\.com/watch/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?s4c\.cymru/clic/programme/(?P<id>[0-9]+)'
     _TESTS = [{
-        'url': 'https://yourextractor.com/watch/42',
-        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
+        'url': 'https://www.s4c.cymru/clic/programme/861362209',
         'info_dict': {
-            'id': '42',
+            'id': '861362209',
             'ext': 'mp4',
-            'title': 'Video title goes here',
-            'thumbnail': r're:^https?://.*\.jpg$',
-            # TODO more properties, either as:
-            # * A value
-            # * MD5 checksum; start the string with md5:
-            # * A regular expression; start the string with re:
-            # * Any Python type, e.g. int or float
+            'title': 'Y Swn',
+            'description': 'When Margaret Thatcher\'s government breaks a promise to establish a Welsh language channel in 1979 it unleashes a wave of anger across Wales.  This film portrays the efforts of the Welsh Language Society and Plaid Cymru to realise a television channel and Gwynfor Evans\'s declaration to fast until death over the matter.  A unique film about one of the most colourful chapters in modern Welsh history.',
+            'duration': 5340
         }
-    }]
+    },
+        {
+        'url': 'https://www.s4c.cymru/clic/programme/856636948',
+        'info_dict': {
+            'id': '856636948',
+            'ext': 'mp4',
+            'title': 'Am Dro',
+            'duration': 2880,
+            'description': 'In this programme Geraint will be leading the crew on a walk through Llanelli while introducing them to some unusual creatures. Barney will be taking them on a walk along the border near Oswestry. Ena will be following St David\'s footsteps in Pembrokeshire, while Ann-Marie will take them up the mountain in Eglwysilan before descending to the town of Senghenydd',
+        }
+    },
+    ]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id)
+        programme_metadata = self._download_json(f'https://www.s4c.cymru/df/full_prog_details?lang=e&programme_id={video_id}', video_id)
 
-        # TODO more code goes here, for example ...
-        title = self._html_search_regex(r'<h1>(.+?)</h1>', webpage, 'title')
-
-        return {
+        programme_details = programme_metadata.get('full_prog_details') or []
+        metadata = {
             'id': video_id,
-            'title': title,
-            'description': self._og_search_description(webpage),
-            'uploader': self._search_regex(r'<div[^>]+id="uploader"[^>]*>([^<]+)<', webpage, 'uploader', fatal=False),
-            # TODO more properties (see yt_dlp/extractor/common.py)
+            **traverse_obj(programme_details[0], {
+                'description': ('full_billing', {str.strip}),
+                'duration': ('duration', {lambda x: int(x) * 60}),
+            })
         }
+
+        title = programme_details[0].get('programme_title') or programme_details[0].get('series_title')
+
+        metadata['title'] = title
+
+        player_config = self._download_json(f'https://player-api.s4c-cdn.co.uk/player-configuration/prod?programme_id={video_id}&signed=0&lang=en&mode=od&appId=clic&streamName=', video_id)
+
+        filename = player_config.get('filename')
+
+        streaming_urls = self._download_json(f'https://player-api.s4c-cdn.co.uk/streaming-urls/prod?mode=od&application=clic&region=WW&extra=false&thirdParty=false&filename={filename}', filename)
+
+        m3u8_url = streaming_urls.get('hls')
+
+        formats = self._extract_m3u8_formats(
+            m3u8_url, video_id, 'mp4', 'm3u8_native', m3u8_id='hls',
+            note='Downloading HD m3u8 information', errnote='Unable to download HD m3u8 information')
+        metadata['formats'] = formats
+        return metadata

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -1,19 +1,17 @@
 from .common import InfoExtractor
 
-from ..utils import (
-    traverse_obj
-)
+from ..utils import traverse_obj
 
 
 class S4CIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?s4c\.cymru/clic/programme/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?s4c\.cymru/clic/programme/(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.s4c.cymru/clic/programme/861362209',
         'info_dict': {
             'id': '861362209',
             'ext': 'mp4',
             'title': 'Y Swn',
-            'description': 'When Margaret Thatcher\'s government breaks a promise to establish a Welsh language channel in 1979 it unleashes a wave of anger across Wales.  This film portrays the efforts of the Welsh Language Society and Plaid Cymru to realise a television channel and Gwynfor Evans\'s declaration to fast until death over the matter.  A unique film about one of the most colourful chapters in modern Welsh history.',
+            'description': 'md5:f7681a30e4955b250b3224aa9fe70cf0',
             'duration': 5340
         }
     },
@@ -24,38 +22,44 @@ class S4CIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'Am Dro',
             'duration': 2880,
-            'description': 'In this programme Geraint will be leading the crew on a walk through Llanelli while introducing them to some unusual creatures. Barney will be taking them on a walk along the border near Oswestry. Ena will be following St David\'s footsteps in Pembrokeshire, while Ann-Marie will take them up the mountain in Eglwysilan before descending to the town of Senghenydd',
+            'description': 'md5:100d8686fc9a632a0cb2db52a3433ffe',
         }
     },
     ]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        programme_metadata = self._download_json(f'https://www.s4c.cymru/df/full_prog_details?lang=e&programme_id={video_id}', video_id)
+        details = self._download_json(
+            f'https://www.s4c.cymru/df/full_prog_details?lang=e&programme_id={video_id}',
+            video_id, fatal=False)
 
-        programme_details = programme_metadata.get('full_prog_details') or []
-        metadata = {
+        filename = self._download_json(
+            'https://player-api.s4c-cdn.co.uk/player-configuration/prod', video_id, query={
+                'programme_id': video_id,
+                'signed': '0',
+                'lang': 'en',
+                'mode': 'od',
+                'appId': 'clic',
+                'streamName': '',
+            }, note='Downloading player config JSON')['filename']
+        m3u8_url = self._download_json(
+            'https://player-api.s4c-cdn.co.uk/streaming-urls/prod', video_id, query={
+                'mode': 'od',
+                'application': 'clic',
+                'region': 'WW',
+                'extra': 'false',
+                'thirdParty': 'false',
+                'filename': filename,
+            }, note='Downloading streaming urls JSON')['hls']
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id='hls')
+        return {
             'id': video_id,
-            **traverse_obj(programme_details[0], {
+            'formats': formats,
+            'subtitles': subtitles,
+            **traverse_obj(details, ('full_prog_details', 0, {
+                'title': (('programme_title', 'series_title'), {str}),
                 'description': ('full_billing', {str.strip}),
                 'duration': ('duration', {lambda x: int(x) * 60}),
-            })
+            }), get_all=False),
         }
-
-        title = programme_details[0].get('programme_title') or programme_details[0].get('series_title')
-
-        metadata['title'] = title
-
-        player_config = self._download_json(f'https://player-api.s4c-cdn.co.uk/player-configuration/prod?programme_id={video_id}&signed=0&lang=en&mode=od&appId=clic&streamName=', video_id)
-
-        filename = player_config.get('filename')
-
-        streaming_urls = self._download_json(f'https://player-api.s4c-cdn.co.uk/streaming-urls/prod?mode=od&application=clic&region=WW&extra=false&thirdParty=false&filename={filename}', filename)
-
-        m3u8_url = streaming_urls.get('hls')
-
-        formats = self._extract_m3u8_formats(
-            m3u8_url, video_id, 'mp4', 'm3u8_native', m3u8_id='hls',
-            note='Downloading HD m3u8 information', errnote='Unable to download HD m3u8 information')
-        metadata['formats'] = formats
-        return metadata

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -1,0 +1,36 @@
+from .common import InfoExtractor
+
+
+class S4CIE(InfoExtractor):
+    
+    _VALID_URL = r'https?://(?:www\.)?yourextractor\.com/watch/(?P<id>[0-9]+)'
+    _TESTS = [{
+        'url': 'https://yourextractor.com/watch/42',
+        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
+        'info_dict': {
+            'id': '42',
+            'ext': 'mp4',
+            'title': 'Video title goes here',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            # TODO more properties, either as:
+            # * A value
+            # * MD5 checksum; start the string with md5:
+            # * A regular expression; start the string with re:
+            # * Any Python type, e.g. int or float
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        # TODO more code goes here, for example ...
+        title = self._html_search_regex(r'<h1>(.+?)</h1>', webpage, 'title')
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': self._og_search_description(webpage),
+            'uploader': self._search_regex(r'<div[^>]+id="uploader"[^>]*>([^<]+)<', webpage, 'uploader', fatal=False),
+            # TODO more properties (see yt_dlp/extractor/common.py)
+        }

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -1,5 +1,4 @@
 from .common import InfoExtractor
-
 from ..utils import traverse_obj
 
 
@@ -13,9 +12,8 @@ class S4CIE(InfoExtractor):
             'title': 'Y Swn',
             'description': 'md5:f7681a30e4955b250b3224aa9fe70cf0',
             'duration': 5340
-        }
-    },
-        {
+        },
+    }, {
         'url': 'https://www.s4c.cymru/clic/programme/856636948',
         'info_dict': {
             'id': '856636948',
@@ -23,9 +21,8 @@ class S4CIE(InfoExtractor):
             'title': 'Am Dro',
             'duration': 2880,
             'description': 'md5:100d8686fc9a632a0cb2db52a3433ffe',
-        }
-    },
-    ]
+        },
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
@@ -51,8 +48,8 @@ class S4CIE(InfoExtractor):
                 'thirdParty': 'false',
                 'filename': filename,
             }, note='Downloading streaming urls JSON')['hls']
-
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id='hls')
+
         return {
             'id': video_id,
             'formats': formats,

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -11,7 +11,8 @@ class S4CIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'Y Swn',
             'description': 'md5:f7681a30e4955b250b3224aa9fe70cf0',
-            'duration': 5340
+            'duration': 5340,
+            'thumbnail': 'https://www.s4c.cymru/amg/1920x1080/Y_Swn_2023S4C_099_ii.jpg'
         },
     }, {
         'url': 'https://www.s4c.cymru/clic/programme/856636948',
@@ -21,6 +22,7 @@ class S4CIE(InfoExtractor):
             'title': 'Am Dro',
             'duration': 2880,
             'description': 'md5:100d8686fc9a632a0cb2db52a3433ffe',
+            'thumbnail': 'https://www.s4c.cymru/amg/1920x1080/Am_Dro_2022-23S4C_P6_4005.jpg'
         },
     }]
 
@@ -39,13 +41,14 @@ class S4CIE(InfoExtractor):
                 'appId': 'clic',
                 'streamName': '',
             }, note='Downloading player config JSON')
-        filename = playerConfig['filename']
+        thumbnail = playerConfig['poster']
         subtitlesList = playerConfig['subtitles']
         subtitles = {}
 
         for i in subtitlesList:
             subtitles[i['3']] = [{'url': i['0']}]
 
+        filename = playerConfig['filename']
         m3u8_url = self._download_json(
             'https://player-api.s4c-cdn.co.uk/streaming-urls/prod', video_id, query={
                 'mode': 'od',
@@ -60,6 +63,7 @@ class S4CIE(InfoExtractor):
             'id': video_id,
             'formats': formats,
             'subtitles': subtitles,
+            'thumbnail': thumbnail,
             **traverse_obj(details, ('full_prog_details', 0, {
                 'title': (('programme_title', 'series_title'), {str}),
                 'description': ('full_billing', {str.strip}),

--- a/yt_dlp/extractor/s4c.py
+++ b/yt_dlp/extractor/s4c.py
@@ -30,7 +30,7 @@ class S4CIE(InfoExtractor):
             f'https://www.s4c.cymru/df/full_prog_details?lang=e&programme_id={video_id}',
             video_id, fatal=False)
 
-        filename = self._download_json(
+        playerConfig = self._download_json(
             'https://player-api.s4c-cdn.co.uk/player-configuration/prod', video_id, query={
                 'programme_id': video_id,
                 'signed': '0',
@@ -38,7 +38,14 @@ class S4CIE(InfoExtractor):
                 'mode': 'od',
                 'appId': 'clic',
                 'streamName': '',
-            }, note='Downloading player config JSON')['filename']
+            }, note='Downloading player config JSON')
+        filename = playerConfig['filename']
+        subtitlesList = playerConfig['subtitles']
+        subtitles = {}
+
+        for i in subtitlesList:
+            subtitles[i['3']] = [{'url': i['0']}]
+
         m3u8_url = self._download_json(
             'https://player-api.s4c-cdn.co.uk/streaming-urls/prod', video_id, query={
                 'mode': 'od',
@@ -48,8 +55,7 @@ class S4CIE(InfoExtractor):
                 'thirdParty': 'false',
                 'filename': filename,
             }, note='Downloading streaming urls JSON')['hls']
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id='hls')
-
+        formats = self._extract_m3u8_formats(m3u8_url, video_id, 'mp4', m3u8_id='hls')
         return {
             'id': video_id,
             'formats': formats,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->


Improves the exisiting S4C extractor by including subtitles and the thumbnail in the extraction of a programme. Adds support for downloading a series. 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd599da</samp>

### Summary
🏴󠁧󠁢󠁷󠁬󠁳󠁿🎬🐍

<!--
1.  🏴󠁧󠁢󠁷󠁬󠁳󠁿 - This emoji represents the Welsh flag, and it can be used to indicate that the changes are related to the Welsh-language broadcaster S4C and its website. This emoji can also convey a sense of pride and identity for the Welsh language and culture, as well as a recognition of the diversity and richness of the UK's media landscape.
2.  🎬 - This emoji represents a clapperboard, and it can be used to indicate that the changes are related to video and media content. This emoji can also convey a sense of creativity and production, as well as a reference to the entertainment and cultural value of S4C's programmes.
3.  🐍 - This emoji represents a snake, and it can be used to indicate that the changes are written in Python, the programming language used by yt-dlp and youtube-dl. This emoji can also convey a sense of flexibility and versatility, as well as a reference to the logo and mascot of Python.
-->
Add support for downloading videos and playlists from S4C, a Welsh-language broadcaster. Create a new module `s4c.py` that defines two extractor classes: `S4CIE` and `S4CSeriesIE`. Import these classes in `_extractors.py`.

> _`S4CIE` extracts_
> _videos from Welsh website_
> _`S4CSeriesIE` too_

### Walkthrough
*  Add support for S4C video and playlist extraction ([link](https://github.com/yt-dlp/yt-dlp/pull/7776/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1712-R1715), [link](https://github.com/yt-dlp/yt-dlp/pull/7776/files?diff=unified&w=0#diff-f46e285911b6cf1cd74747a6d69c157dc730b6b3a38c25b3b034a0ca5e264d38R1-R114))
   * Import `S4CIE` and `S4CSeriesIE` classes from `s4c.py` module in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7776/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1712-R1715))
   * Define `S4CIE` class to extract video information and formats from S4C JSON API and player ([link](https://github.com/yt-dlp/yt-dlp/pull/7776/files?diff=unified&w=0#diff-f46e285911b6cf1cd74747a6d69c157dc730b6b3a38c25b3b034a0ca5e264d38R1-R114))
   * Define `S4CSeriesIE` class to extract playlist information and entries from S4C JSON API ([link](https://github.com/yt-dlp/yt-dlp/pull/7776/files?diff=unified&w=0#diff-f46e285911b6cf1cd74747a6d69c157dc730b6b3a38c25b3b034a0ca5e264d38R1-R114))



</details>
