### PR TITLE
Fixes the issue #7575 [Nitter] unable to extract OpenGraph description

### DIFF
--- a/yt_dlp/extractor/nitter.py
+++ b/yt_dlp/extractor/nitter.py
@@ -266,7 +266,7 @@ class NitterIE(InfoExtractor):
                 'comment_count': int,
             }
         }, {  # test for OpenGraph patch #7575
-            'url': f'https://nitter.net/LocalBateman/status/1678455464038735895#m',
+            'url': f'https://{current_instance}/LocalBateman/status/1678455464038735895#m',
             'info_dict': {
                 'id': '1678455464038735895',
                 'ext': 'mp4',
@@ -275,7 +275,7 @@ class NitterIE(InfoExtractor):
                 'thumbnail': r're:^https?://.*\.jpg$',
                 'uploader': 'Your Typical Local Man',
                 'uploader_id': 'LocalBateman',
-                'uploader_url': f'https://nitter.net/LocalBateman',
+                'uploader_url': f'https://{current_instance}/LocalBateman',
                 'upload_date': '20230710',
                 'timestamp': 1689009900,
                 'view_count': int,

--- a/yt_dlp/extractor/nitter.py
+++ b/yt_dlp/extractor/nitter.py
@@ -265,7 +265,7 @@ class NitterIE(InfoExtractor):
                 'repost_count': int,
                 'comment_count': int,
             }
-        }, {  # test for OpenGraph patch #7575
+        }, {  # no OpenGraph title
             'url': f'https://{current_instance}/LocalBateman/status/1678455464038735895#m',
             'info_dict': {
                 'id': '1678455464038735895',

--- a/yt_dlp/extractor/nitter.py
+++ b/yt_dlp/extractor/nitter.py
@@ -265,6 +265,26 @@ class NitterIE(InfoExtractor):
                 'repost_count': int,
                 'comment_count': int,
             }
+        }, {  # test for OpenGraph patch #7575
+            'url': f'https://nitter.net/LocalBateman/status/1678455464038735895#m',
+            'info_dict': {
+                'id': '1678455464038735895',
+                'ext': 'mp4',
+                'title': 'Your Typical Local Man - Local man, what did Romanians ever do to you?',
+                'description': 'Local man, what did Romanians ever do to you?',
+                'thumbnail': r're:^https?://.*\.jpg$',
+                'uploader': 'Your Typical Local Man',
+                'uploader_id': 'LocalBateman',
+                'uploader_url': f'https://nitter.net/LocalBateman',
+                'upload_date': '20230710',
+                'timestamp': 1689009900,
+                'view_count': int,
+                'like_count': int,
+                'repost_count': int,
+                'comment_count': int,
+            },
+            'expected_warnings': ['Ignoring subtitle tracks found in the HLS manifest'],
+            'params': {'skip_download': 'm3u8'},
         }
     ]
 
@@ -292,7 +312,7 @@ class NitterIE(InfoExtractor):
                 'ext': ext
             }]
 
-        title = description = self._og_search_description(full_webpage) or self._html_search_regex(
+        title = description = self._og_search_description(full_webpage, default=None) or self._html_search_regex(
             r'<div class="tweet-content[^>]+>([^<]+)</div>', webpage, 'title', fatal=False)
 
         uploader_id = self._html_search_regex(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes issue #7575 [Nitter] unable to extract OpenGraph description. A new test is added for Nitter for the same issue, along with the patch fix. 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 10b8958</samp>

### Summary
🐦🌐🛠️

<!--
1.  🐦 for nitter and tweets
2.  🌐 for OpenGraph and rich media content
3.  🛠️ for fixing and modifying code
-->
Fix nitter extractor to handle OpenGraph patches in tweets. Update `nitter.py` and add a new test case.

> _Nitter extractor_
> _Fixes OpenGraph patches_
> _`_real_extract` changed_

### Walkthrough
*  Fix nitter video extraction for tweets with OpenGraph patch (#7575)
  * Add a test case for a tweet with OpenGraph patch that embeds a YouTube video (`yt_dlp/extractor/nitter.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/8102/files?diff=unified&w=0#diff-ffae0713595fd2e6d2adc226e7897c3b7026b5ef6447405f613544fb9be933a8R268-R287))
  * Modify the `_real_extract` function of the `NitterIE` class to handle missing or malformed OpenGraph descriptions (`yt_dlp/extractor/nitter.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/8102/files?diff=unified&w=0#diff-ffae0713595fd2e6d2adc226e7897c3b7026b5ef6447405f613544fb9be933a8L295-R315))



</details>
