### PR TITLE
[amazonminitv] Fix extraction

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -93,7 +93,9 @@ from .amazon import (
     AmazonReviewsIE,
 )
 from .amazonminitv import (
-    AmazonMiniTVIE
+    AmazonMiniTVIE,
+    AmazonMiniTVSeasonIE,
+    AmazonMiniTVSeriesIE,
 )
 from .americastestkitchen import (
     AmericasTestKitchenIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -93,9 +93,7 @@ from .amazon import (
     AmazonReviewsIE,
 )
 from .amazonminitv import (
-    AmazonMiniTVIE,
-    AmazonMiniTVSeasonIE,
-    AmazonMiniTVSeriesIE,
+    AmazonMiniTVIE
 )
 from .americastestkitchen import (
     AmericasTestKitchenIE,

--- a/yt_dlp/extractor/amazonminitv.py
+++ b/yt_dlp/extractor/amazonminitv.py
@@ -1,4 +1,5 @@
 import json
+
 from .common import InfoExtractor
 from ..utils import ExtractorError, int_or_none, traverse_obj, try_get
 
@@ -12,7 +13,6 @@ class AmazonMiniTVBaseIE(InfoExtractor):
 
     def _call_api(self, asin, data=None, note=None):
         device = {'clientId': 'ATVIN', 'deviceLocale': 'en_GB'}
-
         if data:
             data['variables'].update({
                 'contentType': 'VOD',
@@ -33,7 +33,7 @@ class AmazonMiniTVBaseIE(InfoExtractor):
         if resp.get('errors'):
             raise ExtractorError(f'MiniTV said: {resp["errors"][0]["message"]}')
         elif not data:
-            raise ExtractorError(f'Unable to {note or "NextJS data"}', expected=True)
+            return resp
         return resp['data'][data['operationName']]
 
 

--- a/yt_dlp/extractor/amazonminitv.py
+++ b/yt_dlp/extractor/amazonminitv.py
@@ -1,5 +1,3 @@
-import json
-
 from .common import InfoExtractor
 from ..utils import ExtractorError, int_or_none, traverse_obj, try_get
 

--- a/yt_dlp/extractor/amazonminitv.py
+++ b/yt_dlp/extractor/amazonminitv.py
@@ -5,36 +5,13 @@ from ..utils import ExtractorError, int_or_none, traverse_obj, try_get
 
 
 class AmazonMiniTVBaseIE(InfoExtractor):
-    def _real_initialize(self):
-        self._download_webpage(
-            'https://www.amazon.in/minitv', None,
-            note='Fetching guest session cookies')
-        AmazonMiniTVBaseIE.session_id = self._get_cookies('https://www.amazon.in')['session-id'].value
+    def _get_nextjs_data(self, asin, webpage=None, note=None):
+        resp = self._search_nextjs_data(webpage, asin, fatal=False) or {}
 
-    def _call_api(self, asin, data=None, note=None):
-        device = {'clientId': 'ATVIN', 'deviceLocale': 'en_GB'}
-        if data:
-            data['variables'].update({
-                'contentType': 'VOD',
-                'sessionIdToken': self.session_id,
-                **device,
-            })
-
-        resp = self._download_json(
-            f'https://www.amazon.in/minitv/api/web/{"graphql" if data else "prs"}',
-            asin, note=note, headers={'Content-Type': 'application/json'},
-            data=json.dumps(data).encode() if data else None,
-            query=None if data else {
-                'deviceType': 'A1WMMUXPCUJL4N',
-                'contentId': asin,
-                **device,
-            })
-
-        if resp.get('errors'):
-            raise ExtractorError(f'MiniTV said: {resp["errors"][0]["message"]}')
-        elif not data:
+        if not resp:
+            raise ExtractorError(f'Unable to {note or "NextJS data"}', expected=True)
+        else:
             return resp
-        return resp['data'][data['operationName']]
 
 
 class AmazonMiniTVIE(AmazonMiniTVBaseIE):
@@ -86,56 +63,13 @@ class AmazonMiniTVIE(AmazonMiniTVBaseIE):
         'only_matching': True,
     }]
 
-    _GRAPHQL_QUERY_CONTENT = '''
-query content($sessionIdToken: String!, $deviceLocale: String, $contentId: ID!, $contentType: ContentType!, $clientId: String) {
-  content(
-    applicationContextInput: {deviceLocale: $deviceLocale, sessionIdToken: $sessionIdToken, clientId: $clientId}
-    contentId: $contentId
-    contentType: $contentType
-  ) {
-    contentId
-    name
-    ... on Episode {
-      contentId
-      vodType
-      name
-      images
-      description {
-        synopsis
-        contentLengthInSeconds
-      }
-      publicReleaseDateUTC
-      audioTracks
-      seasonId
-      seriesId
-      seriesName
-      seasonNumber
-      episodeNumber
-      timecode {
-        endCreditsTime
-      }
-    }
-    ... on MovieContent {
-      contentId
-      vodType
-      name
-      description {
-        synopsis
-        contentLengthInSeconds
-      }
-      images
-      publicReleaseDateUTC
-      audioTracks
-    }
-  }
-}'''
-
     def _real_extract(self, url):
         asin = f'amzn1.dv.gti.{self._match_id(url)}'
-        prs = self._call_api(asin, note='Downloading playback info')
+        webpage = self._download_webpage(url, asin)
+        prs = self._get_nextjs_data(asin, note='Retrieve playback info', webpage=webpage)
 
         formats, subtitles = [], {}
-        for type_, asset in prs['playbackAssets'].items():
+        for type_, asset in prs['props']['pageProps']['ssrProps']['playbackData']['playbackAssets'].items():
             if not traverse_obj(asset, 'manifestUrl'):
                 continue
             if type_ == 'hls':
@@ -152,12 +86,7 @@ query content($sessionIdToken: String!, $deviceLocale: String, $contentId: ID!, 
             else:
                 self.report_warning(f'Unknown asset type: {type_}')
 
-        title_info = self._call_api(
-            asin, note='Downloading title info', data={
-                'operationName': 'content',
-                'variables': {'contentId': asin},
-                'query': self._GRAPHQL_QUERY_CONTENT,
-            })
+        title_info = prs['props']['pageProps']['ssrProps']['contentData']
         credits_time = try_get(title_info, lambda x: x['timecode']['endCreditsTime'] / 1000)
         is_episode = title_info.get('vodType') == 'EPISODE'
 
@@ -186,106 +115,3 @@ query content($sessionIdToken: String!, $deviceLocale: String, $contentId: ID!, 
             'episode_number': title_info.get('episodeNumber'),
             'episode_id': asin if is_episode else None,
         }
-
-
-class AmazonMiniTVSeasonIE(AmazonMiniTVBaseIE):
-    IE_NAME = 'amazonminitv:season'
-    _VALID_URL = r'amazonminitv:season:(?:amzn1\.dv\.gti\.)?(?P<id>[a-f0-9-]+)'
-    IE_DESC = 'Amazon MiniTV Season, "minitv:season:" prefix'
-    _TESTS = [{
-        'url': 'amazonminitv:season:amzn1.dv.gti.0aa996eb-6a1b-4886-a342-387fbd2f1db0',
-        'playlist_mincount': 6,
-        'info_dict': {
-            'id': 'amzn1.dv.gti.0aa996eb-6a1b-4886-a342-387fbd2f1db0',
-        },
-    }, {
-        'url': 'amazonminitv:season:0aa996eb-6a1b-4886-a342-387fbd2f1db0',
-        'only_matching': True,
-    }]
-
-    _GRAPHQL_QUERY = '''
-query getEpisodes($sessionIdToken: String!, $clientId: String, $episodeOrSeasonId: ID!, $deviceLocale: String) {
-  getEpisodes(
-    applicationContextInput: {sessionIdToken: $sessionIdToken, deviceLocale: $deviceLocale, clientId: $clientId}
-    episodeOrSeasonId: $episodeOrSeasonId
-  ) {
-    episodes {
-      ... on Episode {
-        contentId
-        name
-        images
-        seriesName
-        seasonId
-        seriesId
-        seasonNumber
-        episodeNumber
-        description {
-          synopsis
-          contentLengthInSeconds
-        }
-        publicReleaseDateUTC
-      }
-    }
-  }
-}
-'''
-
-    def _entries(self, asin):
-        season_info = self._call_api(
-            asin, note='Downloading season info', data={
-                'operationName': 'getEpisodes',
-                'variables': {'episodeOrSeasonId': asin},
-                'query': self._GRAPHQL_QUERY,
-            })
-
-        for episode in season_info['episodes']:
-            yield self.url_result(
-                f'amazonminitv:{episode["contentId"]}', AmazonMiniTVIE, episode['contentId'])
-
-    def _real_extract(self, url):
-        asin = f'amzn1.dv.gti.{self._match_id(url)}'
-        return self.playlist_result(self._entries(asin), asin)
-
-
-class AmazonMiniTVSeriesIE(AmazonMiniTVBaseIE):
-    IE_NAME = 'amazonminitv:series'
-    _VALID_URL = r'amazonminitv:series:(?:amzn1\.dv\.gti\.)?(?P<id>[a-f0-9-]+)'
-    IE_DESC = 'Amazon MiniTV Series, "minitv:series:" prefix'
-    _TESTS = [{
-        'url': 'amazonminitv:series:amzn1.dv.gti.56521d46-b040-4fd5-872e-3e70476a04b0',
-        'playlist_mincount': 3,
-        'info_dict': {
-            'id': 'amzn1.dv.gti.56521d46-b040-4fd5-872e-3e70476a04b0',
-        },
-    }, {
-        'url': 'amazonminitv:series:56521d46-b040-4fd5-872e-3e70476a04b0',
-        'only_matching': True,
-    }]
-
-    _GRAPHQL_QUERY = '''
-query getSeasons($sessionIdToken: String!, $deviceLocale: String, $episodeOrSeasonOrSeriesId: ID!, $clientId: String) {
-  getSeasons(
-    applicationContextInput: {deviceLocale: $deviceLocale, sessionIdToken: $sessionIdToken, clientId: $clientId}
-    episodeOrSeasonOrSeriesId: $episodeOrSeasonOrSeriesId
-  ) {
-    seasons {
-      seasonId
-    }
-  }
-}
-'''
-
-    def _entries(self, asin):
-        season_info = self._call_api(
-            asin, note='Downloading series info', data={
-                'operationName': 'getSeasons',
-                'variables': {'episodeOrSeasonOrSeriesId': asin},
-                'query': self._GRAPHQL_QUERY,
-            })
-
-        for season in season_info['seasons']:
-            yield self.url_result(f'amazonminitv:season:{season["seasonId"]}', AmazonMiniTVSeasonIE, season['seasonId'])
-
-    def _real_extract(self, url):
-        asin = f'amzn1.dv.gti.{self._match_id(url)}'
-        return self.playlist_result(self._entries(asin), asin)

--- a/yt_dlp/extractor/amazonminitv.py
+++ b/yt_dlp/extractor/amazonminitv.py
@@ -1,18 +1,43 @@
+import json
 from .common import InfoExtractor
 from ..utils import ExtractorError, int_or_none, traverse_obj, try_get
 
 
 class AmazonMiniTVBaseIE(InfoExtractor):
-    def _get_nextjs_data(self, asin, webpage=None, note=None):
-        resp = self._search_nextjs_data(webpage, asin, fatal=False) or {}
+    def _real_initialize(self):
+        self._download_webpage(
+            'https://www.amazon.in/minitv', None,
+            note='Fetching guest session cookies')
+        AmazonMiniTVBaseIE.session_id = self._get_cookies('https://www.amazon.in')['session-id'].value
 
-        if not resp:
+    def _call_api(self, asin, data=None, note=None):
+        device = {'clientId': 'ATVIN', 'deviceLocale': 'en_GB'}
+
+        if data:
+            data['variables'].update({
+                'contentType': 'VOD',
+                'sessionIdToken': self.session_id,
+                **device,
+            })
+
+        resp = self._download_json(
+            f'https://www.amazon.in/minitv/api/web/{"graphql" if data else "prs"}',
+            asin, note=note, headers={'Content-Type': 'application/json'},
+            data=json.dumps(data).encode() if data else None,
+            query=None if data else {
+                'deviceType': 'A1WMMUXPCUJL4N',
+                'contentId': asin,
+                **device,
+            })
+
+        if resp.get('errors'):
+            raise ExtractorError(f'MiniTV said: {resp["errors"][0]["message"]}')
+        elif not data:
             raise ExtractorError(f'Unable to {note or "NextJS data"}', expected=True)
-        else:
-            return resp
+        return resp['data'][data['operationName']]
 
 
-class AmazonMiniTVIE(AmazonMiniTVBaseIE):
+class AmazonMiniTVIE(InfoExtractor):
     _VALID_URL = r'(?:https?://(?:www\.)?amazon\.in/minitv/tp/|amazonminitv:(?:amzn1\.dv\.gti\.)?)(?P<id>[a-f0-9-]+)'
     _TESTS = [{
         'url': 'https://www.amazon.in/minitv/tp/75fe3a75-b8fe-4499-8100-5c9424344840?referrer=https%3A%2F%2Fwww.amazon.in%2Fminitv',
@@ -62,12 +87,13 @@ class AmazonMiniTVIE(AmazonMiniTVBaseIE):
     }]
 
     def _real_extract(self, url):
-        asin = f'amzn1.dv.gti.{self._match_id(url)}'
-        webpage = self._download_webpage(url, asin)
-        prs = self._get_nextjs_data(asin, note='Retrieve playback info', webpage=webpage)
+        video_uuid = self._match_id(url)
+        asin = f'amzn1.dv.gti.{video_uuid}'
+        webpage = self._download_webpage(f'https://www.amazon.in/minitv/tp/{video_uuid}', asin)
+        data = self._search_nextjs_data(webpage, asin)['props']['pageProps']['ssrProps']
 
         formats, subtitles = [], {}
-        for type_, asset in prs['props']['pageProps']['ssrProps']['playbackData']['playbackAssets'].items():
+        for type_, asset in traverse_obj(data, ('playbackData', 'playbackAssets', {dict.items}, ...)):
             if not traverse_obj(asset, 'manifestUrl'):
                 continue
             if type_ == 'hls':
@@ -84,7 +110,7 @@ class AmazonMiniTVIE(AmazonMiniTVBaseIE):
             else:
                 self.report_warning(f'Unknown asset type: {type_}')
 
-        title_info = prs['props']['pageProps']['ssrProps']['contentData']
+        title_info = traverse_obj(data, ('contentData', {dict})) or {}
         credits_time = try_get(title_info, lambda x: x['timecode']['endCreditsTime'] / 1000)
         is_episode = title_info.get('vodType') == 'EPISODE'
 
@@ -113,3 +139,108 @@ class AmazonMiniTVIE(AmazonMiniTVBaseIE):
             'episode_number': title_info.get('episodeNumber'),
             'episode_id': asin if is_episode else None,
         }
+
+
+class AmazonMiniTVSeasonIE(AmazonMiniTVBaseIE):
+    IE_NAME = 'amazonminitv:season'
+    _VALID_URL = r'amazonminitv:season:(?:amzn1\.dv\.gti\.)?(?P<id>[a-f0-9-]+)'
+    IE_DESC = 'Amazon MiniTV Season, "minitv:season:" prefix'
+    _WORKING = False
+    _TESTS = [{
+        'url': 'amazonminitv:season:amzn1.dv.gti.0aa996eb-6a1b-4886-a342-387fbd2f1db0',
+        'playlist_mincount': 6,
+        'info_dict': {
+            'id': 'amzn1.dv.gti.0aa996eb-6a1b-4886-a342-387fbd2f1db0',
+        },
+    }, {
+        'url': 'amazonminitv:season:0aa996eb-6a1b-4886-a342-387fbd2f1db0',
+        'only_matching': True,
+    }]
+
+    _GRAPHQL_QUERY = '''
+query getEpisodes($sessionIdToken: String!, $clientId: String, $episodeOrSeasonId: ID!, $deviceLocale: String) {
+  getEpisodes(
+    applicationContextInput: {sessionIdToken: $sessionIdToken, deviceLocale: $deviceLocale, clientId: $clientId}
+    episodeOrSeasonId: $episodeOrSeasonId
+  ) {
+    episodes {
+      ... on Episode {
+        contentId
+        name
+        images
+        seriesName
+        seasonId
+        seriesId
+        seasonNumber
+        episodeNumber
+        description {
+          synopsis
+          contentLengthInSeconds
+        }
+        publicReleaseDateUTC
+      }
+    }
+  }
+}
+'''
+
+    def _entries(self, asin):
+        season_info = self._call_api(
+            asin, note='Downloading season info', data={
+                'operationName': 'getEpisodes',
+                'variables': {'episodeOrSeasonId': asin},
+                'query': self._GRAPHQL_QUERY,
+            })
+
+        for episode in season_info['episodes']:
+            yield self.url_result(
+                f'amazonminitv:{episode["contentId"]}', AmazonMiniTVIE, episode['contentId'])
+
+    def _real_extract(self, url):
+        asin = f'amzn1.dv.gti.{self._match_id(url)}'
+        return self.playlist_result(self._entries(asin), asin)
+
+
+class AmazonMiniTVSeriesIE(AmazonMiniTVBaseIE):
+    IE_NAME = 'amazonminitv:series'
+    _VALID_URL = r'amazonminitv:series:(?:amzn1\.dv\.gti\.)?(?P<id>[a-f0-9-]+)'
+    IE_DESC = 'Amazon MiniTV Series, "minitv:series:" prefix'
+    _WORKING = False
+    _TESTS = [{
+        'url': 'amazonminitv:series:amzn1.dv.gti.56521d46-b040-4fd5-872e-3e70476a04b0',
+        'playlist_mincount': 3,
+        'info_dict': {
+            'id': 'amzn1.dv.gti.56521d46-b040-4fd5-872e-3e70476a04b0',
+        },
+    }, {
+        'url': 'amazonminitv:series:56521d46-b040-4fd5-872e-3e70476a04b0',
+        'only_matching': True,
+    }]
+
+    _GRAPHQL_QUERY = '''
+query getSeasons($sessionIdToken: String!, $deviceLocale: String, $episodeOrSeasonOrSeriesId: ID!, $clientId: String) {
+  getSeasons(
+    applicationContextInput: {deviceLocale: $deviceLocale, sessionIdToken: $sessionIdToken, clientId: $clientId}
+    episodeOrSeasonOrSeriesId: $episodeOrSeasonOrSeriesId
+  ) {
+    seasons {
+      seasonId
+    }
+  }
+}
+'''
+
+    def _entries(self, asin):
+        season_info = self._call_api(
+            asin, note='Downloading series info', data={
+                'operationName': 'getSeasons',
+                'variables': {'episodeOrSeasonOrSeriesId': asin},
+                'query': self._GRAPHQL_QUERY,
+            })
+
+        for season in season_info['seasons']:
+            yield self.url_result(f'amazonminitv:season:{season["seasonId"]}', AmazonMiniTVSeasonIE, season['seasonId'])
+
+    def _real_extract(self, url):
+        asin = f'amzn1.dv.gti.{self._match_id(url)}'
+        return self.playlist_result(self._entries(asin), asin)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Changed AmazonMiniTV extraction process.

- Changed playback info retrieval from GraphQL to __NEXT_DATA__
- Dropped support for seasons and series extraction since GraphQL URLs are no longer working.

Fixes #7817 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 024d6a7</samp>

### Summary
🗑️🔄🚀

<!--
1.  🗑️ for removing unused imports and code.
2.  🔄 for updating the extractor to use a different data source.
3.  🚀 for improving the performance of the extractor.
-->
Update `amazonminitv.py` extractor to use NextJS data and remove unused code and imports. This simplifies the extractor and makes it more reliable and efficient.

> _`amazonminitv`_
> _NextJS data, not GraphQL_
> _Spring cleaning imports_

### Walkthrough
*  Remove unused imports of `AmazonMiniTVSeasonIE` and `AmazonMiniTVSeriesIE` from `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8103/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L96-R96))
*  Remove unused import of `json` from `amazonminitv.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8103/files?diff=unified&w=0#diff-3496c6b93cdbfba39b15495a3dab0f3f6a07a9ac94b8241503ec8fe7e732fc7eL1-L2))
*  Replace `_call_api` method with `_get_nextjs_data` method in `AmazonMiniTVBaseIE` class to use NextJS data instead of GraphQL queries ([link](https://github.com/yt-dlp/yt-dlp/pull/8103/files?diff=unified&w=0#diff-3496c6b93cdbfba39b15495a3dab0f3f6a07a9ac94b8241503ec8fe7e732fc7eL8-R12))
*  Use `prs` variable to extract playback and title info from NextJS data in `AmazonMiniTVIE` class and update keys accordingly ([link](https://github.com/yt-dlp/yt-dlp/pull/8103/files?diff=unified&w=0#diff-3496c6b93cdbfba39b15495a3dab0f3f6a07a9ac94b8241503ec8fe7e732fc7eL89-R70))
*  Use `title_info` variable to extract content info from NextJS data in `AmazonMiniTVIE` class and update keys accordingly ([link](https://github.com/yt-dlp/yt-dlp/pull/8103/files?diff=unified&w=0#diff-3496c6b93cdbfba39b15495a3dab0f3f6a07a9ac94b8241503ec8fe7e732fc7eL155-R87))
*  Remove `AmazonMiniTVSeasonIE` and `AmazonMiniTVSeriesIE` classes from `amazonminitv.py` as they are no longer needed ([link](https://github.com/yt-dlp/yt-dlp/pull/8103/files?diff=unified&w=0#diff-3496c6b93cdbfba39b15495a3dab0f3f6a07a9ac94b8241503ec8fe7e732fc7eL189-L291))



</details>
