### PR TITLE
[ie/RTVSLO] Fix format extraction

### DIFF
--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -99,13 +99,14 @@ class RTVSLOIE(InfoExtractor):
         media = self._download_json(self._API_BASE.format('getMedia', v_id), v_id, query={'jwt': jwt})['response']
 
         formats = []
+        skip_protocols = ['smil', 'f4m', 'dash']
         adaptive_url = traverse_obj(media, ('addaptiveMedia', 'hls_sec'), expected_type=url_or_none)
         if adaptive_url:
-            formats = self._extract_wowza_formats(adaptive_url, v_id, skip_protocols=['smil'])
+            formats = self._extract_wowza_formats(adaptive_url, v_id, skip_protocols=skip_protocols)
 
         adaptive_url = traverse_obj(media, ('addaptiveMedia_sl', 'hls_sec'), expected_type=url_or_none)
         if adaptive_url:
-            for f in self._extract_wowza_formats(adaptive_url, v_id, skip_protocols=['smil']):
+            for f in self._extract_wowza_formats(adaptive_url, v_id, skip_protocols=skip_protocols):
                 formats.append({
                     **f,
                     'format_id': 'sign-' + f['format_id'],
@@ -127,7 +128,7 @@ class RTVSLOIE(InfoExtractor):
 
         for mediafile in traverse_obj(media, ('mediaFiles', lambda _, v: url_or_none(v['streams']['hls_sec']))):
             formats.extend(self._extract_wowza_formats(
-                mediafile['streams']['hls_sec'], v_id, skip_protocols=['smil']))
+                mediafile['streams']['hls_sec'], v_id, skip_protocols=skip_protocols))
 
         if any('intermission.mp4' in x['url'] for x in formats):
             self.raise_geo_restricted(countries=self._GEO_COUNTRIES, metadata_available=True)

--- a/yt_dlp/extractor/rtvslo.py
+++ b/yt_dlp/extractor/rtvslo.py
@@ -26,7 +26,7 @@ class RTVSLOIE(InfoExtractor):
             'url': 'https://www.rtvslo.si/rtv365/arhiv/174842550?s=tv',
             'info_dict': {
                 'id': '174842550',
-                'ext': 'flv',
+                'ext': 'mp4',
                 'release_timestamp': 1643140032,
                 'upload_date': '20220125',
                 'series': 'Dnevnik',
@@ -70,7 +70,21 @@ class RTVSLOIE(InfoExtractor):
                 'tbr': 128000,
                 'release_date': '20220201',
             },
-
+        }, {
+            'url': 'https://365.rtvslo.si/arhiv/razred-zase/148350750',
+            'info_dict': {
+                'id': '148350750',
+                'ext': 'mp4',
+                'title': 'Prvi šolski dan, mozaična oddaja za mlade',
+                'series': 'Razred zase',
+                'series_id': '148185730',
+                'duration': 1481,
+                'upload_date': '20121019',
+                'timestamp': 1350672122,
+                'release_date': '20121019',
+                'release_timestamp': 1350672122,
+                'thumbnail': 'https://img.rtvcdn.si/_up/ava/ava_misc/show_logos/148185730/razred_zase_2014_logo_4d_wide2.jpg',
+            },
         }, {
             'url': 'https://4d.rtvslo.si/arhiv/dnevnik/174842550',
             'only_matching': True


### PR DESCRIPTION
Fixes #8020


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91a4b7d</samp>

### Summary
🛠️🧪🚫

<!--
1.  🛠️ - This emoji can be used to represent the improvement of the extractor by importing a utility function, which is a kind of tool or fix for the code.
2.  🧪 - This emoji can be used to represent the updating and adding of test cases, which are a kind of experiment or test for the code quality and functionality.
3.  🚫 - This emoji can be used to represent the skipping of unsupported protocols, which are a kind of restriction or limitation for the code.
-->
Enhance the `rtvslo` extractor to handle more formats and protocols, and update tests and imports.

> _The rtvslo extractor was slow_
> _And had some issues to undergo_
> _So they imported `utils`_
> _And updated the rules_
> _To skip protocols they don't know_

### Walkthrough
* Import `int_or_none` function to parse integers from metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/8131/files?diff=unified&w=0#diff-7b928e37731136da5f00634b428b700d4ce72c1ad3969d46b7bb618d005aaf92R4))
* Update `ext` field of test case to match actual video format ([link](https://github.com/yt-dlp/yt-dlp/pull/8131/files?diff=unified&w=0#diff-7b928e37731136da5f00634b428b700d4ce72c1ad3969d46b7bb618d005aaf92L28-R29))
* Add test case for `365.rtvslo.si` domain with expected metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/8131/files?diff=unified&w=0#diff-7b928e37731136da5f00634b428b700d4ce72c1ad3969d46b7bb618d005aaf92L72-R88))
* Skip unsupported `f4m` and `dash` protocols when extracting wowza formats ([link](https://github.com/yt-dlp/yt-dlp/pull/8131/files?diff=unified&w=0#diff-7b928e37731136da5f00634b428b700d4ce72c1ad3969d46b7bb618d005aaf92L101-R123))
* Refactor and improve format extraction from `mediaFiles` list using `traverse_obj` function and add support for `hls_sec` stream ([link](https://github.com/yt-dlp/yt-dlp/pull/8131/files?diff=unified&w=0#diff-7b928e37731136da5f00634b428b700d4ce72c1ad3969d46b7bb618d005aaf92L117-R146))



</details>
