### PR TITLE
Banbye support for URL's containing a hyphen

### DIFF
--- a/yt_dlp/extractor/banbye.py
+++ b/yt_dlp/extractor/banbye.py
@@ -59,7 +59,27 @@ class BanByeIE(BanByeBaseIE):
             'title': 'Krzysztof Karoń',
             'id': 'p_Ld82N6gBw_OJ',
         },
-        'playlist_count': 9,
+        'playlist_mincount': 9,
+    }, {
+        'url': 'https://banbye.com/watch/v_kb6_o1Kyq-CD',
+        'info_dict': {
+            'id': 'v_kb6_o1Kyq-CD',
+            'ext': 'mp4',
+            'title': 'Co tak naprawdę dzieje się we Francji?! Czy Warszawa a potem cała Polska będzie drugim Paryżem?!🤔🇵🇱',
+            'description': 'md5:82be4c0e13eae8ea1ca8b9f2e07226a8',
+            'uploader': 'Marcin Rola - MOIM ZDANIEM!🇵🇱',
+            'channel_id': 'ch_QgWnHvDG2fo5',
+            'channel_url': 'https://banbye.com/channel/ch_QgWnHvDG2fo5',
+            'duration': 597,
+            'timestamp': 1688642656,
+            'upload_date': '20230706',
+            'thumbnail': 'https://cdn.banbye.com/video/v_kb6_o1Kyq-CD/96.webp',
+            'tags': ['Paryż', 'Francja', 'Polska', 'Imigranci', 'Morawiecki', 'Tusk'],
+            'like_count': int,
+            'dislike_count': int,
+            'view_count': int,
+            'comment_count': int,
+        },
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/banbye.py
+++ b/yt_dlp/extractor/banbye.py
@@ -31,7 +31,7 @@ class BanByeBaseIE(InfoExtractor):
 
 
 class BanByeIE(BanByeBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?banbye.com/(?:en/)?watch/(?P<id>\w+)'
+    _VALID_URL = r'https?://(?:www\.)?banbye.com/(?:en/)?watch/(?P<id>[\w-]+)'
     _TESTS = [{
         'url': 'https://banbye.com/watch/v_ytfmvkVYLE8T',
         'md5': '2f4ea15c5ca259a73d909b2cfd558eb5',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Example:
https://banbye.com/watch/v_kb6_o1Kyq-CD
yt-dlp only takes the part preceding the -:
[BanBye] v_kb6_o1Kyq: Downloading JSON metadata

What does work, is copying the video URL via right-click and feed that to yt-dlp.
But then it saves as 480 [480].mp4...

yt-dlp -vU --ignore-config "https://vod.banbye.com:31005/video/v_kb6_o1Kyq-CD/480.mp4"
[debug] Command-line config: ['-vU', '--ignore-config', 'https://vod.banbye.com:31005/video/v_kb6_o1Kyq-CD/480.mp4']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version nightly@2023.08.14.182926 [876b70c8e] (zip)
[debug] Python 3.8.10 (CPython x86_64 64bit) - Linux-5.4.0-156-generic-x86_64-with-glibc2.29 (OpenSSL 1.1.1f  31 Mar 2020, glibc 2.31)
[debug] exe versions: ffmpeg N-111711-gd295b6b693-Nico-20230808 (fdk,setts), ffprobe N-111711-gd295b6b693-Nico-20230808, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.18.0, brotli-1.0.9, certifi-2023.07.22, mutagen-1.46.0, secretstorage-3.3.3, sqlite3-2.6.0, websockets-11.0.3, xattr-0.9.6
[debug] Proxy map: {}
[debug] Loaded 1863 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp-nightly-builds/releases/latest
Available version: nightly@2023.08.14.182926, Current version: nightly@2023.08.14.182926
Current Build Hash: d66b5383fd468d11b0400e423e6db8704cc0f5fcfd3db28e06d0e821ceb3a546
yt-dlp is up to date (nightly@2023.08.14.182926)
[generic] Extracting URL: https://vod.banbye.com:31005/video/v_kb6_o1Kyq-CD/480.mp4
[generic] 480: Downloading webpage
[debug] Identified a direct video link
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 480: Downloading 1 format(s): mp4
[debug] Invoking http downloader on "https://vod.banbye.com:31005/video/v_kb6_o1Kyq-CD/480.mp4"
[download] Destination: 480 [480].mp4
[download] 100% of   88.91MiB in 00:00:08 at 10.24MiB/s
Fixes #7895


<details open><summary>Banbye support for URL's containing a hyphen</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2ad6270</samp>

### Summary
🖊️🎞️🐛

<!--
1.  🖊️ - This emoji means "pen" or "writing", and it can be used to indicate that something was edited or modified.
2.  🎞️ - This emoji means "film frames" or "cinema", and it can be used to indicate that something relates to videos or movies.
3.  🐛 - This emoji means "bug" or "insect", and it can be used to indicate that something was a bug or an error that was fixed.
-->
Fix extraction of videos with hyphens in id on `banbye.py` extractor. Update the `_VALID_URL` pattern to match them.

> _`_VALID_URL` changed_
> _Hyphens in video id_
> _Autumn leaves fall fast_

### Walkthrough
* Allow hyphens in video id for Banbye extractor (`_VALID_URL` in [link](https://github.com/yt-dlp/yt-dlp/pull/8059/files?diff=unified&w=0#diff-d3d97f0ddc09172c44cdac1ab754fb8c6e24d93b922e1a19cecb60d14979da41L34-R34))



</details>
