### PR TITLE
[extractor/noodlemagazine] Fix format metadata not found

### DIFF
--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -1,6 +1,5 @@
 from .common import InfoExtractor
 from ..utils import (
-    ExtractorError,
     extract_attributes,
     get_element_html_by_id,
     int_or_none,

--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -38,10 +38,13 @@ class NoodleMagazineIE(InfoExtractor):
         like_count = parse_count(self._html_search_meta('ya:ovs:likes', webpage, default=None))
         upload_date = unified_strdate(self._html_search_meta('ya:ovs:upload_date', webpage, default=''))
 
-        player_url = self._html_search_regex(rf'(/player/{video_id}[^"\'\s,]+)', webpage, 'player-url')
-        player_iframe = self._download_webpage(f'https://adult.noodlemagazine.com{player_url}', video_id)
-        playlist_url = self._html_search_regex(rf'(/playlist/{video_id}[^"\'\s,]+)', player_iframe, 'playlist-url')
-        playlist_info = self._download_json(f'https://adult.noodlemagazine.com{playlist_url}', video_id)
+        player_path = extract_attributes(get_element_html_by_id('iplayer', webpage) or '')['src']
+        player_iframe = self._download_webpage(
+            urljoin('https://adult.noodlemagazine.com', player_path), video_id, 'Downloading iframe page')
+        playlist_url = self._search_regex(
+            r'window\.playlistUrl\s*=\s*["\']([^"\']+)["\']', player_iframe, 'playlist url')
+        playlist_info = self._download_json(
+            urljoin('https://adult.noodlemagazine.com', playlist_url), video_id, headers={'Referer': url})
 
         thumbnail = self._og_search_property('image', webpage, default=None) or playlist_info.get('image')
         sources = playlist_info.get('sources')

--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -3,6 +3,11 @@ from ..utils import (
     parse_duration,
     parse_count,
     unified_strdate,
+    extract_attributes,
+    get_element_html_by_id,
+    urljoin,
+    traverse_obj,
+    int_or_none,
     ExtractorError
 )
 
@@ -51,11 +56,12 @@ class NoodleMagazineIE(InfoExtractor):
         if not sources:
             raise ExtractorError('Player sources not found!', expected=False, video_id=video_id)
 
-        formats = [{
-            'url': source.get('file'),
-            'quality': source.get('label'),
-            'ext': source.get('type'),
-        } for source in sources]
+        formats = traverse_obj(playlist_info, ('sources', lambda _, v: v['file'], {
+            'url': 'file',
+            'format_id': 'label',
+            'height': ('label', {int_or_none}),
+            'ext': 'type',
+        }))
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -10,6 +10,7 @@ from ..utils import (
 )
 from ..utils.traversal import traverse_obj
 
+
 class NoodleMagazineIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www|adult\.)?noodlemagazine\.com/watch/(?P<id>[0-9-_]+)'
     _TEST = {

--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -52,10 +52,6 @@ class NoodleMagazineIE(InfoExtractor):
             urljoin('https://adult.noodlemagazine.com', playlist_url), video_id, headers={'Referer': url})
 
         thumbnail = self._og_search_property('image', webpage, default=None) or playlist_info.get('image')
-        sources = playlist_info.get('sources')
-        if not sources:
-            raise ExtractorError('Player sources not found!', expected=False, video_id=video_id)
-
         formats = traverse_obj(playlist_info, ('sources', lambda _, v: v['file'], {
             'url': 'file',
             'format_id': 'label',

--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -1,16 +1,15 @@
 from .common import InfoExtractor
 from ..utils import (
-    parse_duration,
-    parse_count,
-    unified_strdate,
+    ExtractorError,
     extract_attributes,
     get_element_html_by_id,
-    urljoin,
-    traverse_obj,
     int_or_none,
-    ExtractorError
+    parse_count,
+    parse_duration,
+    unified_strdate,
+    urljoin,
 )
-
+from ..utils.traversal import traverse_obj
 
 class NoodleMagazineIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www|adult\.)?noodlemagazine\.com/watch/(?P<id>[0-9-_]+)'

--- a/yt_dlp/extractor/noodlemagazine.py
+++ b/yt_dlp/extractor/noodlemagazine.py
@@ -2,7 +2,8 @@ from .common import InfoExtractor
 from ..utils import (
     parse_duration,
     parse_count,
-    unified_strdate
+    unified_strdate,
+    ExtractorError
 )
 
 
@@ -37,15 +38,21 @@ class NoodleMagazineIE(InfoExtractor):
         like_count = parse_count(self._html_search_meta('ya:ovs:likes', webpage, default=None))
         upload_date = unified_strdate(self._html_search_meta('ya:ovs:upload_date', webpage, default=''))
 
-        key = self._html_search_regex(rf'/{video_id}\?(?:.*&)?m=([^&"\'\s,]+)', webpage, 'key')
-        playlist_info = self._download_json(f'https://adult.noodlemagazine.com/playlist/{video_id}?m={key}', video_id)
+        player_url = self._html_search_regex(rf'(/player/{video_id}[^"\'\s,]+)', webpage, 'player-url')
+        player_iframe = self._download_webpage(f'https://adult.noodlemagazine.com{player_url}', video_id)
+        playlist_url = self._html_search_regex(rf'(/playlist/{video_id}[^"\'\s,]+)', player_iframe, 'playlist-url')
+        playlist_info = self._download_json(f'https://adult.noodlemagazine.com{playlist_url}', video_id)
+
         thumbnail = self._og_search_property('image', webpage, default=None) or playlist_info.get('image')
+        sources = playlist_info.get('sources')
+        if not sources:
+            raise ExtractorError('Player sources not found!', expected=False, video_id=video_id)
 
         formats = [{
             'url': source.get('file'),
             'quality': source.get('label'),
             'ext': source.get('type'),
-        } for source in playlist_info.get('sources')]
+        } for source in sources]
 
         return {
             'id': video_id,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The site is currently broken after seemingly some changes were made.
The extractor produces a "TypeError" because the format metadata is no longer found.

Sidenote: The "Referer" header is now required (any non-whitespace value works), as I get a 403 error if I don't use it. Previously this was not needed. Can the user get some warning message regarding this?

Fixes #7917
* The extractor again finds the correct format metadata
* Additionally, instead of throwing a TypeError, a more helpful error message is thrown if the sources aren't found.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ef2f3ba</samp>

### Summary
🎥🛠️🧹

<!--
1.  🎥 - This emoji represents the video sources and playlist information that were improved by the changes. It also suggests that the changes are related to media content and streaming.
2.  🛠️ - This emoji represents the improvement and refinement of the extraction process and the use of `ExtractorError` to handle missing sources. It also suggests that the changes are related to fixing and enhancing the functionality and reliability of the code.
3.  🧹 - This emoji represents the avoidance of hardcoding and repetition of code, which implies cleaning and simplifying the code and making it more maintainable and readable. It also suggests that the changes are related to code quality and style.
-->
Improved Noodle Magazine extractor by handling errors, extracting playlists, and simplifying code.

> _Sing, O Muse, of the skillful coder who improved_
> _The extraction of video sources and playlists sublime_
> _From Noodle Magazine, the site of many a mood_
> _And handled errors with `ExtractorError` in his prime_

### Walkthrough
* Import `ExtractorError` class to raise exception for missing player sources ([link](https://github.com/yt-dlp/yt-dlp/pull/7830/files?diff=unified&w=0#diff-da9b42457bc0314dcc03d448c42082d0c4660607e07287a4b68f572710d13dc4L5-R6))
* Extract player URL and playlist URL from webpage and iframe instead of using hardcoded values ([link](https://github.com/yt-dlp/yt-dlp/pull/7830/files?diff=unified&w=0#diff-da9b42457bc0314dcc03d448c42082d0c4660607e07287a4b68f572710d13dc4L40-R49))
* Simplify code by using `sources` variable instead of repeating `playlist_info.get('sources')` ([link](https://github.com/yt-dlp/yt-dlp/pull/7830/files?diff=unified&w=0#diff-da9b42457bc0314dcc03d448c42082d0c4660607e07287a4b68f572710d13dc4L48-R55))



</details>
