### PR TITLE
fix for --trim-filenames bug when title contains dot char

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -851,7 +851,7 @@ class TestYoutubeDL(unittest.TestCase):
             ('1234.1024.info.json', '123.info.json'),
             info=dict(self.outtmpl_info, ext='info.json'), trim_file_name=3
         )
-        test('12 34.%(filesize)s.%(ext)s', ('12 34.1024.mp4', '12.mp4'), trim_file_name=3)
+        test('12 34.%(filesize)s.%(ext)s', ('12 34.1024.mp4', '12 .mp4'), trim_file_name=3)
 
         # Environment variable expansion for prepare_filename
         os.environ['__yt_dlp_var'] = 'expanded'

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1383,9 +1383,7 @@ class YoutubeDL:
             if trim_file_name:
                 # https://github.com/yt-dlp/yt-dlp/issues/5526#issuecomment-1312783517
                 no_ext, *ext = filename.rsplit('.', info_dict.get('ext', '').count('.') + 1)
-                # cut filename and remove trailing spaces and extra dots
-                name = no_ext[:trim_file_name].strip().rstrip('.')
-                filename = join_nonempty(name, *ext, delim='.')
+                filename = join_nonempty(no_ext[:trim_file_name], *ext, delim='.')
 
             if tmpl_type in ('', 'temp'):
                 final_ext, ext = self.params.get('final_ext'), info_dict.get('ext')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

1. Fix for `--trim-filenames` bug
1. Testcase


Fixes #2314

Ref: https://github.com/yt-dlp/yt-dlp/issues/5526#issuecomment-1312783517

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [  I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fcafc42</samp>

### Summary
:white_check_mark::wrench::sparkles:

<!--
1.  :white_check_mark: for adding test cases
2.  :wrench: for fixing a bug or improving a function
3.  :sparkles: for adding a new feature
-->
Add and test a new `trim_file_name` feature for `yt-dlp` that limits the output filename length. Improve the `join_nonempty` function to strip whitespace from values.

> _To trim the output filename_
> _We added a new parameter_
> _But we had to fix_
> _The extension mix_
> _And strip the whitespace from the center_

### Walkthrough
* Implement `trim_file_name` feature to limit output filename length by removing characters from the left ([link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR1382-R1387), [link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL1391-L1396), [link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-f1abc5b91afa326c01cbc20d98d5fe6e2fb38ea0e03bcc31d7f1a5b5ee23e0eaR847-R855))
  - Use `join_nonempty` helper function to join base name and extension with a dot ([link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR1382-R1387), [link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL4736-R4736))
  - Strip whitespace from values before joining them with `join_nonempty` ([link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-feda8f56946dc048e754111850baaef0eec4b9f8bbc2d3f04b1a785626ea5c0eL4736-R4736))
  - Use `info_dict` parameter to get correct extension count from output template ([link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR1382-R1387))
  - Remove previous implementation that used hardcoded extension count and did not handle multiple extensions ([link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL1391-L1396))
  - Add test cases for `trim_file_name` with `filesize` and `ext` fields in `test/test_YoutubeDL.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/7954/files?diff=unified&w=0#diff-f1abc5b91afa326c01cbc20d98d5fe6e2fb38ea0e03bcc31d7f1a5b5ee23e0eaR847-R855))



</details>


