### PR TITLE
[extractor/indavideo] Fix video extraction

### DIFF
--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -4,8 +4,8 @@ from ..utils import (
     int_or_none,
     parse_age_limit,
     parse_iso8601,
-    update_url_query,
     time_seconds,
+    update_url_query,
 )
 
 
@@ -36,6 +36,23 @@ class IndavideoEmbedIE(InfoExtractor):
             'tags': ['tánc', 'cica', 'cuki', 'cukiajanlo', 'newsroom'],
         },
     }, {
+        'url': 'https://indavideo.hu/video/Vicces_cica_1',
+        'md5': '8c82244ba85d2a2310275b318eb51eac',
+        'info_dict': {
+            'id': '1335611',
+            'ext': 'mp4',
+            'title': 'Vicces cica',
+            'description': 'Játszik a tablettel. :D',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'uploader': 'Jet_Pack',
+            'uploader_id': '491217',
+            'timestamp': 1390821212,
+            'upload_date': '20140127',
+            'duration': 7,
+            'age_limit': 0,
+            'tags': ['cica', 'Jet_Pack'],
+        },
+    }, {
         'url': 'https://embed.indavideo.hu/player/video/1bdc3c6d80?autostart=1&hide=1',
         'only_matching': True,
     }, {
@@ -47,8 +64,8 @@ class IndavideoEmbedIE(InfoExtractor):
         video_id = self._match_id(url)
 
         video = self._download_json(
-            'https://amfphp.indavideo.hu/SYm0json.php/player.playerHandler.getVideoData/%s/?_=%d' % (video_id, time_seconds()),
-            video_id)['data']
+            f'https://amfphp.indavideo.hu/SYm0json.php/player.playerHandler.getVideoData/{video_id}/',
+            video_id, query={'_': time_seconds()})['data']
 
         video_urls = []
 
@@ -74,13 +91,12 @@ class IndavideoEmbedIE(InfoExtractor):
             height = int_or_none(self._search_regex(
                 r'\.(\d{3,4})\.mp4(?:\?|$)', video_url, 'height', default=None))
             if not height and len(filesh) == 1:
-                height = int(list(filesh.keys())[0])
-            token = filesh.get(compat_str(height))
+                height = int_or_none(list(filesh.keys())[0])
+            token = filesh.get(str(height))
             if token is None:
                 continue
-            video_url = update_url_query(video_url, {'token': token})
             formats.append({
-                'url': video_url,
+                'url': update_url_query(video_url, {'token': token}),
                 'height': height,
             })
 

--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -83,7 +83,7 @@ class IndavideoEmbedIE(InfoExtractor):
             if flv_url not in video_urls:
                 video_urls.append(flv_url)
 
-        filesh = video.get('filesh')
+        filesh = video.get('filesh') or {}
 
         formats = []
         for video_url in video_urls:

--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -1,5 +1,4 @@
 from .common import InfoExtractor
-from ..compat import compat_str
 from ..utils import (
     int_or_none,
     parse_age_limit,

--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -37,9 +37,6 @@ class IndavideoEmbedIE(InfoExtractor):
     }, {
         'url': 'https://embed.indavideo.hu/player/video/1bdc3c6d80?autostart=1&hide=1',
         'only_matching': True,
-    }, {
-        'url': 'https://assets.indavideo.hu/swf/player.swf?v=fe25e500&vID=1bdc3c6d80&autostart=1&hide=1&i=1',
-        'only_matching': True,
     }]
     _WEBPAGE_TESTS = [{
         'url': 'https://indavideo.hu/video/Vicces_cica_1',
@@ -75,13 +72,6 @@ class IndavideoEmbedIE(InfoExtractor):
             video_urls.extend(video_files.values())
 
         video_urls = list(set(video_urls))
-
-        video_prefix = video_urls[0].rsplit('/', 1)[0]
-
-        for flv_file in video.get('flv_files', []):
-            flv_url = '%s/%s' % (video_prefix, flv_file)
-            if flv_url not in video_urls:
-                video_urls.append(flv_url)
 
         filesh = video.get('filesh') or {}
 

--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -5,21 +5,21 @@ from ..utils import (
     parse_age_limit,
     parse_iso8601,
     update_url_query,
+    time_seconds,
 )
 
 
 class IndavideoEmbedIE(InfoExtractor):
     _VALID_URL = r'https?://(?:(?:embed\.)?indavideo\.hu/player/video/|assets\.indavideo\.hu/swf/player\.swf\?.*\b(?:v(?:ID|id))=)(?P<id>[\da-f]+)'
     # Some example URLs covered by generic extractor:
-    #   http://indavideo.hu/video/Vicces_cica_1
-    #   http://index.indavideo.hu/video/2015_0728_beregszasz
-    #   http://auto.indavideo.hu/video/Sajat_utanfutoban_a_kis_tacsko
-    #   http://erotika.indavideo.hu/video/Amator_tini_punci
-    #   http://film.indavideo.hu/video/f_hrom_nagymamm_volt
-    #   http://palyazat.indavideo.hu/video/Embertelen_dal_Dodgem_egyuttes
-    _EMBED_REGEX = [r'<iframe[^>]+\bsrc=["\'](?P<url>(?:https?:)?//embed\.indavideo\.hu/player/video/[\da-f]+)']
+    #   https://indavideo.hu/video/Vicces_cica_1
+    #   https://index.indavideo.hu/video/Hod_Nemetorszagban
+    #   https://auto.indavideo.hu/video/Sajat_utanfutoban_a_kis_tacsko
+    #   https://film.indavideo.hu/video/f_farkaslesen
+    #   https://palyazat.indavideo.hu/video/Embertelen_dal_Dodgem_egyuttes
+    _EMBED_REGEX = [r'<iframe[^>]+\bsrc=["\'](?P<url>(?:https?:)//embed\.indavideo\.hu/player/video/[\da-f]+)']
     _TESTS = [{
-        'url': 'http://indavideo.hu/player/video/1bdc3c6d80/',
+        'url': 'https://indavideo.hu/player/video/1bdc3c6d80/',
         'md5': 'c8a507a1c7410685f83a06eaeeaafeab',
         'info_dict': {
             'id': '1837039',
@@ -36,10 +36,10 @@ class IndavideoEmbedIE(InfoExtractor):
             'tags': ['tánc', 'cica', 'cuki', 'cukiajanlo', 'newsroom'],
         },
     }, {
-        'url': 'http://embed.indavideo.hu/player/video/1bdc3c6d80?autostart=1&hide=1',
+        'url': 'https://embed.indavideo.hu/player/video/1bdc3c6d80?autostart=1&hide=1',
         'only_matching': True,
     }, {
-        'url': 'http://assets.indavideo.hu/swf/player.swf?v=fe25e500&vID=1bdc3c6d80&autostart=1&hide=1&i=1',
+        'url': 'https://assets.indavideo.hu/swf/player.swf?v=fe25e500&vID=1bdc3c6d80&autostart=1&hide=1&i=1',
         'only_matching': True,
     }]
 
@@ -47,10 +47,8 @@ class IndavideoEmbedIE(InfoExtractor):
         video_id = self._match_id(url)
 
         video = self._download_json(
-            'https://amfphp.indavideo.hu/SYm0json.php/player.playerHandler.getVideoData/%s' % video_id,
+            'https://amfphp.indavideo.hu/SYm0json.php/player.playerHandler.getVideoData/%s/?_=%d' % (video_id, time_seconds()),
             video_id)['data']
-
-        title = video['title']
 
         video_urls = []
 
@@ -60,9 +58,6 @@ class IndavideoEmbedIE(InfoExtractor):
         elif isinstance(video_files, dict):
             video_urls.extend(video_files.values())
 
-        video_file = video.get('video_file')
-        if video:
-            video_urls.append(video_file)
         video_urls = list(set(video_urls))
 
         video_prefix = video_urls[0].rsplit('/', 1)[0]
@@ -78,13 +73,12 @@ class IndavideoEmbedIE(InfoExtractor):
         for video_url in video_urls:
             height = int_or_none(self._search_regex(
                 r'\.(\d{3,4})\.mp4(?:\?|$)', video_url, 'height', default=None))
-            if filesh:
-                if not height:
-                    continue
-                token = filesh.get(compat_str(height))
-                if token is None:
-                    continue
-                video_url = update_url_query(video_url, {'token': token})
+            if not height and len(filesh) == 1:
+                height = int(list(filesh.keys())[0])
+            token = filesh.get(compat_str(height))
+            if token is None:
+                continue
+            video_url = update_url_query(video_url, {'token': token})
             formats.append({
                 'url': video_url,
                 'height': height,
@@ -103,7 +97,7 @@ class IndavideoEmbedIE(InfoExtractor):
 
         return {
             'id': video.get('id') or video_id,
-            'title': title,
+            'title': video.get('title'),
             'description': video.get('description'),
             'thumbnails': thumbnails,
             'uploader': video.get('user_name'),

--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -35,8 +35,14 @@ class IndavideoEmbedIE(InfoExtractor):
             'tags': ['tánc', 'cica', 'cuki', 'cukiajanlo', 'newsroom'],
         },
     }, {
-        'url': 'https://embed.indavideo.hu/player/video/3b63bc219c?autostart=1',
-        'md5': '8c82244ba85d2a2310275b318eb51eac',
+        'url': 'https://embed.indavideo.hu/player/video/1bdc3c6d80?autostart=1&hide=1',
+        'only_matching': True,
+    }, {
+        'url': 'https://assets.indavideo.hu/swf/player.swf?v=fe25e500&vID=1bdc3c6d80&autostart=1&hide=1&i=1',
+        'only_matching': True,
+    }]
+    _WEBPAGE_TESTS = [{
+        'url': 'https://indavideo.hu/video/Vicces_cica_1',
         'info_dict': {
             'id': '1335611',
             'ext': 'mp4',
@@ -51,12 +57,6 @@ class IndavideoEmbedIE(InfoExtractor):
             'age_limit': 0,
             'tags': ['cica', 'Jet_Pack'],
         },
-    }, {
-        'url': 'https://embed.indavideo.hu/player/video/1bdc3c6d80?autostart=1&hide=1',
-        'only_matching': True,
-    }, {
-        'url': 'https://assets.indavideo.hu/swf/player.swf?v=fe25e500&vID=1bdc3c6d80&autostart=1&hide=1&i=1',
-        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/indavideo.py
+++ b/yt_dlp/extractor/indavideo.py
@@ -36,7 +36,7 @@ class IndavideoEmbedIE(InfoExtractor):
             'tags': ['tánc', 'cica', 'cuki', 'cukiajanlo', 'newsroom'],
         },
     }, {
-        'url': 'https://indavideo.hu/video/Vicces_cica_1',
+        'url': 'https://embed.indavideo.hu/player/video/3b63bc219c?autostart=1',
         'md5': '8c82244ba85d2a2310275b318eb51eac',
         'info_dict': {
             'id': '1335611',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

- Fix video extraction
- Remove dead links in example urls section
- Some code cleanup

Fixes #7190


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1a1bf43</samp>

### Summary
🛠️🔒🧹

<!--
1.  🛠️ for fixing the extraction logic
2.  🔒 for using HTTPS for security
3.  🧹 for simplifying some code
-->
Fix indavideo extraction by adding timestamp, using HTTPS, and simplifying code. Update example and test URLs in `indavideo.py`.

> _Oh we're the crew of the indavideo.py_
> _And we've fixed the extraction of the clips_
> _We've added a `timestamp` and used HTTPS_
> _And we've simplified some of the scripts_

### Walkthrough
* Import `time_seconds` function from `utils` module to append timestamp to video data URL ([link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaR8))
* Use HTTPS instead of HTTP for example URLs, `_EMBED_REGEX`, and test URLs to avoid redirection or mixed content issues ([link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL14-R22), [link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL39-R42))
* Add timestamp parameter to video data URL using `time_seconds` function to bypass caching issue ([link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL50-R52))
* Remove redundant assignment of `title` from video data and retrieve it from the video itself ([link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL50-R52), [link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL106-R100))
* Remove unnecessary check and append of `video_file` to `video_urls` list and avoid duplicates or invalid URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL63-L65))
* Simplify logic of extracting `height` and `token` from `filesh` dictionary and remove redundant check of `filesh` being truthy ([link](https://github.com/yt-dlp/yt-dlp/pull/8129/files?diff=unified&w=0#diff-801de90d10401cb3ee744f95bbd39dab532e58d698a3542284458fb12b1e3dfaL81-R81))



</details>
