### PR TITLE
[extractor/litv] Fix playlist and video download

### DIFF
--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -40,15 +40,15 @@ class LiTVIE(InfoExtractor):
         'skip': 'Georestricted to Taiwan',
     }]
 
-    def _extract_playlist(self, seasons_list, content_type):
-        episode_title = seasons_list['title']
-        content_id = seasons_list['contentId']
+    def _extract_playlist(self, playlist_data, content_type):
+        episode_title = playlist_data['title']
+        content_id = playlist_data['contentId']
 
         all_episodes = [
             self.url_result(smuggle_url(
                 self._URL_TEMPLATE % (content_type, episode['contentId']),
                 {'force_noplaylist': True}))  # To prevent infinite recursion
-            for season in seasons_list['seasons']
+            for season in playlist_data['seasons']
             for episode in season['episode']]
 
         return self.playlist_result(all_episodes, content_id, episode_title)

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -39,6 +39,16 @@ class LiTVIE(InfoExtractor):
             'noplaylist': True,
         },
         'skip': 'Georestricted to Taiwan',
+    }, {
+        'url': 'https://www.litv.tv/promo/miyuezhuan/?content_id=VOD00044841&',
+        'md5': '88322ea132f848d6e3e18b32a832b918',
+        'info_dict': {
+            'id': 'VOD00044841',
+            'ext': 'mp4',
+            'title': '芈月傳第1集　霸星芈月降世楚國',
+            'description': '楚威王二年，太史令唐昧夜觀星象，發現霸星即將現世。王后得知霸星的預言後，想盡辦法不讓孩子順利出生，幸得莒姬相護化解危機。沒想到眾人期待下出生的霸星卻是位公主，楚威王對此失望至極。楚王后命人將女嬰丟棄河中，居然奇蹟似的被少司命像攔下，楚威王認為此女非同凡響，為她取名芈月。',
+        },
+        'skip': 'No longer exists',
     }]
 
     def _extract_playlist(self, playlist_data, content_type):

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -74,8 +74,7 @@ class LiTVIE(InfoExtractor):
             program_info = self._download_json(
                 'https://www.litv.tv/vod/ajax/getProgramInfo', video_id,
                 query={'contentId': video_id},
-                headers={'Content-Type': 'application/json',
-                         'Accept': 'application/json'})
+                headers={'Accept': 'application/json'})
 
         series_id = program_info['seriesId']
         if self._yes_playlist(series_id, video_id, smuggled_data):
@@ -83,8 +82,7 @@ class LiTVIE(InfoExtractor):
                 'https://www.litv.tv/vod/ajax/getSeriesTree',
                 video_id,
                 query={'seriesId': series_id},
-                headers={'Content-Type': 'application/json',
-                         'Accept': 'application/json'})
+                headers={'Accept': 'application/json'})
             return self._extract_playlist(playlist_data, program_info['contentType'])
 
         video_data = self._parse_json(self._search_regex(

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -41,9 +41,6 @@ class LiTVIE(InfoExtractor):
     }]
 
     def _extract_playlist(self, playlist_data, content_type):
-        episode_title = playlist_data['title']
-        content_id = playlist_data['contentId']
-
         all_episodes = [
             self.url_result(smuggle_url(
                 self._URL_TEMPLATE % (content_type, episode['contentId']),
@@ -51,7 +48,7 @@ class LiTVIE(InfoExtractor):
             for season in playlist_data['seasons']
             for episode in season['episode']]
 
-        return self.playlist_result(all_episodes, content_id, episode_title)
+        return self.playlist_result(all_episodes, playlist_data['contentId'], playlist_data['title'])
 
     def _real_extract(self, url):
         url, smuggled_data = unsmuggle_url(url, {})

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -6,6 +6,7 @@ from ..utils import (
     int_or_none,
     smuggle_url,
     unsmuggle_url,
+    traverse_obj,
 )
 
 
@@ -45,8 +46,7 @@ class LiTVIE(InfoExtractor):
             self.url_result(smuggle_url(
                 self._URL_TEMPLATE % (content_type, episode['contentId']),
                 {'force_noplaylist': True}))  # To prevent infinite recursion
-            for season in playlist_data['seasons']
-            for episode in season['episode']]
+            for episode in traverse_obj(playlist_data, ('seasons', ..., 'episode', lambda _, v: v['contentId']))]
 
         return self.playlist_result(all_episodes, playlist_data['contentId'], playlist_data['title'])
 

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -67,7 +67,9 @@ class LiTVIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id)
 
-        if '<meta http-equiv="refresh" content="1;url=https://www.litv.tv/"' in webpage:
+        if self._search_regex(
+                r'(?i)<meta\s[^>]*http-equiv="refresh"\s[^>]*content="[0-9]+;\s*url=https://www\.litv\.tv/"',
+                webpage, 'meta refresh redirect', default=False, group=0):
             raise ExtractorError('No such content', expected=True)
 
         program_info = self._parse_json(self._search_regex(

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -5,8 +5,8 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     smuggle_url,
-    unsmuggle_url,
     traverse_obj,
+    unsmuggle_url,
 )
 
 

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -58,7 +58,7 @@ class LiTVIE(InfoExtractor):
                 {'force_noplaylist': True}))  # To prevent infinite recursion
             for episode in traverse_obj(playlist_data, ('seasons', ..., 'episode', lambda _, v: v['contentId']))]
 
-        return self.playlist_result(all_episodes, playlist_data['contentId'], playlist_data['title'])
+        return self.playlist_result(all_episodes, playlist_data['contentId'], playlist_data.get('title'))
 
     def _real_extract(self, url):
         url, smuggled_data = unsmuggle_url(url, {})
@@ -70,7 +70,7 @@ class LiTVIE(InfoExtractor):
         if self._search_regex(
                 r'(?i)<meta\s[^>]*http-equiv="refresh"\s[^>]*content="[0-9]+;\s*url=https://www\.litv\.tv/"',
                 webpage, 'meta refresh redirect', default=False, group=0):
-            raise ExtractorError('No such content', expected=True)
+            raise ExtractorError('No such content found', expected=True)
 
         program_info = self._parse_json(self._search_regex(
             r'var\s+programInfo\s*=\s*([^;]+)', webpage, 'VOD data', default='{}'),
@@ -88,10 +88,8 @@ class LiTVIE(InfoExtractor):
         series_id = program_info['seriesId']
         if self._yes_playlist(series_id, video_id, smuggled_data):
             playlist_data = self._download_json(
-                'https://www.litv.tv/vod/ajax/getSeriesTree',
-                video_id,
-                query={'seriesId': series_id},
-                headers={'Accept': 'application/json'})
+                'https://www.litv.tv/vod/ajax/getSeriesTree', video_id,
+                query={'seriesId': series_id}, headers={'Accept': 'application/json'})
             return self._extract_playlist(playlist_data, program_info['contentType'])
 
         video_data = self._parse_json(self._search_regex(

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -39,16 +39,6 @@ class LiTVIE(InfoExtractor):
             'noplaylist': True,
         },
         'skip': 'Georestricted to Taiwan',
-    }, {
-        'url': 'https://www.litv.tv/promo/miyuezhuan/?content_id=VOD00044841&',
-        'md5': '88322ea132f848d6e3e18b32a832b918',
-        'info_dict': {
-            'id': 'VOD00044841',
-            'ext': 'mp4',
-            'title': '芈月傳第1集　霸星芈月降世楚國',
-            'description': '楚威王二年，太史令唐昧夜觀星象，發現霸星即將現世。王后得知霸星的預言後，想盡辦法不讓孩子順利出生，幸得莒姬相護化解危機。沒想到眾人期待下出生的霸星卻是位公主，楚威王對此失望至極。楚王后命人將女嬰丟棄河中，居然奇蹟似的被少司命像攔下，楚威王認為此女非同凡響，為她取名芈月。',
-        },
-        'skip': 'Georestricted to Taiwan',
     }]
 
     def _extract_playlist(self, seasons_list, content_type):
@@ -70,6 +60,9 @@ class LiTVIE(InfoExtractor):
         video_id = self._match_id(url)
 
         webpage = self._download_webpage(url, video_id)
+
+        if '<meta http-equiv="refresh" content="1;url=https://www.litv.tv/"' in webpage:
+            raise ExtractorError('No such content', expected=True)
 
         program_info = self._parse_json(self._search_regex(
             r'var\s+programInfo\s*=\s*([^;]+)', webpage, 'VOD data', default='{}'),

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -5,7 +5,6 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     smuggle_url,
-    traverse_obj,
     unsmuggle_url,
 )
 

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -13,7 +13,7 @@ from ..utils import (
 class LiTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?litv\.tv/(?:vod|promo)/[^/]+/(?:content\.do)?\?.*?\b(?:content_)?id=(?P<id>[^&]+)'
 
-    _URL_TEMPLATE = 'https://www.litv.tv/vod/%s/content.do?id=%s'
+    _URL_TEMPLATE = 'https://www.litv.tv/vod/%s/content.do?content_id=%s'
 
     _TESTS = [{
         'url': 'https://www.litv.tv/vod/drama/content.do?brc_id=root&id=VOD00041610&isUHEnabled=true&autoPlay=1',

--- a/yt_dlp/extractor/litv.py
+++ b/yt_dlp/extractor/litv.py
@@ -24,13 +24,15 @@ class LiTVIE(InfoExtractor):
         'playlist_count': 51,  # 50 episodes + 1 trailer
     }, {
         'url': 'https://www.litv.tv/vod/drama/content.do?brc_id=root&id=VOD00041610&isUHEnabled=true&autoPlay=1',
-        'md5': '969e343d9244778cb29acec608e53640',
+        'md5': 'b90ff1e9f1d8f5cfcd0a44c3e2b34c7a',
         'info_dict': {
             'id': 'VOD00041610',
             'ext': 'mp4',
             'title': '花千骨第1集',
             'thumbnail': r're:https?://.*\.jpg$',
-            'description': 'md5:c7017aa144c87467c4fb2909c4b05d6f',
+            'description': '《花千骨》陸劇線上看。十六年前，平靜的村莊內，一名女嬰隨異相出生，途徑此地的蜀山掌門清虛道長算出此女命運非同一般，她體內散發的異香易招惹妖魔。一念慈悲下，他在村莊周邊設下結界阻擋妖魔入侵，讓其年滿十六後去蜀山，並賜名花千骨。',
+            'categories': ['奇幻', '愛情', '中國', '仙俠'],
+            'episode': 'Episode 1',
             'episode_number': 1,
         },
         'params': {
@@ -102,7 +104,7 @@ class LiTVIE(InfoExtractor):
                 'contentType': program_info['contentType'],
             }
             video_data = self._download_json(
-                'https://www.litv.tv/vod/getMainUrl', video_id,
+                'https://www.litv.tv/vod/ajax/getMainUrlNoAuth', video_id,
                 data=json.dumps(payload).encode('utf-8'),
                 headers={'Content-Type': 'application/json'})
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fixes the LiTV extractor, including playlist and video download. Note that all the videos on litv.tv are georestricted to Taiwan, while playlists are not.

Fixes #5456.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cfd7c8c</samp>

### Summary
🛠️🌟🎞️

<!--
1.  🛠️ - This emoji represents fixing or repairing something, which is suitable for the changes that fix some issues with the LiTV extractor, such as the incorrect URL format, the missing metadata, and the broken playlist extraction.
2.  🌟 - This emoji represents something shiny, new, or improved, which is suitable for the changes that improve the extraction of metadata and playlists, such as adding more fields, extracting more information, and using a better method.
3.  🎞️ - This emoji represents a film strip or a video, which is suitable for the changes that affect the video URL endpoint, such as using a different API and adding a query parameter.
-->
Update `litv.py` extractor to handle new URL format, fix tests, and enhance metadata and playlist extraction. Use a different endpoint to get video URLs that works for more cases.

> _Oh we're the crew of the LiTV ship, and we sail the web so wide_
> _We fix the bugs and scrape the data, and we do it all with pride_
> _We changed the `URL` and the `test` and the `playlist` too_
> _And we heave away on the count of three, for the `video URL` is new_

### Walkthrough
*  Simplify and update playlist extraction for LiTV (`yt_dlp/extractor/litv.py`)
  - Use `content_id` instead of `id` as query parameter in `_URL_TEMPLATE` ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L16-R15))
  - Use `getProgramInfo` and `getSeriesTree` endpoints to get program and playlist data ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L71-R89))
  - Use `seriesId` as playlist id instead of `contentId` of first season ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L71-R89))
  - Use `getMainUrlNoAuth` endpoint instead of `getMainUrl` endpoint to avoid authentication ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L99-R100))
  - Check for meta refresh tag and raise error if content is not available ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L71-R89))
  - Simplify `_extract_playlist` method to take only two arguments and iterate over all seasons and episodes ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L40-R52))
  - Add `description`, `categories`, and `episode` fields to `info_dict` for second test case ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L33-R34))
  - Update `playlist_count` and `md5` values for second test case ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L24-R26))
  - Delete `traverse_obj` from import statement ([link](https://github.com/yt-dlp/yt-dlp/pull/7785/files?diff=unified&w=0#diff-2e2099b7b1d94e1b02c97214a6476e44a9d29d445e451acf456f1062fd98add5L8))



</details>
