### PR TITLE
Add NsfwYoutube as a Valid URL

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -441,6 +441,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         r'(?:www\.)?hyperpipe\.esmailelbob\.xyz',
         r'(?:www\.)?listen\.whatever\.social',
         r'(?:www\.)?music\.adminforge\.de',
+        # Nsfw Youtube 
+        r'(?:www\.)?nsfwyoutube\.com'
     )
 
     # extracted from account/account_menu ep


### PR DESCRIPTION

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Came about this when I tried to do this in yt-dlp so I wanted to add in NsfwYoutube-urls as another url to use. Surprised it hasn't been added yet so I added it in to the existing youtube extractor to make it be a working option.

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at be6968e</samp>

### Summary
:sparkles::lock::mag:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or functionality, which in this case is the ability to extract videos from nsfwyoutube.com.
2.  :lock: This emoji represents the security or privacy aspect of the change, which in this case is related to bypassing the age-restriction of YouTube videos.
3.  :mag: This emoji represents the improvement or enhancement of the existing code, which in this case is the extension of the `_VALID_URL` pattern to support more domains.
-->
Add support for nsfwyoutube.com by extending the URL pattern of `YoutubeBaseInfoExtractor` in `yt_dlp/extractor/youtube.py`. This allows extracting age-restricted YouTube videos without logging in.

> _`_VALID_URL` grows_
> _To handle nsfwyoutube_
> _A winter workaround_

### Walkthrough
* Add support for nsfwyoutube.com extraction ([link](https://github.com/yt-dlp/yt-dlp/pull/7857/files?diff=unified&w=0#diff-b7b9f6790de4427214b61939432e667d95b929d07fd918b9da1a36d7996cc506R444-R445),                              F



</details>
