### PR TITLE
Ensure dir existence for thumbnails and subtitles

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -4229,7 +4229,7 @@ class YoutubeDL:
         return ret
 
     def _write_thumbnails(self, label, info_dict, filename, thumb_filename_base=None):
-        ''' Write thumbnails to file and return list of (thumb_filename, final_thumb_filename) '''
+        ''' Write thumbnails to file and return list of (thumb_filename, final_thumb_filename); or None if error '''
         write_all = self.params.get('write_all_thumbnails', False)
         thumbnails, ret = [], []
         if write_all or self.params.get('writethumbnail', False):
@@ -4244,6 +4244,9 @@ class YoutubeDL:
         if thumbnails and not thumb_filename_base:
             self.write_debug(f'Skipping writing {label} thumbnail')
             return ret
+
+        if not self._ensure_dir_exists(filename):
+            return None
 
         for idx, t in list(enumerate(thumbnails))[::-1]:
             thumb_ext = (f'{t["id"]}.' if multiple else '') + determine_ext(t['url'], 'jpg')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fixes output template `pl_thumbnail`.

Before this PR, trying to download a playlist with an output template of type `pl_thumbnail` pointing to a missing subdirectory doesn't create it, instead erroring out.

This problem went unnoticed while downloading videos because they're written into an already ensured dir, while playlists called the thumbnail writing method directly.

~~The subtitle change, while technically not required (playlists don't usually have subs) is done for consistency with all the other metadata writing methods. I can remove it if there's the need but it shouldn't hurt.~~

Also I'm not really sure of the expected order of conditions, like, whether I should've put the checks right at the beginning or somewhere else. Please tell me if you'd like them somewhere else, I can change them no problem.

Example of a fixed invocation (tested with commit 4b3a6ef1b3e235ba9a45142830b6edb357c71696):

`yt-dlp -vU --no-config --flat-playlist --write-thumbnail -o 'pl_thumbnail:test/%(id)s.%(ext)s' https://youtube.com/playlist?list=PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir`

<details><summary>verbose log before fix</summary>

```
[debug] Command-line config: ['-vU', '--no-config', '--flat-playlist', '--write-thumbnail', '-o', 'pl_thumbnail:test/%(id)s.%(ext)s', 'https://youtube.com/playlist?list=PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8 (No ANSI), error utf-8 (No ANSI), screen utf-8 (No ANSI)
[debug] yt-dlp version stable@2023.07.06 [b532a3481] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 4b3a6ef1b
[debug] Python 3.11.4 (CPython x86_64 64bit) - Linux-6.4.10-x86_64-with-libc (OpenSSL 3.1.2 1 Aug 2023, libc)
[debug] exe versions: ffmpeg git-2023-07-24-5b11ee9 (setts), ffprobe git-2023-07-24-5b11ee9
[debug] Optional libraries: certifi-2022.12.07, sqlite3-2.6.0
[debug] Proxy map: {}
[debug] Loaded 1864 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Available version: stable@2023.07.06, Current version: stable@2023.07.06
yt-dlp is up to date (stable@2023.07.06)
[youtube:tab] Extracting URL: https://youtube.com/playlist?list=PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading webpage
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Redownloading playlist API JSON with unavailable videos
[download] Downloading playlist: ULTRAKILL
[info] Downloading playlist thumbnail 3 ...
[info] Writing playlist thumbnail 3 to: test/PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir.jpg
ERROR: [Errno 2] No such file or directory: 'test/PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir.jpg'
Traceback (most recent call last):
  File "/home/riteo/srg/yt-dlp/yt_dlp/YoutubeDL.py", line 1575, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riteo/srg/yt-dlp/yt_dlp/YoutubeDL.py", line 1731, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riteo/srg/yt-dlp/yt_dlp/YoutubeDL.py", line 1860, in process_ie_result
    return self.__process_playlist(ie_result, download)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riteo/srg/yt-dlp/yt_dlp/YoutubeDL.py", line 1958, in __process_playlist
    self._write_thumbnails('playlist', ie_result, self.prepare_filename(ie_copy, 'pl_thumbnail'))
  File "/home/riteo/srg/yt-dlp/yt_dlp/YoutubeDL.py", line 4265, in _write_thumbnails
    with open(encodeFilename(thumb_filename), 'wb') as thumbf:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'test/PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir.jpg'
```

</details>

<details><summary>verbose log after fix</summary>

```
[debug] Command-line config: ['-vU', '--no-config', '--flat-playlist', '--write-thumbnail', '-o', 'pl_thumbnail:test/%(id)s.%(ext)s', 'https://youtube.com/playlist?list=PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8 (No ANSI), error utf-8 (No ANSI), screen utf-8 (No ANSI)
[debug] yt-dlp version stable@2023.03.04 [392389b7d] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: a675ef135
[debug] Python 3.11.4 (CPython x86_64 64bit) - Linux-6.4.10-x86_64-with-libc (OpenSSL 3.1.2 1 Aug 2023, libc)
[debug] exe versions: ffmpeg git-2023-07-24-5b11ee9 (setts), ffprobe git-2023-07-24-5b11ee9
[debug] Optional libraries: certifi-2022.12.07, sqlite3-2.6.0
[debug] Proxy map: {}
[debug] Loaded 1839 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Available version: stable@2023.07.06, Current version: stable@2023.03.04
[debug] Downloading _update_spec from https://github.com/yt-dlp/yt-dlp/releases/latest/download/_update_spec
ERROR: You cannot update when running from source code; Use git to pull the latest changes
[youtube:tab] Extracting URL: https://youtube.com/playlist?list=PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading webpage
WARNING: [youtube:tab] unable to extract yt initial data; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: [youtube:tab] Incomplete yt initial data received. Retrying (1/3)...
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading webpage
WARNING: [youtube:tab] unable to extract yt initial data; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: [youtube:tab] Incomplete yt initial data received. Retrying (2/3)...
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading webpage
WARNING: [youtube:tab] unable to extract yt initial data; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: [youtube:tab] Incomplete yt initial data received. Retrying (3/3)...
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading webpage
WARNING: [youtube:tab] unable to extract yt initial data; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
WARNING: [youtube:tab] Incomplete yt initial data received; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U. Giving up after 3 retries
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading API parameters API JSON
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Downloading API JSON
[youtube:tab] PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir: Redownloading playlist API JSON with unavailable videos
[download] Downloading playlist: ULTRAKILL
[info] Downloading playlist thumbnail 3 ...
[info] Writing playlist thumbnail 3 to: test/PLFG57rtsH8Jso3qfd5eO6egyBtW3nyvir.jpg
[youtube:tab] Playlist ULTRAKILL: Downloading 81 items of 81
[debug] The information of all playlist entries will be held in memory
[download] Downloading item 1 of 81
[download] Downloading item 2 of 81
[download] Downloading item 3 of 81
[download] Downloading item 4 of 81
[download] Downloading item 5 of 81
[download] Downloading item 6 of 81
[download] Downloading item 7 of 81
[download] Downloading item 8 of 81
[download] Downloading item 9 of 81
[download] Downloading item 10 of 81
[download] Downloading item 11 of 81
[download] Downloading item 12 of 81
[download] Downloading item 13 of 81
[download] Downloading item 14 of 81
[download] Downloading item 15 of 81
[download] Downloading item 16 of 81
[download] Downloading item 17 of 81
[download] Downloading item 18 of 81
[download] Downloading item 19 of 81
[download] Downloading item 20 of 81
[download] Downloading item 21 of 81
[download] Downloading item 22 of 81
[download] Downloading item 23 of 81
[download] Downloading item 24 of 81
[download] Downloading item 25 of 81
[download] Downloading item 26 of 81
[download] Downloading item 27 of 81
[download] Downloading item 28 of 81
[download] Downloading item 29 of 81
[download] Downloading item 30 of 81
[download] Downloading item 31 of 81
[download] Downloading item 32 of 81
[download] Downloading item 33 of 81
[download] Downloading item 34 of 81
[download] Downloading item 35 of 81
[download] Downloading item 36 of 81
[download] Downloading item 37 of 81
[download] Downloading item 38 of 81
[download] Downloading item 39 of 81
[download] Downloading item 40 of 81
[download] Downloading item 41 of 81
[download] Downloading item 42 of 81
[download] Downloading item 43 of 81
[download] Downloading item 44 of 81
[download] Downloading item 45 of 81
[download] Downloading item 46 of 81
[download] Downloading item 47 of 81
[download] Downloading item 48 of 81
[download] Downloading item 49 of 81
[download] Downloading item 50 of 81
[download] Downloading item 51 of 81
[download] Downloading item 52 of 81
[download] Downloading item 53 of 81
[download] Downloading item 54 of 81
[download] Downloading item 55 of 81
[download] Downloading item 56 of 81
[download] Downloading item 57 of 81
[download] Downloading item 58 of 81
[download] Downloading item 59 of 81
[download] Downloading item 60 of 81
[download] Downloading item 61 of 81
[download] Downloading item 62 of 81
[download] Downloading item 63 of 81
[download] Downloading item 64 of 81
[download] Downloading item 65 of 81
[download] Downloading item 66 of 81
[download] Downloading item 67 of 81
[download] Downloading item 68 of 81
[download] Downloading item 69 of 81
[download] Downloading item 70 of 81
[download] Downloading item 71 of 81
[download] Downloading item 72 of 81
[download] Downloading item 73 of 81
[download] Downloading item 74 of 81
[download] Downloading item 75 of 81
[download] Downloading item 76 of 81
[download] Downloading item 77 of 81
[download] Downloading item 78 of 81
[download] Downloading item 79 of 81
[download] Downloading item 80 of 81
[download] Downloading item 81 of 81
[download] Finished downloading playlist: ULTRAKILL
```
</details>

Fixes... Nothing I could find with a couple of searches with various keywords.

Sorry, it's my first time here. Do you allow direct PRs? `CONTRIBUTING.MD` doesn't say much either. If that's not the case, I can open a simple issue right away.

I hope that making the fix directly is better (merged or not I still need some workaround for this issue in the meantime so I'm not wasting time for myself anyways).

Closes #8203

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a675ef1</samp>

### Summary
🐛📝🚨

<!--
1.  🐛 - This emoji represents a bug fix, since the pull request fixes a potential error that could occur when the output directory does not exist.
2.  📝 - This emoji represents documentation, since the pull request updates the docstring of the `_write_thumbnails` function to reflect the new behavior.
3.  🚨 - This emoji represents tests, since the pull request adds a test case to verify that the functions work as expected when the output directory does not exist.
-->
Add checks for output directory existence in `_write_subtitles` and `_write_thumbnails`. Update docstring of `_write_thumbnails`.

> _When writing subtitles or thumbs_
> _You might face some errors or bums_
> _If the dir does not exist_
> _You'll get an exception twist_
> _So this PR adds some checks and sums_

### Walkthrough
* Add checks to ensure output directories exist before writing subtitle and thumbnail files ([link](https://github.com/yt-dlp/yt-dlp/pull/7985/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR4032-R4034), [link](https://github.com/yt-dlp/yt-dlp/pull/7985/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR4086-R4088))
  * Modify the docstring of `_write_thumbnails` to reflect this possibility ([link](https://github.com/yt-dlp/yt-dlp/pull/7985/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL4073-R4076))



</details>
