### PR TITLE
[ie/Bild.de] fix extraction when HLS formats are available (fixes #7951)

### DIFF
--- a/yt_dlp/extractor/bild.py
+++ b/yt_dlp/extractor/bild.py
@@ -8,7 +8,8 @@ from ..utils import (
 class BildIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?bild\.de/(?:[^/]+/)+(?P<display_id>[^/]+)-(?P<id>\d+)(?:,auto=true)?\.bild\.html?'
     IE_DESC = 'Bild.de'
-    _TEST = {
+    _TESTS = [{
+        'note': 'static MP4 only',
         'url': 'http://www.bild.de/video/clip/apple-ipad-air/das-koennen-die-neuen-ipads-38184146.bild.html',
         'md5': 'dd495cbd99f2413502a1713a1156ac8a',
         'info_dict': {
@@ -19,7 +20,19 @@ class BildIE(InfoExtractor):
             'thumbnail': r're:^https?://.*\.jpg$',
             'duration': 196,
         }
-    }
+    }, {
+        'note': 'static MP4 and HLS',
+        'url': 'https://www.bild.de/video/clip/news-ausland/deftiger-abgang-vom-10m-turm-bademeister-sorgt-fuer-skandal-85158620.bild.htm',
+        'md5': 'fb0ed4f09c495d4ba7ce2eee0bb90de1',
+        'info_dict': {
+            'id': '85158620',
+            'ext': 'mp4',
+            'title': 'Der Sprungturm-Skandal',
+            'description': 'md5:709b543c24dc31bbbffee73bccda34ad',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'duration': 69,
+        }
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/yt_dlp/extractor/bild.py
+++ b/yt_dlp/extractor/bild.py
@@ -6,7 +6,7 @@ from ..utils import (
 
 
 class BildIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?bild\.de/(?:[^/]+/)+(?P<display_id>[^/]+)-(?P<id>\d+)(?:,auto=true)?\.bild\.html'
+    _VALID_URL = r'https?://(?:www\.)?bild\.de/(?:[^/]+/)+(?P<display_id>[^/]+)-(?P<id>\d+)(?:,auto=true)?\.bild\.html?'
     IE_DESC = 'Bild.de'
     _TEST = {
         'url': 'http://www.bild.de/video/clip/apple-ipad-air/das-koennen-die-neuen-ipads-38184146.bild.html',
@@ -27,11 +27,21 @@ class BildIE(InfoExtractor):
         video_data = self._download_json(
             url.split('.bild.html')[0] + ',view=json.bild.html', video_id)
 
+        formats = []
+        for src in video_data['clipList'][0]['srces']:
+            if src['type'] == 'application/x-mpegURL':
+                formats.extend(
+                    self._extract_m3u8_formats(
+                        src['src'], video_id, 'mp4',
+                        entry_protocol='m3u8_native', m3u8_id='hls', fatal=False))
+            elif src['type'] == 'video/mp4':
+                formats.append({'url': src['src'], 'format_id': 'http-mp4'})
+
         return {
             'id': video_id,
             'title': unescapeHTML(video_data['title']).strip(),
             'description': unescapeHTML(video_data.get('description')),
-            'url': video_data['clipList'][0]['srces'][0]['src'],
+            'formats': formats,
             'thumbnail': video_data.get('poster'),
             'duration': int_or_none(video_data.get('durationSec')),
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Previously, only static download formats were supported. With the appearance of (additional) HLS formats, the extractor broke when they are available.

This PR adds the handling of those HLS formats in addition to the static one(s).

Fixes https://github.com/yt-dlp/yt-dlp/issues/7951

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I don't quite understand. I am not the original author of the code, I am only fixing it. I don't know if the _original_ code is under Public Domain or Unlicense. I place my contribution under either, if desired.

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3f5fcd7</samp>

### Summary
🛠️🆕🎞️

<!--
1.  🛠️ - This emoji represents fixing or improving something, and can be used to indicate that the `bild` extractor was enhanced to handle more scenarios and video formats.
2.  🆕 - This emoji represents something new or added, and can be used to indicate that a new test case was added to verify the functionality of the `bild` extractor.
3.  🎞️ - This emoji represents film or video, and can be used to indicate that the HLS and MP4 formats were extracted from the video data.
-->
Improved the `bild` extractor to handle more video scenarios and formats. Added a test and extracted `HLS` and `MP4` from `videoData`.

> _Sing, O Muse, of the skillful coder who improved the `bild` extractor_
> _And made it work with various URLs and sources of video streams_
> _He added a new test to verify his clever work and extracted_
> _The formats of HLS and MP4 from the data, like Hermes stealing Apollo's herds_

### Walkthrough
* Modify the URL regex and the test cases to support different video page formats and sources ([link](https://github.com/yt-dlp/yt-dlp/pull/8032/files?diff=unified&w=0#diff-b8246626b3a649947e8b58b5cc7fd0a2db4f841526c9650d56b2da48249d9886L9-R12), [link](https://github.com/yt-dlp/yt-dlp/pull/8032/files?diff=unified&w=0#diff-b8246626b3a649947e8b58b5cc7fd0a2db4f841526c9650d56b2da48249d9886L22-R35))
* Extract and return multiple video formats from the video data, preferring HLS over MP4 ([link](https://github.com/yt-dlp/yt-dlp/pull/8032/files?diff=unified&w=0#diff-b8246626b3a649947e8b58b5cc7fd0a2db4f841526c9650d56b2da48249d9886L30-R57))
* Use the `_extract_m3u8_formats` method to parse the HLS manifest and add the formats to the list ([link](https://github.com/yt-dlp/yt-dlp/pull/8032/files?diff=unified&w=0#diff-b8246626b3a649947e8b58b5cc7fd0a2db4f841526c9650d56b2da48249d9886L30-R57))
* Assign the format IDs `hls` and `http-mp4` to the HLS and MP4 sources respectively ([link](https://github.com/yt-dlp/yt-dlp/pull/8032/files?diff=unified&w=0#diff-b8246626b3a649947e8b58b5cc7fd0a2db4f841526c9650d56b2da48249d9886L30-R57))



</details>
