### PR TITLE
[ie/zaiko] add thumbnails from event pages

### DIFF
--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -93,7 +93,7 @@ class ZaikoIE(ZaikoBaseIE):
         thumbnail_urls = [
             traverse_obj(player_meta, ('initial_event_info', 'poster_url')),
             self._og_search_thumbnail(self._download_webpage(
-                f'https://zaiko.io/event/{video_id}', video_id, 'Downloading event page', fatal=False)),
+                f'https://zaiko.io/event/{video_id}', video_id, 'Downloading event page', fatal=False) or ''),
         ]
 
         return {

--- a/yt_dlp/extractor/zaiko.py
+++ b/yt_dlp/extractor/zaiko.py
@@ -46,18 +46,14 @@ class ZaikoIE(ZaikoBaseIE):
             'uploader_id': '454',
             'uploader': 'ZAIKO ZERO',
             'release_timestamp': 1583809200,
-            'thumbnails': [{
-                'id': r're:[a-z0-9_]+',
-                'url': r're:https://[a-z0-9]+.cloudfront.net/[a-z0-9_]+/[a-z0-9_]+',
-            }, {
-                'id': r're:[a-z0-9_]+',
-                'url': r're:https://media.zaiko.io/[a-z0-9_]+/[a-z0-9_]+',
-            }],
+            'thumbnail': r're:^https://[\w.-]+/\w+/\w+',
+            'thumbnails': 'maxcount:2',
             'release_date': '20200310',
             'categories': ['Tech House'],
             'live_status': 'was_live',
         },
         'params': {'skip_download': 'm3u8'},
+        'skip': 'Your account does not have tickets to this event',
     }]
 
     def _real_extract(self, url):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Hi.

This PR improves #7254.

This commit could not be finished without help of @c-basalt.

### Different thumbnails?

The newly added thumbnail, which is from the event page, may be the same as the one of "poster_url", but not always. I participated in a live event that has two different thumbnails before. A thumbnail was shown first and contained something like "there's a special guest coming". The second thumbnail, a few days later, replaced the first one and contained that special guest's name and photo. Fans were pleasantly surprised.

The first thumbnail I saw looks like this:

![20230907-yt-dlp-zaiko-thumbnail-cover-suprise](https://github.com/yt-dlp/yt-dlp/assets/29089388/b51bc458-af9a-4388-a7ae-5bd4595c8feb)

### Local test

Unfortunately, the testing URL "ZAIKO STREAMING TEST" does not seem to work anymore, so I've tested the code with my own ticket only. I don't post the url because posting a real URL might give Zaiko a chance to find the user who shared their ticket.

```JSON
{
    "id": "...",
    //...
    "thumbnails": [
        {
            "url": "https://d38fgd7fmrcuct.cloudfront.net/pf_1/1_3ybh***",
            "id": "1_3ybh***"
        },
        {
            "url": "https://media.zaiko.io/pf_1/1_3ybi***",
            "id": "1_3ybi***"
        }
    ],
```

```console
> Get-FileHash *1_3yb*

Algorithm       Hash         Path
---------       ----         ----
SHA256          9B7***       ***
SHA256          C60***       ***

```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7ad8088</samp>

### Summary
:sparkles::hammer::mag:

<!--
1.  :sparkles: - This emoji is often used to indicate a new feature or enhancement, and adding support for multiple thumbnails is a significant improvement for the zaiko extractor.
2.  :hammer: - This emoji is often used to indicate a refactor or improvement of existing code, and using the `url_basename` function to generate thumbnail IDs from URLs is a more robust and consistent way of handling thumbnail metadata than relying on the order of the JSON array.
3.  :mag: - This emoji is often used to indicate a bug fix or improvement of user experience, and collecting thumbnail URLs from both JSON and Open Graph data ensures that the extractor can handle different sources of thumbnail information and provide more accurate and complete results.
-->
Added support for multiple thumbnails in `zaiko.py`. Extracted thumbnail URLs from different sources and assigned them IDs based on their filenames.

> _We'll scrape the web for thumbnails, me hearties, yo ho ho_
> _We'll use the `url_basename` to name them as we go_
> _We'll fetch them from the JSON and Open Graph, you see_
> _And store them in the zaiko extractor, one, two, three_

### Walkthrough
* Import `url_basename` function from `utils` module to generate thumbnail IDs from URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8054/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854R12))
* Modify `_real_extract` function to collect two possible thumbnail URLs from `player_meta` and Open Graph tags ([link](https://github.com/yt-dlp/yt-dlp/pull/8054/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854R93-R98))
* Replace `thumbnail` field with `thumbnails` field in `info_dict`, using `url_basename` to create a list of dictionaries with `id` and `url` keys for each thumbnail ([link](https://github.com/yt-dlp/yt-dlp/pull/8054/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854L99-R113))
* Update test case to reflect the change from `thumbnail` to `thumbnails` field, and provide two expected thumbnail URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8054/files?diff=unified&w=0#diff-7d130eab65fcf03eadc31278b6ba72081994079a527d403533d2ebb83dc2e854L48-R55))



</details>
