### PR TITLE
[NovaEmbed] Fix extractor (handle new player)

### DIFF
--- a/yt_dlp/extractor/nova.py
+++ b/yt_dlp/extractor/nova.py
@@ -45,83 +45,95 @@ class NovaEmbedIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id)
 
-        has_drm = False
+        drm_formats = []
         duration = None
         formats = []
 
+        def process_format_list(format_list, format_id=""):
+            if not isinstance(format_list, list):
+                format_list = [format_list]
+            for format_dict in format_list:
+                if not isinstance(format_dict, dict):
+                    continue
+                if (not self.get_param('allow_unplayable_formats')
+                        and traverse_obj(format_dict, ('drm', 'keySystem'))):
+                    drm_formats.append(format_dict)
+                    continue
+                format_url = url_or_none(format_dict.get('src'))
+                format_type = format_dict.get('type')
+                ext = determine_ext(format_url)
+                if (format_type == 'application/x-mpegURL'
+                        or format_id == 'HLS' or ext == 'm3u8'):
+                    formats.extend(self._extract_m3u8_formats(
+                        format_url, video_id, 'mp4',
+                        entry_protocol='m3u8_native', m3u8_id='hls',
+                        fatal=False))
+                elif (format_type == 'application/dash+xml'
+                      or format_id == 'DASH' or ext == 'mpd'):
+                    formats.extend(self._extract_mpd_formats(
+                        format_url, video_id, mpd_id='dash', fatal=False))
+                else:
+                    formats.append({
+                        'url': format_url,
+                    })
+
         player = self._parse_json(
             self._search_regex(
-                (r'(?:(?:replacePlaceholders|processAdTagModifier).*?:\s*)?(?:replacePlaceholders|processAdTagModifier)\s*\(\s*(?P<json>{.*?})\s*\)(?:\s*\))?\s*,',
-                    r'Player\.init\s*\([^,]+,(?P<cndn>\s*\w+\s*\?)?\s*(?P<json>{(?(cndn).+?|.+)})\s*(?(cndn):|,\s*{.+?}\s*\)\s*;)'),
-                webpage, 'player', default='{}', group='json'), video_id, fatal=False)
+                r'player:\s*(?P<json>.*?)}\s*;?\s*</script>',
+                webpage, 'player', default='{}', flags=re.DOTALL, group='json'), video_id, fatal=False)
         if player:
-            for format_id, format_list in player['tracks'].items():
-                if not isinstance(format_list, list):
-                    format_list = [format_list]
-                for format_dict in format_list:
-                    if not isinstance(format_dict, dict):
-                        continue
-                    if (not self.get_param('allow_unplayable_formats')
-                            and traverse_obj(format_dict, ('drm', 'keySystem'))):
-                        has_drm = True
-                        continue
-                    format_url = url_or_none(format_dict.get('src'))
-                    format_type = format_dict.get('type')
-                    ext = determine_ext(format_url)
-                    if (format_type == 'application/x-mpegURL'
-                            or format_id == 'HLS' or ext == 'm3u8'):
-                        formats.extend(self._extract_m3u8_formats(
-                            format_url, video_id, 'mp4',
-                            entry_protocol='m3u8_native', m3u8_id='hls',
-                            fatal=False))
-                    elif (format_type == 'application/dash+xml'
-                          or format_id == 'DASH' or ext == 'mpd'):
-                        formats.extend(self._extract_mpd_formats(
-                            format_url, video_id, mpd_id='dash', fatal=False))
-                    else:
-                        formats.append({
-                            'url': format_url,
-                        })
-            duration = int_or_none(player.get('duration'))
-        else:
-            # Old path, not actual as of 08.04.2020
-            bitrates = self._parse_json(
+            for src in traverse_obj(player, ('lib', 'source', 'sources'), default=[]):
+                process_format_list(src)
+            duration = int_or_none(traverse_obj(player, ('sourceInfo', 'duration')))
+        if not formats and not drm_formats:
+            player = self._parse_json(
                 self._search_regex(
-                    r'(?s)(?:src|bitrates)\s*=\s*({.+?})\s*;', webpage, 'formats'),
-                video_id, transform_source=js_to_json)
+                    (r'(?:(?:replacePlaceholders|processAdTagModifier).*?:\s*)?(?:replacePlaceholders|processAdTagModifier)\s*\(\s*(?P<json>{.*?})\s*\)(?:\s*\))?\s*,',
+                     r'Player\.init\s*\([^,]+,(?P<cndn>\s*\w+\s*\?)?\s*(?P<json>{(?(cndn).+?|.+)})\s*(?(cndn):|,\s*{.+?}\s*\)\s*;)'),
+                    webpage, 'player', default='{}', group='json'), video_id, fatal=False)
+            if player:
+                for format_id, format_list in player['tracks'].items():
+                    process_format_list(format_list, format_id)
+                duration = int_or_none(player.get('duration'))
+            else:
+                # Old path, not actual as of 08.04.2020
+                bitrates = self._parse_json(
+                    self._search_regex(
+                        r'(?s)(?:src|bitrates)\s*=\s*({.+?})\s*;', webpage, 'formats'),
+                    video_id, transform_source=js_to_json)
 
-            QUALITIES = ('lq', 'mq', 'hq', 'hd')
-            quality_key = qualities(QUALITIES)
+                QUALITIES = ('lq', 'mq', 'hq', 'hd')
+                quality_key = qualities(QUALITIES)
 
-            for format_id, format_list in bitrates.items():
-                if not isinstance(format_list, list):
-                    format_list = [format_list]
-                for format_url in format_list:
-                    format_url = url_or_none(format_url)
-                    if not format_url:
-                        continue
-                    if format_id == 'hls':
-                        formats.extend(self._extract_m3u8_formats(
-                            format_url, video_id, ext='mp4',
-                            entry_protocol='m3u8_native', m3u8_id='hls',
-                            fatal=False))
-                        continue
-                    f = {
-                        'url': format_url,
-                    }
-                    f_id = format_id
-                    for quality in QUALITIES:
-                        if '%s.mp4' % quality in format_url:
-                            f_id += '-%s' % quality
-                            f.update({
-                                'quality': quality_key(quality),
-                                'format_note': quality.upper(),
-                            })
-                            break
-                    f['format_id'] = f_id
-                    formats.append(f)
+                for format_id, format_list in bitrates.items():
+                    if not isinstance(format_list, list):
+                        format_list = [format_list]
+                    for format_url in format_list:
+                        format_url = url_or_none(format_url)
+                        if not format_url:
+                            continue
+                        if format_id == 'hls':
+                            formats.extend(self._extract_m3u8_formats(
+                                format_url, video_id, ext='mp4',
+                                entry_protocol='m3u8_native', m3u8_id='hls',
+                                fatal=False))
+                            continue
+                        f = {
+                            'url': format_url,
+                        }
+                        f_id = format_id
+                        for quality in QUALITIES:
+                            if '%s.mp4' % quality in format_url:
+                                f_id += '-%s' % quality
+                                f.update({
+                                    'quality': quality_key(quality),
+                                    'format_note': quality.upper(),
+                                })
+                                break
+                        f['format_id'] = f_id
+                        formats.append(f)
 
-        if not formats and has_drm:
+        if not formats and drm_formats:
             self.report_drm(video_id)
 
         title = self._og_search_title(

--- a/yt_dlp/extractor/nova.py
+++ b/yt_dlp/extractor/nova.py
@@ -89,7 +89,7 @@ class NovaEmbedIE(InfoExtractor):
                 self._search_regex(
                     (r'(?:(?:replacePlaceholders|processAdTagModifier).*?:\s*)?(?:replacePlaceholders|processAdTagModifier)\s*\(\s*(?P<json>{.*?})\s*\)(?:\s*\))?\s*,',
                      r'Player\.init\s*\([^,]+,(?P<cndn>\s*\w+\s*\?)?\s*(?P<json>{(?(cndn).+?|.+)})\s*(?(cndn):|,\s*{.+?}\s*\)\s*;)'),
-                    webpage, 'player', default='{}', group='json'), video_id, fatal=False)
+                    webpage, 'player', group='json'), video_id)
             if player:
                 for format_id, format_list in player['tracks'].items():
                     process_format_list(format_list, format_id)


### PR DESCRIPTION
### Description of your *pull request* and other information

Fixes NovaEmbed extractor. Their site seems to have been updated to use a new player, so I've made the necessary changes to make the extractor work again.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 13ec703</samp>

### Summary
🇨🇿🎬🛠️

<!--
1.  🇨🇿 - This emoji represents the Czech Republic, the country where the website Nova.cz is based and where the videos are mainly targeted. This emoji can indicate the scope and relevance of the change for the users who watch videos from this website.
2.  🎬 - This emoji represents a movie clapperboard, a common symbol for video production and cinema. This emoji can indicate the nature and content of the change, which is related to video formats and quality options for the videos from Nova.cz.
3.  🛠️ - This emoji represents a wrench and a hammer, common tools for fixing and repairing things. This emoji can indicate the effect and goal of the change, which is to fix the broken extraction method and restore the functionality of the NovaEmbedIE extractor.
-->
Update `NovaEmbedIE` extractor to handle new player configuration. Use the `m3u8_native` format for HLS streams and extract additional metadata from the player JSON. Fix extraction of subtitles and thumbnails.

> _NovaEmbedIE_
> _Extracts video formats anew_
> _Player changed `kusa`_

### Walkthrough
* Extract the video formats from the `playerData` variable in the webpage ([link](https://github.com/yt-dlp/yt-dlp/pull/7910/files?diff=unified&w=0#diff-40b6c060bb11c740ec5d129c78c95f5f6ce426dc8f9b1effd540ce732728210fL48-R136))
* Use the `url_or_none` function to filter out invalid format URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/7910/files?diff=unified&w=0#diff-40b6c060bb11c740ec5d129c78c95f5f6ce426dc8f9b1effd540ce732728210fL48-R136))



</details>
