### PR TITLE
[ie/twitter] Fix retweet extraction & remove broken fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,7 +1854,7 @@ The following extractors use this feature:
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`
 
 #### twitter
-* `legacy_api`: Force usage of the legacy Twitter API instead of the GraphQL API for tweet extraction. Has no effect if login cookies are passed
+* `api`: Select one of `graphql` (default), `legacy` or `syndication` as the API for tweet extraction. Has no effect if logged in
 
 #### stacommu, wrestleuniverse
 * `device_id`: UUID value assigned by the website and used to enforce device limits for paid livestream content. Can be found in browser local storage

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1088,6 +1088,19 @@ class TwitterIE(TwitterBaseIE):
         },
         'params': {'extractor_args': {'twitter': {'legacy_api': ['']}}},
     }, {
+        # Broadcast embedded in tweet
+        'url': 'https://twitter.com/JessicaDobsonWX/status/1693057346933600402',
+        'info_dict': {
+            'id': '1yNGaNLjEblJj',
+            'ext': 'mp4',
+            'title': 'Jessica Dobson - WAVE Weather Now - Saturday 8/19/23 Update',
+            'uploader': 'Jessica Dobson',
+            'uploader_id': '1DZEoDwDovRQa',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'view_count': int,
+        },
+        'add_ie': ['TwitterBroadcast'],
+    }, {
         # onion route
         'url': 'https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/TwitterBlue/status/1484226494708662273',
         'only_matching': True,

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -720,6 +720,7 @@ class TwitterIE(TwitterBaseIE):
             'view_count': int,
         },
         'add_ie': ['TwitterBroadcast'],
+        'skip': 'Broadcast no longer exists',
     }, {
         # unified card
         'url': 'https://twitter.com/BrooklynNets/status/1349794411333394432?s=20',
@@ -772,9 +773,9 @@ class TwitterIE(TwitterBaseIE):
         'url': 'https://twitter.com/UltimaShadowX/status/1577719286659006464',
         'info_dict': {
             'id': '1577719286659006464',
-            'title': 'Ultima📛 | #вʟм - Test',
+            'title': 'Ultima📛| New Era - Test',
             'description': 'Test https://t.co/Y3KEZD7Dad',
-            'uploader': 'Ultima📛 | #вʟм',
+            'uploader': 'Ultima📛| New Era',
             'uploader_id': 'UltimaShadowX',
             'uploader_url': 'https://twitter.com/UltimaShadowX',
             'upload_date': '20221005',
@@ -830,6 +831,7 @@ class TwitterIE(TwitterBaseIE):
             'age_limit': 18,
             'tags': []
         },
+        'params': {'skip_download': True},  # XXX: HTTP Error 416 Requested Range Not Satisfiable
         'skip': 'Requires authentication',
     }, {
         # Playlist result only with auth
@@ -897,7 +899,7 @@ class TwitterIE(TwitterBaseIE):
             'uploader_id': 'MoniqueCamarra',
             'live_status': 'was_live',
             'release_timestamp': 1658417414,
-            'description': 'md5:4dc8e972f1d8b3c6580376fabb02a3ad',
+            'description': 'md5:acce559345fd49f129c20dbcda3f1201',
             'timestamp': 1658407771,
             'release_date': '20220721',
             'upload_date': '20220721',
@@ -1006,10 +1008,10 @@ class TwitterIE(TwitterBaseIE):
             'view_count': int,
             'thumbnail': 'https://pbs.twimg.com/ext_tw_video_thumb/1600009362759733248/pu/img/XVhFQivj75H_YxxV.jpg?name=orig',
             'age_limit': 0,
-            'uploader': 'Mün The Friend Of YWAP',
+            'uploader': 'Mün',
             'repost_count': int,
             'upload_date': '20221206',
-            'title': 'Mün The Friend Of YWAP - This is a genius ad by Apple. \U0001f525\U0001f525\U0001f525\U0001f525\U0001f525',
+            'title': 'Mün - This is a genius ad by Apple. \U0001f525\U0001f525\U0001f525\U0001f525\U0001f525',
             'comment_count': int,
             'like_count': int,
             'tags': [],
@@ -1018,7 +1020,7 @@ class TwitterIE(TwitterBaseIE):
             'timestamp': 1670306984.0,
         },
     }, {
-        # url to retweet id w/ legacy api
+        # retweeted_status (private)
         'url': 'https://twitter.com/liberdalau/status/1623739803874349067',
         'info_dict': {
             'id': '1623274794488659969',
@@ -1041,29 +1043,50 @@ class TwitterIE(TwitterBaseIE):
         'params': {'extractor_args': {'twitter': {'legacy_api': ['']}}},
         'skip': 'Protected tweet',
     }, {
-        # orig tweet w/ graphql
-        'url': 'https://twitter.com/liberdalau/status/1623739803874349067',
+        # retweeted_status
+        'url': 'https://twitter.com/playstrumpcard/status/1695424220702888009',
         'info_dict': {
-            'id': '1623274794488659969',
-            'display_id': '1623739803874349067',
+            'id': '1694928337846538240',
             'ext': 'mp4',
-            'title': '@selfisekai@hackerspace.pl 🐀 - RT @Johnnybull3ts: Me after going viral to over 30million people:    Whoopsie-daisy',
-            'description': 'md5:9258bdbb54793bdc124fe1cd47e96c6a',
-            'uploader': '@selfisekai@hackerspace.pl 🐀',
-            'uploader_id': 'liberdalau',
-            'uploader_url': 'https://twitter.com/liberdalau',
+            'display_id': '1695424220702888009',
+            'title': 'md5:e8daa9527bc2b947121395494f786d9d',
+            'description': 'md5:004f2d37fd58737724ec75bc7e679938',
+            'uploader': 'Benny Johnson',
+            'uploader_id': 'bennyjohnson',
+            'uploader_url': 'https://twitter.com/bennyjohnson',
             'age_limit': 0,
             'tags': [],
-            'duration': 8.033,
-            'timestamp': 1675964711.0,
-            'upload_date': '20230209',
-            'thumbnail': r're:https://pbs\.twimg\.com/ext_tw_video_thumb/.+',
+            'duration': 45.001,
+            'timestamp': 1692962814.0,
+            'upload_date': '20230825',
+            'thumbnail': r're:https://pbs\.twimg\.com/amplify_video_thumb/.+',
             'like_count': int,
-            'view_count': int,
             'repost_count': int,
+            'view_count': int,
             'comment_count': int,
         },
-        'skip': 'Protected tweet',
+    }, {
+        # retweeted_status w/ legacy_api
+        'url': 'https://twitter.com/playstrumpcard/status/1695424220702888009',
+        'info_dict': {
+            'id': '1694928337846538240',
+            'ext': 'mp4',
+            'display_id': '1695424220702888009',
+            'title': 'md5:e8daa9527bc2b947121395494f786d9d',
+            'description': 'md5:004f2d37fd58737724ec75bc7e679938',
+            'uploader': 'Benny Johnson',
+            'uploader_id': 'bennyjohnson',
+            'uploader_url': 'https://twitter.com/bennyjohnson',
+            'age_limit': 0,
+            'tags': [],
+            'duration': 45.001,
+            'timestamp': 1692962814.0,
+            'upload_date': '20230825',
+            'thumbnail': r're:https://pbs\.twimg\.com/amplify_video_thumb/.+',
+            'like_count': int,
+            'repost_count': int,
+        },
+        'params': {'extractor_args': {'twitter': {'legacy_api': ['']}}},
     }, {
         # onion route
         'url': 'https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/TwitterBlue/status/1484226494708662273',

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1162,6 +1162,8 @@ class TwitterIE(TwitterBaseIE):
         'only_matching': True,
     }]
 
+    _MEDIA_ID_RE = re.compile(r'_video/(\d+)/')
+
     @property
     def _GRAPHQL_ENDPOINT(self):
         if self.is_logged_in:
@@ -1306,8 +1308,7 @@ class TwitterIE(TwitterBaseIE):
             media = []
             for detail in traverse_obj(status, ((None, 'quoted_tweet'), 'mediaDetails', ..., {dict})):
                 detail['id_str'] = traverse_obj(detail, (
-                    'video_info', 'variants', ..., 'url',
-                    {functools.partial(re.search, r'_video/(\d+)/')}, 1), get_all=False) or twid
+                    'video_info', 'variants', ..., 'url', {self._MEDIA_ID_RE.search}, 1), get_all=False) or twid
                 media.append(detail)
             status['extended_entities'] = {'media': media}
 

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1518,6 +1518,8 @@ class TwitterBroadcastIE(TwitterBaseIE, PeriscopeBaseIE):
         broadcast = self._call_api(
             'broadcasts/show.json', broadcast_id,
             {'ids': broadcast_id})['broadcasts'][broadcast_id]
+        if not broadcast:
+            raise ExtractorError('Broadcast no longer exists', expected=True)
         info = self._parse_broadcast_data(broadcast, broadcast_id)
         media_key = broadcast['media_key']
         source = self._call_api(

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -712,6 +712,7 @@ class TwitterIE(TwitterBaseIE):
             'tags': [],
             'age_limit': 0,
         },
+        'skip': 'This Tweet is unavailable',
     }, {
         # not available in Periscope
         'url': 'https://twitter.com/ViviEducation/status/1136534865145286656',
@@ -837,7 +838,7 @@ class TwitterIE(TwitterBaseIE):
             'age_limit': 18,
             'tags': []
         },
-        'params': {'skip_download': True},  # XXX: HTTP Error 416 Requested Range Not Satisfiable
+        'params': {'skip_download': 'The media could not be played'},
         'skip': 'Requires authentication',
     }, {
         # Playlist result only with graphql API

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1106,6 +1106,25 @@ class TwitterIE(TwitterBaseIE):
         },
         'add_ie': ['TwitterBroadcast'],
     }, {
+        # Animated gif and quote tweet video, with syndication API
+        'url': 'https://twitter.com/BAKKOOONN/status/1696256659889565950',
+        'playlist_mincount': 2,
+        'info_dict': {
+            'id': '1696256659889565950',
+            'title': 'BAKOON - https://t.co/zom968d0a0',
+            'description': 'https://t.co/zom968d0a0',
+            'tags': [],
+            'uploader': 'BAKOON',
+            'uploader_id': 'BAKKOOONN',
+            'uploader_url': 'https://twitter.com/BAKKOOONN',
+            'age_limit': 18,
+            'timestamp': 1693254077.0,
+            'upload_date': '20230828',
+            'like_count': int,
+        },
+        'params': {'extractor_args': {'twitter': {'api': ['syndication']}}},
+        'expected_warnings': ['Not all metadata'],
+    }, {
         # onion route
         'url': 'https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/TwitterBlue/status/1484226494708662273',
         'only_matching': True,

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1297,7 +1297,8 @@ class TwitterIE(TwitterBaseIE):
                 'https://cdn.syndication.twimg.com/tweet-result', twid, 'Downloading syndication JSON',
                 headers={'User-Agent': 'Googlebot'}, query={
                     'id': twid,
-                    'token': ''.join(random.choices('0123456789abcdef', k=11)),
+                    # TODO: token = ((Number(twid) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '')
+                    'token': ''.join(random.choices('123456789abcdefghijklmnopqrstuvwxyz', k=10)),
                 })
             if not status:
                 raise ExtractorError('Syndication endpoint returned empty JSON response')

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1138,7 +1138,11 @@ class TwitterIE(TwitterBaseIE):
             'retweeted_status': ('legacy', 'retweeted_status_result', 'result', 'legacy'),
         }, expected_type=dict, default={}))
 
-        # extra transformation is needed since result does not match legacy format
+        # extra transformations needed since result does not match legacy format
+        if status.get('retweeted_status'):
+            status['retweeted_status']['user'] = traverse_obj(status, (
+                'retweeted_status_result', 'result', 'core', 'user_results', 'result', 'legacy', {dict})) or {}
+
         binding_values = {
             binding_value.get('key'): binding_value.get('value')
             for binding_value in traverse_obj(status, ('card', 'binding_values', ..., {dict}))


### PR DESCRIPTION
When the input URL is for a tweet of a retweeted video, the actual tweet that's being reposted should be extracted instead of the content-less retweet itself. This was being done correctly when passing the `legacy_api` extractor-arg, but the necessary transformations to the GraphQL response were not being made otherwise.

Since I was already rewriting `TwitterIE._extract_status()`, I cleaned it up by removing the syndication fallback that is now broken. This will make debugging much simpler.

Finally, in the process of running/updating the tests, I realized the `TwitterBroadcast` extractor was raising an unexpected `AttributeError` when a broadcast no longer exists, so I added 2 lines to catch that.

Addresses https://github.com/yt-dlp/yt-dlp/issues/7850#issuecomment-1694418935


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e8b6fdb</samp>

### Summary
🐦🎥🔄

<!--
1.  🐦 for Twitter
2. 🎥 for videos
3. 🔄 for retweets
-->
Improve Twitter extraction and fix bugs. Add support for retweets, handle missing or private broadcasts, and use legacy API as fallback. Update and add tests for `yt_dlp/extractor/twitter.py`.

> _Oh we are the coders of the Twitter sea_
> _We extract the tweets and the videos with glee_
> _We handle the retweets and the broadcasts that are gone_
> _And we use the `legacy API` when we need to carry on_

### Walkthrough
*  Remove unused import of `functools` ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1))
*  Add and update test cases for `TwitterIE` class, testing different scenarios of tweets, retweets, and broadcasts ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103R723), [link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L776-R778), [link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103R834), [link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L901-R902), [link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1010-R1014), [link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1022-R1023), [link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1045-R1103))
*  Add `_GRAPHQL_ENDPOINT` property to `TwitterIE` class, returning the appropriate GraphQL endpoint depending on login status ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103R1141-R1146))
*  Modify `_graphql_to_legacy` method of `TwitterIE` class, adding support for extracting retweeted status and user from GraphQL response ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1133-R1181))
*  Modify `_extract_status` method of `TwitterIE` class, changing the order and logic of API calls, preferring legacy API over GraphQL API if not logged in and `legacy_api` argument is set, and returning retweeted status if present ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1211-R1258))
*  Modify `_real_extract` method of `TwitterIE` class, removing redundant extraction of media id from video URL ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1225-R1269))
*  Modify `_real_extract` method of `TwitterBroadcastIE` class, adding a check for the existence of broadcast in API response, and raising extractor error if missing ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103L1269-R1300))
*  Add comment to `_real_extract` method of `TwitterBroadcastIE` class, explaining the purpose of broadcast id extraction ([link](https://github.com/yt-dlp/yt-dlp/pull/8016/files?diff=unified&w=0#diff-8b22c3c3c6185164ce8c3e82541f91c728397dec66456eef7e05f664d5729103R1534-R1535))



</details>
