### PR TITLE
[extractor/neteasemusic] Fix broken extractor

### DIFF
--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -9,7 +9,6 @@ from .common import InfoExtractor
 from ..aes import aes_ecb_encrypt, pkcs7_padding
 from ..utils import (
     ExtractorError,
-    clean_html,
     int_or_none,
     str_or_none,
     strftime_or_none,

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -57,15 +57,13 @@ class NetEaseMusicBaseIE(InfoExtractor):
                 'MUSIC_U': ('MUSIC_U', {lambda i: i.value}),
             })
         }
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Referer': 'https://music.163.com',
-            'Cookie': '; '.join([f'{k}={v}' for k, v in cookies.items()]),
-            **headers,
-        }
-        url = urljoin('https://interface3.music.163.com/', f'/eapi{path}')
-        data = self._create_eapi_cipher(f'/api{path}', query_body, cookies)
-        return self._download_json(url, video_id, data=data, headers=headers, **kwargs)
+        return self._download_json(
+            urljoin('https://interface3.music.163.com/', f'/eapi{path}'), video_id,
+            data=self._create_eapi_cipher(f'/api{path}', query_body, cookies), headers={
+                'Referer': 'https://music.163.com',
+                'Cookie': '; '.join([f'{k}={v}' for k, v in cookies.items()]),
+                **headers,
+            }, **kwargs)
 
     def _call_player_api(self, song_id, bitrate):
         return self._download_eapi_json(

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -582,7 +582,9 @@ class NetEaseMusicDjRadioIE(NetEaseMusicBaseIE):
                 f'dj/program/byradio?asc=false&limit={self._PAGE_SIZE}&radioId={dj_id}&offset={offset}',
                 dj_id, note=f'Downloading dj programs - {offset}')
 
-            entries.extend(self._get_entries(info, 'programs'))
+            entries.extend(self.url_result(
+                f'http://music.163.com/#/program?id={program["id"]}', NetEaseMusicProgramIE,
+                program['id'], program.get('name')) for program in info['programs'])
             if not metainfo:
                 metainfo = traverse_obj(info, ('programs', 0, 'radio', {
                     'title': ('name', {str}),

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -137,7 +137,7 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             'timestamp': 1522944000,
             'upload_date': '20180405',
             'description': 'md5:3650af9ee22c87e8637cb2dde22a765c',
-            'subtitles': {'lyric': [{'ext': 'lrc'}]},
+            'subtitles': {'lyrics': [{'ext': 'lrc'}]},
             "duration": 256,
             'thumbnail': r're:^http.*\.jpg',
         },
@@ -165,7 +165,7 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             'upload_date': '19911130',
             'timestamp': 691516800,
             'description': 'md5:1ba2f911a2b0aa398479f595224f2141',
-            'subtitles': {'lyric': [{'ext': 'lrc'}]},
+            'subtitles': {'lyrics': [{'ext': 'lrc'}]},
             'duration': 268,
             'alt_title': '伴唱:现代人乐队 合唱:总政歌舞团',
             'thumbnail': r're:^http.*\.jpg',
@@ -181,7 +181,7 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             'upload_date': '20150516',
             'timestamp': 1431792000,
             'description': 'md5:21535156efb73d6d1c355f95616e285a',
-            'subtitles': {'lyric': [{'ext': 'lrc'}]},
+            'subtitles': {'lyrics': [{'ext': 'lrc'}]},
             'duration': 199,
             'thumbnail': r're:^http.*\.jpg',
         },
@@ -196,8 +196,8 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             'creator': '少女时代',
             'upload_date': '20100127',
             'timestamp': 1264608000,
-            'description': 'md5:79d99cc560e4ca97e0c4d86800ee4184',
-            'subtitles': {'lyric': [{'ext': 'lrc'}]},
+            'description': 'md5:03d1ffebec3139aa4bafe302369269c5',
+            'subtitles': {'lyrics': [{'ext': 'lrc'}]},
             'duration': 229,
             'alt_title': '说出愿望吧(Genie)',
             'thumbnail': r're:^http.*\.jpg',
@@ -246,7 +246,7 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
         lyrics = self._process_lyrics(self.query_api(
             f'song/lyric?id={song_id}&lv=-1&tv=-1', song_id, 'Downloading lyrics data'))
         lyric_data = {
-            'description': lyrics['lyrics']['data'],
+            'description': lyrics['lyrics'][0]['data'],
             'subtitles': lyrics,
         } if lyrics else {}
 

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -215,7 +215,6 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
         if not translated:
             return {
                 'lyrics': [{'data': original, 'ext': 'lrc'}],
-                'lyrics_original': [{'data': original, 'ext': 'lrc'}],
             }
 
         lyrics_expr = r'(\[[0-9]{2}:[0-9]{2}\.[0-9]{2,}\])([^\n]+)'
@@ -227,8 +226,8 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             for timestamp, text in original_ts_texts)
 
         return {
-            'lyrics': [{'data': merged, 'ext': 'lrc'}],
-            'lyrics_original': [{'data': original, 'ext': 'lrc'}],
+            'lyrics_merged': [{'data': merged, 'ext': 'lrc'}],
+            'lyrics': [{'data': original, 'ext': 'lrc'}],
             'lyrics_translated': [{'data': translated, 'ext': 'lrc'}],
         }
 
@@ -243,7 +242,7 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
         lyrics = self._process_lyrics(self.query_api(
             f'song/lyric?id={song_id}&lv=-1&tv=-1', song_id, 'Downloading lyrics data'))
         lyric_data = {
-            'description': lyrics['lyrics'][0]['data'],
+            'description': traverse_obj(lyrics, (('lyrics_merged', 'lyrics'), 0, 'data'), get_all=False),
             'subtitles': lyrics,
         } if lyrics else {}
 

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -341,12 +341,10 @@ class NetEaseMusicSingerIE(NetEaseMusicBaseIE):
         info = self.query_api(
             f'artist/{singer_id}?id={singer_id}', singer_id, note='Downloading singer data')
 
-        name_and_aliases = traverse_obj(info, (
-            'artist', ('name', 'trans', ('alias', ...)), {str}, {lambda i: i or None}))
-        if len(name_and_aliases) > 1:
-            name = f'{name_and_aliases[0]} - {";".join(name_and_aliases[1:])}'
-        else:
-            name = traverse_obj(name_and_aliases, 0)
+        name = join_nonempty(
+            traverse_obj(info, ('artist', 'name', {str})),
+            ';'.join(traverse_obj(info, ('artist', ('trans', ('alias', ...)), {str}))),
+            delim=' - ')
 
         return self.playlist_result(self._get_entries(info, 'hotSongs'), singer_id, name)
 

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -23,6 +23,7 @@ from ..utils import (
 class NetEaseMusicBaseIE(InfoExtractor):
     _FORMATS = ['bMusic', 'mMusic', 'hMusic']
     _API_BASE = 'http://music.163.com/api/'
+    _GEO_BYPASS = False
 
     @staticmethod
     def kilo_or_none(value):
@@ -100,7 +101,8 @@ class NetEaseMusicBaseIE(InfoExtractor):
             if err != 0 and (err < 200 or err >= 400):
                 raise ExtractorError(f'No media links found (site code {err})', expected=True)
             else:
-                self.raise_geo_restricted('No media links found: probably due to geo restriction.')
+                self.raise_geo_restricted(
+                    'No media links found: probably due to geo restriction.', countries=['CN'])
         return formats
 
     def query_api(self, endpoint, video_id, note):

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -14,14 +14,14 @@ from ..networking import Request
 from ..utils import (
     ExtractorError,
     bytes_to_intlist,
-    strftime_or_none,
     float_or_none,
     int_or_none,
-    str_or_none,
-    traverse_obj,
     intlist_to_bytes,
-    urljoin,
+    str_or_none,
+    strftime_or_none,
+    traverse_obj,
     try_get,
+    urljoin,
 )
 
 

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -10,6 +10,7 @@ from ..aes import aes_ecb_encrypt, pkcs7_padding
 from ..utils import (
     ExtractorError,
     int_or_none,
+    join_nonempty,
     str_or_none,
     strftime_or_none,
     traverse_obj,
@@ -343,7 +344,7 @@ class NetEaseMusicSingerIE(NetEaseMusicBaseIE):
 
         name = join_nonempty(
             traverse_obj(info, ('artist', 'name', {str})),
-            ';'.join(traverse_obj(info, ('artist', ('trans', ('alias', ...)), {str}))),
+            join_nonempty(*traverse_obj(info, ('artist', ('trans', ('alias', ...)), {str})), delim=';'),
             delim=' - ')
 
         return self.playlist_result(self._get_entries(info, 'hotSongs'), singer_id, name)

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -339,7 +339,7 @@ class NetEaseMusicSingerIE(NetEaseMusicBaseIE):
         if len(name_and_aliases) > 1:
             name = f'{name_and_aliases[0]} - {";".join(name_and_aliases[1:])}'
         else:
-            name = name_and_aliases[0]
+            name = traverse_obj(name_and_aliases, 0)
 
         entries = [
             self.url_result('http://music.163.com/#/song?id=%s' % song['id'],

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -287,9 +287,9 @@ class NetEaseMusicAlbumIE(NetEaseMusicBaseIE):
             end_pattern=r'</textarea>', contains_pattern=r'\[(?s:.+)\]')
         metainfo = {
             'title': self._og_search_property('title', webpage, 'title', fatal=False),
-            'description': clean_html(self._search_regex(
-                r'(?:<div id="album-desc-dot".*)?<div id="album-desc-(?:dot|more)"[^>]*>(.*?)</div>', webpage,
-                'description', flags=re.S, fatal=False)),  # match album-desc-more or fallback to album-desc-dot
+            'description': self._html_search_regex(
+                (f'<div[^>]+\\bid="album-desc-{i}"[^>]*>(.*?)</div>' for i in ['more', 'dot']),
+                webpage, 'description', flags=re.S, fatal=False),
             'thumbnail': self._og_search_property('image', webpage, 'thumbnail', fatal=False),
             'upload_date': unified_strdate(self._html_search_meta('music:release_date', webpage, 'date', fatal=False)),
         }

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -14,7 +14,6 @@ from ..utils import (
     str_or_none,
     strftime_or_none,
     traverse_obj,
-    try_get,
     unified_strdate,
     url_or_none,
     urljoin,
@@ -24,6 +23,10 @@ from ..utils import (
 class NetEaseMusicBaseIE(InfoExtractor):
     _FORMATS = ['bMusic', 'mMusic', 'hMusic']
     _API_BASE = 'http://music.163.com/api/'
+
+    @staticmethod
+    def kilo_or_none(value):
+        return int_or_none(value, scale=1000)
 
     def _create_eapi_cipher(self, api_path, query_body, cookies):
         request_text = json.dumps({**query_body, 'header': cookies}, separators=(',', ':'))
@@ -86,7 +89,7 @@ class NetEaseMusicBaseIE(InfoExtractor):
                         'asr': traverse_obj(details, ('sr', {int_or_none})),
                         **traverse_obj(song, {
                             'ext': ('type', {str}),
-                            'abr': ('br', {kilo_or_none}),
+                            'abr': ('br', {self.kilo_or_none}),
                             'filesize': ('size', {int_or_none}),
                         }),
                     })
@@ -242,9 +245,9 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             **lyric_data,
             **traverse_obj(info, {
                 'title': ('name', {str}),
-                'timestamp': ('album', 'publishTime', {kilo_or_none}),
+                'timestamp': ('album', 'publishTime', {self.kilo_or_none}),
                 'thumbnail': ('album', 'picUrl', {url_or_none}),
-                'duration': ('duration', {kilo_or_none}),
+                'duration': ('duration', {self.kilo_or_none}),
             }),
         }
 
@@ -406,7 +409,7 @@ class NetEaseMusicListIE(NetEaseMusicBaseIE):
             'tags': ('tags', ..., {str}),
             'uploader': ('creator', 'nickname', {str}),
             'uploader_id': ('creator', 'userId', {str_or_none}),
-            'timestamp': ('updateTime', {kilo_or_none}),
+            'timestamp': ('updateTime', {self.kilo_or_none}),
         }))
         if traverse_obj(info, ('playlist', 'specialType')) == 10:
             meta['title'] = f'{meta.get("title")} {strftime_or_none(meta.get("timestamp"), "%Y-%m-%d")}'
@@ -473,7 +476,7 @@ class NetEaseMusicMvIE(NetEaseMusicBaseIE):
                 'creator': ('artistName', {str}),
                 'upload_date': ('publishTime', {unified_strdate}),
                 'thumbnail': ('cover', {url_or_none}),
-                'duration': ('duration', {kilo_or_none}),
+                'duration': ('duration', {self.kilo_or_none}),
                 'view_count': ('playCount', {int_or_none}),
                 'like_count': ('likeCount', {int_or_none}),
                 'comment_count': ('commentCount', {int_or_none}),
@@ -541,7 +544,7 @@ class NetEaseMusicProgramIE(NetEaseMusicBaseIE):
             'description': ('description', {str}),
             'creator': ('dj', 'brand', {str}),
             'thumbnail': ('coverUrl', {url_or_none}),
-            'timestamp': ('createTime', {kilo_or_none}),
+            'timestamp': ('createTime', {self.kilo_or_none}),
         })
 
         if not self._yes_playlist(info['songs'] and program_id, info['mainSong']['id']):
@@ -550,7 +553,7 @@ class NetEaseMusicProgramIE(NetEaseMusicBaseIE):
             return {
                 'id': str(info['mainSong']['id']),
                 'formats': formats,
-                'duration': traverse_obj(info, ('mainSong', 'duration', {kilo_or_none})),
+                'duration': traverse_obj(info, ('mainSong', 'duration', {self.kilo_or_none})),
                 **metainfo,
             }
 

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -115,12 +115,14 @@ class NetEaseMusicBaseIE(InfoExtractor):
             raise ExtractorError(f'Failed to get meta info: {code} {message}')
         return result
 
-    def _get_entries(self, songs_data, entry_keys=None, id_key='id', name_key='name', ie='NetEaseMusic'):
-        for song in traverse_obj(songs_data, (*variadic(entry_keys, (str, bytes, dict, set)), ...)):
-            song_id = traverse_obj(song, (id_key, {int_or_none}))
-            song_name = traverse_obj(song, (name_key, {str})) if name_key else None
-            if song_id:
-                yield self.url_result(f'http://music.163.com/#/song?id={song_id}', ie, str(song_id), song_name)
+    def _get_entries(self, songs_data, entry_keys=None, id_key='id', name_key='name'):
+        for song in traverse_obj(songs_data, (
+                *variadic(entry_keys, (str, bytes, dict, set)),
+                lambda _, v: int_or_none(v[id_key]) is not None)):
+            song_id = str(song[id_key])
+            yield self.url_result(
+                f'http://music.163.com/#/song?id={song_id}', NetEaseMusicIE,
+                song_id, traverse_obj(song, (name_key, {str})))
 
 
 class NetEaseMusicIE(NetEaseMusicBaseIE):

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -49,6 +49,9 @@ class NetEaseMusicBaseIE(InfoExtractor):
             'os': 'pc',
             'channel': 'undefined',
             'requestId': f'{int(time.time() * 1000)}_{randint(0, 1000):04}',
+            **traverse_obj(self._get_cookies(self._API_BASE), {
+                'MUSIC_U': ('MUSIC_U', {lambda i: i.value}),
+            })
         }
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded',
@@ -195,10 +198,10 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
         original = traverse_obj(lyrics_info, ('lrc', 'lyric', {str}))
         translated = traverse_obj(lyrics_info, ('tlyric', 'lyric', {str}))
 
-        if original.strip() == '[99:00.00]纯音乐，请欣赏':
+        if not original or original == '[99:00.00]纯音乐，请欣赏\n':
             return None
 
-        if not translated or not original:
+        if not translated:
             return original
 
         lyrics_expr = r'(\[[0-9]{2}:[0-9]{2}\.[0-9]{2,}\])([^\n]+)'

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -222,11 +222,10 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
         original_ts_texts = re.findall(lyrics_expr, original)
         translation_ts_dict = dict(re.findall(lyrics_expr, translated))
 
-        for i in range(len(original_ts_texts)):
-            timestamp, text = original_ts_texts[i]
-            if translation_ts_dict.get(timestamp):
-                original_ts_texts[i] = timestamp, f'{text} / {translation_ts_dict[timestamp]}'
-        merged = '\n'.join(map(''.join, original_ts_texts))
+        merged = '\n'.join(
+            join_nonempty(f'{timestamp}{text}', translation_ts_dict.get(timestamp, ''), delim=' / ')
+            for timestamp, text in original_ts_texts)
+
         return {
             'lyrics': [{'data': merged, 'ext': 'lrc'}],
             'lyrics_original': [{'data': original, 'ext': 'lrc'}],


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #4388

Fix broken extractors and re-write some of the exsiting lines with better traversal.

Remove unused `NetEaseMusicBaseIE._encrypt()`


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1a7ad74</samp>

### Summary
🎵🛠️🧪

<!--
1.  🎵 for updating the music extractors and adding more metadata fields.
2.  🛠️ for fixing errors and typos, and removing unused or redundant code.
3.  🧪 for updating the test cases.
-->
Improve NetEase Music extractors by using new API, adding metadata, and fixing bugs.

> _Sing, O Muse, of the skillful coder who updated_
> _The NetEase Music extractors, `eapi` endpoints using_
> _And adding more fields of metadata, rich and splendid_
> _As the golden apples of the Hesperides, shining._

### Walkthrough
*  Refactor and update the methods for downloading JSON data from the EAPI and the old API endpoints, and add error handling and login requirements ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL43-R61), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL59-R88), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL151-R141), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL366-R432))
*  Use the `traverse_obj` function to simplify and standardize the extraction of metadata fields from the JSON responses ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL417-R496), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL390-R454), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL366-R432))
*  Remove an unused import of `datetime` module ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL7))
*  Add some missing imports of utility functions ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL18-R27))
*  Convert the program ID to a string to fix a type error in the `url_result` method ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL485-R559))
*  Update the test cases for the `NetEaseMusicIE`, `NetEaseMusicAlbumIE`, `NetEaseMusicSingerIE`, `NetEaseMusicDjRadioIE`, `NetEaseMusicListIE`, `NetEaseMusicMvIE`, and `NetEaseMusicProgramIE` classes to use new URLs and info dicts, and add some missing fields to the info dicts ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL159-R159), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL179-R204), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL190-R219), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL266-R321), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL302-R335), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL314), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL347-R399), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL390-R454), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL397-R469), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL434-R516), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL449-R542), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL514-R590))
*  Fix some typos and errors in the test cases ([link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL266-R321), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL397-R469), [link](https://github.com/yt-dlp/yt-dlp/pull/8181/files?diff=unified&w=0#diff-ef518849a6d7b0f3923c20058cda5da3f6931526cf36aadce1eda0f4e7620f5cL449-R542))



</details>
