### PR TITLE
fix(wat.tv): remove `MYTF1` context to remove "Permission insuffisante" error

### DIFF
--- a/yt_dlp/extractor/tf1.py
+++ b/yt_dlp/extractor/tf1.py
@@ -28,6 +28,25 @@ class TF1IE(InfoExtractor):
             'skip_download': True,
         },
     }, {
+        'url': 'https://www.tf1.fr/tmc/burger-quiz/videos/burger-quiz-du-19-aout-2023-s03-episode-21-85585666.html',
+        'info_dict': {
+            'id': '14010600',
+            'ext': 'mp4',
+            'title': 'Burger Quiz - S03 EP21 avec Eye Haidara, Anne Depétrini, Jonathan Zaccaï et Pio Marmaï',
+            'thumbnail': 'https://photos.tf1.fr/1280/720/burger-quiz-11-9adb79-0@1x.jpg',
+            'description': 'Manu Payet recevra Eye Haidara, Anne Depétrini, Jonathan Zaccaï et Pio Marmaï.',
+            'upload_date': '20230819',
+            'timestamp': 1692469471,
+            'season_number': 3,
+            'series': 'Burger Quiz',
+            'episode_number': 21,
+            'season': 'Season 3',
+            'tags': 'count:13',
+            'episode': 'Episode 21',
+            'duration': 2312
+        },
+        'params': {'skip_download': 'm3u8'},
+    }, {
         'url': 'http://www.tf1.fr/tf1/koh-lanta/videos/replay-koh-lanta-22-mai-2015.html',
         'only_matching': True,
     }, {

--- a/yt_dlp/extractor/wat.py
+++ b/yt_dlp/extractor/wat.py
@@ -41,6 +41,18 @@ class WatIE(InfoExtractor):
             'expected_warnings': ["Ce contenu n'est pas disponible pour l'instant."],
             'skip': 'This content is no longer available',
         },
+        {
+            'url': 'wat:14010600',
+            'info_dict': {
+                'id': '14010600',
+                'title': 'Burger Quiz - S03 EP21 avec Eye Haidara, Anne Depétrini, Jonathan Zaccaï et Pio Marmaï',
+                'thumbnail': 'https://photos.tf1.fr/1280/720/burger-quiz-11-9adb79-0@1x.jpg',
+                'upload_date': '20230819',
+                'duration': 2312,
+                'ext': 'mp4',
+            },
+            'params': {'skip_download': 'all'},
+        }
     ]
     _GEO_BYPASS = False
 
@@ -54,7 +66,7 @@ class WatIE(InfoExtractor):
         #     'http://www.wat.tv/interface/contentv4s/' + video_id, video_id)
         video_data = self._download_json(
             'https://mediainfo.tf1.fr/mediainfocombo/' + video_id,
-            video_id, query={'context': 'MYTF1', 'pver': '4020003'})
+            video_id, query={'pver': '5010000'})
         video_info = video_data['media']
 
         error_desc = video_info.get('error_desc')

--- a/yt_dlp/extractor/wat.py
+++ b/yt_dlp/extractor/wat.py
@@ -51,7 +51,7 @@ class WatIE(InfoExtractor):
                 'duration': 2312,
                 'ext': 'mp4',
             },
-            'params': {'skip_download': 'all'},
+            'params': {'skip_download': 'm3u8'},
         }
     ]
     _GEO_BYPASS = False


### PR DESCRIPTION
### Description of your *pull request* and other information

Modification in the `wat.py` extractor to be compatible with changes applied by the platform. See issue #7303 for more detail. I've just applied modification tested in this issue and locally. 

Fixes #7303


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5106412</samp>

### Summary
🛠️🔄❌

<!--
1.  🛠️ - This emoji represents a wrench and a hammer, and it can be used to indicate a fix or a repair of something that was broken or not working properly. In this case, the change was made to fix the extraction of videos from the wat.tv website, which was broken by the API change.
2.  🔄 - This emoji represents a clockwise arrow, and it can be used to indicate an update or a refresh of something. In this case, the change was made to update the pver value to match the new API version required by the wat.tv website.
3.  ❌ - This emoji represents a cross mark, and it can be used to indicate a removal or a deletion of something. In this case, the change was made to remove the context parameter, which was not needed anymore and caused an error.
-->
Fix wat.tv extraction by updating URL parameters in `yt_dlp/extractor/wat.py`

> _`wat.tv` changed API_
> _`pver` updated, `context` dropped_
> _video extraction fixed_

### Walkthrough
* Remove `context` and update `pver` in JSON URL to fix video extraction from wat.tv ([link](https://github.com/yt-dlp/yt-dlp/pull/7898/files?diff=unified&w=0#diff-45cafb67cb871bcf2d966a0fa5b23b1062a8381d0fb25cc37683c72151c011bcL57-R57))



</details>
