### PR TITLE
[massengeschmacktv] Update extractor

### DIFF
--- a/yt_dlp/extractor/massengeschmacktv.py
+++ b/yt_dlp/extractor/massengeschmacktv.py
@@ -66,7 +66,7 @@ class MassengeschmackTVIE(InfoExtractor):
         return {
             'id': episode,
             'title': clean_html(self._html_search_regex(
-                '<[^>]+ (?:id|ID)=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title', fatal=False)),
+                r'<span[^>]+\bid=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title', fatal=False)),
             'formats': formats,
             'thumbnail': self._search_regex(r'POSTER\s*=\s*"([^"]+)', webpage, 'thumbnail', fatal=False),
         }

--- a/yt_dlp/extractor/massengeschmacktv.py
+++ b/yt_dlp/extractor/massengeschmacktv.py
@@ -66,7 +66,7 @@ class MassengeschmackTVIE(InfoExtractor):
         return {
             'id': episode,
             'title': clean_html(self._html_search_regex(
-                '<[^>]+\b(?:id|ID)=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title', fatal=False)),
+                '<[^>]+ (?:id|ID)=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title', fatal=False)),
             'formats': formats,
             'thumbnail': self._search_regex(r'POSTER\s*=\s*"([^"]+)', webpage, 'thumbnail', fatal=False),
         }

--- a/yt_dlp/extractor/massengeschmacktv.py
+++ b/yt_dlp/extractor/massengeschmacktv.py
@@ -30,9 +30,6 @@ class MassengeschmackTVIE(InfoExtractor):
         episode = self._match_id(url)
 
         webpage = self._download_webpage(url, episode)
-        title = clean_html(self._html_search_regex(
-            '<[^>]+(?:id|ID)=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title'))
-        thumbnail = self._search_regex(r'POSTER\s*=\s*"([^"]+)', webpage, 'thumbnail', fatal=False)
         sources = self._parse_json(self._search_regex(r'(?s)MEDIA\s*=\s*(\[.+?\]);', webpage, 'media'), episode, js_to_json)
 
         formats = []
@@ -68,7 +65,8 @@ class MassengeschmackTVIE(InfoExtractor):
 
         return {
             'id': episode,
-            'title': title,
+            'title': clean_html(self._html_search_regex(
+                '<[^>]+\b(?:id|ID)=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title', fatal=False)),
             'formats': formats,
-            'thumbnail': thumbnail,
+            'thumbnail': self._search_regex(r'POSTER\s*=\s*"([^"]+)', webpage, 'thumbnail', fatal=False),
         }

--- a/yt_dlp/extractor/massengeschmacktv.py
+++ b/yt_dlp/extractor/massengeschmacktv.py
@@ -17,11 +17,12 @@ class MassengeschmackTVIE(InfoExtractor):
 
     _TEST = {
         'url': 'https://massengeschmack.tv/play/fktv202',
-        'md5': 'a9e054db9c2b5a08f0a0527cc201e8d3',
+        'md5': '9996f314994a49fefe5f39aa1b07ae21',
         'info_dict': {
             'id': 'fktv202',
             'ext': 'mp4',
-            'title': 'Fernsehkritik-TV - Folge 202',
+            'title': 'Fernsehkritik-TV #202',
+            'thumbnail': 'https://cache.massengeschmack.tv/img/mag/fktv202.jpg'
         },
     }
 
@@ -30,7 +31,7 @@ class MassengeschmackTVIE(InfoExtractor):
 
         webpage = self._download_webpage(url, episode)
         title = clean_html(self._html_search_regex(
-            '<h3>([^<]+)</h3>', webpage, 'title'))
+            '<[^>]+(?:id|ID)=["\']clip-title["\'][^>]*>([^<]+)', webpage, 'title'))
         thumbnail = self._search_regex(r'POSTER\s*=\s*"([^"]+)', webpage, 'thumbnail', fatal=False)
         sources = self._parse_json(self._search_regex(r'(?s)MEDIA\s*=\s*(\[.+?\]);', webpage, 'media'), episode, js_to_json)
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information
<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The current implementation of the Massengeschmack.tv extractor fails to get the title of the video.

From the regex, it seems previously the title was contained within an `h3` element, while now the following HTML is used on the site:

```html
<div class="heading-wrapper">
  <h2 class="heading-black small">
    <span id="clip-title">Fernsehkritik-TV #202</span>
  </h2>
</div>
```

This pull requests updates the regex to work with the current HTML. Additionally the test case was updated, to reflect changes to the expected values.

#### Logs 
<details><summary>Before</summary>
[debug] Command-line config: ['--cookies', 'cookies.txt', '-vU', 'https://massengeschmack.tv/play/fktvplus41']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.07.06 [b532a3481] (pip)
[debug] Python 3.11.4 (CPython arm64 64bit) - macOS-14.0-arm64-arm-64bit (OpenSSL 3.1.2 1 Aug 2023)
[debug] exe versions: ffmpeg 6.0 (setts), ffprobe 6.0, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.18.0, brotli-1.0.9, certifi-2023.07.22, mutagen-1.46.0, sqlite3-2.6.0, websockets-11.0.3
[debug] Proxy map: {}
[debug] Loaded 1855 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Available version: stable@2023.07.06, Current version: stable@2023.07.06
yt-dlp is up to date (stable@2023.07.06)
[massengeschmack.tv] Extracting URL: https://massengeschmack.tv/play/fktvplus41
[massengeschmack.tv] fktvplus41: Downloading webpage
ERROR: [massengeschmack.tv] fktvplus41: Unable to extract title; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
  File "/opt/homebrew/Cellar/yt-dlp/2023.7.6_1/libexec/lib/python3.11/site-packages/yt_dlp/extractor/common.py", line 710, in extract
    ie_result = self._real_extract(url)
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yt-dlp/2023.7.6_1/libexec/lib/python3.11/site-packages/yt_dlp/extractor/massengeschmacktv.py", line 32, in _real_extract
    title = clean_html(self._html_search_regex(
                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yt-dlp/2023.7.6_1/libexec/lib/python3.11/site-packages/yt_dlp/extractor/common.py", line 1294, in _html_search_regex
    res = self._search_regex(pattern, string, name, default, fatal, flags, group)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yt-dlp/2023.7.6_1/libexec/lib/python3.11/site-packages/yt_dlp/extractor/common.py", line 1258, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
```
</details>

<details>
<summary>After</summary>
[debug] Command-line config: ['--cookies', 'cookies.txt', '-vU', 'https://massengeschmack.tv/play/fktvplus41']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.07.06 [b532a3481] (pip)
[debug] Python 3.11.4 (CPython arm64 64bit) - macOS-14.0-arm64-arm-64bit (OpenSSL 3.1.2 1 Aug 2023)
[debug] exe versions: ffmpeg 6.0 (setts), ffprobe 6.0, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.18.0, brotli-1.0.9, certifi-2023.07.22, mutagen-1.46.0, sqlite3-2.6.0, websockets-11.0.3
[debug] Proxy map: {}
[debug] Loaded 1855 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Available version: stable@2023.07.06, Current version: stable@2023.07.06
yt-dlp is up to date (stable@2023.07.06)
[massengeschmack.tv] Extracting URL: https://massengeschmack.tv/play/fktvplus41
[massengeschmack.tv] fktvplus41: Downloading webpage
[massengeschmack.tv] fktvplus41: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] fktvplus41: Downloading 1 format(s): hls-2465
[debug] Invoking hlsnative downloader on "https://dla3.massengeschmack.tv/stream/95876ce2afc8f7145a53fd765cdb2bcb/64d6b477/fktvplus41/5750k/fktvplus41_.m3u8"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 67
[download] Destination: FKTV PLUS #41 [fktvplus41].mp4
[download] 100% of  195.62MiB in 00:00:20 at 9.57MiB/s
[debug] ffprobe command line: ffprobe -hide_banner -show_format -show_streams -print_format json 'file:FKTV PLUS #41 [fktvplus41].mp4'
[debug] ffmpeg command line: ffprobe -show_streams 'file:FKTV PLUS #41 [fktvplus41].mp4'
[FixupM3u8] Fixing MPEG-TS in MP4 container of "FKTV PLUS #41 [fktvplus41].mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:FKTV PLUS #41 [fktvplus41].mp4' -map 0 -dn -ignore_unknown -c copy -f mp4 -bsf:a aac_adtstoasc -movflags +faststart 'file:FKTV PLUS #41 [fktvplus41].temp.mp4'
</details>

Fixes [issue not reported yet]


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc04e06</samp>

### Summary
🛠️🖼️✅

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the extractor was improved or fixed to handle website changes.
2.  🖼️ - This emoji represents a picture or a frame, and can be used to indicate that a thumbnail field was added to the test case.
3.  ✅ - This emoji represents a check mark or a confirmation, and can be used to indicate that a test case was updated or passed.
-->
Improved an extractor for a German media website and updated its test case.

> _Oh, we're the crew of the Massengeschmack_
> _And we scrape the web for videos to watch_
> _We've improved our `extractor` to handle the changes_
> _And we've added a `thumbnail` field to our test cases_

### Walkthrough
*  Update title extraction regex to handle different HTML layouts and capitalizations ([link](https://github.com/yt-dlp/yt-dlp/pull/7813/files?diff=unified&w=0#diff-4e1a95a1c75d3764577c0ae5c19da87143e7945c43d287ea8834eb6cf922403cL33-R34))
*  Update test case for `MassengeschmackTVIE` extractor to match the new title format, video hash, and thumbnail URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7813/files?diff=unified&w=0#diff-4e1a95a1c75d3764577c0ae5c19da87143e7945c43d287ea8834eb6cf922403cL20-R25))



</details>
