### PR TITLE
[devscripts] `make_changelog`: Fix changelog groups and add networking

### DIFF
--- a/devscripts/changelog_override.json
+++ b/devscripts/changelog_override.json
@@ -79,14 +79,8 @@
     },
     {
         "action": "change",
-        "when": "db7b054a6111ca387220d0eb87bf342f9c130eb8",
-        "short": "[rh] Add request handler preference framework (#7603)",
-        "authors": ["coletdjnz"]
-    },
-    {
-        "action": "change",
         "when": "59e92b1f1833440bb2190f847eb735cf0f90bc85",
-        "short": "[rh] `urllib`: Simplify gzip decoding (#7611)",
+        "short": "[rh:urllib] Simplify gzip decoding (#7611)",
         "authors": ["Grub4K"]
     }
 ]

--- a/devscripts/changelog_override.json
+++ b/devscripts/changelog_override.json
@@ -68,6 +68,25 @@
     {
         "action": "change",
         "when": "b03fa7834579a01cc5fba48c0e73488a16683d48",
-        "short": "[ie/twitter] Revert 92315c03774cfabb3a921884326beb4b981f786b"
+        "short": "[ie/twitter] Revert 92315c03774cfabb3a921884326beb4b981f786b",
+        "authors": ["pukkandan"]
+    },
+    {
+        "action": "change",
+        "when": "fcd6a76adc49d5cd8783985c7ce35384b72e545f",
+        "short": "[test] Add tests for socks proxies (#7908)",
+        "authors": ["coletdjnz"]
+    },
+    {
+        "action": "change",
+        "when": "db7b054a6111ca387220d0eb87bf342f9c130eb8",
+        "short": "[rh] Add request handler preference framework (#7603)",
+        "authors": ["coletdjnz"]
+    },
+    {
+        "action": "change",
+        "when": "59e92b1f1833440bb2190f847eb735cf0f90bc85",
+        "short": "[rh] `urllib`: Simplify gzip decoding (#7611)",
+        "authors": ["Grub4K"]
     }
 ]

--- a/devscripts/changelog_override.json
+++ b/devscripts/changelog_override.json
@@ -79,6 +79,12 @@
     },
     {
         "action": "change",
+        "when": "4bf912282a34b58b6b35d8f7e6be535770c89c76",
+        "short": "[rh:urllib] Remove dot segments during URL normalization (#7662)",
+        "authors": ["coletdjnz"]
+    },
+    {
+        "action": "change",
         "when": "59e92b1f1833440bb2190f847eb735cf0f90bc85",
         "short": "[rh:urllib] Simplify gzip decoding (#7611)",
         "authors": ["Grub4K"]

--- a/devscripts/make_changelog.py
+++ b/devscripts/make_changelog.py
@@ -204,19 +204,20 @@ class Changelog:
         for commit_infos in cleanup_misc_items.values():
             sorted_items.append(CommitInfo(
                 'cleanup', ('Miscellaneous',), ', '.join(
-                    self._format_message_link(None, info.commit.hash).strip()
+                    self._format_message_link(None, info.commit.hash)
                     for info in sorted(commit_infos, key=lambda item: item.commit.hash or '')),
                 [], Commit(None, '', commit_infos[0].commit.authors), []))
 
         return sorted_items
 
-    def format_single_change(self, info):
-        message = self._format_message_link(info.message, info.commit.hash)
+    def format_single_change(self, info: CommitInfo):
+        message_line, sep, rest = info.message.partition('\n')
+        message = self._format_message_link(message_line, info.commit.hash)
         if info.issues:
-            message = message.replace('\n', f' ({self._format_issues(info.issues)})\n', 1)
+            message = f'{message} ({self._format_issues(info.issues)})'
 
         if info.commit.authors:
-            message = message.replace('\n', f' by {self._format_authors(info.commit.authors)}\n', 1)
+            message = f'{message} by {self._format_authors(info.commit.authors)}'
 
         if info.fixes:
             fix_message = ', '.join(f'{self._format_message_link(None, fix.hash)}' for fix in info.fixes)
@@ -225,16 +226,14 @@ class Changelog:
             if authors != info.commit.authors:
                 fix_message = f'{fix_message} by {self._format_authors(authors)}'
 
-            message = message.replace('\n', f' (With fixes in {fix_message})\n', 1)
+            message = f'{message} (With fixes in {fix_message})'
 
-        return message[:-1]
+        return message if not sep else f'{message}{sep}{rest}'
 
     def _format_message_link(self, message, hash):
         assert message or hash, 'Improperly defined commit message or override'
         message = message if message else hash[:HASH_LENGTH]
-        if not hash:
-            return f'{message}\n'
-        return f'[{message}\n'.replace('\n', f']({self.repo_url}/commit/{hash})\n', 1)
+        return f'[{message}]({self.repo_url}/commit/{hash})' if hash else message
 
     def _format_issues(self, issues):
         return ', '.join(f'[#{issue}]({self.repo_url}/issues/{issue})' for issue in issues)
@@ -343,7 +342,7 @@ class CommitRange:
         for override in overrides:
             when = override.get('when')
             if when and when not in self and when != self._start:
-                logger.debug(f'Ignored {when!r}, not in commits {self._start!r}')
+                logger.debug(f'Ignored {when!r}, not in commits')
                 continue
 
             override_hash = override.get('hash') or when

--- a/devscripts/make_changelog.py
+++ b/devscripts/make_changelog.py
@@ -31,6 +31,7 @@ class CommitGroup(enum.Enum):
     EXTRACTOR = 'Extractor'
     DOWNLOADER = 'Downloader'
     POSTPROCESSOR = 'Postprocessor'
+    NETWORKING = 'Networking'
     MISC = 'Misc.'
 
     @classmethod
@@ -48,7 +49,6 @@ class CommitGroup(enum.Enum):
                     'dependencies',
                     'formats',
                     'jsinterp',
-                    'networking',
                     'outtmpl',
                     'plugins',
                     'update',
@@ -60,6 +60,9 @@ class CommitGroup(enum.Enum):
                     'devscripts',
                     'docs',
                     'test',
+                },
+                cls.NETWORKING: {
+                    'rh',
                 },
             }.items()
             for name in names
@@ -427,6 +430,8 @@ class CommitRange:
 
         if details == 'common':
             details = None
+        elif group is CommitGroup.NETWORKING and details == 'rh':
+            details = 'Request Handler'
 
         return group, details, sub_details
 

--- a/devscripts/make_changelog.py
+++ b/devscripts/make_changelog.py
@@ -326,7 +326,7 @@ class CommitRange:
         for commitish, revert_commit in reverts.items():
             reverted = commits.pop(commitish, None)
             if reverted:
-                logger.debug(f'{commit} fully reverted {reverted}')
+                logger.debug(f'{commitish} fully reverted {reverted}')
             else:
                 commits[revert_commit.hash] = revert_commit
 
@@ -345,7 +345,7 @@ class CommitRange:
         for override in overrides:
             when = override.get('when')
             if when and when not in self and when != self._start:
-                logger.debug(f'Ignored {when!r}, not in commits')
+                logger.debug(f'Ignored {when!r} override')
                 continue
 
             override_hash = override.get('hash') or when

--- a/devscripts/make_changelog.py
+++ b/devscripts/make_changelog.py
@@ -214,8 +214,11 @@ class Changelog:
         return sorted_items
 
     def format_single_change(self, info: CommitInfo):
-        message_line, sep, rest = info.message.partition('\n')
-        message = self._format_message_link(message_line, info.commit.hash)
+        message, sep, rest = info.message.partition('\n')
+        if '[' not in message:
+            # If the message doesn't already contain markdown links, try to add a link to the commit
+            message = self._format_message_link(message, info.commit.hash)
+
         if info.issues:
             message = f'{message} ({self._format_issues(info.issues)})'
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fixes the issue with groups not being separated from the details.
It also fixes some bugs in the multiline handling in https://github.com/yt-dlp/yt-dlp/commit/62b5c94cadaa5f596dc1a7083db9db12efe357be that resulted in some trailing newlines.

Furthermore it adds the `Networking` commit group and updates the changelog override accordingly.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 99eba13</samp>

### Summary
📝🌐🛠️

<!--
1.  📝 - This emoji means "memo" or "document" and can be used to indicate changes related to documentation, writing, or editing. It is suitable for the first change, which modifies the changelog override file to improve the quality and accuracy of the release notes.
2. 🌐 - This emoji means "globe with meridians" or "world wide web" and can be used to indicate changes related to networking, internet, or web development. It is suitable for the second change, which adds a new networking group and subgroup to the changelog generation script to better categorize the relevant commits.
3. 🛠️ - This emoji means "hammer and wrench" or "tools" and can be used to indicate changes related to fixing, improving, or refactoring code, scripts, or tools. It is suitable for the second change, which also involves refactoring the code, fixing some bugs, and changing some prefixes in the changelog generation script.
-->
This pull request enhances the `make_changelog.py` script and the `changelog_override.json` file to produce a better changelog for the yt-dlp project. It improves the script's performance, readability, and accuracy, and adds the missing author names to some override entries.

> _`changelog` improved_
> _networking group added, bugs fixed_
> _autumn of credit_

### Walkthrough
*  Add a new commit group for networking and a new subgroup for request handler ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L34-R42), [link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L70-R66))
*  Refactor the commit group class to return both group and subgroup, and improve the lookup methods ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L81-R96))
*  Remove redundant prefixes from the core commit group ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L54-R54))
*  Add author names to the changelog override entries ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-323808d1d1a45be3d06ea051c76192878238cd5c25e74087fbdad00eab2c6a16L71-R90))
*  Fix the message link formatting for the miscellaneous cleanup items and the commits with markdown links ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L201-R210), [link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L207-R226))
*  Simplify the message link formatting method with a ternary operator ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L222-R242))
*  Change the prefix of the upstream merge commits to upstream ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L368-R379))
*  Refactor the details from prefix method to handle multiple parts in the prefix ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L413-R438))
*  Fix a minor bug in the get commits and fixes method with the reverted commit variable ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L321-R332))
*  Modify the log message in the apply overrides method to remove the start commit hash ([link](https://github.com/yt-dlp/yt-dlp/pull/8124/files?diff=unified&w=0#diff-6cc7bbf1b5bf1eb458b440d2f7459a0e5ded9ffbfc9cce7fae3f10ac37b20648L340-R351))



</details>
