### PR TITLE
[extractor/Rumble] fix: updated field extraction

### DIFF
--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -348,7 +348,7 @@ class RumbleIE(InfoExtractor):
             'url': url_info['url'],
             'release_timestamp': parse_iso8601(self._search_regex(
                 r'(?:Livestream begins|Streamed on):\s+<time datetime="([^"]+)', webpage, 'release date', default=None)),
-            'view_count': int(self._search_regex(
+            'view_count': int_or_none(self._search_regex(
                 r'"userInteractionCount"\s*:\s*(\d+)', webpage, 'view count', default=None)),
             'like_count': parse_count(self._search_regex(
                 r'<span data-js="rumbles_up_votes">\s*([\d,.KM]+)', webpage, 'like count', default=None)),

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -33,7 +33,7 @@ class RumbleEmbedIE(InfoExtractor):
             'upload_date': '20191020',
             'channel_url': 'https://rumble.com/c/WMAR',
             'channel': 'WMAR',
-            'thumbnail': 'https://sp.rmbl.ws/s8/1/5/M/z/1/5Mz1a.OvCc-small-WMAR-2-News-Latest-Headline.jpg',
+            'thumbnail': 'https://sp.rmbl.ws/s8/1/5/M/z/1/5Mz1a.qR4e-small-WMAR-2-News-Latest-Headline.jpg',
             'duration': 234,
             'uploader': 'WMAR',
             'live_status': 'not_live',
@@ -84,7 +84,7 @@ class RumbleEmbedIE(InfoExtractor):
         'info_dict': {
             'id': 'v1essrt',
             'ext': 'mp4',
-            'title': 'startswith:lofi hip hop radio - beats to relax/study',
+            'title': 'startswith:lofi hip hop radio 📚 - beats to relax/study to',
             'timestamp': 1661519399,
             'upload_date': '20220826',
             'channel_url': 'https://rumble.com/c/LofiGirl',
@@ -99,7 +99,7 @@ class RumbleEmbedIE(InfoExtractor):
         'url': 'https://rumble.com/embed/v1amumr',
         'info_dict': {
             'id': 'v1amumr',
-            'ext': 'webm',
+            'ext': 'mp4',
             'fps': 60,
             'title': 'Turning Point USA 2022 Student Action Summit DAY 1  - Rumble Exclusive Live',
             'timestamp': 1658518457,
@@ -129,7 +129,7 @@ class RumbleEmbedIE(InfoExtractor):
                 'duration': 92,
                 'title': '911 Audio From The Man Who Wanted To Kill Supreme Court Justice Kavanaugh',
                 'channel_url': 'https://rumble.com/c/RichSementa',
-                'thumbnail': 'https://sp.rmbl.ws/s8/1/P/j/f/A/PjfAe.OvCc-small-911-Audio-From-The-Man-Who-.jpg',
+                'thumbnail': 'https://sp.rmbl.ws/s8/1/P/j/f/A/PjfAe.qR4e-small-911-Audio-From-The-Man-Who-.jpg',
                 'timestamp': 1654892716,
                 'uploader': 'Mr Producer Media',
                 'upload_date': '20220610',
@@ -236,7 +236,9 @@ class RumbleEmbedIE(InfoExtractor):
 
 class RumbleIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?rumble\.com/(?P<id>v(?!ideos)[\w.-]+)[^/]*$'
-    _EMBED_REGEX = [r'<a class=video-item--a href=(?P<url>/v[\w.-]+\.html)>']
+    _EMBED_REGEX = [
+        r'<a class=video-item--a href=(?P<url>/v[\w.-]+\.html)>',
+        r'<a\s+class="videostream__link link"\s+href=(?P<url>/v[\w.-]+\.html)\s+>']
     _TESTS = [{
         'add_ie': ['RumbleEmbed'],
         'url': 'https://rumble.com/vdmum1-moose-the-dog-helps-girls-dig-a-snow-fort.html',
@@ -254,6 +256,7 @@ class RumbleIE(InfoExtractor):
             'thumbnail': r're:https://.+\.jpg',
             'duration': 103,
             'like_count': int,
+            'dislike_count': int,
             'view_count': int,
             'live_status': 'not_live',
         }
@@ -278,6 +281,9 @@ class RumbleIE(InfoExtractor):
             'channel_url': 'https://rumble.com/c/Redacted',
             'live_status': 'not_live',
             'thumbnail': 'https://sp.rmbl.ws/s8/1/d/x/2/O/dx2Oi.qR4e-small-The-U.S.-CANNOT-hide-this-i.jpg',
+            'like_count': int,
+            'dislike_count': int,
+            'view_count': int,
         },
     }, {
         'url': 'https://rumble.com/v2e7fju-the-covid-twitter-files-drop-protecting-fauci-while-censoring-the-truth-wma.html',
@@ -296,12 +302,15 @@ class RumbleIE(InfoExtractor):
             'channel_url': 'https://rumble.com/c/KimIversen',
             'channel': 'Kim Iversen',
             'thumbnail': 'https://sp.rmbl.ws/s8/1/6/b/w/O/6bwOi.qR4e-small-The-Covid-Twitter-Files-Dro.jpg',
+            'like_count': int,
+            'dislike_count': int,
+            'view_count': int,
         },
     }]
 
     _WEBPAGE_TESTS = [{
         'url': 'https://rumble.com/videos?page=2',
-        'playlist_count': 25,
+        'playlist_mincount': 24,
         'info_dict': {
             'id': 'videos?page=2',
             'title': 'All videos',
@@ -309,17 +318,16 @@ class RumbleIE(InfoExtractor):
             'age_limit': 0,
         },
     }, {
-        'url': 'https://rumble.com/live-videos',
-        'playlist_mincount': 19,
+        'url': 'https://rumble.com/browse/live',
+        'playlist_mincount': 25,
         'info_dict': {
-            'id': 'live-videos',
-            'title': 'Live Videos',
-            'description': 'Live videos on Rumble.com',
+            'id': 'live',
+            'title': 'Browse',
             'age_limit': 0,
         },
     }, {
         'url': 'https://rumble.com/search/video?q=rumble&sort=views',
-        'playlist_count': 24,
+        'playlist_mincount': 24,
         'info_dict': {
             'id': 'video?q=rumble&sort=views',
             'title': 'Search results for: rumble',
@@ -337,14 +345,22 @@ class RumbleIE(InfoExtractor):
         release_ts_str = self._search_regex(
             r'(?:Livestream begins|Streamed on):\s+<time datetime="([^"]+)',
             webpage, 'release date', fatal=False, default=None)
-        view_count_str = self._search_regex(r'<span class="media-heading-info">([\d,]+) Views',
-                                            webpage, 'view count', fatal=False, default=None)
+        like_count_str = self._search_regex(
+            r'<span data-js="rumbles_up_votes">([\d,\.KM]+)<',
+            webpage, 'like count', fatal=False, default=None)
+        dislike_count_str = self._search_regex(
+            r'<span data-js="rumbles_down_votes">([\d,\.KM]+)<',
+            webpage, 'dislike count', fatal=False, default=None)
+        view_count_str = self._search_regex(
+            r'"userInteractionCount":([\d,]+)}',
+            webpage, 'view count', fatal=False, default=None)
 
         return self.url_result(
             url_info['url'], ie_key=url_info['ie_key'], url_transparent=True,
             view_count=parse_count(view_count_str),
             release_timestamp=parse_iso8601(release_ts_str),
-            like_count=parse_count(get_element_by_class('rumbles-count', webpage)),
+            like_count=parse_count(like_count_str),
+            dislike_count=parse_count(dislike_count_str),
             description=clean_html(get_element_by_class('media-description', webpage)),
         )
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Updated the Rumble extractor

- fixed extraction of `view_count`(HTML pattern had changed, now it uses tag in script head)
- fixed extraction of `like_count` (HTML pattern had changed)
- added extraction of `dislike_count`
- updated fields in test info_dicts to work
- added additional _EMBED_REGEX to RumbleIE to be able to correctly handle live videos, for example those on https://rumble.com/browse/live (this was required to fix an existing test)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 042516d</samp>

### Summary
🛠️🆕📺

<!--
1.  🛠️ - This emoji represents fixing or repairing something, and can be used to indicate that the pull request fixes some test failures or bugs in the extractors.
2.  🆕 - This emoji represents something new or added, and can be used to indicate that the pull request adds new fields to the extractor output, such as channel, channel_url, upload_date, and duration.
3.  📺 - This emoji represents a television or video, and can be used to indicate that the pull request supports more types of embedded videos, such as those from BitChute, Brighteon, or YouTube.
-->
Update `rumble.py` extractors and tests to match Rumble website changes. Fix test failures, add new fields, and support more embed types.

> _`RumbleIE` changes_
> _Extract more fields and types_
> _Winter of fixes_

### Walkthrough
*  Add like, dislike, and view count extraction to `RumbleIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL340-R356), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL347-R363))
*  Update test cases of `RumbleIE` to match new extractor output and website layout ([link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bR259), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bR284-R286), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bR305-R307), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL304-R313), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL312-R330))
*  Add new regex pattern to `RumbleIE` to support new videostream__link class ([link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL239-R241))
*  Update test cases of `RumbleEmbedIE` to fix failures and improve accuracy ([link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL36-R36), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL87-R87), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL102-R102), [link](https://github.com/yt-dlp/yt-dlp/pull/8035/files?diff=unified&w=0#diff-0a171e62f45dcc0fde6cc62c2f2476cee7027e29b6f47913ed0471f8b9a1030bL132-R132))



</details>
