### PR TITLE
[ie/facebook] improve format sorting

### DIFF
--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -504,8 +504,9 @@ class FacebookIE(InfoExtractor):
             # Downloads with browser's User-Agent are rate limited. Working around
             # with non-browser User-Agent.
             for f in info['formats']:
+                if 'quality' not in f:
+                    f['quality'] = 2
                 f.setdefault('http_headers', {})['User-Agent'] = 'facebookexternalhit/1.1'
-            info['_format_sort_fields'] = ('res', 'quality')
 
         def extract_relay_data(_filter):
             return self._parse_json(self._search_regex(

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -552,6 +552,7 @@ class FacebookIE(InfoExtractor):
                             formats.append({
                                 'format_id': format_id,
                                 # downgrade quality of old sd, hd formats to be lower than formats from DASH
+                                # since they are only up to 720p and no tech info can be extracted.
                                 'quality': q(format_id) - 3,
                                 'url': playable_url,
                             })

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -551,8 +551,7 @@ class FacebookIE(InfoExtractor):
                         else:
                             formats.append({
                                 'format_id': format_id,
-                                # downgrade quality of old sd, hd formats to be lower than formats from DASH
-                                # since they are only up to 720p and no tech info can be extracted.
+                                # sd, hd formats w/o resolution info should be deprioritized below DASH
                                 'quality': q(format_id) - 3,
                                 'url': playable_url,
                             })
@@ -720,8 +719,8 @@ class FacebookIE(InfoExtractor):
                 for src_type in ('src', 'src_no_ratelimit'):
                     src = f[0].get('%s_%s' % (quality, src_type))
                     if src:
-                        # downgrade quality of old sd, hd formats to be lower than formats from DASH
-                        # since they are only up to 720p and no tech info can be extracted.
+                        # sd, hd formats w/o resolution info should be deprioritized below DASH
+                        # TODO: investigate if progressive or src formats still exist
                         preference = -10 if format_id == 'progressive' else -3
                         if quality == 'hd':
                             preference += 1

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -504,8 +504,6 @@ class FacebookIE(InfoExtractor):
             # Downloads with browser's User-Agent are rate limited. Working around
             # with non-browser User-Agent.
             for f in info['formats']:
-                if 'quality' not in f:
-                    f['quality'] = 2
                 f.setdefault('http_headers', {})['User-Agent'] = 'facebookexternalhit/1.1'
 
         def extract_relay_data(_filter):
@@ -553,7 +551,8 @@ class FacebookIE(InfoExtractor):
                         else:
                             formats.append({
                                 'format_id': format_id,
-                                'quality': q(format_id),
+                                # downgrade quality of old sd, hd formats to be lower than formats from DASH
+                                'quality': q(format_id) - 3,
                                 'url': playable_url,
                             })
                     extract_dash_manifest(video, formats)
@@ -720,7 +719,9 @@ class FacebookIE(InfoExtractor):
                 for src_type in ('src', 'src_no_ratelimit'):
                     src = f[0].get('%s_%s' % (quality, src_type))
                     if src:
-                        preference = -10 if format_id == 'progressive' else 0
+                        # downgrade quality of old sd, hd formats to be lower than formats from DASH
+                        # since they are only up to 720p and no tech info can be extracted.
+                        preference = -10 if format_id == 'progressive' else -3
                         if quality == 'hd':
                             preference += 1
                         formats.append({

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -720,9 +720,9 @@ class FacebookIE(InfoExtractor):
                 for src_type in ('src', 'src_no_ratelimit'):
                     src = f[0].get('%s_%s' % (quality, src_type))
                     if src:
-                        preference = -10 if format_id == 'progressive' else -1
+                        preference = -10 if format_id == 'progressive' else 0
                         if quality == 'hd':
-                            preference += 5
+                            preference += 1
                         formats.append({
                             'format_id': '%s_%s_%s' % (format_id, quality, src_type),
                             'url': src,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Improve how the formats are sorted.

This IE extracts video formats from:

1. plain URLs which are denoted as "HD" (usually 720p) and SD (anything lower), and they're assigned quality = 0 and 1 respectively. No other technical info can be easily extracted.
2. formats extracted from MPD, which have all the info including resolution etc. It can have up to 1080p (potentially higher?) resolution. They have no "quality" assigned at the moment.

The IE currently also have a sort order of `res, quality`, which makes sure that all the formats from MPD will have higher priority than the "sd" and "hd" formats (because they have no `res` key). This is desired because (best) MPD ones have better, or at least equal, quality of video than SD/HD ones.

This works fine under default settings. However, this causes a problem: if the user have assigned `-S` for other reasons, even if it is similar to what the default has (`lang,quality,res,fps,...`), it will overwrite the extractor's and therefore causes these "sd" and "hd" to have higher priority than MPD formats. Because the default sort order have quality before res.

This PR changes it to:
1. Assign quality = 2 to all the MPD formats. SD and HD formats still have quality of 0 and 1, respectively. 
2. Get rid of `_format_sort_fields`.

This makes the default behavior identical to previous: MPD formats will still be ahead of HD/SD due to have better "quality" now, instead of due to having "res". But no longer cause any issues when the user have any sensible custom `-S`.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 64b4e47</samp>

### Summary
📹🛠️📈

<!--
1.  📹 This emoji represents the video format or extraction aspect of the change, as well as the Facebook platform that is affected by the change.
2.  🛠️ This emoji represents the fixing or improvement of the extraction logic, as well as the use of the pull request as a tool to implement the change.
3.  📈 This emoji represents the enhancement of the quality sorting or comparison of the formats, as well as the potential increase in the quality of the extracted videos.
-->
Fix Facebook GraphQl video extraction by adding default quality to formats. Update `yt_dlp/extractor/facebook.py` to handle formats without quality field.

> _`quality` added_
> _Facebook videos fixed now_
> _Autumn of errors_

### Walkthrough
* Add a default quality value to formats without quality field ([link](https://github.com/yt-dlp/yt-dlp/pull/8074/files?diff=unified&w=0#diff-ca6052d2c84eb4ac45aaf04463a4eaecdc75fb3ae4766e234917d8ab131b60ecL507-R509)) in `facebook.py` to avoid sorting errors



</details>
