### PR TITLE
[extractor/AbemaTV] Fix adding proxy parameters (fixes #8036)

### DIFF
--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -37,7 +37,7 @@ def add_opener(ydl, handler):  # FIXME: Create proper API in .networking
         return
     headers = ydl.params['http_headers'].copy()
     proxies = ydl.proxies.copy()
-    clean_proxies(proxies,headers)
+    clean_proxies(proxies, headers)
     opener = rh._get_instance(cookiejar=ydl.cookiejar, proxies=proxies)
     assert isinstance(opener, urllib.request.OpenerDirector)
     opener.add_handler(handler)

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -12,7 +12,7 @@ import urllib.parse
 import urllib.request
 import urllib.response
 import uuid
-
+from ..utils.networking import clean_proxies
 from .common import InfoExtractor
 from ..aes import aes_ecb_decrypt
 from ..utils import (
@@ -35,7 +35,10 @@ def add_opener(ydl, handler):  # FIXME: Create proper API in .networking
     rh = ydl._request_director.handlers['Urllib']
     if 'abematv-license' in rh._SUPPORTED_URL_SCHEMES:
         return
-    opener = rh._get_instance(cookiejar=ydl.cookiejar, proxies=ydl.proxies)
+    headers = ydl.params['http_headers'].copy()
+    proxies = ydl.proxies.copy()
+    clean_proxies(proxies,headers)
+    opener = rh._get_instance(cookiejar=ydl.cookiejar, proxies=proxies)
     assert isinstance(opener, urllib.request.OpenerDirector)
     opener.add_handler(handler)
     rh._SUPPORTED_URL_SCHEMES = (*rh._SUPPORTED_URL_SCHEMES, 'abematv-license')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

-->

ADD DESCRIPTION HERE

Fixes #8036
- Fix the issue of downloading failure at AbemaTV site due to the addition of non-standard proxy parameters.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 02c3220</samp>

### Summary
🧹🛠️📺

<!--
1.  🧹 - This emoji can represent the act of cleaning the proxies, as well as the function name `clean_proxies`.
2.  🛠️ - This emoji can represent the act of modifying or fixing the `add_opener` function, as well as the tool-like nature of the function.
3.  📺 - This emoji can represent the AbemaTV license server, as well as the video content that the user is trying to download.
-->
Fix proxy issues with AbemaTV extractor by using `clean_proxies` function. Update `add_opener` to apply this function to `ydl.proxies`.

> _Oh we're the crew of the Python ship, and we sail the web so free_
> _We use `ydl` to download our shows, from AbemaTV_
> _But we need to clean our proxies well, or the license won't come through_
> _So we import `clean_proxies` now, and we call it in `add_opener` too_

### Walkthrough
* Import and use `clean_proxies` function to remove proxy headers from requests to AbemaTV license server ([link](https://github.com/yt-dlp/yt-dlp/pull/8046/files?diff=unified&w=0#diff-f742532ffb2bf66143f1c93e4717e74b5383aadfda0fab85d2fb82a927d33107L15-R15), [link](https://github.com/yt-dlp/yt-dlp/pull/8046/files?diff=unified&w=0#diff-f742532ffb2bf66143f1c93e4717e74b5383aadfda0fab85d2fb82a927d33107L38-R41))
* Update `add_opener` function to pass cleaned proxies to `rh._get_instance` method ([link](https://github.com/yt-dlp/yt-dlp/pull/8046/files?diff=unified&w=0#diff-f742532ffb2bf66143f1c93e4717e74b5383aadfda0fab85d2fb82a927d33107L38-R41))



</details>
