### PR TITLE
[BBC Sounds] Tracklist Extraction

### DIFF
--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -833,16 +833,16 @@ class BBCIE(BBCCoUkIE):  # XXX: Do not subclass from concrete IE
         },
     }, {
         # BBC Sounds
-        'url': 'https://www.bbc.co.uk/sounds/play/m001p2jp',
+        'url': 'https://www.bbc.co.uk/sounds/play/m001q78b',
         'info_dict': {
-            'id': 'm001p2jn',
+            'id': 'm001q789',
             'ext': 'mp4',
-            'title': 'Late Junction - Bonjo Iyabinghi Noah and GAIKA in session',
-            'thumbnail': 'https://ichef.bbci.co.uk/images/ic/raw/p0cgqwnb.jpg',
-            'duration': 7200,
-            'chapters': 'count:24',
-            'description': 'md5:36f16179df6ee9992e80fea912d97ea8',
+            'title': 'The Night Tracks Mix - Music for the darkling hour',
+            'thumbnail': 'https://ichef.bbci.co.uk/images/ic/raw/p0c00hym.jpg',
+            'chapters': 'count:8',
+            'description': 'md5:815fb51cbdaa270040aab8145b3f1d67',
             'uploader': 'Radio 3',
+            'duration': 1800,
             'uploader_id': 'bbc_radio_three',
         },
     }, {  # onion routes

--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -220,20 +220,6 @@ class BBCCoUkIE(InfoExtractor):
                 'skip_download': True,
             },
         }, {
-            'url': 'https://www.bbc.co.uk/sounds/play/m0007jzb',
-            'note': 'Audio',
-            'info_dict': {
-                'id': 'm0007jz9',
-                'ext': 'mp4',
-                'title': 'BBC Proms, 2019, Prom 34: West–Eastern Divan Orchestra',
-                'description': "Live BBC Proms. West–Eastern Divan Orchestra with Daniel Barenboim and Martha Argerich.",
-                'duration': 9840,
-            },
-            'params': {
-                # rtmp download
-                'skip_download': True,
-            }
-        }, {
             'url': 'http://www.bbc.co.uk/iplayer/playlist/p01dvks4',
             'only_matching': True,
         }, {
@@ -844,6 +830,20 @@ class BBCIE(BBCCoUkIE):  # XXX: Do not subclass from concrete IE
             'thumbnail': r're:https?://.+/p07c9dsr.jpg',
             'upload_date': '20190604',
             'categories': ['Psychology'],
+        },
+    }, {
+        # BBC Sounds
+        'url': 'https://www.bbc.co.uk/sounds/play/m001p2jp',
+        'info_dict': {
+            'id': 'm001p2jn',
+            'ext': 'mp4',
+            'title': 'Late Junction - Bonjo Iyabinghi Noah and GAIKA in session',
+            'thumbnail': 'https://ichef.bbci.co.uk/images/ic/raw/p0cgqwnb.jpg',
+            'duration': 7200,
+            'chapters': 'count:24',
+            'description': 'md5:36f16179df6ee9992e80fea912d97ea8',
+            'uploader': 'Radio 3',
+            'uploader_id': 'bbc_radio_three',
         },
     }, {  # onion routes
         'url': 'https://www.bbcnewsd73hkzno2ini43t4gblxvycyac5aw4gnv7t2rccijh7745uqd.onion/news/av/world-europe-63208576',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds tracklist extraction for BBC Sounds.
In doing so, it moves the BBC Sounds extraction from `BBCCoUkIE` to `BBCIE`, changing the metadata extracted slightly.

I've greatly enjoyed having tracklists extracted as chapters for another radio extractor I've written - it lets me see what's playing without having to use shazam etc, and I can skip past songs I don't like. It also works quite well for skipping news breaks. The BBC Sounds website and app have tracklists available, with full start and end times - but this isn't being extracted.

Looking at the site's HTML, I saw a big JSON blob in `window.__PRELOADED_STATE__` with all the programme's metadata, including the tracklist.
Ctrl-F'ing for `__PRELOADED_STATE__` in the extractor, I saw that `BBCIE` had a section that handled this, but it didn't seem to be using it for Sounds. Instead, it was handled by something in `BBCCoUkIE`.
I didn't see the metadata that I needed available in `BBCCoUkIE`'s network requests, so I removed the `sounds/play/` from `BBCCoUkIE`'s `_VALID_URL` regex.
Now `BBCIE` handles it with the existing preloaded state code + new tracklist code.

I don't think this breaks any other pages, but I can't be sure as a lot of the URLs in the tests are long gone.
The tests that weren't for dead links didn't seem to be broken by _this_, at least. (mostly title changes)

The metadata that's extracted has changed. The main changes I noticed were:
- `Programme, Episode` is now `Programme - Episode`
- the description is now the long, full length, version
- the station name is extracted as the uploader
- there are a few more formats

So this will doubtless break someone's workflow.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f007598</samp>

### Summary
🎧🔧📜

<!--
1.  🎧 - This emoji represents the addition of BBC Sounds URLs, which are a platform for listening to audio content from the BBC.
2.  🔧 - This emoji represents the removal of redundant code and the refactoring of the extractors, which are tasks that involve fixing or improving the code quality.
3.  📜 - This emoji represents the extraction of audio chapters from the tracklist, which are segments of the audio content that have titles and descriptions.
-->
Improved BBC Sounds extraction and cleaned up BBC code. Added support for `BBCIE` to handle BBC Sounds URLs and audio chapters, and removed unused code and tests from `BBCCoUkIE`.

> _To handle the BBC Sounds links_
> _The `BBCIE` extractor thinks_
> _It parses the tracklist_
> _For audio chapters to list_
> _And imports some utils for kinks_

### Walkthrough
* Import `join_nonempty` and `traverse_obj` functions from `utils.py` for string concatenation and nested value access ([link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57R18), [link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57R24))
* Remove `sounds/play/` pattern from `BBCCoUkIE` extractor and its test case, since it is now handled by `BBCIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57L44), [link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57L222-L235))
* Add a new test case for `sounds/play/` URL to `BBCIE` extractor, demonstrating audio extraction and metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57R834-R847))
* Parse tracklist information from `preload_state` variable in `BBCIE` extractor, and assign it as chapters to the audio ([link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57R1122-R1130), [link](https://github.com/yt-dlp/yt-dlp/pull/7788/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57R1141))



</details>