### PR TITLE
[extractor/Funker530] fix: funker530 rumble embed link extraction and video download

### DIFF
--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -1,79 +1,96 @@
 from .common import InfoExtractor
-from .rumble import RumbleEmbedIE
+from .generic import GenericIE
 from .youtube import YoutubeIE
 from ..utils import ExtractorError, clean_html, get_element_by_class, strip_or_none
+import re
+
+
+def extract_video_id(response):
+    # Define a regular expression pattern to match "Rumble" followed by parentheses and content inside them.
+    pattern = r'Rumble\s*\((.*?)\)'
+
+    # Use re.search() to find the first occurrence of the pattern in the response.
+    match = re.search(pattern, response)
+
+    # Check if a match is found.
+    if match:
+        # Extract the content inside parentheses using group(1).
+        content_inside_parentheses = match.group(1)
+
+        # Use another regular expression to extract the video ID.
+        video_id_match = re.search(r'video:\s*"([^"]+)"', content_inside_parentheses)
+
+        if video_id_match:
+            # Extract the video ID using group(1).
+            video_id = video_id_match.group(1)
+            return video_id
+    return None  # Return None if "Rumble" followed by parentheses or video ID is not found.
+
+
+def url_clean(self, display_id, video_id):
+    url = f"https://rumble.com/embedJS/{video_id}"
+
+    webpage = self._download_webpage(url, display_id)
+
+    # Extract the link after "url" from the response using regex.
+    link_match = re.search(r'"url":"(.*?)",', webpage)
+
+    if link_match:
+        link = link_match.group(1)
+
+        # Remove all "\" symbols from the link.
+        cleaned_link = link.replace('/', '')
+        cleaned_link = cleaned_link.replace('\\', '/')
+        return cleaned_link
 
 
 class Funker530IE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?funker530\.com/video/(?P<id>[^/?#]+)'
     _TESTS = [{
         'url': 'https://funker530.com/video/azov-patrol-caught-in-open-under-automatic-grenade-launcher-fire/',
-        'md5': '085f50fea27523a388bbc22e123e09c8',
+        'md5': 'fcb1880a5703f5c17e9191bab27fb822',
         'info_dict': {
-            'id': 'v2qbmu4',
+            'id': 'c1Mgk.caa',
             'ext': 'mp4',
-            'title': 'Azov Patrol Caught In Open Under Automatic Grenade Launcher Fire',
-            'thumbnail': r're:^https?://.*\.jpg$',
-            'uploader': 'Funker530',
-            'channel': 'Funker530',
-            'channel_url': 'https://rumble.com/c/c-1199543',
-            'width': 1280,
-            'height': 720,
-            'fps': 25,
-            'duration': 27,
+            'title': 'c1Mgk.caa',
             'upload_date': '20230608',
-            'timestamp': 1686241321,
-            'live_status': 'not_live',
-            'description': 'md5:bea2e1f458095414e04b5ac189c2f980',
-        }
-    }, {
-        'url': 'https://funker530.com/video/my-friends-joined-the-russians-civdiv/',
-        'md5': 'a42c2933391210662e93e867d7124b70',
-        'info_dict': {
-            'id': 'k-pk4bOvoac',
-            'ext': 'mp4',
-            'view_count': int,
-            'channel': 'Civ Div',
-            'comment_count': int,
-            'channel_follower_count': int,
-            'thumbnail': 'https://i.ytimg.com/vi/k-pk4bOvoac/maxresdefault.jpg',
-            'uploader_id': '@CivDiv',
-            'duration': 357,
-            'channel_url': 'https://www.youtube.com/channel/UCgsCiwJ88up-YyMHo7hL5-A',
-            'tags': [],
-            'uploader_url': 'https://www.youtube.com/@CivDiv',
-            'channel_id': 'UCgsCiwJ88up-YyMHo7hL5-A',
-            'like_count': int,
-            'description': 'md5:aef75ec3f59c07a0e39400f609b24429',
-            'live_status': 'not_live',
-            'age_limit': 0,
-            'uploader': 'Civ Div',
-            'categories': ['People & Blogs'],
-            'title': 'My “Friends” joined the Russians.',
-            'availability': 'public',
-            'upload_date': '20230608',
-            'playable_in_embed': True,
-            'heatmap': 'count:100',
+            'timestamp': 1686241352.0,
+            'direct': True
         }
     }]
 
     def _real_extract(self, url):
+        info = {}
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
-        rumble_url = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
+
+        video_id = extract_video_id(webpage)
+        cleaned_link = url_clean(self, display_id, video_id)
+        rumble_url = cleaned_link
+
+        youtube_url = list(YoutubeIE._extract_embed_urls(url, webpage))
+
         if rumble_url:
-            info = {'url': rumble_url[0], 'ie_key': RumbleEmbedIE.ie_key()}
-        else:
-            youtube_url = list(YoutubeIE._extract_embed_urls(url, webpage))
-            if youtube_url:
-                info = {'url': youtube_url[0], 'ie_key': YoutubeIE.ie_key()}
-        if not info:
+            info = {
+                'url': rumble_url,
+                'info_dict': {
+                    'ext': 'mp4',
+                    'direct': True
+                },
+
+                'ie_key': GenericIE.ie_key()
+            }
+        elif youtube_url:
+            info = {'url': youtube_url[0], 'ie_key': YoutubeIE.ie_key()}
+        if info == {}:
             raise ExtractorError('No videos found on webpage', expected=True)
 
         return {
             **info,
-            '_type': 'url_transparent',
+            '_type': 'url',
             'description': strip_or_none(self._search_regex(
                 r'(?s)(.+)About the Author', clean_html(get_element_by_class('video-desc-paragraph', webpage)),
-                'description', default=None))
+                'description', default=None)),
+
+
         }

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -60,8 +60,8 @@ class Funker530IE(InfoExtractor):
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
-        rumble_url = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
         info = {}
+        rumble_url = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
         if rumble_url:
             info = {'url': rumble_url[0], 'ie_key': RumbleEmbedIE.ie_key()}
         else:

--- a/yt_dlp/extractor/funker530.py
+++ b/yt_dlp/extractor/funker530.py
@@ -1,96 +1,80 @@
 from .common import InfoExtractor
-from .generic import GenericIE
+from .rumble import RumbleEmbedIE
 from .youtube import YoutubeIE
 from ..utils import ExtractorError, clean_html, get_element_by_class, strip_or_none
-import re
-
-
-def extract_video_id(response):
-    # Define a regular expression pattern to match "Rumble" followed by parentheses and content inside them.
-    pattern = r'Rumble\s*\((.*?)\)'
-
-    # Use re.search() to find the first occurrence of the pattern in the response.
-    match = re.search(pattern, response)
-
-    # Check if a match is found.
-    if match:
-        # Extract the content inside parentheses using group(1).
-        content_inside_parentheses = match.group(1)
-
-        # Use another regular expression to extract the video ID.
-        video_id_match = re.search(r'video:\s*"([^"]+)"', content_inside_parentheses)
-
-        if video_id_match:
-            # Extract the video ID using group(1).
-            video_id = video_id_match.group(1)
-            return video_id
-    return None  # Return None if "Rumble" followed by parentheses or video ID is not found.
-
-
-def url_clean(self, display_id, video_id):
-    url = f"https://rumble.com/embedJS/{video_id}"
-
-    webpage = self._download_webpage(url, display_id)
-
-    # Extract the link after "url" from the response using regex.
-    link_match = re.search(r'"url":"(.*?)",', webpage)
-
-    if link_match:
-        link = link_match.group(1)
-
-        # Remove all "\" symbols from the link.
-        cleaned_link = link.replace('/', '')
-        cleaned_link = cleaned_link.replace('\\', '/')
-        return cleaned_link
 
 
 class Funker530IE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?funker530\.com/video/(?P<id>[^/?#]+)'
     _TESTS = [{
         'url': 'https://funker530.com/video/azov-patrol-caught-in-open-under-automatic-grenade-launcher-fire/',
-        'md5': 'fcb1880a5703f5c17e9191bab27fb822',
+        'md5': '085f50fea27523a388bbc22e123e09c8',
         'info_dict': {
-            'id': 'c1Mgk.caa',
+            'id': 'v2qbmu4',
             'ext': 'mp4',
-            'title': 'c1Mgk.caa',
+            'title': 'Azov Patrol Caught In Open Under Automatic Grenade Launcher Fire',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'uploader': 'Funker530',
+            'channel': 'Funker530',
+            'channel_url': 'https://rumble.com/c/c-1199543',
+            'width': 1280,
+            'height': 720,
+            'fps': 25,
+            'duration': 27,
             'upload_date': '20230608',
-            'timestamp': 1686241352.0,
-            'direct': True
+            'timestamp': 1686241321,
+            'live_status': 'not_live',
+            'description': 'md5:bea2e1f458095414e04b5ac189c2f980',
+        }
+    }, {
+        'url': 'https://funker530.com/video/my-friends-joined-the-russians-civdiv/',
+        'md5': 'a42c2933391210662e93e867d7124b70',
+        'info_dict': {
+            'id': 'k-pk4bOvoac',
+            'ext': 'mp4',
+            'view_count': int,
+            'channel': 'Civ Div',
+            'comment_count': int,
+            'channel_follower_count': int,
+            'thumbnail': 'https://i.ytimg.com/vi/k-pk4bOvoac/maxresdefault.jpg',
+            'uploader_id': '@CivDiv',
+            'duration': 357,
+            'channel_url': 'https://www.youtube.com/channel/UCgsCiwJ88up-YyMHo7hL5-A',
+            'tags': [],
+            'uploader_url': 'https://www.youtube.com/@CivDiv',
+            'channel_id': 'UCgsCiwJ88up-YyMHo7hL5-A',
+            'like_count': int,
+            'description': 'md5:aef75ec3f59c07a0e39400f609b24429',
+            'live_status': 'not_live',
+            'age_limit': 0,
+            'uploader': 'Civ Div',
+            'categories': ['People & Blogs'],
+            'title': 'My “Friends” joined the Russians.',
+            'availability': 'public',
+            'upload_date': '20230608',
+            'playable_in_embed': True,
+            'heatmap': 'count:100',
         }
     }]
 
     def _real_extract(self, url):
-        info = {}
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
-
-        video_id = extract_video_id(webpage)
-        cleaned_link = url_clean(self, display_id, video_id)
-        rumble_url = cleaned_link
-
-        youtube_url = list(YoutubeIE._extract_embed_urls(url, webpage))
-
+        rumble_url = list(RumbleEmbedIE._extract_embed_urls(url, webpage))
+        info = {}
         if rumble_url:
-            info = {
-                'url': rumble_url,
-                'info_dict': {
-                    'ext': 'mp4',
-                    'direct': True
-                },
-
-                'ie_key': GenericIE.ie_key()
-            }
-        elif youtube_url:
-            info = {'url': youtube_url[0], 'ie_key': YoutubeIE.ie_key()}
-        if info == {}:
+            info = {'url': rumble_url[0], 'ie_key': RumbleEmbedIE.ie_key()}
+        else:
+            youtube_url = list(YoutubeIE._extract_embed_urls(url, webpage))
+            if youtube_url:
+                info = {'url': youtube_url[0], 'ie_key': YoutubeIE.ie_key()}
+        if not info:
             raise ExtractorError('No videos found on webpage', expected=True)
 
         return {
             **info,
-            '_type': 'url',
+            '_type': 'url_transparent',
             'description': strip_or_none(self._search_regex(
                 r'(?s)(.+)About the Author', clean_html(get_element_by_class('video-desc-paragraph', webpage)),
-                'description', default=None)),
-
-
+                'description', default=None))
         }

--- a/yt_dlp/extractor/rumble.py
+++ b/yt_dlp/extractor/rumble.py
@@ -144,7 +144,7 @@ class RumbleEmbedIE(InfoExtractor):
         if embeds:
             return embeds
         return [f'https://rumble.com/embed/{mobj.group("id")}' for mobj in re.finditer(
-            r'<script>[^<]*\bRumble\(\s*"play"\s*,\s*{\s*[\'"]?video[\'"]?\s*:\s*[\'"](?P<id>[0-9a-z]+)[\'"]', webpage)]
+            r'<script>[^<]*\bRumble\(\s*"play"\s*,\s*{[^}]*[\'"]?video[\'"]?\s*:\s*[\'"](?P<id>[0-9a-z]+)[\'"]', webpage)]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible 

-->

Fixes the Funker530 rumble embed video download. Funker530 changed its rumble video embeds format and they couldn't be extracted by RumbleEmbedIE _extract_embed_urls method anymore because the direct link was not present in the webpage. 
I fixed this by getting video id from the page and crafting an api request to rumble with that id and get the direct link to the video from the response.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a52904</samp>

### Summary
:wastebasket::arrows_counterclockwise::heavy_plus_sign:

<!--
1.  :wastebasket: for removing unused imports
2.  :arrows_counterclockwise: for changing the base class of the extractor
3.  :heavy_plus_sign: for adding a new import
-->
Simplify Funker530 extractor by using generic extractor for direct video links. Remove unused imports of `RumbleEmbedIE` and `common`, and add import of `generic`.

> _`RumbleEmbedIE` gone_
> _`generic.GenericIE` handles_
> _video links in fall_

### Walkthrough
* Replace `RumbleEmbedIE` with `generic.GenericIE` for extracting video URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8040/files?diff=unified&w=0#diff-d0247fbe6e50e3bb2255d168c3dbc63ee7a551ea6ba67bec168766f1e9f19c25L2-R95),                            



</details>
