### PR TITLE
[tenplay] Add support for downloading whole seasons

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1957,7 +1957,10 @@ from .tencent import (
     WeTvSeriesIE,
 )
 from .tennistv import TennisTVIE
-from .tenplay import TenPlayIE, TenPlaySeasonIE
+from .tenplay import (
+    TenPlayIE,
+    TenPlaySeasonIE,
+)
 from .testurl import TestURLIE
 from .tf1 import TF1IE
 from .tfo import TFOIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1957,7 +1957,7 @@ from .tencent import (
     WeTvSeriesIE,
 )
 from .tennistv import TennisTVIE
-from .tenplay import TenPlayIE
+from .tenplay import TenPlayIE, TenPlaySeasonIE
 from .testurl import TestURLIE
 from .tf1 import TF1IE
 from .tfo import TFOIE

--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -119,27 +119,20 @@ class TenPlayIE(InfoExtractor):
 
 class TenPlaySeasonIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?10play\.com\.au/(?P<show>[^/?#]+)/episodes/(?P<season>[^/?#]+)/?(?:$|[?#])'
-
     _TESTS = [{
         'url': 'https://10play.com.au/masterchef/episodes/season-14',
         'info_dict': {
             'title': 'Season 14',
             'id': 'MjMyOTIy',
         },
-        'playlist_count': 64,
-        'params': {
-            'skip_download': True,
-        },
+        'playlist_mincount': 64,
     }, {
         'url': 'https://10play.com.au/the-bold-and-the-beautiful-fast-tracked/episodes/season-2022',
         'info_dict': {
             'title': 'Season 2022',
             'id': 'Mjc0OTIw',
         },
-        'playlist_count': 256,
-        'params': {
-            'skip_download': True,
-        }
+        'playlist_mincount': 256,
     }]
 
     def _entries(self, load_more_url, display_id=None):
@@ -159,7 +152,6 @@ class TenPlaySeasonIE(InfoExtractor):
 
     def _real_extract(self, url):
         show, season = self._match_valid_url(url).group('show', 'season')
-
         season_info = self._download_json(
             f'https://10play.com.au/api/shows/{show}/episodes/{season}', f'{show}/{season}')
 

--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -140,22 +140,20 @@ class TenPlaySeasonIE(InfoExtractor):
         }
     }]
 
-    def _entries(self, show, season, load_more_url):
+    def _entries(self, load_more_url, display_id=None):
         skip_ids = []
-        has_more = True
-
-        base_url = f'https://10play.com.au/{show}/episodes/{season}'
-
-        while has_more:
+        for page in itertools.count(1):
             episodes_carousel = self._download_json(
-                load_more_url, f'{show}/{season}', query={'skipIds[]': skip_ids},
-                note=f'Fetching episodes {len(skip_ids)}+')
+                load_more_url, display_id, query={'skipIds[]': skip_ids},
+                note=f'Fetching episodes page {page}')
 
-            has_more = episodes_carousel['hasMore']
             episodes_chunk = episodes_carousel['items']
-            skip_ids += [ep['id'] for ep in episodes_chunk]
+            skip_ids.extend(ep['id'] for ep in episodes_chunk)
 
-            yield from [urljoin(base_url, ep['cardLink']) for ep in episodes_chunk]
+            for ep in episodes_chunk:
+                yield ep['cardLink']
+            if not episodes_carousel['hasMore']:
+                break
 
     def _real_extract(self, url):
         show, season = self._match_valid_url(url).group('show', 'season')
@@ -163,13 +161,15 @@ class TenPlaySeasonIE(InfoExtractor):
         season_info = self._download_json(
             f'https://10play.com.au/api/shows/{show}/episodes/{season}', f'{show}/{season}')
 
-        episodes_carousel = traverse_obj(season_info, ('content', 0, 'components', (
-            lambda _, v: v['title'].lower() == 'episodes', (..., {dict}))), get_all=False) or {}
+        episodes_carousel = traverse_obj(season_info, (
+            'content', 0, 'components', (
+                lambda _, v: v['title'].lower() == 'episodes',
+                (..., {dict}),
+            )), get_all=False) or {}
 
         playlist_id = episodes_carousel['tpId']
-        playlist_title = traverse_obj(season_info, ('content', 0, 'title', {str}))
-
-        load_more_url = urljoin(url, episodes_carousel['loadMoreUrl'])
 
         return self.playlist_from_matches(
-            self._entries(show, season, load_more_url), playlist_id, playlist_title)
+            self._entries(urljoin(url, episodes_carousel['loadMoreUrl']), playlist_id),
+            playlist_id, traverse_obj(season_info, ('content', 0, 'title', {str})),
+            getter=functools.partial(urljoin, url))

--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -1,7 +1,7 @@
-from datetime import datetime
 import base64
 import functools
 import itertools
+from datetime import datetime
 
 from .common import InfoExtractor
 from ..networking import HEADRequest

--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 import base64
+import functools
+import itertools
 
 from .common import InfoExtractor
 from ..networking import HEADRequest

--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -3,7 +3,7 @@ import base64
 
 from .common import InfoExtractor
 from ..networking import HEADRequest
-from ..utils import int_or_none, urlencode_postdata
+from ..utils import int_or_none, traverse_obj, urlencode_postdata, urljoin
 
 
 class TenPlayIE(InfoExtractor):
@@ -113,3 +113,63 @@ class TenPlayIE(InfoExtractor):
             'uploader': 'Channel 10',
             'uploader_id': '2199827728001',
         }
+
+
+class TenPlaySeasonIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?10play\.com\.au/(?P<show>[^/?#]+)/episodes/(?P<season>[^/?#]+)/?(?:$|[?#])'
+
+    _TESTS = [{
+        'url': 'https://10play.com.au/masterchef/episodes/season-14',
+        'info_dict': {
+            'title': 'Season 14',
+            'id': 'MjMyOTIy',
+        },
+        'playlist_count': 64,
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://10play.com.au/the-bold-and-the-beautiful-fast-tracked/episodes/season-2022',
+        'info_dict': {
+            'title': 'Season 2022',
+            'id': 'Mjc0OTIw',
+        },
+        'playlist_count': 256,
+        'params': {
+            'skip_download': True,
+        }
+    }]
+
+    def _entries(self, show, season, load_more_url):
+        skip_ids = []
+        has_more = True
+
+        base_url = f'https://10play.com.au/{show}/episodes/{season}'
+
+        while has_more:
+            episodes_carousel = self._download_json(
+                load_more_url, f'{show}/{season}', query={'skipIds[]': skip_ids},
+                note=f'Fetching episodes {len(skip_ids)}+')
+
+            has_more = episodes_carousel['hasMore']
+            episodes_chunk = episodes_carousel['items']
+            skip_ids += [ep['id'] for ep in episodes_chunk]
+
+            yield from [urljoin(base_url, ep['cardLink']) for ep in episodes_chunk]
+
+    def _real_extract(self, url):
+        show, season = self._match_valid_url(url).group('show', 'season')
+
+        season_info = self._download_json(
+            f'https://10play.com.au/api/shows/{show}/episodes/{season}', f'{show}/{season}')
+
+        episodes_carousel = traverse_obj(season_info, ('content', 0, 'components', (
+            lambda _, v: v['title'].lower() == 'episodes', (..., {dict}))), get_all=False) or {}
+
+        playlist_id = episodes_carousel['tpId']
+        playlist_title = traverse_obj(season_info, ('content', 0, 'title', {str}))
+
+        load_more_url = urljoin(url, episodes_carousel['loadMoreUrl'])
+
+        return self.playlist_from_matches(
+            self._entries(show, season, load_more_url), playlist_id, playlist_title)


### PR DESCRIPTION
### Description of your *pull request* and other information

Adapted from gormster's Fix 10Play PR on youtube-dl; https://github.com/ytdl-org/youtube-dl/pull/31892

Allows to download whole seasons, e.g. https://10play.com.au/masterchef/episodes/season-14

Fixes #7744


(Not sure if this should be using `_perform_login()`... not quite sure on the details specifically of how the authentication should be setup, but that's existing code :P

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

(adapted from yt-dl 31982; I have written most of it from scratch & structured differently, but most of the logic comes from there. Also the commit message also links to there)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e05e6af</samp>

### Summary
🆕🌐🎞️

<!--
1.  🆕 for adding a new extractor class
2.  🌐 for importing from another module
3.  🎞️ for handling season URLs of a streaming service
-->
Add support for season URLs of 10play in a new extractor class `TenPlaySeasonIE`. Import this class in the `_extractors` module.

> _Sing, O Muse, of the skillful coder who devised_
> _A new extractor class for the 10play website,_
> _Where many a season of shows can be accessed_
> _By the `TenPlaySeasonIE` that joins the URLs aright._

### Walkthrough
*  Import new extractor class `TenPlaySeasonIE` from `tenplay` module ([link](https://github.com/yt-dlp/yt-dlp/pull/7939/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1960-R1960))
* Add `urljoin` function from `utils` module to construct absolute URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/7939/files?diff=unified&w=0#diff-d6c0818e2ab146d324e38d2ff3fcd4e38d16df03d402a02adf16e30655863569L6-R6))
* Define `TenPlaySeasonIE` class that inherits from `TenPlayIE` and extracts a playlist of episodes from a season URL ([link](https://github.com/yt-dlp/yt-dlp/pull/7939/files?diff=unified&w=0#diff-d6c0818e2ab146d324e38d2ff3fcd4e38d16df03d402a02adf16e30655863569R116-R174))



</details>
