### PR TITLE
[ie/RCS] fix incorrect field in tests

### DIFF
--- a/yt_dlp/extractor/rcs.py
+++ b/yt_dlp/extractor/rcs.py
@@ -239,10 +239,10 @@ class RCSEmbedsIE(RCSBaseIE):
         }
     }, {
         'url': 'https://video.gazzanet.gazzetta.it/video-embed/gazzanet-mo05-0000260789',
-        'match_only': True
+        'only_matching': True
     }, {
         'url': 'https://video.gazzetta.it/video-embed/49612410-00ca-11eb-bcd8-30d4253e0140',
-        'match_only': True
+        'only_matching': True
     }]
     _WEBPAGE_TESTS = [{
         'url': 'https://www.iodonna.it/video-iodonna/personaggi-video/monica-bellucci-piu-del-lavoro-oggi-per-me-sono-importanti-lamicizia-e-la-famiglia/',
@@ -325,7 +325,7 @@ class RCSIE(RCSBaseIE):
         }
     }, {
         'url': 'https://video.corriere.it/video-360/metro-copenaghen-tutta-italiana/a248a7f0-e2db-11e9-9830-af2de6b1f945',
-        'match_only': True
+        'only_matching': True
     }]
 
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

In the RCS extractor, some tests are marked incorrectly with `match_only`, provoking an exception when trying to run them:
```
Exception: Test test_RCSEmbeds_1 definition incorrect - "id" key is not present
```
This fix uses the correct key for marking such tests.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 066feb0</samp>

### Summary
:recycle::memo::sparkles:

<!--
1.  :recycle: This emoji could be used to indicate that the change is a refactoring or improvement of existing code or functionality, without adding any new features or breaking changes.
2.  :memo: This emoji could be used to indicate that the change is related to documentation, comments, or naming conventions, which can help readers understand the code or the test cases better.
3.  :sparkles: This emoji could be used to indicate that the change is a new or enhanced feature, which could make the RCS extractor more flexible or powerful. However, this emoji might be misleading or exaggerated if the change is only a minor or cosmetic one.
-->
Fix a naming inconsistency in RCS extractor tests. Use `only_matching` instead of `match_only` in `yt_dlp/extractor/rcs.py`.

> _We're testing the RCS extractor_
> _To find the files that we need_
> _We've renamed `match_only` to `only_matching`_
> _To make our code more clear and consistent indeed_

### Walkthrough
* Rename `match_only` key to `only_matching` in test cases to unify naming and avoid confusion with `match` key ([link](https://github.com/yt-dlp/yt-dlp/pull/8028/files?diff=unified&w=0#diff-1582eb885f5f982b6b2c8e2157383efdb25619fea4ae0b53d0f3b894fa84cb5aL242-R245), [link](https://github.com/yt-dlp/yt-dlp/pull/8028/files?diff=unified&w=0#diff-1582eb885f5f982b6b2c8e2157383efdb25619fea4ae0b53d0f3b894fa84cb5aL328-R328))
* Update test cases in `yt_dlp/extractor/rcs.py` for `RCSEmbedsIE` and `RCSIE` classes to reflect the renaming ([link](https://github.com/yt-dlp/yt-dlp/pull/8028/files?diff=unified&w=0#diff-1582eb885f5f982b6b2c8e2157383efdb25619fea4ae0b53d0f3b894fa84cb5aL242-R245), [link](https://github.com/yt-dlp/yt-dlp/pull/8028/files?diff=unified&w=0#diff-1582eb885f5f982b6b2c8e2157383efdb25619fea4ae0b53d0f3b894fa84cb5aL328-R328))



</details>
