### PR TITLE
[ie/Axs] new extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -165,6 +165,7 @@ from .awaan import (
     AWAANLiveIE,
     AWAANSeasonIE,
 )
+from .axs import AxsIE
 from .azmedien import AZMedienIE
 from .baidu import BaiduVideoIE
 from .banbye import (

--- a/yt_dlp/extractor/axs.py
+++ b/yt_dlp/extractor/axs.py
@@ -1,0 +1,83 @@
+from .common import InfoExtractor
+from ..utils import (
+    float_or_none,
+    js_to_json,
+    parse_iso8601,
+)
+
+
+class AxsIE(InfoExtractor):
+    IE_NAME = 'axs.tv'
+    _VALID_URL = r'https?://(?:www\.)?axs\.tv/(?:channel/[^/]+/)?video/(?P<id>[^?/]+)'
+    _META_URL = 'https://api.myspotlight.tv/dotplayer/video/%s/%s?device_type=desktop_web'
+
+    _TESTS = [{
+        'url': 'https://www.axs.tv/video/5f4dc776b70e4f1c194f22ef/',
+        'md5': '8d97736ae8e50c64df528e5e676778cf',
+        'info_dict': {
+            'id': '5f4dc776b70e4f1c194f22ef',
+            'title': 'Small Town',
+            'ext': 'mp4',
+            'description': 'md5:e314d28bfaa227a4d7ec965fae19997f',
+            'upload_date': '20230602',
+            'timestamp': 1685729564,
+            'duration': 1284.216,
+            'channel': 'Rock & Roll Road Trip with Sammy Hagar',
+            'season': 2,
+            'episode': '3',
+            'thumbnail': 'https://images.dotstudiopro.com/5f4e9d330a0c3b295a7e8394',
+        },
+    }, {
+        'url': 'https://www.axs.tv/channel/rock-star-interview/video/daryl-hall',
+        'md5': '300ae795cd8f9984652c0949734ffbdc',
+        'info_dict': {
+            'id': '5f488148b70e4f392572977c',
+            'title': 'Daryl Hall',
+            'ext': 'mp4',
+            'description': 'md5:e54ecaa0f4b5683fc9259e9e4b196628',
+            'upload_date': '20230214',
+            'timestamp': 1676403615,
+            'duration': 2570.668,
+            'channel': 'The Big Interview with Dan Rather',
+            'season': 3,
+            'episode': '5',
+            'thumbnail': 'https://images.dotstudiopro.com/5f4d1901f340b50d937cec32',
+        },
+    }]
+
+    def _real_extract(self, url):
+        initial_id = self._match_id(url)
+        webpage = self._download_webpage(url, initial_id)
+
+        webpage_json_data = self._search_json(
+            r'mountObj\s*=', webpage, 'video ID data', initial_id,
+            transform_source=js_to_json, default={})
+        video_id = webpage_json_data['video_id']
+        company_id = webpage_json_data['company_id']
+
+        meta_url = self._META_URL % (company_id, video_id)
+        meta = self._download_json(meta_url, video_id)['video']
+
+        format_url = meta['video_m3u8']
+        formats = self._extract_m3u8_formats(
+            format_url, video_id, 'mp4', m3u8_id='hls',
+            entry_protocol='m3u8_native', fatal=False)
+
+        subtitles = {}
+        for cc in meta.get('closeCaption'):
+            subtitles.setdefault(cc.get('srtShortLang') or 'en', []).append(
+                {'ext': cc.get('srtExt'), 'url': cc['srtPath']})
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'title': meta['title'],
+            'description': meta.get('description'),
+            'channel': meta.get('seriestitle'),
+            'season': meta.get('season'),
+            'episode': meta.get('episode'),
+            'duration': float_or_none(meta.get('duration')),
+            'timestamp': parse_iso8601(meta.get('updated_at')),
+            'thumbnail': meta.get('thumb'),
+            'subtitles': subtitles,
+        }

--- a/yt_dlp/extractor/axs.py
+++ b/yt_dlp/extractor/axs.py
@@ -3,13 +3,14 @@ from ..utils import (
     float_or_none,
     js_to_json,
     parse_iso8601,
+    traverse_obj,
+    url_or_none,
 )
 
 
 class AxsIE(InfoExtractor):
     IE_NAME = 'axs.tv'
-    _VALID_URL = r'https?://(?:www\.)?axs\.tv/(?:channel/[^/]+/)?video/(?P<id>[^?/]+)'
-    _META_URL = 'https://api.myspotlight.tv/dotplayer/video/%s/%s?device_type=desktop_web'
+    _VALID_URL = r'https?://(?:www\.)?axs\.tv/(?:channel/(?:[^/?#]+/)+)?video/(?P<id>[^/?#]+)'
 
     _TESTS = [{
         'url': 'https://www.axs.tv/video/5f4dc776b70e4f1c194f22ef/',
@@ -22,7 +23,7 @@ class AxsIE(InfoExtractor):
             'upload_date': '20230602',
             'timestamp': 1685729564,
             'duration': 1284.216,
-            'channel': 'Rock & Roll Road Trip with Sammy Hagar',
+            'series': 'Rock & Roll Road Trip with Sammy Hagar',
             'season': 2,
             'episode': '3',
             'thumbnail': 'https://images.dotstudiopro.com/5f4e9d330a0c3b295a7e8394',
@@ -32,13 +33,14 @@ class AxsIE(InfoExtractor):
         'md5': '300ae795cd8f9984652c0949734ffbdc',
         'info_dict': {
             'id': '5f488148b70e4f392572977c',
+            'display_id': 'daryl-hall',
             'title': 'Daryl Hall',
             'ext': 'mp4',
             'description': 'md5:e54ecaa0f4b5683fc9259e9e4b196628',
             'upload_date': '20230214',
             'timestamp': 1676403615,
             'duration': 2570.668,
-            'channel': 'The Big Interview with Dan Rather',
+            'series': 'The Big Interview with Dan Rather',
             'season': 3,
             'episode': '5',
             'thumbnail': 'https://images.dotstudiopro.com/5f4d1901f340b50d937cec32',
@@ -46,38 +48,40 @@ class AxsIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        initial_id = self._match_id(url)
-        webpage = self._download_webpage(url, initial_id)
+        display_id = self._match_id(url)
+        webpage = self._download_webpage(url, display_id)
 
         webpage_json_data = self._search_json(
-            r'mountObj\s*=', webpage, 'video ID data', initial_id,
-            transform_source=js_to_json, default={})
+            r'mountObj\s*=', webpage, 'video ID data', display_id,
+            transform_source=js_to_json)
         video_id = webpage_json_data['video_id']
         company_id = webpage_json_data['company_id']
 
-        meta_url = self._META_URL % (company_id, video_id)
-        meta = self._download_json(meta_url, video_id)['video']
+        meta = self._download_json(
+            f'https://api.myspotlight.tv/dotplayer/video/{company_id}/{video_id}',
+            video_id, query={'device_type': 'desktop_web'})['video']
 
-        format_url = meta['video_m3u8']
         formats = self._extract_m3u8_formats(
-            format_url, video_id, 'mp4', m3u8_id='hls',
-            entry_protocol='m3u8_native', fatal=False)
+            meta['video_m3u8'], video_id, 'mp4', m3u8_id='hls')
 
         subtitles = {}
-        for cc in meta.get('closeCaption'):
+        for cc in traverse_obj(meta, ('closeCaption', lambda _, v: url_or_none(v['srtPath']))):
             subtitles.setdefault(cc.get('srtShortLang') or 'en', []).append(
                 {'ext': cc.get('srtExt'), 'url': cc['srtPath']})
 
         return {
             'id': video_id,
+            'display_id': display_id,
             'formats': formats,
-            'title': meta['title'],
-            'description': meta.get('description'),
-            'channel': meta.get('seriestitle'),
-            'season': meta.get('season'),
-            'episode': meta.get('episode'),
-            'duration': float_or_none(meta.get('duration')),
-            'timestamp': parse_iso8601(meta.get('updated_at')),
-            'thumbnail': meta.get('thumb'),
+            **traverse_obj(meta, {
+                'title': ('title', {str}),
+                'description': ('description', {str}),
+                'series': ('seriestitle', {str}),
+                'season': ('season', {int}),
+                'episode': ('episode', {str}),
+                'duration': ('duration', {float_or_none}),
+                'timestamp': ('updated_at', {parse_iso8601}),
+                'thumbnail': ('thumb', {url_or_none}),
+            }),
             'subtitles': subtitles,
         }


### PR DESCRIPTION
Fixes https://github.com/yt-dlp/yt-dlp/issues/7451

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Add support for axs.tv.

Fixes #7451

Note: The URLs in the tests may or may not expire. I originally had a one URL, but it seems to have disappeared after a few weeks.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7c1fa05</samp>

### Summary
🎥🎸🌐

<!--
1.  🎥 - This emoji represents videos, which are the main content that the extractor deals with. It also suggests entertainment and media, which are the themes of the AXS TV website.
2.  🎸 - This emoji represents music, which is one of the genres that the AXS TV website features. It also suggests rock and roll, which is a common style of music on the network.
3.  🌐 - This emoji represents the web, which is the source of the videos and the API that the extractor uses. It also suggests global and diverse, which are some of the values of the AXS TV website.
-->
Add support for extracting videos from the AXS TV website. Create a new module `axs.py` that defines the `AxsIE` extractor class and import it in `_extractors.py`.

> _`AxsIE` extracts_
> _videos from AXS TV site_
> _metadata and `HLS`_

### Walkthrough
*  Add `AxsIE` extractor class for AXS TV videos ([link](https://github.com/yt-dlp/yt-dlp/pull/8094/files?diff=unified&w=0#diff-128ed0ce30846ea4f00e43f659d68be76e3236c9844ab4c102e296482d19f3feR1-R83), [link](https://github.com/yt-dlp/yt-dlp/pull/8094/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R168))



</details>
