### PR TITLE
[tests] Add tests for socks proxies

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,11 @@
-import pytest
-import inspect
-from yt_dlp.networking import RequestHandler
-from yt_dlp.utils._utils import _YDLLogger as FakeLogger
 import functools
+import inspect
+
+import pytest
+
+from yt_dlp.networking import RequestHandler
 from yt_dlp.networking.common import _REQUEST_HANDLERS
+from yt_dlp.utils._utils import _YDLLogger as FakeLogger
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+import inspect
+from yt_dlp.networking import RequestHandler
+from yt_dlp.utils._utils import _YDLLogger as FakeLogger
+import functools
+from yt_dlp.networking.common import _REQUEST_HANDLERS
+
+
+@pytest.fixture
+def handler(request):
+    RH_KEY = request.param
+    if inspect.isclass(RH_KEY) and issubclass(RH_KEY, RequestHandler):
+        handler = RH_KEY
+    elif RH_KEY in _REQUEST_HANDLERS:
+        handler = _REQUEST_HANDLERS[RH_KEY]
+    else:
+        pytest.skip(f'{RH_KEY} request handler is not available')
+
+    return functools.partial(handler, logger=FakeLogger)

--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -8,12 +8,10 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import functools
 import gzip
 import http.client
 import http.cookiejar
 import http.server
-import inspect
 import io
 import pathlib
 import random
@@ -40,7 +38,6 @@ from yt_dlp.networking import (
     Response,
 )
 from yt_dlp.networking._urllib import UrllibRH
-from yt_dlp.networking.common import _REQUEST_HANDLERS
 from yt_dlp.networking.exceptions import (
     CertificateVerifyError,
     HTTPError,
@@ -305,19 +302,6 @@ class TestRequestHandlerBase:
         cls.https_server_thread = threading.Thread(target=cls.https_httpd.serve_forever)
         cls.https_server_thread.daemon = True
         cls.https_server_thread.start()
-
-
-@pytest.fixture
-def handler(request):
-    RH_KEY = request.param
-    if inspect.isclass(RH_KEY) and issubclass(RH_KEY, RequestHandler):
-        handler = RH_KEY
-    elif RH_KEY in _REQUEST_HANDLERS:
-        handler = _REQUEST_HANDLERS[RH_KEY]
-    else:
-        pytest.skip(f'{RH_KEY} request handler is not available')
-
-    return functools.partial(handler, logger=FakeLogger)
 
 
 class TestHTTPRequestHandler(TestRequestHandlerBase):

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -151,14 +151,7 @@ class Socks4ProxyHandler(StreamRequestHandler, SocksProxyHandler):
     # SOCKS4A protocol http://www.openssh.com/txt/socks4a.protocol
 
     def _read_until_null(self):
-        # good enough for testing
-        data = b''
-        while True:
-            raw = self.connection.recv(1)
-            if raw == b'\x00':
-                break
-            data += raw
-        return data
+        return b''.join(iter(functools.partial(self.connection.recv, 1), b'\x00'))
 
     def handle(self):
         sleep = self.socks_kwargs.get('sleep')

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -24,7 +24,7 @@ import socket
 import http.server
 from test.helper import FakeYDL, get_params, is_download_test, http_server_port
 from test.test_networking import handler
-
+from yt_dlp.socks import SOCKS4_VERSION, Socks4Command
 SOCKS_NEGOTIATION_NONE = 0x0
 SOCKS_NEGOTIATION_USER_PASS = 0x2
 
@@ -119,20 +119,74 @@ class Socks5ProxyServer(StreamRequestHandler):
             )
 
 
+class Socks4ProxyServer(StreamRequestHandler):
+
+    # SOCKS4 protocol http://www.openssh.com/txt/socks4.protocol
+    # SOCKS4A protocol http://www.openssh.com/txt/socks4a.protocol
+
+    def __init__(self, userid, request_handler_class, *args, **kwargs):
+        self.userid = userid or ''
+        self.request_handler_class = request_handler_class
+        super().__init__(*args, **kwargs)
+
+    def _read_until_null(self):
+        # good enough for testing
+        data = b''
+        while True:
+            raw = self.connection.recv(1)
+            if raw == b'\x00':
+                break
+            data += raw
+        return data
+
+    def handle(self):
+
+        socks_info = {
+            'version': SOCKS_VERSION_SOCKS4,
+            'command': None,
+            'client_address': self.client_address,
+            'ipv4_address': None,
+            'port': None,
+            'domain_address': None,
+        }
+        version, command, dest_port, dest_ip = struct.unpack("!BBHI", self.connection.recv(8))
+        socks_info['port'] = dest_port
+        socks_info['command'] = command
+        if version != SOCKS4_VERSION:
+            self.server.close_request(self.request)
+            return
+        use_remote_dns = False
+        if 0x0 < dest_ip <= 0xFF:
+            use_remote_dns = True
+        else:
+            socks_info['ipv4_address'] = socket.inet_ntoa(struct.pack("!I", dest_ip))
+
+        user_id = self._read_until_null().decode()
+        if user_id != self.userid:
+            self.connection.sendall(struct.pack("!BBHI", 0, 93, 0x00, 0x00000000))
+            self.server.close_request(self.request)
+            return
+
+        if use_remote_dns:
+            socks_info['domain_address'] = self._read_until_null().decode()
+
+        # TODO: test error mapping here
+        self.connection.sendall(struct.pack("!BBHI", 0, 90, 40000, 0x7f000001))
+        self.request_handler_class(
+            self.request,
+            self.client_address,
+            self.server,
+            socks_info=socks_info
+        )
+
+
 class IPv6ThreadingTCPServer(ThreadingTCPServer):
     address_family = socket.AF_INET6
 
 
 class SocksHTTPTestRequestHandler(http.server.BaseHTTPRequestHandler, SocksTestRequestHandler):
     def do_GET(self):
-        if self.path == '/':
-            payload = b'<html><video src="/vid.mp4" /></html>'
-            self.send_response(200)
-            self.send_header('Content-Type', 'text/html; charset=utf-8')
-            self.send_header('Content-Length', str(len(payload)))
-            self.end_headers()
-            self.wfile.write(payload)
-        elif self.path == '/proxy':
+        if self.path == '/proxy':
             payload = json.dumps(self.socks_info.copy())
             self.send_response(200)
             self.send_header('Content-Type', 'application/json; charset=utf-8')
@@ -147,6 +201,60 @@ def request_proxy_info(handler, target=None, **req_kwargs):
     return json.loads(handler.send(request).read().decode())
 
 
+@pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
+class TestSocks4Proxy:
+    @classmethod
+    def setup_class(cls):
+        cls.socks_http_no_auth = ThreadingTCPServer(
+            ('127.0.0.1', 0), functools.partial(Socks4ProxyServer, None, SocksHTTPTestRequestHandler))
+        cls.socks_http_no_auth_port = http_server_port(cls.socks_http_no_auth)
+        cls.socks_http_no_auth_thread = threading.Thread(target=cls.socks_http_no_auth.serve_forever)
+        cls.socks_http_no_auth_thread.daemon = True
+        cls.socks_http_no_auth_thread.start()
+
+        cls.socks_http_auth = ThreadingTCPServer(
+            ('127.0.0.1', 0), functools.partial(Socks4ProxyServer, 'user', SocksHTTPTestRequestHandler))
+        cls.socks_http_auth_port = http_server_port(cls.socks_http_auth)
+        cls.socks_http_auth_thread = threading.Thread(target=cls.socks_http_auth.serve_forever)
+        cls.socks_http_auth_thread.daemon = True
+        cls.socks_http_auth_thread.start()
+
+    def test_socks4_auth(self, handler):
+        with handler() as rh:
+            response = request_proxy_info(
+                rh, proxies={'all': f'socks4://@127.0.0.1:{self.socks_http_no_auth_port}'})
+            assert response['version'] == 4
+
+            response = request_proxy_info(
+                rh, proxies={'all': f'socks4://user:@127.0.0.1:{self.socks_http_auth_port}'})
+            assert response['version'] == 4
+
+    @pytest.mark.skip('socks4a implementation currently broken when destination is not a domain name')
+    def test_socks4a_ipv4(self, handler):
+        with handler(proxies={'all': f'socks4a://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
+            response = request_proxy_info(rh, target='http://127.0.0.1/proxy')
+            assert response['version'] == 4
+            assert response['ipv4_address'] == '127.0.0.1'
+            assert response['domain_address'] is None
+
+    def test_socks4a_domain(self, handler):
+        with handler(proxies={'all': f'socks4a://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
+            response = request_proxy_info(rh, target='http://localhost/proxy')
+            assert response['version'] == 4
+            assert response['ipv4_address'] is None
+            assert response['domain_address'] == 'localhost'
+
+    @pytest.mark.skip('source_address is not yet supported for socks4 proxies')
+    def test_ipv4_client_source_address(self, handler):
+        source_address = f'127.0.0.{random.randint(5, 255)}'
+        with handler(proxies={'all': f'socks4://127.0.0.1:{self.socks_http_no_auth_port}'},
+                     source_address=source_address) as rh:
+            response = request_proxy_info(rh)
+            assert response['client_address'][0] == source_address
+            assert response['version'] == 4
+
+
+@pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
 class TestSocks5Proxy:
     @classmethod
     def setup_class(cls):
@@ -171,14 +279,12 @@ class TestSocks5Proxy:
         cls.socks_http_ipv6_thread.daemon = True
         cls.socks_http_ipv6_thread.start()
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     def test_socks5_no_auth(self, handler):
         with handler(proxies={'all': f'socks5://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
             response = request_proxy_info(rh)
             assert response['auth_methods'] == [0x0]
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     def test_socks5_user_pass(self, handler):
         with handler() as rh:
             with pytest.raises(ProxyError):
@@ -190,7 +296,6 @@ class TestSocks5Proxy:
             assert response['auth_methods'] == [0x0, 0x2]
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     def test_socks5_ipv4_target(self, handler):
         with handler(proxies={'all': f'socks5://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
             response = request_proxy_info(rh, target='http://1.1.1.1/proxy')
@@ -198,7 +303,6 @@ class TestSocks5Proxy:
             assert response['port'] == 80
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     def test_socks5_domain_target(self, handler):
         with handler(proxies={'all': f'socks5://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
             response = request_proxy_info(rh, target='http://localhost:9999/proxy')
@@ -206,7 +310,6 @@ class TestSocks5Proxy:
             assert response['port'] == 9999
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     def test_socks5h_domain_target(self, handler):
         with handler(proxies={'all': f'socks5h://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
             response = request_proxy_info(rh, target='http://localhost:9999/proxy')
@@ -215,7 +318,14 @@ class TestSocks5Proxy:
             assert response['port'] == 9999
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
+    def test_socks5h_ip_target(self, handler):
+        with handler(proxies={'all': f'socks5h://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
+            response = request_proxy_info(rh, target='http://127.0.0.1:9999/proxy')
+            assert response['ipv4_address'] == '127.0.0.1'
+            assert response['domain_address'] is None
+            assert response['port'] == 9999
+            assert response['version'] == 5
+
     @pytest.mark.skip('IPv6 destination addresses are not yet supported')
     def test_socks5_ipv6_destination(self, handler):
         with handler(proxies={'all': f'socks5://127.0.0.1:{self.socks_http_no_auth_port}'}) as rh:
@@ -224,7 +334,6 @@ class TestSocks5Proxy:
             assert response['port'] == 80
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     @pytest.mark.skip('IPv6 socks5 proxies are not yet supported')
     def test_ipv6_socks5_proxy(self, handler):
         with handler(proxies={'all': f'socks5://[::1]:{self.socks_http_ipv6_port}'}) as rh:
@@ -233,7 +342,6 @@ class TestSocks5Proxy:
             assert response['ipv4_address'] == '127.0.0.1'
             assert response['version'] == 5
 
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     def test_domain_socks5_proxy(self, handler):
         with handler(proxies={'all': f'socks5://localhost:{self.socks_http_no_auth_port}'}) as rh:
             response = request_proxy_info(rh)
@@ -241,9 +349,8 @@ class TestSocks5Proxy:
 
     # XXX: is there any feasible way of testing IPv6 source addresses?
     # Same would go for non-proxy source_address test...
-    @pytest.mark.parametrize('handler', ['Urllib'], indirect=True)
     @pytest.mark.skip('source_address is not yet supported for socks5 proxies')
-    def test_ipv4_source_address_socks5_proxy(self, handler):
+    def test_ipv4_client_source_address(self, handler):
         source_address = f'127.0.0.{random.randint(5, 255)}'
         with handler(proxies={'all': f'socks5://127.0.0.1:{self.socks_http_no_auth_port}'}, source_address=source_address) as rh:
             response = request_proxy_info(rh)

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -135,7 +135,6 @@ class Socks5ProxyHandler(StreamRequestHandler, SocksProxyHandler):
 
         socks_info['port'] = struct.unpack('!H', self.connection.recv(2))[0]
 
-        # TODO: test error mapping here
         self.connection.sendall(struct.pack(
             '!BBBBIH', SOCKS5_VERSION, self.socks_kwargs.get('reply', Socks5Reply.SUCCEEDED), 0x0, 0x1, 0x7f000001, 40000))
 

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -83,11 +83,9 @@ class Socks5ProxyHandler(StreamRequestHandler, SocksProxyHandler):
         sleep = self.socks_kwargs.get('sleep')
         if sleep:
             time.sleep(sleep)
-        version, nmethods = struct.unpack('!BB', self.connection.recv(2))
+        version, nmethods = self.connection.recv(2)
         assert version == SOCKS5_VERSION
-        methods = []
-        for i in range(nmethods):
-            methods.append(ord(self.connection.recv(1)))
+        methods = list(self.connection.recv(nmethods))
 
         auth = self.socks_kwargs.get('auth')
 
@@ -139,6 +137,7 @@ class Socks5ProxyHandler(StreamRequestHandler, SocksProxyHandler):
 
         socks_info['port'] = struct.unpack('!H', self.connection.recv(2))[0]
 
+        # dummy response, the returned IP is just a placeholder
         self.connection.sendall(struct.pack(
             '!BBBBIH', SOCKS5_VERSION, self.socks_kwargs.get('reply', Socks5Reply.SUCCEEDED), 0x0, 0x1, 0x7f000001, 40000))
 
@@ -187,6 +186,7 @@ class Socks4ProxyHandler(StreamRequestHandler, SocksProxyHandler):
         if use_remote_dns:
             socks_info['domain_address'] = self._read_until_null().decode()
 
+        # dummy response, the returned IP is just a placeholder
         self.connection.sendall(
             struct.pack(
                 '!BBHI', SOCKS4_REPLY_VERSION,

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -392,7 +392,7 @@ class TestSocks5Proxy:
             reason='IPv6 destination addresses are not yet supported'))
     ], indirect=True)
     def test_socks5_ipv6_destination(self, handler, ctx):
-        with ctx.socks_server() as server_address:
+        with ctx.socks_server(Socks5ProxyHandler) as server_address:
             with handler(proxies={'all': f'socks5://{server_address}'}) as rh:
                 response = ctx.socks_info_request(rh, target_domain='[::1]')
                 assert response['ipv6_address'] == '::1'


### PR DESCRIPTION
This PR implements some long needed test cases for our socks proxy module. Previously, only a few e2e tests were implemented and were disabled by default. 

As part of this I have written basic socks4/5 dummy proxy servers (as per the specs) that allow us to get back proxy debug information to test against.

Instead of testing the socks.py module directly, I am testing at the handler level. This is to allow us to test socks proxy implementations in multiple handlers. Additionally, the tests are written to work with different protocols other than http (for when we need to implement websockets over socks, for instance).

When writing these tests, the following bugs/issues with our socks client implementation have been found:
- IPv6 socks4/5 proxies are not supported (https://github.com/ytdl-org/youtube-dl/issues/15368)
- IPv6 over socks5 is not supported
- `--source-address` is not obeyed for either socks4 and socks5
- Using an IP instead of a domain name for a destination does not work with socks4a due to a bug in the implementation

Tests have been written for these cases but are currently skipped until they are fixed. I plan to look into these in followup PRs.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [X] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37438eb</samp>

### Summary
📄🔧🧪

<!--
1.  📄 for adding a new file `conftest.py`.
2.  🔧 for refactoring the imports and the fixture in the networking tests.
3.  🧪 for testing different networking backends for yt-dlp.
-->
Refactor networking tests and add a `handler` fixture. This change improves the code structure and reusability of the tests for different networking backends.

> _`Pytest` fixture of doom, testing the `handler` of the beast_
> _Refactoring the imports, breaking the chains of the code_
> _`Conftest.py` is the file, where the magic happens_
> _Networking backends of fire, burning the bridges of the web_

### Walkthrough
*  Add a new pytest fixture `handler` in `conftest.py` that returns a partial function of a request handler class based on the parameter passed to the test function ([link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-7dae78a00d8d69422a3bfbde96c7c5d794eede504a0df763853896a1ba1b5ff2R1-R19))
* Use the `handler` fixture to test different networking backends for yt-dlp, such as urllib, pycurl, etc. ([link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L310-L322), [link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L43), [link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L11-R14))
* Set a fake logger for the request handler to avoid printing messages to the console during testing ([link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-7dae78a00d8d69422a3bfbde96c7c5d794eede504a0df763853896a1ba1b5ff2R1-R19))
* Move some of the imports from `test_networking.py` to `conftest.py` since they are only used by the `handler` fixture and not by the test functions ([link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L11-R14))
* Remove the import of `_REQUEST_HANDLERS` from `test_networking.py` since it is no longer needed there ([link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L43))
* Remove the definition of the `handler` fixture from `test_networking.py` since it is now moved to `conftest.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7908/files?diff=unified&w=0#diff-e92498eb46ad8369b16aed0d65fa7c8d56c81b2d595f6510981c6cfb0c0f7e78L310-L322))



</details>
