### PR TITLE
[zoom] Fixed screen share and added combined video

### DIFF
--- a/yt_dlp/extractor/zoom.py
+++ b/yt_dlp/extractor/zoom.py
@@ -44,6 +44,17 @@ class ZoomIE(InfoExtractor):
             'title': 'Timea Andrea Lelik\'s Personal Meeting Room',
         },
         'skip': 'This recording has expired',
+    }, {
+        # view_with_share URL
+        'url': 'https://cityofdetroit.zoom.us/rec/share/VjE-5kW3xmgbEYqR5KzRgZ1OFZvtMtiXk5HyRJo5kK4m5PYE6RF4rF_oiiO_9qaM.UTAg1MI7JSnF3ZjX',
+        'md5': 'bdc7867a5934c151957fb81321b3c024',
+        'info_dict': {
+            'id': 'VjE-5kW3xmgbEYqR5KzRgZ1OFZvtMtiXk5HyRJo5kK4m5PYE6RF4rF_oiiO_9qaM.UTAg1MI7JSnF3ZjX',
+            'ext': 'mp4',
+            'title': 'February 2022 Detroit Revenue Estimating Conference',
+            'duration': 7299,
+            'formats': 'mincount:3',
+        },
     }]
 
     def _get_page_data(self, webpage, video_id):

--- a/yt_dlp/extractor/zoom.py
+++ b/yt_dlp/extractor/zoom.py
@@ -93,7 +93,7 @@ class ZoomIE(InfoExtractor):
         json_path = f'{base_url}nws/recording/1.0/play/info/{file_id}'
 
         if url_type == 'share':
-            json_path += '?continueMode=true' 
+            json_path += '?continueMode=true'
 
         data = self._download_json(
             json_path, video_id, note='Downloading play info JSON')['result']
@@ -163,9 +163,8 @@ class ZoomIE(InfoExtractor):
 
         if not file_path:
             return
-        
+
         resolutino_str = file_path[file_path.rfind('_') + 1:file_path.rfind('.')]
 
         if resolutino_str:
             return resolutino_str.split('x')
-

--- a/yt_dlp/extractor/zoom.py
+++ b/yt_dlp/extractor/zoom.py
@@ -17,15 +17,6 @@ class ZoomIE(InfoExtractor):
     IE_NAME = 'zoom'
     _VALID_URL = r'(?P<base_url>https?://(?:[^.]+\.)?zoom.us/)rec(?:ording)?/(?P<type>play|share)/(?P<id>[A-Za-z0-9_.-]+)'
     _TESTS = [{
-        # play URL
-        'url': 'https://ffgolf.zoom.us/rec/play/qhEhXbrxq1Zoucx8CMtHzq1Z_2YZRPVCqWK_K-2FkEGRsSLDeOX8Tu4P6jtjZcRry8QhIbvKZdtr4UNo.QcPn2debFskI9whJ',
-        'md5': '2c4b1c4e5213ebf9db293e88d9385bee',
-        'info_dict': {
-            'id': 'qhEhXbrxq1Zoucx8CMtHzq1Z_2YZRPVCqWK_K-2FkEGRsSLDeOX8Tu4P6jtjZcRry8QhIbvKZdtr4UNo.QcPn2debFskI9whJ',
-            'ext': 'mp4',
-            'title': 'Prépa AF2023 - Séance 5 du 11 avril - R20/VM/GO',
-        },
-    }, {
         'url': 'https://economist.zoom.us/rec/play/dUk_CNBETmZ5VA2BwEl-jjakPpJ3M1pcfVYAPRsoIbEByGsLjUZtaa4yCATQuOL3der8BlTwxQePl_j0.EImBkXzTIaPvdZO5',
         'md5': 'ab445e8c911fddc4f9adc842c2c5d434',
         'info_dict': {
@@ -34,6 +25,15 @@ class ZoomIE(InfoExtractor):
             'title': 'China\'s "two sessions" and the new five-year plan',
         },
         'skip': 'Recording requires email authentication to access',
+    }, {
+        # play URL
+        'url': 'https://ffgolf.zoom.us/rec/play/qhEhXbrxq1Zoucx8CMtHzq1Z_2YZRPVCqWK_K-2FkEGRsSLDeOX8Tu4P6jtjZcRry8QhIbvKZdtr4UNo.QcPn2debFskI9whJ',
+        'md5': '2c4b1c4e5213ebf9db293e88d9385bee',
+        'info_dict': {
+            'id': 'qhEhXbrxq1Zoucx8CMtHzq1Z_2YZRPVCqWK_K-2FkEGRsSLDeOX8Tu4P6jtjZcRry8QhIbvKZdtr4UNo.QcPn2debFskI9whJ',
+            'ext': 'mp4',
+            'title': 'Prépa AF2023 - Séance 5 du 11 avril - R20/VM/GO',
+        },
     }, {
         # share URL
         'url': 'https://us02web.zoom.us/rec/share/hkUk5Zxcga0nkyNGhVCRfzkA2gX_mzgS3LpTxEEWJz9Y_QpIQ4mZFOUx7KZRZDQA.9LGQBdqmDAYgiZ_8',

--- a/yt_dlp/extractor/zoom.py
+++ b/yt_dlp/extractor/zoom.py
@@ -17,15 +17,6 @@ class ZoomIE(InfoExtractor):
     IE_NAME = 'zoom'
     _VALID_URL = r'(?P<base_url>https?://(?:[^.]+\.)?zoom.us/)rec(?:ording)?/(?P<type>play|share)/(?P<id>[A-Za-z0-9_.-]+)'
     _TESTS = [{
-        'url': 'https://economist.zoom.us/rec/play/dUk_CNBETmZ5VA2BwEl-jjakPpJ3M1pcfVYAPRsoIbEByGsLjUZtaa4yCATQuOL3der8BlTwxQePl_j0.EImBkXzTIaPvdZO5',
-        'md5': 'ab445e8c911fddc4f9adc842c2c5d434',
-        'info_dict': {
-            'id': 'dUk_CNBETmZ5VA2BwEl-jjakPpJ3M1pcfVYAPRsoIbEByGsLjUZtaa4yCATQuOL3der8BlTwxQePl_j0.EImBkXzTIaPvdZO5',
-            'ext': 'mp4',
-            'title': 'China\'s "two sessions" and the new five-year plan',
-        },
-        'skip': 'Recording requires email authentication to access',
-    }, {
         # play URL
         'url': 'https://ffgolf.zoom.us/rec/play/qhEhXbrxq1Zoucx8CMtHzq1Z_2YZRPVCqWK_K-2FkEGRsSLDeOX8Tu4P6jtjZcRry8QhIbvKZdtr4UNo.QcPn2debFskI9whJ',
         'md5': '2c4b1c4e5213ebf9db293e88d9385bee',
@@ -34,6 +25,15 @@ class ZoomIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'Prépa AF2023 - Séance 5 du 11 avril - R20/VM/GO',
         },
+    }, {
+        'url': 'https://economist.zoom.us/rec/play/dUk_CNBETmZ5VA2BwEl-jjakPpJ3M1pcfVYAPRsoIbEByGsLjUZtaa4yCATQuOL3der8BlTwxQePl_j0.EImBkXzTIaPvdZO5',
+        'md5': 'ab445e8c911fddc4f9adc842c2c5d434',
+        'info_dict': {
+            'id': 'dUk_CNBETmZ5VA2BwEl-jjakPpJ3M1pcfVYAPRsoIbEByGsLjUZtaa4yCATQuOL3der8BlTwxQePl_j0.EImBkXzTIaPvdZO5',
+            'ext': 'mp4',
+            'title': 'China\'s "two sessions" and the new five-year plan',
+        },
+        'skip': 'Recording requires email authentication to access',
     }, {
         # share URL
         'url': 'https://us02web.zoom.us/rec/share/hkUk5Zxcga0nkyNGhVCRfzkA2gX_mzgS3LpTxEEWJz9Y_QpIQ4mZFOUx7KZRZDQA.9LGQBdqmDAYgiZ_8',


### PR DESCRIPTION
### Fixed screen share and added combined video

Downloading the screen share video was broken, so I fixed it

while fixing it I noticed that zoom added support for video with the camera and screen share combined, so I added support for it

I also made the combined video the default for videos with screen share

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d104e95</samp>

### Summary
🛠️🆕🌐

<!--
1.  🛠️ - This emoji represents fixing or repairing something, and can be used to indicate that a bug or issue was resolved. In this case, it can signify that the extraction of Zoom recordings was fixed.
2.  🆕 - This emoji represents something new or added, and can be used to indicate that a feature or functionality was introduced. In this case, it can signify that a new format for view MP4 with share was added.
3.  🌐 - This emoji represents the internet or the web, and can be used to indicate that something related to URLs, web pages, or online services was involved. In this case, it can signify that `urllib` was used to parse URLs and extract resolution dynamically.
-->
Fix and improve Zoom extractor. Add support for `view_mp4_with_share` format and use `urllib` to parse URLs and extract resolution in `zoom.py`.

> _To fix Zoom recordings extraction_
> _And add a new format for action_
> _We use `urllib`_
> _To parse URLs nimbly_
> _And get the resolution by fraction_

### Walkthrough
* Fix share URL extraction by appending query parameter to JSON path ([link](https://github.com/yt-dlp/yt-dlp/pull/7847/files?diff=unified&w=0#diff-70a83df3be21a0a6676f15ef73b80d3f3ccd15db18697c8efeaa7e66ae1e1267L90-R99))
* Add new format for view MP4 with share URL that combines screen share and camera ([link](https://github.com/yt-dlp/yt-dlp/pull/7847/files?diff=unified&w=0#diff-70a83df3be21a0a6676f15ef73b80d3f3ccd15db18697c8efeaa7e66ae1e1267L122-R148))
* Change format ID for view MP4 URL to avoid confusion with share MP4 URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7847/files?diff=unified&w=0#diff-70a83df3be21a0a6676f15ef73b80d3f3ccd15db18697c8efeaa7e66ae1e1267L110-R117))
* Extract resolution from URL using `urllib` module and static method ([link](https://github.com/yt-dlp/yt-dlp/pull/7847/files?diff=unified&w=0#diff-70a83df3be21a0a6676f15ef73b80d3f3ccd15db18697c8efeaa7e66ae1e1267L13-R15), [link](https://github.com/yt-dlp/yt-dlp/pull/7847/files?diff=unified&w=0#diff-70a83df3be21a0a6676f15ef73b80d3f3ccd15db18697c8efeaa7e66ae1e1267R158-R170))
* Skip test case with invalid URL in `zoom.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7847/files?diff=unified&w=0#diff-70a83df3be21a0a6676f15ef73b80d3f3ccd15db18697c8efeaa7e66ae1e1267R46))



</details>
