### PR TITLE
Added CBCPlayerPlaylistIE

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -303,6 +303,7 @@ from .cartoonnetwork import CartoonNetworkIE
 from .cbc import (
     CBCIE,
     CBCPlayerIE,
+    CBCPlayerPlaylistIE,
     CBCGemIE,
     CBCGemPlaylistIE,
     CBCGemLiveIE,

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -2,6 +2,7 @@ import re
 import json
 import base64
 import time
+import urllib
 
 from .common import InfoExtractor
 from ..compat import (
@@ -9,16 +10,17 @@ from ..compat import (
 )
 from ..utils import (
     ExtractorError,
-    get_element_by_id,
     int_or_none,
     join_nonempty,
     js_to_json,
     orderedSet,
     parse_iso8601,
     smuggle_url,
+    str_or_none,
     strip_or_none,
     traverse_obj,
     try_get,
+    url_or_none,
 )
 
 
@@ -237,14 +239,12 @@ class CBCPlayerPlaylistIE(InfoExtractor):
         'playlist_mincount': 25,
         'info_dict': {
             'id': 'news/tv shows/the national/latest broadcast',
-            'ie_key': 'CBCPlayer',
         }
     }, {
         'url': 'https://www.cbc.ca/player/news/Canada/North',
         'playlist_mincount': 25,
         'info_dict': {
             'id': 'news/canada/north',
-            'ie_key': 'CBCPlayer',
         }
     }]
 
@@ -253,6 +253,7 @@ class CBCPlayerPlaylistIE(InfoExtractor):
         webpage = self._download_webpage(url, playlist_id)
         json_content = self._search_json(
             r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', playlist_id)
+
         def entries():
             for video in traverse_obj(json_content, (
                 'video', 'clipsByCategory', lambda k, _: k.lower() == playlist_id, 'items', lambda _, v: v['id']

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -253,10 +253,10 @@ class CBCPlayerPlaylistIE(InfoExtractor):
             r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', playlist_id)
 
         def entries():
-            for video in traverse_obj(json_content, (
-                'video', 'clipsByCategory', lambda k, _: k.lower() == playlist_id, 'items', lambda _, v: v['id']
+            for video_id in traverse_obj(json_content, (
+                'video', 'clipsByCategory', lambda k, _: k.lower() == playlist_id, 'items', ..., 'id'
             )):
-                yield self.url_result(f'https://www.cbc.ca/player/play/{video["id"]}', CBCPlayerIE)
+                yield self.url_result(f'https://www.cbc.ca/player/play/{video_id}', CBCPlayerIE)
 
         return self.playlist_result(entries(), playlist_id)
 

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -231,7 +231,7 @@ class CBCPlayerIE(InfoExtractor):
 
 class CBCPlayerPlaylistIE(InfoExtractor):
     IE_NAME = 'cbc.ca:player:playlist'
-    _VALID_URL = r'(?:cbcplayer:|https?://(?:www\.)?cbc\.ca/(?:player/)(?!play/))(?P<id>.+)'
+    _VALID_URL = r'https?://(?:www\.)?cbc\.ca/(?:player/)(?!play/)(?P<id>[^?#]+)'
     _TESTS = [{
         'url': 'https://www.cbc.ca/player/news/TV%20Shows/The%20National/Latest%20Broadcast',
         'playlist_mincount': 25,

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -2,7 +2,7 @@ import re
 import json
 import base64
 import time
-import urllib
+import urllib.parse
 
 from .common import InfoExtractor
 from ..compat import (
@@ -16,11 +16,9 @@ from ..utils import (
     orderedSet,
     parse_iso8601,
     smuggle_url,
-    str_or_none,
     strip_or_none,
     traverse_obj,
     try_get,
-    url_or_none,
 )
 
 
@@ -258,19 +256,7 @@ class CBCPlayerPlaylistIE(InfoExtractor):
             for video in traverse_obj(json_content, (
                 'video', 'clipsByCategory', lambda k, _: k.lower() == playlist_id, 'items', lambda _, v: v['id']
             )):
-                yield self.url_result(
-                    f'https://www.cbc.ca/player/play/{video["id"]}', CBCPlayerIE,
-                    **traverse_obj(video, {
-                        'id': ('id', {str_or_none}),
-                        'title': 'title',
-                        'description': 'description',
-                        'series': 'showName',
-                        'categories': ('contentArea', {lambda x: [x] if x else None}),
-                        'timestamp': ('airDate', {int_or_none}),
-                        'duration': ('duration', {int_or_none}),
-                        'is_live': ('isLive', {bool}),
-                        'thumbnail': ('thumbnail', {url_or_none}),
-                    }))
+                yield self.url_result(f'https://www.cbc.ca/player/play/{video["id"]}', CBCPlayerIE)
 
         return self.playlist_result(entries(), playlist_id)
 

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -250,13 +250,9 @@ class CBCPlayerPlaylistIE(InfoExtractor):
 
     def _real_extract(self, url):
         playlist_id = urllib.parse.unquote(self._match_id(url)).lower()
-        # the json info we're looking for isn't marked as such, therefore we need a bit of a workaround.
-        json_content = self._parse_json(
-            re.sub(
-                r'^.*?{', '{',
-                get_element_by_id('initialStateDom', self._download_webpage(url, playlist_id))
-            )[:-1],
-            playlist_id)
+        webpage = self._download_webpage(url, playlist_id)
+        json_content = self._search_json(
+            r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', playlist_id)
         playlist_items = []
         for key, value in json_content.get('video').get('clipsByCategory').items():
             # We need to do a case insensitive match. If anyone has a better way, feel free to improve.

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -249,8 +249,7 @@ class CBCPlayerPlaylistIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        # We have no other playlist id other than the URL, so use that
-        playlist_id = self._match_id(url).replace('%20', ' ').lower()
+        playlist_id = urllib.parse.unquote(self._match_id(url)).lower()
         # the json info we're looking for isn't marked as such, therefore we need a bit of a workaround.
         json_content = self._parse_json(
             re.sub(

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -253,7 +253,10 @@ class CBCPlayerPlaylistIE(InfoExtractor):
         playlist_id = self._match_id(url).replace('%20', ' ').lower()
         # the json info we're looking for isn't marked as such, therefore we need a bit of a workaround.
         json_content = self._parse_json(
-            get_element_by_id('initialStateDom', self._download_webpage(url, playlist_id))[27:-1],
+            re.sub(
+                r'^.*?{', '{',
+                get_element_by_id('initialStateDom', self._download_webpage(url, playlist_id))
+            )[:-1],
             playlist_id)
         playlist_items = []
         for key, value in json_content.get('video').get('clipsByCategory').items():


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This adds support for CBC Player playlists. There doesn't seem to be any direct connection to ThePlatform here, so we need to extract this information from JSON in the website - with the difficulty being that it's not marked as JSON. Therefore some methods are a bit blunt. Improvements are welcome.
One question is still kind of open for me: what is considered a playlist and what not? The sites I added in the tests are more or less clear playlists, although they could also be seen as a collection of videos by category. However, when on the page for an individual video, it will often list other videos in the same category (see the videos from the playlists in the tests). I haven't treated the pages for individual videos as playlists. However, internally, the webpage treats them the same way, so it would be a minor change. Let me know if I should change this.

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f692108</samp>

### Summary
:sparkles::memo::mag:

<!--
1.  :sparkles: This emoji represents adding a new feature or functionality, such as a new extractor class.
2.  :memo: This emoji represents writing or updating documentation or comments, such as the docstring for the new class.
3.  :mag: This emoji represents improving or refining code quality, such as using a helper method to parse the HTML page.
-->
Add support for CBC player playlists. Create a new extractor class `CBCPlayerPlaylistIE` in `cbc.py` and register it in `_extractors.py`.

> _`CBCPlayerPlaylistIE`_
> _Extracts videos from HTML_
> _A new class for fall_

### Walkthrough
*  Add support for extracting videos from CBC player playlists ([link](https://github.com/yt-dlp/yt-dlp/pull/7870/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R306), [link](https://github.com/yt-dlp/yt-dlp/pull/7870/files?diff=unified&w=0#diff-f0840207126abfbed9de8bbd0799354c8163c9d8924b24c8eb0bed3378fe6ceeR12), [link](https://github.com/yt-dlp/yt-dlp/pull/7870/files?diff=unified&w=0#diff-f0840207126abfbed9de8bbd0799354c8163c9d8924b24c8eb0bed3378fe6ceeR232-R288))
  * Import `get_element_by_id` function from `utils.py` to find playlist JSON data in HTML page ([link](https://github.com/yt-dlp/yt-dlp/pull/7870/files?diff=unified&w=0#diff-f0840207126abfbed9de8bbd0799354c8163c9d8924b24c8eb0bed3378fe6ceeR12))
  * Define `CBCPlayerPlaylistIE` class in `cbc.py` that inherits from `InfoExtractor` and overrides `_real_extract` method ([link](https://github.com/yt-dlp/yt-dlp/pull/7870/files?diff=unified&w=0#diff-f0840207126abfbed9de8bbd0799354c8163c9d8924b24c8eb0bed3378fe6ceeR232-R288))



</details>
