### PR TITLE
playlist_id should be case-sensitive #8138

### DIFF
--- a/yt_dlp/extractor/ccc.py
+++ b/yt_dlp/extractor/ccc.py
@@ -90,6 +90,13 @@ class CCCPlaylistIE(InfoExtractor):
             'id': '30c3',
         },
         'playlist_count': 135,
+    },{
+        'url':"https://media.ccc.de/c/DS2023",
+        'info_dict':{
+            'title':'Datenspuren 2023',
+            'id':'DS2023',
+        },
+        'playlist_count':37
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/ccc.py
+++ b/yt_dlp/extractor/ccc.py
@@ -90,7 +90,7 @@ class CCCPlaylistIE(InfoExtractor):
             'id': '30c3',
         },
         'playlist_count': 135,
-    },{
+    }, {
         'url': "https://media.ccc.de/c/DS2023",
         'info_dict': {
             'title': 'Datenspuren 2023',

--- a/yt_dlp/extractor/ccc.py
+++ b/yt_dlp/extractor/ccc.py
@@ -91,12 +91,12 @@ class CCCPlaylistIE(InfoExtractor):
         },
         'playlist_count': 135,
     },{
-        'url':"https://media.ccc.de/c/DS2023",
-        'info_dict':{
-            'title':'Datenspuren 2023',
-            'id':'DS2023',
+        'url': "https://media.ccc.de/c/DS2023",
+        'info_dict': {
+            'title': 'Datenspuren 2023',
+            'id': 'DS2023',
         },
-        'playlist_count':37
+        'playlist_count': 37
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/ccc.py
+++ b/yt_dlp/extractor/ccc.py
@@ -93,7 +93,7 @@ class CCCPlaylistIE(InfoExtractor):
     }]
 
     def _real_extract(self, url):
-        playlist_id = self._match_id(url).lower()
+        playlist_id = self._match_id(url)
 
         conf = self._download_json(
             'https://media.ccc.de/public/conferences/' + playlist_id,

--- a/yt_dlp/extractor/ccc.py
+++ b/yt_dlp/extractor/ccc.py
@@ -91,7 +91,7 @@ class CCCPlaylistIE(InfoExtractor):
         },
         'playlist_count': 135,
     }, {
-        'url': "https://media.ccc.de/c/DS2023",
+        'url': 'https://media.ccc.de/c/DS2023',
         'info_dict': {
             'title': 'Datenspuren 2023',
             'id': 'DS2023',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Removed .lower() from [](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/ccc.py#L96) to make playlist id case sensitive.

-->
Playlist Id is now case sensitive.
Console output : 
`./yt-dlp.sh --verbose --ignore-config https://media.ccc.de/c/DS2023
[debug] Command-line config: ['--verbose', '--ignore-config', 'https://media.ccc.de/c/DS2023']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.07.06 [b532a3481] (source)
[debug] Git HEAD: 20fbbd924
[debug] Python 3.9.2 (CPython x86_64 64bit) - Linux-6.1.0-1parrot1-amd64-x86_64-with-glibc2.31 (OpenSSL 1.1.1n  15 Mar 2022, glibc 2.31)
[debug] exe versions: none
[debug] Optional libraries: sqlite3-2.6.0
[debug] Proxy map: {}
[debug] Loaded 1866 extractors
[media.ccc.de:lists] Extracting URL: https://media.ccc.de/c/DS2023
[media.ccc.de:lists] DS2023: Downloading JSON metadata
[download] Downloading playlist: Datenspuren 2023
[media.ccc.de:lists] Playlist Datenspuren 2023: Downloading 37 items of 37
[download] Downloading item 1 of 37`

Fixes #8138 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 94570d4</samp>

### Summary
🐛🆔🔤

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🆔 - This emoji represents an ID, which is the type of variable that was affected by the change.
3.  🔤 - This emoji represents the alphabet or case-sensitivity, which is the aspect of the variable that was modified by the change.
-->
Fix playlist download bug in `ccc.py` extractor. Preserve the original case of the playlist ID instead of lowercasing it.

> _`playlist_id` fixed_
> _No more lowercasing bugs_
> _Winter downloads work_

### Walkthrough
* Fix playlist download bug by removing `.lower()` from `playlist_id` ([link](https://github.com/yt-dlp/yt-dlp/pull/8144/files?diff=unified&w=0#diff-f51824075dfb87d4a82e37e0fcf75eee34a78c52a265cceb6f9fd2f2b3fdb05cL96-R96))



</details>
