### PR TITLE
[ie/pr0gramm] Rewrite pr0gramm extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1519,7 +1519,7 @@ from .puhutv import (
     PuhuTVIE,
     PuhuTVSerieIE,
 )
-from .pr0gramm import Pr0grammStaticIE, Pr0grammIE
+from .pr0gramm import Pr0grammIE
 from .prankcast import PrankCastIE
 from .premiershiprugby import PremiershipRugbyIE
 from .presstv import PressTVIE

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote
 
 from .common import InfoExtractor
 from ..compat import functools
-from ..utils import ExtractorError, urljoin
+from ..utils import ExtractorError, make_archive_id, urljoin
 from ..utils.traversal import traverse_obj
 
 
@@ -100,7 +100,7 @@ class Pr0grammIE(InfoExtractor):
         if error:
             if error in ('nsfwRequired', 'nsflRequired', 'nsfpRequired'):
                 if not self._is_logged_in:
-                    self.raise_login_required(method='cookies')
+                    self.raise_login_required()
                 raise ExtractorError(f'Unverified account cannot access NSFW/NSFL ({error})', expected=True)
             raise ExtractorError(f'API returned: {error}', expected=True)
 
@@ -138,6 +138,7 @@ class Pr0grammIE(InfoExtractor):
             }],
             'tags': tags,
             'age_limit': 18 if traverse_obj(video_info, ('flags', {0b110.__and__})) else 0,
+            '_old_archive_ids': [make_archive_id('Pr0grammStatic', video_id)],
             **traverse_obj(video_info, {
                 'uploader': ('user', {str}),
                 'uploader_id': ('userId', {int}),

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -81,7 +81,7 @@ class Pr0grammIE(InfoExtractor):
             if error in ('nsfwRequired', 'nsflRequired', 'nsfpRequired'):
                 if self._is_logged_in:
                     self.raise_login_required(method='cookies')
-                raise ExtractorError(f'Unverified account cannot access NSFW/NSFL', expected=True)
+                raise ExtractorError(f'Unverified account cannot access NSFW/NSFL ({error})', expected=True)
             raise ExtractorError(f'API returned: {error}', expected=True)
 
         return data

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -79,10 +79,9 @@ class Pr0grammIE(InfoExtractor):
         error = traverse_obj(data, ('error', {str}))
         if error:
             if error in ('nsfwRequired', 'nsflRequired', 'nsfpRequired'):
-                if self._is_logged_in:  # should only trigger for 'nsfwRequired', 'nsflRequired'
-                    raise ExtractorError(f'Unverified account cannot access NSFW/NSFL', expected=True)
-                else:
+                if self._is_logged_in:
                     self.raise_login_required(method='cookies')
+                raise ExtractorError(f'Unverified account cannot access NSFW/NSFL', expected=True)
             raise ExtractorError(f'API returned: {error}', expected=True)
 
         return data

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -102,7 +102,7 @@ class Pr0grammIE(InfoExtractor):
         error = traverse_obj(data, ('error', {str}))
         if error:
             if error in ('nsfwRequired', 'nsflRequired', 'nsfpRequired'):
-                if self._is_logged_in:
+                if not self._is_logged_in:
                     self.raise_login_required(method='cookies')
                 raise ExtractorError(f'Unverified account cannot access NSFW/NSFL ({error})', expected=True)
             raise ExtractorError(f'API returned: {error}', expected=True)

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -1,97 +1,84 @@
-import re
+from datetime import date
 
 from .common import InfoExtractor
-from ..utils import merge_dicts
+from ..utils import urljoin
+from ..utils.traversal import traverse_obj
 
 
-class Pr0grammStaticIE(InfoExtractor):
-    # Possible urls:
-    # https://pr0gramm.com/static/5466437
-    _VALID_URL = r'https?://pr0gramm\.com/static/(?P<id>[0-9]+)'
-    _TEST = {
-        'url': 'https://pr0gramm.com/static/5466437',
-        'md5': '52fa540d70d3edc286846f8ca85938aa',
-        'info_dict': {
-            'id': '5466437',
-            'ext': 'mp4',
-            'title': 'pr0gramm-5466437 by g11st',
-            'uploader': 'g11st',
-            'upload_date': '20221221',
-        }
-    }
-
-    def _real_extract(self, url):
-        video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id)
-
-        # Fetch media sources
-        entries = self._parse_html5_media_entries(url, webpage, video_id)
-        media_info = entries[0]
-
-        # Fetch author
-        uploader = self._html_search_regex(r'by\W+([\w-]+)\W+', webpage, 'uploader')
-
-        # Fetch approx upload timestamp from filename
-        # Have None-defaults in case the extraction fails
-        uploadDay = None
-        uploadMon = None
-        uploadYear = None
-        uploadTimestr = None
-        # (//img.pr0gramm.com/2022/12/21/62ae8aa5e2da0ebf.mp4)
-        m = re.search(r'//img\.pr0gramm\.com/(?P<year>[\d]+)/(?P<mon>[\d]+)/(?P<day>[\d]+)/\w+\.\w{,4}', webpage)
-
-        if (m):
-            # Up to a day of accuracy should suffice...
-            uploadDay = m.groupdict().get('day')
-            uploadMon = m.groupdict().get('mon')
-            uploadYear = m.groupdict().get('year')
-            uploadTimestr = uploadYear + uploadMon + uploadDay
-
-        return merge_dicts({
-            'id': video_id,
-            'title': 'pr0gramm-%s%s' % (video_id, (' by ' + uploader) if uploader else ''),
-            'uploader': uploader,
-            'upload_date': uploadTimestr
-        }, media_info)
-
-
-# This extractor is for the primary url (used for sharing, and appears in the
-# location bar) Since this page loads the DOM via JS, yt-dl can't find any
-# video information here. So let's redirect to a compatibility version of
-# the site, which does contain the <video>-element  by itself,  without requiring
-# js to be ran.
 class Pr0grammIE(InfoExtractor):
-    # Possible urls:
-    # https://pr0gramm.com/new/546637
-    # https://pr0gramm.com/new/video/546637
-    # https://pr0gramm.com/top/546637
-    # https://pr0gramm.com/top/video/546637
-    # https://pr0gramm.com/user/g11st/uploads/5466437
-    # https://pr0gramm.com/user/froschler/dafur-ist-man-hier/5091290
-    # https://pr0gramm.com/user/froschler/reinziehen-1elf/5232030
-    # https://pr0gramm.com/user/froschler/1elf/5232030
-    # https://pr0gramm.com/new/5495710:comment62621020 <- this is not the id!
-    # https://pr0gramm.com/top/fruher war alles damals/5498175
-
-    _VALID_URL = r'https?:\/\/pr0gramm\.com\/(?!static/\d+).+?\/(?P<id>[\d]+)(:|$)'
-    _TEST = {
+    _VALID_URL = r'https?://pr0gramm\.com\/(?:[^/?#]+/)+(?P<id>[\d]+)(?:[/?#:]|$)'
+    _TESTS = [{
         'url': 'https://pr0gramm.com/new/video/5466437',
         'info_dict': {
             'id': '5466437',
             'ext': 'mp4',
             'title': 'pr0gramm-5466437 by g11st',
             'uploader': 'g11st',
+            'uploader_id': 394718,
+            'upload_timestamp': 1671590240,
             'upload_date': '20221221',
-        }
-    }
+            'like_count': int,
+            'dislike_count': int,
+            'thumbnail': r're:^https://thumb\.pr0gramm\.com/.*\.jpg',
+        },
+    }, {
+        'url': 'https://pr0gramm.com/new/3052805:comment28391322',
+        'info_dict': {
+            'id': '3052805',
+            'ext': 'mp4',
+            'title': 'pr0gramm-3052805 by Hansking1',
+            'uploader': 'Hansking1',
+            'uploader_id': 385563,
+            'upload_timestamp': 1552930408,
+            'upload_date': '20190318',
+            'like_count': int,
+            'dislike_count': int,
+            'thumbnail': r're:^https://thumb\.pr0gramm\.com/.*\.jpg',
+        },
+    }, {
+        'url': 'https://pr0gramm.com/static/5466437',
+        'only_matching': True,
+    }, {
+        'url': 'https://pr0gramm.com/new/rowan%20atkinson%20herr%20bohne/3052805',
+        'only_matching': True,
+    }, {
+        'url': 'https://pr0gramm.com/user/froschler/dafur-ist-man-hier/5091290',
+        'only_matching': True,
+    }]
 
-    def _generic_title():
-        return "oof"
+    API_URL = 'https://pr0gramm.com/api/items/get'
+    VIDEO_URL = 'https://img.pr0gramm.com'
+    THUMB_URL = 'https://thumb.pr0gramm.com'
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
+        original_id = self._match_id(url)
+        video_id = int(original_id)
+        video_info = traverse_obj(
+            self._download_json(self.API_URL, video_id, query={'id': video_id}),
+            ('items', lambda _, v: v['id'] == video_id, {dict}), get_all=False) or {}
 
-        return self.url_result(
-            'https://pr0gramm.com/static/' + video_id,
-            video_id=video_id,
-            ie=Pr0grammStaticIE.ie_key())
+        source = urljoin(self.VIDEO_URL, video_info.get('image'))
+        if not source or not source.endswith('mp4'):
+            self.raise_no_formats('Could not extract a video', expected=bool(source), video_id=video_id)
+
+        return {
+            'id': original_id,
+            'title': f'pr0gramm-{video_id} by {video_info.get("user")}',
+            'formats': [{
+                'url': source,
+                'ext': 'mp4',
+                **traverse_obj(video_info, {
+                    'width': ('width', {int}),
+                    'height': ('height', {int}),
+                }),
+            }],
+            **traverse_obj(video_info, {
+                'uploader': ('user', {str}),
+                'uploader_id': ('userId', {int}),
+                'like_count': ('up', {int}),
+                'dislike_count': ('down', {int}),
+                'upload_timestamp': ('created', {int}),
+                'upload_date': ('created', {int}, {date.fromtimestamp}, {lambda x: x.strftime('%Y%m%d')}),
+                'thumbnail': ('thumb', {lambda x: urljoin(self.THUMB_URL, x)})
+            }),
+        }

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -11,31 +11,54 @@ from ..utils.traversal import traverse_obj
 class Pr0grammIE(InfoExtractor):
     _VALID_URL = r'https?://pr0gramm\.com\/(?:[^/?#]+/)+(?P<id>[\d]+)(?:[/?#:]|$)'
     _TESTS = [{
+        # Tags require account
         'url': 'https://pr0gramm.com/new/video/5466437',
         'info_dict': {
             'id': '5466437',
             'ext': 'mp4',
             'title': 'pr0gramm-5466437 by g11st',
+            'tags': ['Neon Genesis Evangelion', 'Touhou Project', 'Fly me to the Moon', 'Marisad', 'Marisa Kirisame', 'video', 'sound', 'Marisa', 'Anime'],
             'uploader': 'g11st',
             'uploader_id': 394718,
             'upload_timestamp': 1671590240,
             'upload_date': '20221221',
             'like_count': int,
             'dislike_count': int,
+            'age_limit': 0,
             'thumbnail': r're:^https://thumb\.pr0gramm\.com/.*\.jpg',
         },
     }, {
+        # Tags require account
         'url': 'https://pr0gramm.com/new/3052805:comment28391322',
         'info_dict': {
             'id': '3052805',
             'ext': 'mp4',
             'title': 'pr0gramm-3052805 by Hansking1',
+            'tags': 'count:15',
             'uploader': 'Hansking1',
             'uploader_id': 385563,
             'upload_timestamp': 1552930408,
             'upload_date': '20190318',
             'like_count': int,
             'dislike_count': int,
+            'age_limit': 0,
+            'thumbnail': r're:^https://thumb\.pr0gramm\.com/.*\.jpg',
+        },
+    }, {
+        # Requires verified account
+        'url': 'https://pr0gramm.com/new/Gianna%20Michaels/5848332',
+        'info_dict': {
+            'id': '5848332',
+            'ext': 'mp4',
+            'title': 'pr0gramm-5848332 by erd0pfel',
+            'tags': 'count:18',
+            'uploader': 'erd0pfel',
+            'uploader_id': 349094,
+            'upload_timestamp': 1694489652,
+            'upload_date': '20230912',
+            'like_count': int,
+            'dislike_count': int,
+            'age_limit': 18,
             'thumbnail': r're:^https://thumb\.pr0gramm\.com/.*\.jpg',
         },
     }, {

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -73,9 +73,6 @@ class Pr0grammIE(InfoExtractor):
     }]
 
     BASE_URL = 'https://pr0gramm.com'
-    API_URL = 'https://pr0gramm.com/api/items'
-    VIDEO_URL = 'https://img.pr0gramm.com'
-    THUMB_URL = 'https://thumb.pr0gramm.com'
 
     @functools.cached_property
     def _is_logged_in(self):
@@ -98,7 +95,7 @@ class Pr0grammIE(InfoExtractor):
         return flags
 
     def _call_api(self, endpoint, video_id, query={}, note='Downloading API json'):
-        data = self._download_json(f'{self.API_URL}/{endpoint}', video_id, query=query, note=note)
+        data = self._download_json(f'https://pr0gramm.com/api/items/{endpoint}', video_id, query=query, note=note)
         error = traverse_obj(data, ('error', {str}))
         if error:
             if error in ('nsfwRequired', 'nsflRequired', 'nsfpRequired'):
@@ -115,7 +112,7 @@ class Pr0grammIE(InfoExtractor):
             self._call_api('get', video_id, {'id': video_id, 'flags': self._maximum_flags}),
             ('items', 0, {dict}))
 
-        source = urljoin(self.VIDEO_URL, video_info.get('image'))
+        source = urljoin('https://img.pr0gramm.com', video_info.get('image'))
         if not source or not source.endswith('mp4'):
             self.raise_no_formats('Could not extract a video', expected=bool(source), video_id=video_id)
 
@@ -148,6 +145,6 @@ class Pr0grammIE(InfoExtractor):
                 'dislike_count': ('down', {int}),
                 'upload_timestamp': ('created', {int}),
                 'upload_date': ('created', {int}, {date.fromtimestamp}, {lambda x: x.strftime('%Y%m%d')}),
-                'thumbnail': ('thumb', {lambda x: urljoin(self.THUMB_URL, x)})
+                'thumbnail': ('thumb', {lambda x: urljoin('https://thumb.pr0gramm.com', x)})
             }),
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Rewrite the extractor to improve on some low quality code. We now use the API and therefore have proper handling for auth-only media (using cookies).


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5cac6ce</samp>

### Summary
🗑️🛠️🧪

<!--
1.  🗑️ for removing the unused import of `Pr0grammStaticIE`.
2.  🛠️ for updating and improving the `Pr0grammIE` extractor.
3.  🧪 for adding more tests and URL support.
-->
This pull request refactors and improves the `Pr0grammIE` extractor for the pr0gramm.com website. It adds support for more URL formats and metadata fields, and updates the tests accordingly. It also removes an unused import from `._extractors.py`.

> _`Pr0grammIE` grows_
> _More URLs and data_
> _Import no longer_

### Walkthrough
*  Refactor and improve `Pr0grammIE` extractor by adding support for more URL formats, fetching more metadata, handling errors and flags, and removing the dependency on `Pr0grammStaticIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8151/files?diff=unified&w=0#diff-308fe09d0ad5be634e4df70963625b2cff808c98f9aed58711947ac2d105879bL1-R14), [link](https://github.com/yt-dlp/yt-dlp/pull/8151/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1522-R1522))
* Update and add tests for `Pr0grammIE` extractor to increase coverage and accuracy, and to ensure compatibility with different URL formats and metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/8151/files?diff=unified&w=0#diff-308fe09d0ad5be634e4df70963625b2cff808c98f9aed58711947ac2d105879bL19-R130))



</details>
