### PR TITLE
[extractor/Facebook] fix: Changed json data retrieval

### DIFF
--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -290,7 +290,7 @@ class FacebookIE(InfoExtractor):
             'title': 'Josef',
             'thumbnail': r're:^https?://.*',
             'concurrent_view_count': int,
-            'uploader_id': 'pfbid02gkCBqv63n3iV79siJTzc4GRk8YT3dfvo2Tc4o2Coy98gUTNbX6ucCwK7bhDdYhvpl',
+            'uploader_id': 'pfbid0cibUN6tV7DYgdbJdsUFN46wc4jKpVSPAvJQhFofGqBGmVn3V3JtAs2tfUwziw2hUl',
             'timestamp': 1549275572,
             'duration': 3.413,
             'uploader': 'Josef Novak',
@@ -513,15 +513,10 @@ class FacebookIE(InfoExtractor):
                 webpage, 'replay data', default='{}'), video_id, fatal=False) or {}
 
         def extract_relay_prefetched_data(_filter):
-            replay_data = extract_relay_data(_filter)
-            for require in (replay_data.get('require') or []):
-                if require[0] == 'RelayPrefetchedStreamCache':
-                    return try_get(require, lambda x: x[3][1]['__bbox']['result']['data'], dict) or {}
-                else:
-                    data = traverse_obj(require, (
-                        ..., ..., '__bbox', 'require', lambda _, v: "RelayPrefetchedStreamCache" in v,
-                        ..., ..., "__bbox", "result", "data"))
-                    return data[0] if data else {}
+            return traverse_obj(extract_relay_data(_filter), (
+                'require', (None, (..., ..., ..., '__bbox', 'require')),
+                lambda _, v: 'RelayPrefetchedStreamCache' in v, ..., ...,
+                '__bbox', 'result', 'data', {dict}), get_all=False) or {}
 
         if not video_data:
             server_js_data = self._parse_json(self._search_regex([

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -73,8 +73,7 @@ class FacebookIE(InfoExtractor):
     _VIDEO_PAGE_TEMPLATE = 'https://www.facebook.com/video/video.php?v=%s'
     _VIDEO_PAGE_TAHOE_TEMPLATE = 'https://www.facebook.com/video/tahoe/async/%s/?chain=true&isvideo=true&payloadtype=primary'
 
-    _TESTS = [
-    {
+    _TESTS = [{
         'url': 'https://www.facebook.com/radiokicksfm/videos/3676516585958356/',
         'info_dict': {
             'id': '3676516585958356',
@@ -90,8 +89,7 @@ class FacebookIE(InfoExtractor):
             'view_count': int,
             'concurrent_view_count': 0,
         },
-    },
-    {
+    }, {
         'url': 'https://www.facebook.com/video.php?v=637842556329505&fref=nf',
         'md5': '6a40d33c0eccbb1af76cf0485a052659',
         'info_dict': {

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -79,7 +79,7 @@ class FacebookIE(InfoExtractor):
             'id': '3676516585958356',
             'ext': 'mp4',
             'title': 'dr Adam Przygoda',
-            'description': 'DR ADAM PRZYGODA LIVE (przepraszamy na początku rozmowy nie ma dźwięku ) Bilety na II Konferencja Zdrowia "Łączy Nas dbałość o zdrowie\' Londyn 2023 | Targi Zdrowia   znajdziesz na Www.konferencjalondyn.co.uk \nRADIO KICKS FM  jest głównym patronem medialnym wydarzenia.',
+            'description': 'md5:34675bda53336b1d16400265c2bb9b3b',
             'uploader': 'RADIO KICKS FM',
             'upload_date': '20230818',
             'timestamp': 1692346159,
@@ -113,7 +113,7 @@ class FacebookIE(InfoExtractor):
             'upload_date': '20140506',
             'timestamp': 1399398998,
             'thumbnail': r're:^https?://.*',
-            'uploader_id': 'pfbid05Gg6yArwD5tAX9g6xdLkTgf6dBnBAPuCYTjfueQBDAYW19tARDAp4BjrnUeUhmuyl',
+            'uploader_id': 'pfbid028wxorhX2ErLFJ578N6P3crHD3PHmXTCqCvfBpsnbSLmbokwSY75p5hWBjHGkG4zxl',
             'duration': 131.03,
             'concurrent_view_count': int,
         },
@@ -195,7 +195,7 @@ class FacebookIE(InfoExtractor):
             'timestamp': 1486648217,
             'upload_date': '20170209',
             'uploader': 'Yaroslav Korpan',
-            'uploader_id': 'pfbid029tEoNV4cHL7NS2NWNkHopnqqK9vo8oDC2w72YueiHkR3pCEdMD3kFfWdtzym2RwPl',
+            'uploader_id': 'pfbid06AScABAWcW91qpiuGrLt99Ef9tvwHoXP6t8KeFYEqkSfreMtfa9nTveh8b2ZEVSWl',
             'concurrent_view_count': int,
             'thumbnail': r're:^https?://.*',
             'view_count': int,
@@ -290,7 +290,7 @@ class FacebookIE(InfoExtractor):
             'title': 'Josef',
             'thumbnail': r're:^https?://.*',
             'concurrent_view_count': int,
-            'uploader_id': 'pfbid02gSPfaQnamrMTEwW53PkXcvmHgtKPuGw9atAhCn545KqXUA1wQ1pNY7F3rjMbqQdvl',
+            'uploader_id': 'pfbid02gkCBqv63n3iV79siJTzc4GRk8YT3dfvo2Tc4o2Coy98gUTNbX6ucCwK7bhDdYhvpl',
             'timestamp': 1549275572,
             'duration': 3.413,
             'uploader': 'Josef Novak',
@@ -417,7 +417,7 @@ class FacebookIE(InfoExtractor):
 
         def extract_metadata(webpage):
             post_data = [self._parse_json(j, video_id, fatal=False) for j in re.findall(
-                r'data-sjs>({.*?ScheduledServerJS.*?})<\/script', webpage)]
+                r'data-sjs>({.*?ScheduledServerJS.*?})</script>', webpage)]
             post = traverse_obj(post_data, (
                 ..., 'require', ..., ..., ..., '__bbox', 'require', ..., ..., ..., '__bbox', 'result', 'data'), expected_type=dict) or []
             media = traverse_obj(post, (..., 'attachments', ..., lambda k, v: (
@@ -509,7 +509,7 @@ class FacebookIE(InfoExtractor):
 
         def extract_relay_data(_filter):
             return self._parse_json(self._search_regex(
-                r'data-sjs>({.*?%s.*?})<\/script' % _filter,
+                r'data-sjs>({.*?%s.*?})</script>' % _filter,
                 webpage, 'replay data', default='{}'), video_id, fatal=False) or {}
 
         def extract_relay_prefetched_data(_filter):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Facebook looks to have changed API and json data is served bit differently.

Fixes #7901 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6357e0f</samp>

### Summary
🛠️🌟➕

<!--
1.  🛠️ for fixing the broken extractor
2.  🌟 for improving the metadata and format extraction
3.  ➕ for adding support for more video URLs
-->
Fix and enhance `FacebookIE` extractor to handle new webpage layout and more video URLs. Update tests, metadata, and formats accordingly.

> _The FacebookIE extractor was broken_
> _By a change that the website had spoken_
> _But this pull request_
> _Fixes it and adds zest_
> _With more URLs and metadata tokens_

### Walkthrough
*  Fix extraction of video formats, subtitles, and thumbnails from Facebook webpages ([link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL404-R424), [link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL496-R514), [link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecR522-R526), [link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL514-R537), [link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL529-R553))
* Update uploader_id values in existing test cases for FacebookIE extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL100-R118), [link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL182-R200), [link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL277-R295))
* Add a new test case for FacebookIE extractor with a different URL and info_dict ([link](https://github.com/yt-dlp/yt-dlp/pull/7890/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL76-R94))



</details>
