### PR TITLE
Add Monstercat extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1119,6 +1119,7 @@ from .mofosex import (
     MofosexEmbedIE,
 )
 from .mojvideo import MojvideoIE
+from .monstercat import MonstercatIE
 from .morningstar import MorningstarIE
 from .motherless import (
     MotherlessIE,

--- a/yt_dlp/extractor/monstercat.py
+++ b/yt_dlp/extractor/monstercat.py
@@ -75,5 +75,5 @@ class MonstercatIE(InfoExtractor):
             'release_date': date,
         }
 
-        return self.playlist_result(self._extract_tracks(tracklist_table, album_meta),
-                                    playlist_id=url_id, **album_meta)
+        return self.playlist_result(
+            self._extract_tracks(tracklist_table, album_meta), playlist_id=url_id, **album_meta)

--- a/yt_dlp/extractor/monstercat.py
+++ b/yt_dlp/extractor/monstercat.py
@@ -41,9 +41,8 @@ class MonstercatIE(InfoExtractor):
 
             track_number = int_or_none(try_call(lambda: get_element_by_class('py-xsmall', td)))
             if not track_id or not release_id:
-                self.report_warning(f'ID not found for track {track_number}')
-                self.write_debug(f'release id: {release_id}')
-                self.write_debug(f'track id: {track_id}')
+                self.report_warning(f'Skipping track {track_number}, ID(s) not found')
+                self.write_debug(f'release_id={repr(release_id)} track_id={repr(track_id)}')
                 continue
             yield {
                 **album_meta,

--- a/yt_dlp/extractor/monstercat.py
+++ b/yt_dlp/extractor/monstercat.py
@@ -1,0 +1,69 @@
+import re
+
+from .common import InfoExtractor
+from ..utils import (
+    extract_attributes,
+    get_element_by_class,
+    get_element_html_by_class,
+    get_element_text_and_html_by_tag,
+    int_or_none,
+    unified_strdate,
+    strip_or_none,
+    traverse_obj,
+)
+
+
+class MonstercatIE(InfoExtractor):
+    _VALID_URL = r'https://www\.monstercat\.com/release/(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://www.monstercat.com/release/742779548009',
+        'playlist_count': 20,
+        'info_dict': {
+            'title': 'The Secret Language of Trees',
+            'id': '742779548009',
+            'thumbnail': 'https://www.monstercat.com/release/742779548009/cover',
+            'release_year': 2023,
+            'release_date': '20230711',
+            'album': 'The Secret Language of Trees',
+            'album_artist': 'BT',
+        }
+    }]
+
+    TRACK_API = 'https://www.monstercat.com/api/release/{release_id}/track-stream/{song_id}'
+
+    def _extract_tracks(self, table, album_meta):
+        for td in re.findall(r'<tr[^<]*>((?:(?!</tr>)[\w\W])+)', table):  # regex by chatgpt due to lack of get_elements_by_tag
+            title = traverse_obj(get_element_by_class('d-inline-flex flex-column', td).partition(" <span"), (0, {strip_or_none}))
+            ids = extract_attributes(get_element_html_by_class("btn-play cursor-pointer mr-small", td))
+            yield {
+                **album_meta,
+                'title': title,
+                'track': title,
+                'track_number': int_or_none(get_element_by_class('py-xsmall', td)),
+                'artist': get_element_by_class('d-block fs-xxsmall', td),
+                'url': self.TRACK_API.format(release_id=ids.get('data-release-id'),
+                                             song_id=ids.get('data-track-id')),
+                'id': ids.get('data-track-id'),
+                'ext': 'mp3'
+            }
+
+    def _real_extract(self, url):
+        url_id = self._match_id(url)
+        html = self._download_webpage(url, url_id)
+        tracklist_table = get_element_by_class('table table-small', html)
+
+        title = get_element_text_and_html_by_tag('h1', html)[0]
+        date = get_element_by_class('font-italic mb-medium d-tablet-none d-phone-block', html)
+        date = traverse_obj(date.partition('Released '), (2, {strip_or_none}, {unified_strdate}))
+
+        album_meta = {
+            'title': title,
+            'album': title,
+            'thumbnail': url + '/cover',
+            'album_artist': get_element_by_class('h-normal text-uppercase mb-desktop-medium mb-smallish', html),
+            'release_year': int_or_none(date[:4]),
+            'release_date': date,
+        }
+
+        return self.playlist_result(self._extract_tracks(tracklist_table, album_meta),
+                                    playlist_id=url_id, **album_meta)

--- a/yt_dlp/extractor/monstercat.py
+++ b/yt_dlp/extractor/monstercat.py
@@ -2,6 +2,7 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
+    clean_html,
     extract_attributes,
     get_element_by_class,
     get_element_html_by_class,
@@ -10,6 +11,7 @@ from ..utils import (
     unified_strdate,
     strip_or_none,
     traverse_obj,
+    try_call,
 )
 
 
@@ -29,39 +31,48 @@ class MonstercatIE(InfoExtractor):
         }
     }]
 
-    TRACK_API = 'https://www.monstercat.com/api/release/{release_id}/track-stream/{song_id}'
-
     def _extract_tracks(self, table, album_meta):
         for td in re.findall(r'<tr[^<]*>((?:(?!</tr>)[\w\W])+)', table):  # regex by chatgpt due to lack of get_elements_by_tag
-            title = traverse_obj(get_element_by_class('d-inline-flex flex-column', td).partition(' <span'), (0, {strip_or_none}))
-            ids = traverse_obj(get_element_html_by_class('btn-play cursor-pointer mr-small', td), {extract_attributes})
+            title = clean_html(try_call(
+                lambda: get_element_by_class('d-inline-flex flex-column', td).partition(' <span')[0]))
+            ids = extract_attributes(try_call(lambda: get_element_html_by_class('btn-play cursor-pointer mr-small', td)) or '')
+            track_id = ids.get('data-track-id')
+            release_id = ids.get('data-release-id')
+
+            track_number = int_or_none(try_call(lambda: get_element_by_class('py-xsmall', td)))
+            if not track_id or not release_id:
+                self.report_warning(f'ID not found for track {track_number}')
+                self.write_debug(f'release id: {release_id}')
+                self.write_debug(f'track id: {track_id}')
+                continue
             yield {
                 **album_meta,
                 'title': title,
                 'track': title,
-                'track_number': traverse_obj(get_element_by_class('py-xsmall', td), {int_or_none}),
-                'artist': traverse_obj(td, {lambda td: get_element_by_class('d-block fs-xxsmall', td)}),
-                'url': self.TRACK_API.format(release_id=ids.get('data-release-id'),
-                                             song_id=ids.get('data-track-id')),
-                'id': ids.get('data-track-id'),
+                'track_number': track_number,
+                'artist': clean_html(try_call(lambda: get_element_by_class('d-block fs-xxsmall', td))),
+                'url': f'https://www.monstercat.com/api/release/{release_id}/track-stream/{track_id}',
+                'id': track_id,
                 'ext': 'mp3'
             }
 
     def _real_extract(self, url):
         url_id = self._match_id(url)
         html = self._download_webpage(url, url_id)
-        tracklist_table = traverse_obj(html, {lambda html: get_element_by_class('table table-small', html)})
+        # wrap all `get_elements` in `try_call`, HTMLParser has problems with site's html
+        tracklist_table = try_call(lambda: get_element_by_class('table table-small', html)) or ''
 
-        title = traverse_obj(get_element_text_and_html_by_tag('h1', html), 0)
+        title = try_call(lambda: get_element_text_and_html_by_tag('h1', html)[0])
         date = traverse_obj(html, ({lambda html: get_element_by_class('font-italic mb-medium d-tablet-none d-phone-block',
                             html).partition('Released ')}, 2, {strip_or_none}, {unified_strdate}))
 
         album_meta = {
             'title': title,
             'album': title,
-            'thumbnail': url + '/cover',
-            'album_artist': traverse_obj(html, {lambda html: get_element_by_class('h-normal text-uppercase mb-desktop-medium mb-smallish', html)}),
-            'release_year': traverse_obj(date, ({lambda x: date[:4]}, {int_or_none})),
+            'thumbnail': f'https://www.monstercat.com/release/{url_id}/cover',
+            'album_artist': try_call(
+                lambda: get_element_by_class('h-normal text-uppercase mb-desktop-medium mb-smallish', html)),
+            'release_year': int_or_none(date[:4]) if date else None,
             'release_date': date,
         }
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds an extractor for the albums on electronic music label Monstercat's website.
It does _not_ cover their paid service, Monstercat Gold.
Closes #8067

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 03d60e1</samp>

### Summary
🎵🐱🆕

<!--
1.  🎵 - This emoji represents music, which is the main content of the Monstercat website and the extractor. It also conveys a positive and fun tone for the new feature.
2.  🐱 - This emoji represents the cat in the Monstercat logo, which is a distinctive and recognizable symbol of the website and the brand. It also adds some personality and humor to the change.
3.  🆕 - This emoji represents the newness of the feature, which is adding support for a website that was not previously handled by yt-dlp or youtube-dl. It also indicates that the change is significant and noteworthy.
-->
Add support for downloading tracks from Monstercat releases. Create a new `monstercat.py` file that defines the `MonstercatIE` extractor class and import it in `_extractors.py`.

> _`MonstercatIE`_
> _New extractor for music_
> _Autumn of downloads_

### Walkthrough
*  Add support for Monstercat website ([link](https://github.com/yt-dlp/yt-dlp/pull/8133/files?diff=unified&w=0#diff-41874c633552dff65aa9b72f56e050e357918342a4263f707fceac79c4442245R1-R69), [link](https://github.com/yt-dlp/yt-dlp/pull/8133/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1122))
   * Define `MonstercatIE` class in `monstercat.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8133/files?diff=unified&w=0#diff-41874c633552dff65aa9b72f56e050e357918342a4263f707fceac79c4442245R1-R69))
   * Import `MonstercatIE` class in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8133/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1122))



</details>
