### PR TITLE
[tv5mondeplus] fix extractor

### DIFF
--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -20,7 +20,7 @@ class TV5MondePlusIE(InfoExtractor):
         'url': 'https://revoir.tv5monde.com/toutes-les-videos/cinema/les-novices',
         'md5': 'c86f60bf8b75436455b1b205f9745955',
         'info_dict': {
-            'id': '106971507_6D4BA7b',
+            'id': 'ZX0ipMyFQq_6D4BA7b',
             'display_id': 'les-novices',
             'ext': 'mp4',
             'title': 'Les novices',
@@ -34,7 +34,7 @@ class TV5MondePlusIE(InfoExtractor):
         # series episode
         'url': 'https://revoir.tv5monde.com/toutes-les-videos/series-fictions/opj-les-dents-de-la-terre-2',
         'info_dict': {
-            'id': '106990379_6D4BA7b',
+            'id': 'wJ0eeEPozr_6D4BA7b',
             'display_id': 'opj-les-dents-de-la-terre-2',
             'ext': 'mp4',
             'title': "OPJ - Les dents de la Terre (2)",
@@ -43,7 +43,7 @@ class TV5MondePlusIE(InfoExtractor):
             'series': 'OPJ',
             'episode': 'Les dents de la Terre (2)',
             'duration': 2877,
-            'thumbnail': 'https://revoir.tv5monde.com/uploads/revoirimages/af/600px_5753448.jpg'
+            'thumbnail': 'https://dl-revoir.tv5monde.com/images/1a/5753448.jpg'
         },
     }, {
         # movie
@@ -99,36 +99,46 @@ class TV5MondePlusIE(InfoExtractor):
         video_files = self._parse_json(
             vpl_data['data-broadcast'], display_id)
         formats = []
-        for video_file in video_files:
-            v_url = video_file.get('url')
-            if not v_url:
-                continue
-            if video_file.get('type') == 'application/deferred':
-                d_param = urllib.parse.quote(v_url)
-                token = video_file.get('token')
-                if not token:
-                    continue
-                deferred_json = self._download_json(
-                    f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
-                    note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
-                v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
+        video_id = None
+
+        def process_video_files(v):
+            nonlocal video_id
+            for video_file in v:
+                v_url = video_file.get('url')
                 if not v_url:
                     continue
-                # data-guid from the webpage isn't stable, use the asset id from the json urls
-                video_id = self._search_regex(
-                    r'assets/([\d]{9}_[\da-fA-F]{7})/materials', v_url, 'video id',
-                    default=display_id)
+                if video_file.get('type') == 'application/deferred':
+                    d_param = urllib.parse.quote(v_url)
+                    token = video_file.get('token')
+                    if not token:
+                        continue
+                    deferred_json = self._download_json(
+                        f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
+                        note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
+                    v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
+                    if not v_url:
+                        continue
+                    # data-guid from the webpage isn't stable, use the material id from the json urls
+                    video_id = self._search_regex(
+                        r'materials/([\da-zA-Z]{10}_[\da-fA-F]{7})/', v_url, 'video id',
+                        default=display_id)
+                    process_video_files(deferred_json)
 
-            video_format = video_file.get('format') or determine_ext(v_url)
-            if video_format == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(
-                    v_url, display_id, 'mp4', 'm3u8_native',
-                    m3u8_id='hls', fatal=False))
-            else:
-                formats.append({
-                    'url': v_url,
-                    'format_id': video_format,
-                })
+                video_format = video_file.get('format') or determine_ext(v_url)
+                if video_format == 'm3u8':
+                    formats.extend(self._extract_m3u8_formats(
+                        v_url, display_id, 'mp4', 'm3u8_native',
+                        m3u8_id='hls', fatal=False))
+                elif video_format == 'mpd':
+                    formats.extend(self._extract_mpd_formats(
+                        v_url, display_id, fatal=False))
+                else:
+                    formats.append({
+                        'url': v_url,
+                        'format_id': video_format,
+                    })
+
+        process_video_files(video_files)
 
         metadata = self._parse_json(
             vpl_data['data-metadata'], display_id)

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -72,10 +72,9 @@ class TV5MondePlusIE(InfoExtractor):
         formats = []
         for video_file in video_files:
             v_url = video_file.get('url')
-            v_type = video_file.get('type')
             if not v_url:
                 continue
-            if v_type == 'application/deferred':
+            if video_file.get('type') == 'application/deferred':
                 d_param = urllib.parse.quote(v_url)
                 headers = {'Authorization': 'Bearer ' + video_file.get('token')}
                 json = self._download_json(

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -96,10 +96,10 @@ class TV5MondePlusIE(InfoExtractor):
             r'(<[^>]+class="video_player_loader"[^>]+>)',
             webpage, 'video player loader'))
 
+        video_id = None
         video_files = self._parse_json(
             vpl_data['data-broadcast'], display_id)
         formats = []
-        video_id = None
         for video_file in video_files:
             v_url = video_file.get('url')
             if not v_url:

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -96,49 +96,43 @@ class TV5MondePlusIE(InfoExtractor):
             r'(<[^>]+class="video_player_loader"[^>]+>)',
             webpage, 'video player loader'))
 
+        video_id = None
         video_files = self._parse_json(
             vpl_data['data-broadcast'], display_id)
         formats = []
-        video_id = None
-
-        def process_video_files(v):
-            nonlocal video_id
-            for video_file in v:
-                v_url = video_file.get('url')
+        for video_file in video_files:
+            v_url = video_file.get('url')
+            if not v_url:
+                continue
+            if video_file.get('type') == 'application/deferred':
+                d_param = urllib.parse.quote(v_url)
+                token = video_file.get('token')
+                if not token:
+                    continue
+                deferred_json = self._download_json(
+                    f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
+                    note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
+                v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
                 if not v_url:
                     continue
-                if video_file.get('type') == 'application/deferred':
-                    d_param = urllib.parse.quote(v_url)
-                    token = video_file.get('token')
-                    if not token:
-                        continue
-                    deferred_json = self._download_json(
-                        f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
-                        note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
-                    v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
-                    if not v_url:
-                        continue
-                    # data-guid from the webpage isn't stable, use the material id from the json urls
-                    video_id = self._search_regex(
-                        r'materials/([\da-zA-Z]{10}_[\da-fA-F]{7})/', v_url, 'video id',
-                        default=display_id)
-                    process_video_files(deferred_json)
+                # data-guid from the webpage isn't stable, use the asset id from the json urls
+                video_id = self._search_regex(
+                    r'assets/([\d]{9}_[\da-fA-F]{7})/materials', v_url, 'video id',
+                    default=display_id)
 
-                video_format = video_file.get('format') or determine_ext(v_url)
-                if video_format == 'm3u8':
-                    formats.extend(self._extract_m3u8_formats(
-                        v_url, display_id, 'mp4', 'm3u8_native',
-                        m3u8_id='hls', fatal=False))
-                elif video_format == 'mpd':
-                    formats.extend(self._extract_mpd_formats(
-                        v_url, display_id, fatal=False))
-                else:
-                    formats.append({
-                        'url': v_url,
-                        'format_id': video_format,
-                    })
-
-        process_video_files(video_files)
+            video_format = video_file.get('format') or determine_ext(v_url)
+            if video_format == 'm3u8':
+                formats.extend(self._extract_m3u8_formats(
+                    v_url, display_id, 'mp4', 'm3u8_native',
+                    m3u8_id='hls', fatal=False))
+            elif video_format == 'mpd':
+                formats.extend(self._extract_mpd_formats(
+                    v_url, display_id, fatal=False))
+            else:
+                formats.append({
+                    'url': v_url,
+                    'format_id': video_format,
+                })
 
         metadata = self._parse_json(
             vpl_data['data-metadata'], display_id)

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -96,10 +96,10 @@ class TV5MondePlusIE(InfoExtractor):
             r'(<[^>]+class="video_player_loader"[^>]+>)',
             webpage, 'video player loader'))
 
-        video_id = None
         video_files = self._parse_json(
             vpl_data['data-broadcast'], display_id)
         formats = []
+        video_id = None
         for video_file in video_files:
             v_url = video_file.get('url')
             if not v_url:

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -76,11 +76,15 @@ class TV5MondePlusIE(InfoExtractor):
                 continue
             if video_file.get('type') == 'application/deferred':
                 d_param = urllib.parse.quote(v_url)
-                headers = {'Authorization': 'Bearer ' + video_file.get('token')}
-                json = self._download_json(
-                    f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', v_url,
-                    note='Downloading deferred info', headers=headers)
-                v_url = json[0]['url']
+                token = video_file.get('token')
+                if not token:
+                    continue
+                deferred_json = self._download_json(
+                    f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
+                    note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
+                v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
+                if not v_url:
+                    continue
                 video_id = self._search_regex(
                     r'assets/([\d]{9}_[\da-fA-F]{7})/materials', v_url, 'video id',
                     default=display_id)

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -114,6 +114,7 @@ class TV5MondePlusIE(InfoExtractor):
                 v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
                 if not v_url:
                     continue
+                # data-guid from the webpage isn't stable, use the asset id from the json urls
                 video_id = self._search_regex(
                     r'assets/([\d]{9}_[\da-fA-F]{7})/materials', v_url, 'video id',
                     default=display_id)

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -6,7 +6,9 @@ from ..utils import (
     extract_attributes,
     int_or_none,
     parse_duration,
+    traverse_obj,
     try_get,
+    url_or_none,
 )
 
 
@@ -38,14 +40,41 @@ class TV5MondePlusIE(InfoExtractor):
             'title': "OPJ - Les dents de la Terre (2)",
             'description': 'md5:288f87fd68d993f814e66e60e5302d9d',
             'upload_date': '20230823',
-            'series': "OPJ",
+            'series': 'OPJ',
             'episode': 'Les dents de la Terre (2)',
             'duration': 2877,
-            'thumbnail': 'https://dl-revoir.tv5monde.com/images/1a/5753448.jpg'
+            'thumbnail': 'https://revoir.tv5monde.com/uploads/revoirimages/af/600px_5753448.jpg'
+        },
+    }, {
+        # movie
+        'url': 'https://revoir.tv5monde.com/toutes-les-videos/cinema/ceux-qui-travaillent',
+        'md5': '32fa0cde16a4480d1251502a66856d5f',
+        'info_dict': {
+            'id': 'dc57a011-ec4b-4648-2a9a-4f03f8352ed3',
+            'display_id': 'ceux-qui-travaillent',
+            'ext': 'mp4',
+            'title': 'Ceux qui travaillent',
+            'description': 'md5:570e8bb688036ace873b2d50d24c026d',
+            'upload_date': '20210819',
+        },
+        'skip': 'no longer available',
+    }, {
+        # series episode
+        'url': 'https://revoir.tv5monde.com/toutes-les-videos/series-fictions/vestiaires-caro-actrice',
+        'info_dict': {
+            'id': '9e9d599e-23af-6915-843e-ecbf62e97925',
+            'display_id': 'vestiaires-caro-actrice',
+            'ext': 'mp4',
+            'title': "Vestiaires - Caro actrice",
+            'description': 'md5:db15d2e1976641e08377f942778058ea',
+            'upload_date': '20210819',
+            'series': "Vestiaires",
+            'episode': 'Caro actrice',
         },
         'params': {
             'skip_download': True,
         },
+        'skip': 'no longer available',
     }, {
         'url': 'https://revoir.tv5monde.com/toutes-les-videos/series-fictions/neuf-jours-en-hiver-neuf-jours-en-hiver',
         'only_matching': True,

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -96,43 +96,49 @@ class TV5MondePlusIE(InfoExtractor):
             r'(<[^>]+class="video_player_loader"[^>]+>)',
             webpage, 'video player loader'))
 
-        video_id = None
         video_files = self._parse_json(
             vpl_data['data-broadcast'], display_id)
         formats = []
-        for video_file in video_files:
-            v_url = video_file.get('url')
-            if not v_url:
-                continue
-            if video_file.get('type') == 'application/deferred':
-                d_param = urllib.parse.quote(v_url)
-                token = video_file.get('token')
-                if not token:
-                    continue
-                deferred_json = self._download_json(
-                    f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
-                    note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
-                v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
+        video_id = None
+
+        def process_video_files(v):
+            nonlocal video_id
+            for video_file in v:
+                v_url = video_file.get('url')
                 if not v_url:
                     continue
-                # data-guid from the webpage isn't stable, use the asset id from the json urls
-                video_id = self._search_regex(
-                    r'assets/([\d]{9}_[\da-fA-F]{7})/materials', v_url, 'video id',
-                    default=display_id)
+                if video_file.get('type') == 'application/deferred':
+                    d_param = urllib.parse.quote(v_url)
+                    token = video_file.get('token')
+                    if not token:
+                        continue
+                    deferred_json = self._download_json(
+                        f'https://api.tv5monde.com/player/asset/{d_param}/resolve?condenseKS=true', display_id,
+                        note='Downloading deferred info', headers={'Authorization': f'Bearer {token}'}, fatal=False)
+                    v_url = traverse_obj(deferred_json, (0, 'url', {url_or_none}))
+                    if not v_url:
+                        continue
+                    # data-guid from the webpage isn't stable, use the material id from the json urls
+                    video_id = self._search_regex(
+                        r'materials/([\da-zA-Z]{10}_[\da-fA-F]{7})/', v_url, 'video id',
+                        default=display_id)
+                    process_video_files(deferred_json)
 
-            video_format = video_file.get('format') or determine_ext(v_url)
-            if video_format == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(
-                    v_url, display_id, 'mp4', 'm3u8_native',
-                    m3u8_id='hls', fatal=False))
-            elif video_format == 'mpd':
-                formats.extend(self._extract_mpd_formats(
-                    v_url, display_id, fatal=False))
-            else:
-                formats.append({
-                    'url': v_url,
-                    'format_id': video_format,
-                })
+                video_format = video_file.get('format') or determine_ext(v_url)
+                if video_format == 'm3u8':
+                    formats.extend(self._extract_m3u8_formats(
+                        v_url, display_id, 'mp4', 'm3u8_native',
+                        m3u8_id='hls', fatal=False))
+                elif video_format == 'mpd':
+                    formats.extend(self._extract_mpd_formats(
+                        v_url, display_id, fatal=False))
+                else:
+                    formats.append({
+                        'url': v_url,
+                        'format_id': video_format,
+                    })
+
+        process_video_files(video_files)
 
         metadata = self._parse_json(
             vpl_data['data-metadata'], display_id)

--- a/yt_dlp/extractor/tv5mondeplus.py
+++ b/yt_dlp/extractor/tv5mondeplus.py
@@ -120,8 +120,7 @@ class TV5MondePlusIE(InfoExtractor):
                         continue
                     # data-guid from the webpage isn't stable, use the material id from the json urls
                     video_id = self._search_regex(
-                        r'materials/([\da-zA-Z]{10}_[\da-fA-F]{7})/', v_url, 'video id',
-                        default=display_id)
+                        r'materials/([\da-zA-Z]{10}_[\da-fA-F]{7})/', v_url, 'video id', default=None)
                     process_video_files(deferred_json)
 
                 video_format = video_file.get('format') or determine_ext(v_url)


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

tv5monde added a video type, which might imply a deferred json info download, to get a m3u8 URL.
Two tests updated.

FIxes #4978 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eaeee05</samp>

### Summary
🛠️📺✅

<!--
1.  🛠️ - This emoji represents fixing or improving something, and can be used for the improved extractor and the bug fix with missing video id.
2.  📺 - This emoji represents television or video content, and can be used for the `tv5mondeplus` extractor and the deferred videos feature.
3.  ✅ - This emoji represents testing or verifying something, and can be used for the updated test cases.
-->
Improved and fixed `tv5mondeplus` extractor. The extractor can now handle deferred videos and has more robust test cases. A potential issue with missing video id was also resolved.

> _Sing, O Muse, of the skillful coder who improved the extractor_
> _Of tv5mondeplus, the splendid channel of the Francophone world_
> _He made it work for deferred videos, those that wait for their hour_
> _And updated the tests, `test_generic` and `test_tv5mondeplus`_

### Walkthrough
* Import `urllib.parse` module to encode URL parameter for deferred videos ([link](https://github.com/yt-dlp/yt-dlp/pull/7952/files?diff=unified&w=0#diff-578b2a642fb1a755e68f970db0179c676cb9837780daed3db3d6c1d0655fed45R1-R2))
* Modify extractor to handle deferred videos by making an additional API call with token and parameter from original video file ([link](https://github.com/yt-dlp/yt-dlp/pull/7952/files?diff=unified&w=0#diff-578b2a642fb1a755e68f970db0179c676cb9837780daed3db3d6c1d0655fed45L68-R88))
* Extract video id from resolved URL if not available from webpage ([link](https://github.com/yt-dlp/yt-dlp/pull/7952/files?diff=unified&w=0#diff-578b2a642fb1a755e68f970db0179c676cb9837780daed3db3d6c1d0655fed45L68-R88), [link](https://github.com/yt-dlp/yt-dlp/pull/7952/files?diff=unified&w=0#diff-578b2a642fb1a755e68f970db0179c676cb9837780daed3db3d6c1d0655fed45L103-R126))
* Check if video id is assigned before using it in API call to avoid error ([link](https://github.com/yt-dlp/yt-dlp/pull/7952/files?diff=unified&w=0#diff-578b2a642fb1a755e68f970db0179c676cb9837780daed3db3d6c1d0655fed45L103-R126))
* Update test cases to use more recent and available videos and include more metadata fields ([link](https://github.com/yt-dlp/yt-dlp/pull/7952/files?diff=unified&w=0#diff-578b2a642fb1a755e68f970db0179c676cb9837780daed3db3d6c1d0655fed45L16-R44))



</details>
