### PR TITLE
[ie/bilibili] Extract Dolby Vision & Dolby Audio

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -63,6 +63,9 @@ class BilibiliBaseIE(InfoExtractor):
             'format_id': str_or_none(audio.get('id')),
         } for audio in audios]
 
+        # ref: https://github.com/SocialSisterYi/bilibili-API-collect/blob/92b30f354ab21b97fe52357161fd04e2ca687c97/docs/video/videostream_url.md
+        id_to_dr = {126: 'DV', 125: 'HDR10'}.get
+
         formats.extend({
             'url': traverse_obj(video, 'baseUrl', 'base_url', 'url'),
             'ext': mimetype2ext(traverse_obj(video, 'mimeType', 'mime_type')),
@@ -71,6 +74,7 @@ class BilibiliBaseIE(InfoExtractor):
             'height': int_or_none(video.get('height')),
             'vcodec': video.get('codecs'),
             'acodec': 'none' if audios else None,
+            'dynamic_range': id_to_dr(video.get('id')) or 'SDR',
             'tbr': float_or_none(video.get('bandwidth'), scale=1000),
             'filesize': int_or_none(video.get('size')),
             'quality': int_or_none(video.get('id')),

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -69,7 +69,7 @@ class BilibiliBaseIE(InfoExtractor):
             'height': int_or_none(video.get('height')),
             'vcodec': video.get('codecs'),
             'acodec': 'none' if audios else None,
-            'dynamic_range': {126: 'DV', 125: 'HDR10'}.get(video.get('id')),
+            'dynamic_range': {126: 'DV', 125: 'HDR10'}.get(int_or_none(video.get('id'))),
             'tbr': float_or_none(video.get('bandwidth'), scale=1000),
             'filesize': int_or_none(video.get('size')),
             'quality': int_or_none(video.get('id')),

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -51,6 +51,8 @@ class BilibiliBaseIE(InfoExtractor):
         flac_audio = traverse_obj(play_info, ('dash', 'flac', 'audio'))
         if flac_audio:
             audios.append(flac_audio)
+        # dolby audio (if exists)
+        audios.extend(traverse_obj(play_info, ('dash', 'dolby', 'audio', ...)))
         formats = [{
             'url': traverse_obj(audio, 'baseUrl', 'base_url', 'url'),
             'ext': mimetype2ext(traverse_obj(audio, 'mimeType', 'mime_type')),

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -56,7 +56,7 @@ class BilibiliBaseIE(InfoExtractor):
         formats = [{
             'url': traverse_obj(audio, 'baseUrl', 'base_url', 'url'),
             'ext': mimetype2ext(traverse_obj(audio, 'mimeType', 'mime_type')),
-            'acodec': audio.get('codecs'),
+            'acodec': (audio.get('codecs') or '').lower() or None,
             'vcodec': 'none',
             'tbr': float_or_none(audio.get('bandwidth'), scale=1000),
             'filesize': int_or_none(audio.get('size')),


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
Fixes #4050

This PR adds the ability to extract Dolby Audio formats and improves the extraction of HDR and Dolby Vision formats when the user is logged in and has an active premium subscription.

```
> python '.\yt-dlp\yt_dlp\__main__.py' -v -F --cookies .\sess.txt -I 1 https://www.bilibili.com/video/BV1oL411c77X
[debug] Command-line config: ['-v', '-F', '--cookies', '.\\sess.txt', '-I', '1', 'https://www.bilibili.com/video/BV1oL411c77X']
[debug] Encodings: locale utf-8, fs utf-8, pref utf-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.07.06 [b532a3481] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 2d2a73b99
[debug] Python 3.10.0 (CPython AMD64 64bit) - Windows-10-10.0.19045-SP0 (OpenSSL 1.1.1l  24 Aug 2021)
[debug] exe versions: ffmpeg 6.0-full_build-www.gyan.dev (setts), ffprobe 6.0-full_build-www.gyan.dev, rtmpdump 2.3
[debug] Optional libraries: brotli-1.0.9, certifi-2021.10.08, pycrypto-3.15.0, sqlite3-2.6.0
[debug] Proxy map: {}
[debug] Loaded 1866 extractors
[BiliBili] Extracting URL: https://www.bilibili.com/video/BV1oL411c77X
[BiliBili] 1oL411c77X: Downloading webpage
[BiliBili] BV1oL411c77X: Extracting videos in anthology
[BiliBili] Downloading playlist BV1oL411c77X - add --no-playlist to download just the video BV1oL411c77X
[download] Downloading playlist: [杜比视界·杜比全景声]官方演示片合集
[BiliBili] Playlist [杜比视界·杜比全景声]官方演示片合集: Downloading 1 items
[download] Downloading item 1 of 1
[BiliBili] Extracting URL: https://www.bilibili.com/video/BV1oL411c77X?p=1
[BiliBili] 1oL411c77X: Downloading webpage
[BiliBili] BV1oL411c77X: Extracting videos in anthology
[BiliBili] 465781050: Extracting chapters
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for BV1oL411c77X_p1:
ID     EXT RESOLUTION FPS HDR │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC       ABR
─────────────────────────────────────────────────────────────────────────────────────────────
30250  m4a audio only         │ ≈ 38.28MiB 1668k https │ audio only          ac-3       1668k
30216  m4a audio only         │ ≈  1.55MiB   67k https │ audio only          mp4a.40.2    67k
30232  m4a audio only         │ ≈  3.05MiB  133k https │ audio only          mp4a.40.2   133k
30280  m4a audio only         │ ≈  7.56MiB  329k https │ audio only          mp4a.40.2   329k
100022 mp4 640x360     24     │ ≈  2.75MiB  120k https │ av01.0.01M.08  120k video only
30016  mp4 640x360     24     │ ≈  8.08MiB  352k https │ avc1.64001E    352k video only
30011  mp4 640x360     24     │ ≈  4.81MiB  210k https │ hev1.1.6.L120  210k video only
100023 mp4 852x480     24     │ ≈  3.35MiB  146k https │ av01.0.04M.08  146k video only
30032  mp4 852x480     24     │ ≈ 17.59MiB  766k https │ avc1.64001F    766k video only
30033  mp4 852x480     24     │ ≈  9.98MiB  435k https │ hev1.1.6.L120  435k video only
100024 mp4 1280x720    24     │ ≈  6.21MiB  271k https │ av01.0.05M.08  271k video only
30064  mp4 1280x720    24     │ ≈ 26.82MiB 1168k https │ avc1.640028   1168k video only
30066  mp4 1280x720    24     │ ≈ 15.18MiB  661k https │ hev1.1.6.L120  661k video only
100026 mp4 1920x1080   24     │ ≈ 12.81MiB  558k https │ av01.0.08M.08  558k video only
30080  mp4 1920x1080   24     │ ≈ 33.28MiB 1450k https │ avc1.640032   1450k video only
30077  mp4 1920x1080   24     │ ≈ 18.84MiB  821k https │ hev1.1.6.L120  821k video only
100027 mp4 1920x1080   24     │ ≈ 21.93MiB  956k https │ av01.0.08M.08  956k video only
30112  mp4 1920x1080   24     │ ≈ 46.99MiB 2047k https │ avc1.640032   2047k video only
30102  mp4 1920x1080   24     │ ≈ 26.44MiB 1152k https │ hev1.1.6.L120 1152k video only
100029 mp4 3840x2160   24     │ ≈ 49.26MiB 2146k https │ av01.0.12M.08 2146k video only
30120  mp4 3840x2160   24     │ ≈132.61MiB 5778k https │ avc1.4D4033   5778k video only
30121  mp4 3840x2160   24     │ ≈ 74.46MiB 3244k https │ hev1.1.6.L153 3244k video only
30126  mp4 3840x2160   24 DV  │ ≈174.99MiB 7625k https │ hvc1.2.4.L150 7625k video only
[download] Finished downloading playlist: [杜比视界·杜比全景声]官方演示片合集
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d2a73b</samp>

### Summary
🎵🌈🆔

<!--
1.  🎵 for Dolby audio
2.  🌈 for dynamic range
3.  🆔 for id_to_dr mapping
-->
Enhance Bilibili extractor to support Dolby audio and dynamic range formats. Add new fields and documentation to `yt_dlp/extractor/bilibili.py`.

> _Bilibili extracts_
> _`acodec`, `dynamic_range` -_
> _New fields for sound_

### Walkthrough
* Add support for extracting Dolby audio formats from Bilibili videos ([link](https://github.com/yt-dlp/yt-dlp/pull/8142/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39L54-R59))
* Map Bilibili video IDs to dynamic range labels, such as DV and HDR10 ([link](https://github.com/yt-dlp/yt-dlp/pull/8142/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39R66-R68))
* Include dynamic range information in the video format dictionary ([link](https://github.com/yt-dlp/yt-dlp/pull/8142/files?diff=unified&w=0#diff-0686f03bd3109c08ddda9475b9ed29b13aca3e3381fa3c14bfdef1bcffc78c39R77))



</details>
