### PR TITLE
Added two hooks before and after fragment download

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -121,12 +121,21 @@ class FragmentFD(FileDownloader):
             frag_resume_len = self.filesize_or_none(self.temp_name(fragment_filename))
         fragment_info_dict['frag_resume_len'] = ctx['frag_resume_len'] = frag_resume_len
 
+        execute_before_frag_dl = info_dict.get('_fragment_hook_before_dl')
+        if execute_before_frag_dl is not None and callable(execute_before_frag_dl):
+            execute_before_frag_dl(fragment_filename, fragment_info_dict, ctx)
+
         success, _ = ctx['dl'].download(fragment_filename, fragment_info_dict)
         if not success:
             return False
         if fragment_info_dict.get('filetime'):
             ctx['fragment_filetime'] = fragment_info_dict.get('filetime')
         ctx['fragment_filename_sanitized'] = fragment_filename
+
+        execute_after_frag_dl = info_dict.get('_fragment_hook_after_dl')
+        if execute_after_frag_dl is not None and callable(execute_after_frag_dl):
+            execute_after_frag_dl(fragment_filename, fragment_info_dict, ctx)
+
         return True
 
     def _read_fragment(self, ctx):

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -389,6 +389,16 @@ class InfoExtractor:
                     extracted will not be available to output template and
                     match_filter. So, only "comments" and "comment_count" are
                     currently allowed to be extracted via this method.
+    _fragment_hook_before_dl: A function to be called just before fragment is
+                    downloaded. It should take three positional arguments:
+                    'fragment_filename', 'fragment_info_dict' and 'ctx'.
+                    This is useful for special sites that need to change
+                    access cookies on every fragment/every few seconds.
+    _fragment_hook_after_dl: A function to be called right after fragment is
+                    downloaded. It should take three positional arguments:
+                    'fragment_filename', 'fragment_info_dict' and 'ctx'.
+                    This is useful for special sites that need to change
+                    access cookies on every fragment/every few seconds.
 
     The following fields should only be used when the video belongs to some logical
     chapter or section:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Added two hooks that are provided via info_dict from extractor under keys '_fragment_hook_before_dl' and '_fragment_hook_after_dl' that run before and after each fragment is downloaded. This is useful for [Arnes extractor](https://github.com/yt-dlp/yt-dlp/pull/8177) because it needs to update video_access_cookie every 10 seconds whilst downloading fragments. I also talked about this to Grub4K on discord->yt-dlp->yt-dlp-developers.

Here is a description of the two hooks:
```
_fragment_hook_before_dl: A function to be called just before fragment is
                    downloaded. It should take three positional arguments:
                    'fragment_filename', 'fragment_info_dict' and 'ctx'.
                    This is useful for special sites that need to change
                    access cookies on every fragment/every few seconds.
_fragment_hook_after_dl: A function to be called right after fragment is
                downloaded. It should take three positional arguments:
                'fragment_filename', 'fragment_info_dict' and 'ctx'.
                This is useful for special sites that need to change
                access cookies on every fragment/every few seconds.
```


Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

copilot:all

</details>
