### PR TITLE
[ie/nfl.com:plus:replay] Fix extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1865,9 +1865,6 @@ The following extractors use this feature:
 #### nhkradirulive (NHK らじる★らじる LIVE)
 * `area`: Which regional variation to extract. Valid areas are: `sapporo`, `sendai`, `tokyo`, `nagoya`, `osaka`, `hiroshima`, `matsuyama`, `fukuoka`. Defaults to `tokyo`
 
-#### nflplusreplay
-* `type`: Type(s) of game replays to extract. Valid types are: `full_game`, `full_game_spanish`, `condensed_game` and `all_22`. You can use `all` to extract all available replay types, which is the default
-
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 
 <!-- MANPAGE: MOVE "INSTALLATION" SECTION HERE -->

--- a/README.md
+++ b/README.md
@@ -1318,7 +1318,6 @@ The available fields are:
  - `was_live` (boolean): Whether this video was originally a live stream
  - `playable_in_embed` (string): Whether this video is allowed to play in embedded players on other sites
  - `availability` (string): Whether the video is "private", "premium_only", "subscriber_only", "needs_auth", "unlisted" or "public"
- - `media_type` (string): The type of video as defined by the site, e.g. "clip", "episode", "trailer"
  - `start_time` (numeric): Time in seconds where the reproduction should start, as specified in the URL
  - `end_time` (numeric): Time in seconds where the reproduction should end, as specified in the URL
  - `extractor` (string): Name of the extractor
@@ -1865,6 +1864,9 @@ The following extractors use this feature:
 
 #### nhkradirulive (NHK らじる★らじる LIVE)
 * `area`: Which regional variation to extract. Valid areas are: `sapporo`, `sendai`, `tokyo`, `nagoya`, `osaka`, `hiroshima`, `matsuyama`, `fukuoka`. Defaults to `tokyo`
+
+#### nflplusreplay
+* `type`: Type(s) of game replays to extract. Valid types are: `full_game`, `full_game_spanish`, `condensed_game` and `all_22`. You can use `all` to extract all available replay types, which is the default
 
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/README.md
+++ b/README.md
@@ -1318,6 +1318,7 @@ The available fields are:
  - `was_live` (boolean): Whether this video was originally a live stream
  - `playable_in_embed` (string): Whether this video is allowed to play in embedded players on other sites
  - `availability` (string): Whether the video is "private", "premium_only", "subscriber_only", "needs_auth", "unlisted" or "public"
+ - `media_type` (string): The type of video as defined by the site, e.g. "clip", "episode", "trailer"
  - `start_time` (numeric): Time in seconds where the reproduction should start, as specified in the URL
  - `end_time` (numeric): Time in seconds where the reproduction should end, as specified in the URL
  - `extractor` (string): Name of the extractor

--- a/README.md
+++ b/README.md
@@ -1865,6 +1865,9 @@ The following extractors use this feature:
 #### nhkradirulive (NHK らじる★らじる LIVE)
 * `area`: Which regional variation to extract. Valid areas are: `sapporo`, `sendai`, `tokyo`, `nagoya`, `osaka`, `hiroshima`, `matsuyama`, `fukuoka`. Defaults to `tokyo`
 
+#### nflplusreplay
+* `type`: Type(s) of game replays to extract. Valid types are: `full_game`, `full_game_spanish`, `condensed_game` and `all_22`. You can use `all` to extract all available replay types, which is the default
+
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 
 <!-- MANPAGE: MOVE "INSTALLATION" SECTION HERE -->

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -379,7 +379,6 @@ class InfoExtractor:
                     'private', 'premium_only', 'subscriber_only', 'needs_auth',
                     'unlisted' or 'public'. Use 'InfoExtractor._availability'
                     to set it
-    media_type:     The type of video as defined by the site, e.g. 'clip', 'episode', 'trailer'
     _old_archive_ids: A list of old archive ids needed for backward compatibility
     _format_sort_fields: A list of fields to use for sorting formats
     __post_extractor: A function to be called just before the metadata is

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -379,6 +379,7 @@ class InfoExtractor:
                     'private', 'premium_only', 'subscriber_only', 'needs_auth',
                     'unlisted' or 'public'. Use 'InfoExtractor._availability'
                     to set it
+    media_type:     The type of video as defined by the site, e.g. 'clip', 'episode', 'trailer'
     _old_archive_ids: A list of old archive ids needed for backward compatibility
     _format_sort_fields: A list of fields to use for sorting formats
     __post_extractor: A function to be called just before the metadata is

--- a/yt_dlp/extractor/nfl.py
+++ b/yt_dlp/extractor/nfl.py
@@ -294,6 +294,8 @@ class NFLPlusReplayIE(NFLBaseIE):
         replays = self._download_json(
             'https://api.nfl.com/content/v1/videos/replays', slug, 'Downloading replays JSON',
             query={'gameId': game_id}, headers=headers)
+        self.to_screen(f'Available replay types: {", ".join(traverse_obj(replays, ("items", ..., "subType")))}')
+        self.to_screen('Use --match-filter "media_type = \'REPLAY TYPE\'" to filter for a specific replay type')
 
         def entries():
             for replay in traverse_obj(replays, ('items', lambda _, v: v['mcpPlaybackId'])):

--- a/yt_dlp/extractor/nfl.py
+++ b/yt_dlp/extractor/nfl.py
@@ -278,31 +278,64 @@ class NFLPlusReplayIE(NFLBaseIE):
         'info_dict': {
             'id': 'giants-at-patriots-2011-pre-4',
         },
+    }, {
+        'note': 'Subscription required',
+        'url': 'https://www.nfl.com/plus/games/giants-at-patriots-2011-pre-4',
+        'info_dict': {
+            'id': '950701',
+            'ext': 'mp4',
+            'title': 'Giants @ Patriots',
+            'description': 'Giants at Patriots on September 01, 2011',
+            'uploader': 'NFL',
+            'upload_date': '20210724',
+            'timestamp': 1627085874,
+            'duration': 1532,
+            'categories': ['Game Highlights'],
+            'tags': ['play-by-play'],
+            'thumbnail': r're:^https?://.*\.jpg',
+        },
+        'params': {
+            'skip_download': 'm3u8',
+            'extractor_args': {'nflplusreplay': {'type': ['condensed_game']}},
+        },
     }]
+
+    _REPLAY_TYPES = {
+        'full_game': 'Full Game',
+        'full_game_spanish': 'Full Game - Spanish',
+        'condensed_game': 'Condensed Game',
+        'all_22': 'All-22',
+    }
 
     def _real_extract(self, url):
         slug, video_id = self._match_valid_url(url).group('slug', 'id')
+        requested_types = self._configuration_arg('type', ['all'])
+        if 'all' in requested_types:
+            requested_types = list(self._REPLAY_TYPES.keys())
+        requested_types = traverse_obj(self._REPLAY_TYPES, (None, requested_types))
+
+        if not video_id:
+            self._get_auth_token(url, slug)
+            headers = {'Authorization': f'Bearer {self._TOKEN}'}
+            game_id = self._download_json(
+                f'https://api.nfl.com/football/v2/games/externalId/slug/{slug}', slug,
+                'Downloading game ID', query={'withExternalIds': 'true'}, headers=headers)['id']
+            replays = self._download_json(
+                'https://api.nfl.com/content/v1/videos/replays', slug, 'Downloading replays JSON',
+                query={'gameId': game_id}, headers=headers)
+            if len(requested_types) == 1:
+                video_id = traverse_obj(replays, (
+                    'items', lambda _, v: v['subType'] == requested_types[0], 'mcpPlaybackId'), get_all=False)
 
         if video_id:
             return self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
 
-        self._get_auth_token(url, slug)
-        headers = {'Authorization': f'Bearer {self._TOKEN}'}
-        game_id = self._download_json(
-            f'https://api.nfl.com/football/v2/games/externalId/slug/{slug}', slug,
-            'Downloading game ID', query={'withExternalIds': 'true'}, headers=headers)['id']
-        replays = self._download_json(
-            'https://api.nfl.com/content/v1/videos/replays', slug, 'Downloading replays JSON',
-            query={'gameId': game_id}, headers=headers)
-        self.to_screen(f'Available replay types: {", ".join(traverse_obj(replays, ("items", ..., "subType")))}')
-        self.to_screen('Use --match-filter "media_type = \'REPLAY TYPE\'" to filter for a specific replay type')
-
         def entries():
-            for replay in traverse_obj(replays, ('items', lambda _, v: v['mcpPlaybackId'])):
+            for replay in traverse_obj(
+                replays, ('items', lambda _, v: v['mcpPlaybackId'] and v['subType'] in requested_types)
+            ):
                 video_id = replay['mcpPlaybackId']
-                yield self.url_result(
-                    f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id,
-                    media_type=replay.get('subType'), url_transparent=True)
+                yield self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
 
         return self.playlist_result(entries(), slug)
 

--- a/yt_dlp/extractor/nfl.py
+++ b/yt_dlp/extractor/nfl.py
@@ -64,6 +64,85 @@ class NFLBaseIE(InfoExtractor):
     _VIDEO_CONFIG_REGEX = r'<script[^>]+id="[^"]*video-config-[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}[^"]*"[^>]*>\s*({.+});?\s*</script>'
     _ANVATO_PREFIX = 'anvato:GXvEgwyJeWem8KCYXfeoHWknwP48Mboj:'
 
+    _CLIENT_DATA = {
+        'clientKey': '4cFUW6DmwJpzT9L7LrG3qRAcABG5s04g',
+        'clientSecret': 'CZuvCL49d9OwfGsR',
+        'deviceId': str(uuid.uuid4()),
+        'deviceInfo': base64.b64encode(json.dumps({
+            'model': 'desktop',
+            'version': 'Chrome',
+            'osName': 'Windows',
+            'osVersion': '10.0',
+        }, separators=(',', ':')).encode()).decode(),
+        'networkType': 'other',
+        'nflClaimGroupsToAdd': [],
+        'nflClaimGroupsToRemove': [],
+    }
+    _ACCOUNT_INFO = {}
+    _API_KEY = None
+
+    _TOKEN = None
+    _TOKEN_EXPIRY = 0
+
+    def _get_account_info(self, url, slug):
+        if not self._API_KEY:
+            webpage = self._download_webpage(url, slug, fatal=False) or ''
+            self._API_KEY = self._search_regex(
+                r'window\.gigyaApiKey\s*=\s*["\'](\w+)["\'];', webpage, 'API key',
+                fatal=False) or '3_Qa8TkWpIB8ESCBT8tY2TukbVKgO5F6BJVc7N1oComdwFzI7H2L9NOWdm11i_BY9f'
+
+        cookies = self._get_cookies('https://auth-id.nfl.com/')
+        login_token = traverse_obj(cookies, (
+            (f'glt_{self._API_KEY}', lambda k, _: k.startswith('glt_')), {lambda x: x.value}), get_all=False)
+        if not login_token:
+            self.raise_login_required()
+        if 'ucid' not in cookies:
+            raise ExtractorError(
+                'Required cookies for the auth-id.nfl.com domain were not found among passed cookies. '
+                'If using --cookies, these cookies must be exported along with .nfl.com cookies, '
+                'or else try using --cookies-from-browser instead', expected=True)
+
+        account = self._download_json(
+            'https://auth-id.nfl.com/accounts.getAccountInfo', slug,
+            note='Downloading account info', data=urlencode_postdata({
+                'include': 'profile,data',
+                'lang': 'en',
+                'APIKey': self._API_KEY,
+                'sdk': 'js_latest',
+                'login_token': login_token,
+                'authMode': 'cookie',
+                'pageURL': url,
+                'sdkBuild': traverse_obj(cookies, (
+                    'gig_canary_ver', {lambda x: x.value.partition('-')[0]}), default='15170'),
+                'format': 'json',
+            }), headers={'Content-Type': 'application/x-www-form-urlencoded'})
+
+        self._ACCOUNT_INFO = traverse_obj(account, {
+            'signatureTimestamp': 'signatureTimestamp',
+            'uid': 'UID',
+            'uidSignature': 'UIDSignature',
+        })
+
+        if len(self._ACCOUNT_INFO) != 3:
+            raise ExtractorError('Failed to retrieve account info with provided cookies', expected=True)
+
+    def _get_auth_token(self, url, slug):
+        if self._TOKEN and self._TOKEN_EXPIRY > int(time.time() + 30):
+            return
+
+        if not self._ACCOUNT_INFO:
+            self._get_account_info(url, slug)
+
+        token = self._download_json(
+            'https://api.nfl.com/identity/v3/token%s' % (
+                '/refresh' if self._ACCOUNT_INFO.get('refreshToken') else ''),
+            slug, headers={'Content-Type': 'application/json'}, note='Downloading access token',
+            data=json.dumps({**self._CLIENT_DATA, **self._ACCOUNT_INFO}, separators=(',', ':')).encode())
+
+        self._TOKEN = token['accessToken']
+        self._TOKEN_EXPIRY = token['expiresIn']
+        self._ACCOUNT_INFO['refreshToken'] = token['refreshToken']
+
     def _parse_video_config(self, video_config, display_id):
         video_config = self._parse_json(video_config, display_id)
         item = video_config['playlist'][0]
@@ -168,7 +247,7 @@ class NFLArticleIE(NFLBaseIE):
 
 class NFLPlusReplayIE(NFLBaseIE):
     IE_NAME = 'nfl.com:plus:replay'
-    _VALID_URL = r'https?://(?:www\.)?nfl.com/plus/games/[\w-]+/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?nfl.com/plus/games/(?P<slug>[\w-]+)(?:/(?P<id>\d+))?'
     _TESTS = [{
         'url': 'https://www.nfl.com/plus/games/giants-at-vikings-2022-post-1/1572108',
         'info_dict': {
@@ -187,9 +266,44 @@ class NFLPlusReplayIE(NFLBaseIE):
         'params': {'skip_download': 'm3u8'},
     }]
 
+    _REPLAY_TYPES = {
+        'full_game': 'Full Game',
+        'full_game_spanish': 'Full Game - Spanish',
+        'condensed_game': 'Condensed Game',
+        'all_22': 'All-22',
+    }
+
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        return self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
+        slug, video_id = self._match_valid_url(url).group('slug', 'id')
+        requested_types = self._configuration_arg('type', ['all'])
+        if 'all' in requested_types:
+            requested_types = list(self._REPLAY_TYPES.keys())
+        requested_types = traverse_obj(self._REPLAY_TYPES, (None, requested_types))
+
+        if not video_id:
+            self._get_auth_token(url, slug)
+            headers = {'Authorization': f'Bearer {self._TOKEN}'}
+            game_id = self._download_json(
+                f'https://api.nfl.com/football/v2/games/externalId/slug/{slug}', slug,
+                'Downloading game ID', query={'withExternalIds': 'true'}, headers=headers)['id']
+            replays = self._download_json(
+                'https://api.nfl.com/content/v1/videos/replays', slug, 'Downloading replays JSON',
+                query={'gameId': game_id}, headers=headers)
+            if len(requested_types) == 1:
+                video_id = traverse_obj(replays, (
+                    'items', lambda _, v: v['subType'] == requested_types[0], 'mcpPlaybackId'), get_all=False)
+
+        if video_id:
+            return self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
+
+        def entries():
+            for replay in traverse_obj(
+                replays, ('items', lambda _, v: v['mcpPlaybackId'] and v['subType'] in requested_types)
+            ):
+                video_id = replay['mcpPlaybackId']
+                yield self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
+
+        return self.playlist_result(entries(), slug)
 
 
 class NFLPlusEpisodeIE(NFLBaseIE):
@@ -214,85 +328,9 @@ class NFLPlusEpisodeIE(NFLBaseIE):
         'params': {'skip_download': 'm3u8'},
     }]
 
-    _CLIENT_DATA = {
-        'clientKey': '4cFUW6DmwJpzT9L7LrG3qRAcABG5s04g',
-        'clientSecret': 'CZuvCL49d9OwfGsR',
-        'deviceId': str(uuid.uuid4()),
-        'deviceInfo': base64.b64encode(json.dumps({
-            'model': 'desktop',
-            'version': 'Chrome',
-            'osName': 'Windows',
-            'osVersion': '10.0',
-        }, separators=(',', ':')).encode()).decode(),
-        'networkType': 'other',
-        'nflClaimGroupsToAdd': [],
-        'nflClaimGroupsToRemove': [],
-    }
-    _ACCOUNT_INFO = {}
-    _API_KEY = None
-
-    _TOKEN = None
-    _TOKEN_EXPIRY = 0
-
-    def _get_account_info(self, url, video_id):
-        cookies = self._get_cookies('https://www.nfl.com/')
-        login_token = traverse_obj(cookies, (
-            (f'glt_{self._API_KEY}', f'gig_loginToken_{self._API_KEY}',
-             lambda k, _: k.startswith('glt_') or k.startswith('gig_loginToken_')),
-            {lambda x: x.value}), get_all=False)
-        if not login_token:
-            self.raise_login_required()
-
-        account = self._download_json(
-            'https://auth-id.nfl.com/accounts.getAccountInfo', video_id,
-            note='Downloading account info', data=urlencode_postdata({
-                'include': 'profile,data',
-                'lang': 'en',
-                'APIKey': self._API_KEY,
-                'sdk': 'js_latest',
-                'login_token': login_token,
-                'authMode': 'cookie',
-                'pageURL': url,
-                'sdkBuild': traverse_obj(cookies, (
-                    'gig_canary_ver', {lambda x: x.value.partition('-')[0]}), default='13642'),
-                'format': 'json',
-            }), headers={'Content-Type': 'application/x-www-form-urlencoded'})
-
-        self._ACCOUNT_INFO = traverse_obj(account, {
-            'signatureTimestamp': 'signatureTimestamp',
-            'uid': 'UID',
-            'uidSignature': 'UIDSignature',
-        })
-
-        if len(self._ACCOUNT_INFO) != 3:
-            raise ExtractorError('Failed to retrieve account info with provided cookies', expected=True)
-
-    def _get_auth_token(self, url, video_id):
-        if not self._ACCOUNT_INFO:
-            self._get_account_info(url, video_id)
-
-        token = self._download_json(
-            'https://api.nfl.com/identity/v3/token%s' % (
-                '/refresh' if self._ACCOUNT_INFO.get('refreshToken') else ''),
-            video_id, headers={'Content-Type': 'application/json'}, note='Downloading access token',
-            data=json.dumps({**self._CLIENT_DATA, **self._ACCOUNT_INFO}, separators=(',', ':')).encode())
-
-        self._TOKEN = token['accessToken']
-        self._TOKEN_EXPIRY = token['expiresIn']
-        self._ACCOUNT_INFO['refreshToken'] = token['refreshToken']
-
     def _real_extract(self, url):
         slug = self._match_id(url)
-
-        if not self._API_KEY:
-            webpage = self._download_webpage(url, slug, fatal=False) or ''
-            self._API_KEY = self._search_regex(
-                r'window\.gigyaApiKey=["\'](\w+)["\'];', webpage, 'API key',
-                default='3_Qa8TkWpIB8ESCBT8tY2TukbVKgO5F6BJVc7N1oComdwFzI7H2L9NOWdm11i_BY9f')
-
-        if not self._TOKEN or self._TOKEN_EXPIRY <= int(time.time()):
-            self._get_auth_token(url, slug)
-
+        self._get_auth_token(url, slug)
         video_id = self._download_json(
             f'https://api.nfl.com/content/v1/videos/episodes/{slug}', slug, headers={
                 'Authorization': f'Bearer {self._TOKEN}',

--- a/yt_dlp/extractor/nfl.py
+++ b/yt_dlp/extractor/nfl.py
@@ -264,6 +264,40 @@ class NFLPlusReplayIE(NFLBaseIE):
             'thumbnail': r're:^https?://.*\.jpg',
         },
         'params': {'skip_download': 'm3u8'},
+    }, {
+        'note': 'Subscription required',
+        'url': 'https://www.nfl.com/plus/games/giants-at-vikings-2022-post-1',
+        'playlist_count': 4,
+        'info_dict': {
+            'id': 'giants-at-vikings-2022-post-1',
+        },
+    }, {
+        'note': 'Subscription required',
+        'url': 'https://www.nfl.com/plus/games/giants-at-patriots-2011-pre-4',
+        'playlist_count': 2,
+        'info_dict': {
+            'id': 'giants-at-patriots-2011-pre-4',
+        },
+    }, {
+        'note': 'Subscription required',
+        'url': 'https://www.nfl.com/plus/games/giants-at-patriots-2011-pre-4',
+        'info_dict': {
+            'id': '950701',
+            'ext': 'mp4',
+            'title': 'Giants @ Patriots',
+            'description': 'Giants at Patriots on September 01, 2011',
+            'uploader': 'NFL',
+            'upload_date': '20210724',
+            'timestamp': 1627085874,
+            'duration': 1532,
+            'categories': ['Game Highlights'],
+            'tags': ['play-by-play'],
+            'thumbnail': r're:^https?://.*\.jpg',
+        },
+        'params': {
+            'skip_download': 'm3u8',
+            'extractor_args': {'nflplusreplay': {'type': ['condensed_game']}},
+        },
     }]
 
     _REPLAY_TYPES = {
@@ -310,12 +344,12 @@ class NFLPlusEpisodeIE(NFLBaseIE):
     IE_NAME = 'nfl.com:plus:episode'
     _VALID_URL = r'https?://(?:www\.)?nfl.com/plus/episodes/(?P<id>[\w-]+)'
     _TESTS = [{
-        'note': 'premium content',
+        'note': 'Subscription required',
         'url': 'https://www.nfl.com/plus/episodes/kurt-s-qb-insider-conference-championships',
         'info_dict': {
             'id': '1576832',
             'ext': 'mp4',
-            'title': 'Kurt\'s QB Insider: Conference Championships',
+            'title': 'Conference Championships',
             'description': 'md5:944f7fab56f7a37430bf8473f5473857',
             'uploader': 'NFL',
             'upload_date': '20230127',


### PR DESCRIPTION
The NFL Plus website no longer includes the video ID in the Game Replay hyperlink URLs. This impacts the extractor in a few different ways:
 - `_VALID_URL` needs to be updated to match URLs without video IDs
 - The video ID(s) now need to be extracted from the API, which requires auth
 - URLs with the new format must return a playlist, since there are 2-4 different types of replay videos per ID-less URL

This PR addresses all of the above points, as well as doing the following:
 - Adds extractor-arg `type` to allow user to select specific type of game replay, since this was possible before via the old URL format w/video ID
 - Moves all auth code from `NFLPlusEpisodeIE` to the base class (as it is also needed by `NFLPlusReplayIE` now), and refactors it
 - Adds error handling for when passed cookiefile does not include necessary `auth-id.nfl.com` domain cookies
 
Closes #7836


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9686849</samp>

### Summary
🏈🎞️🔧

<!--
1.  🏈 - This emoji represents the NFL, the main topic of the changes, and the sport that the extractors are related to.
2.  🎞️ - This emoji represents the replays, the new feature that the changes introduce, and the type of video content that the extractors can download.
3.  🔧 - This emoji represents the enhancements, the improvements that the changes make to the existing code, and the tool that the extractors can be seen as.
-->
This pull request improves the NFL extractors by adding more features and simplifying the code. It adds support for video IDs and replay types in `nflplusreplay`, refactors the authentication and extraction logic in `nflplusepisode`, and stores the common data in `nflbase`. It also updates the `README.md` file to document the new option.

> _If you want to watch NFL replays_
> _With `nhkradirulive` in various ways_
> _You can use `nflplusreplay`_
> _To choose the type of display_
> _And pass optional video IDs for the games_

### Walkthrough
*  Add a new option `nflplusreplay` to the `nhkradirulive` extractor and document it in the README.md file ([link](https://github.com/yt-dlp/yt-dlp/pull/7838/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1868-R1870))
*  Add new class attributes `_CLIENT_DATA`, `_ACCOUNT_INFO`, and `_API_KEY` to the `NFLBaseIE` extractor in the `yt_dlp/extractor/nfl.py` file to store the data required for authentication with the NFL API ([link](https://github.com/yt-dlp/yt-dlp/pull/7838/files?diff=unified&w=0#diff-be19376aab1be1d7a00269126aca53f08771e4738e381672ca7b92b1a4de53ddR67-R145))
*  Modify the `_VALID_URL` pattern and the `_TESTS` list of the `NFLPlusReplayIE` extractor in the `yt_dlp/extractor/nfl.py` file to handle URLs with or without video IDs and to test different replay types ([link](https://github.com/yt-dlp/yt-dlp/pull/7838/files?diff=unified&w=0#diff-be19376aab1be1d7a00269126aca53f08771e4738e381672ca7b92b1a4de53ddL171-R250))
*  Modify the `_real_extract` method of the `NFLPlusReplayIE` extractor in the `yt_dlp/extractor/nfl.py` file to use the `nflplusreplay` option, the game slug, and the NFL API to extract the requested replays ([link](https://github.com/yt-dlp/yt-dlp/pull/7838/files?diff=unified&w=0#diff-be19376aab1be1d7a00269126aca53f08771e4738e381672ca7b92b1a4de53ddL188-R352))
*  Simplify the `_real_extract` method of the `NFLPlusEpisodeIE` extractor in the `yt_dlp/extractor/nfl.py` file by calling the `_get_auth_token` method of the `NFLBaseIE` extractor and removing duplicated code ([link](https://github.com/yt-dlp/yt-dlp/pull/7838/files?diff=unified&w=0#diff-be19376aab1be1d7a00269126aca53f08771e4738e381672ca7b92b1a4de53ddL217-R367))



</details>
