### PR TITLE
[Mediaklikk] Fix extractor (fixes #8053)

### DIFF
--- a/yt_dlp/extractor/mediaklikk.py
+++ b/yt_dlp/extractor/mediaklikk.py
@@ -1,5 +1,8 @@
 from ..utils import (
-    unified_strdate
+    ExtractorError,
+    traverse_obj,
+    unified_strdate,
+    url_or_none,
 )
 from .common import InfoExtractor
 from ..compat import (
@@ -15,7 +18,7 @@ class MediaKlikkIE(InfoExtractor):
                         (?P<id>[^/#?_]+)'''
 
     _TESTS = [{
-        # mediaklikk. date in html.
+        # (old) mediaklikk. date in html.
         'url': 'https://mediaklikk.hu/video/hazajaro-delnyugat-bacska-a-duna-menten-palankatol-doroszloig/',
         'info_dict': {
             'id': '4754129',
@@ -23,9 +26,21 @@ class MediaKlikkIE(InfoExtractor):
             'ext': 'mp4',
             'upload_date': '20210901',
             'thumbnail': 'http://mediaklikk.hu/wp-content/uploads/sites/4/2014/02/hazajarouj_JO.jpg'
+        },
+        'skip': 'Webpage redirects to 404 page',
+    }, {
+        # mediaklikk. date in html.
+        'url': 'https://mediaklikk.hu/video/hazajaro-fabova-hegyseg-kishont-koronaja/',
+        'info_dict': {
+            'id': '6696133',
+            'title': 'Hazajáró, Fabova-hegység - Kishont koronája',
+            'display_id': 'hazajaro-fabova-hegyseg-kishont-koronaja',
+            'ext': 'mp4',
+            'upload_date': '20230903',
+            'thumbnail': 'https://mediaklikk.hu/wp-content/uploads/sites/4/2014/02/hazajarouj_JO.jpg'
         }
     }, {
-        # m4sport
+        # (old) m4sport
         'url': 'https://m4sport.hu/video/2021/08/30/gyemant-liga-parizs/',
         'info_dict': {
             'id': '4754999',
@@ -33,6 +48,18 @@ class MediaKlikkIE(InfoExtractor):
             'ext': 'mp4',
             'upload_date': '20210830',
             'thumbnail': 'http://m4sport.hu/wp-content/uploads/sites/4/2021/08/vlcsnap-2021-08-30-18h21m20s10-1024x576.jpg'
+        },
+        'skip': 'Webpage redirects to 404 page',
+    }, {
+        # m4sport
+        'url': 'https://m4sport.hu/sportkozvetitesek/video/2023/09/08/atletika-gyemant-liga-brusszel/',
+        'info_dict': {
+            'id': '6711136',
+            'title': 'Atlétika – Gyémánt Liga, Brüsszel',
+            'display_id': 'atletika-gyemant-liga-brusszel',
+            'ext': 'mp4',
+            'upload_date': '20230908',
+            'thumbnail': 'https://m4sport.hu/wp-content/uploads/sites/4/2023/09/vlcsnap-2023-09-08-22h43m18s691.jpg'
         }
     }, {
         # m4sport with *video/ url and no date
@@ -40,20 +67,33 @@ class MediaKlikkIE(InfoExtractor):
         'info_dict': {
             'id': '4492099',
             'title': 'Real Madrid - Chelsea 1-1',
+            'display_id': 'real-madrid-chelsea-1-1',
             'ext': 'mp4',
-            'thumbnail': 'http://m4sport.hu/wp-content/uploads/sites/4/2021/04/Sequence-01.Still001-1024x576.png'
+            'thumbnail': 'https://m4sport.hu/wp-content/uploads/sites/4/2021/04/Sequence-01.Still001-1024x576.png'
         }
     }, {
-        # hirado
+        # (old) hirado
         'url': 'https://hirado.hu/videok/felteteleket-szabott-a-fovaros/',
         'info_dict': {
             'id': '4760120',
             'title': 'Feltételeket szabott a főváros',
             'ext': 'mp4',
             'thumbnail': 'http://hirado.hu/wp-content/uploads/sites/4/2021/09/vlcsnap-2021-09-01-20h20m37s165.jpg'
+        },
+        'skip': 'Webpage redirects to video list page',
+    }, {
+        # hirado
+        'url': 'https://hirado.hu/belfold/video/2023/09/11/marad-az-eves-elszamolas-a-napelemekre-beruhazo-csaladoknal',
+        'info_dict': {
+            'id': '6716068',
+            'title': 'Marad az éves elszámolás a napelemekre beruházó családoknál',
+            'display_id': 'marad-az-eves-elszamolas-a-napelemekre-beruhazo-csaladoknal',
+            'ext': 'mp4',
+            'upload_date': '20230911',
+            'thumbnail': 'https://hirado.hu/wp-content/uploads/sites/4/2023/09/vlcsnap-2023-09-11-09h16m09s882.jpg'
         }
     }, {
-        # petofilive
+        # (old) petofilive
         'url': 'https://petofilive.hu/video/2021/06/07/tha-shudras-az-akusztikban/',
         'info_dict': {
             'id': '4571948',
@@ -61,6 +101,18 @@ class MediaKlikkIE(InfoExtractor):
             'ext': 'mp4',
             'upload_date': '20210607',
             'thumbnail': 'http://petofilive.hu/wp-content/uploads/sites/4/2021/06/vlcsnap-2021-06-07-22h14m23s915-1024x576.jpg'
+        },
+        'skip': 'Webpage redirects to empty page',
+    }, {
+        # petofilive
+        'url': 'https://petofilive.hu/video/2023/09/09/futball-fesztival-a-margitszigeten/',
+        'info_dict': {
+            'id': '6713233',
+            'title': 'Futball Fesztivál a Margitszigeten',
+            'display_id': 'futball-fesztival-a-margitszigeten',
+            'ext': 'mp4',
+            'upload_date': '20230909',
+            'thumbnail': 'https://petofilive.hu/wp-content/uploads/sites/4/2023/09/Clipboard11-2.jpg'
         }
     }]
 
@@ -84,8 +136,12 @@ class MediaKlikkIE(InfoExtractor):
 
         player_data['video'] = player_data.pop('token')
         player_page = self._download_webpage('https://player.mediaklikk.hu/playernew/player.php', video_id, query=player_data)
-        playlist_url = self._proto_relative_url(compat_urllib_parse_unquote(
-            self._html_search_regex(r'\"file\":\s*\"(\\?/\\?/.*playlist\.m3u8)\"', player_page, 'playlist_url')).replace('\\/', '/'))
+        player_json = self._search_json(
+            r'\bpl\.setup\s*\(', player_page, 'player json', video_id, end_pattern=r'\);')
+        playlist_url = traverse_obj(
+            player_json, ('playlist', lambda _, v: v['type'] == 'hls', 'file', {url_or_none}), get_all=False)
+        if not playlist_url:
+            raise ExtractorError('Unable to extract playlist url')
 
         formats = self._extract_wowza_formats(
             playlist_url, video_id, skip_protocols=['f4m', 'smil', 'dash'])


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Mediaklikk modified its site structure and the extractor broke. [bashonly](https://github.com/bashonly) fixed the extractor. I only tested it and updated the included tests.

Old tests:
1. Dead URL, opens a 404 page. Fixed with a newer video
2. Dead URL, opens a 404 page. Fixed with a newer video
3. Live URL. Fixed with extra info 
4. Dead URL, opens the video list page. Fixed with a newer video
5. Dead URL, opens an empty page.  Fixed with a newer video
 
Fixes #8053


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (I only fixed the tests, the original code fix was published by [bashonly](https://github.com/bashonly) under the issue in a comment)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a953c5a</samp>

### Summary
🛠️📺🆔

<!--
1.  🛠️ - This emoji represents the improvement or fixing of the extractor, as it suggests a tool or a repair.
2.  📺 - This emoji represents the media or video content that the extractor handles, as it suggests a TV or a screen.
3.  🆔 - This emoji represents the addition of the display_id field, which is a unique identifier for the video, as it suggests an ID card or a badge.
-->
Improved extraction for MediaKlikk videos. The extractor now uses a better way to find the playlist url, updates the tests with fresh data, and adds a new field for the video identifier.

> _The `MediaKlikkIE` extractor_
> _Was not very good at its factor_
> _So it got a new way_
> _To find the playlist url_
> _And also a nice display_id actor_

### Walkthrough
* Add display_id field to info_dict of test cases and derive it from url path ([link](https://github.com/yt-dlp/yt-dlp/pull/8086/files?diff=unified&w=0#diff-a115fc5f83492168a903cc5828d532e6ef1d43b6a3ee28661ebf9daecf19c7e2L43-R72), [link](https://github.com/yt-dlp/yt-dlp/pull/8086/files?diff=unified&w=0#diff-a115fc5f83492168a903cc5828d532e6ef1d43b6a3ee28661ebf9daecf19c7e2L19-R40))
* Update test cases with new urls, ids, upload_dates and thumbnails that match current website layout and content ([link](https://github.com/yt-dlp/yt-dlp/pull/8086/files?diff=unified&w=0#diff-a115fc5f83492168a903cc5828d532e6ef1d43b6a3ee28661ebf9daecf19c7e2L19-R40))
* Extract playlist url from player json using traverse_obj and url_or_none instead of regex and raise error if invalid ([link](https://github.com/yt-dlp/yt-dlp/pull/8086/files?diff=unified&w=0#diff-a115fc5f83492168a903cc5828d532e6ef1d43b6a3ee28661ebf9daecf19c7e2L87-R101), [link](https://github.com/yt-dlp/yt-dlp/pull/8086/files?diff=unified&w=0#diff-a115fc5f83492168a903cc5828d532e6ef1d43b6a3ee28661ebf9daecf19c7e2L2-R5))



</details>
