### PR TITLE
[WIP] [ie/lbry] playlist support, fix #5982

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -951,6 +951,7 @@ from .lastfm import (
 from .lbry import (
     LBRYIE,
     LBRYChannelIE,
+    LBRYPlaylistIE,
 )
 from .lci import LCIIE
 from .lcp import (

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -80,7 +80,7 @@ class LBRYBaseIE(InfoExtractor):
 
 class LBRYIE(LBRYBaseIE):
     IE_NAME = 'lbry'
-    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + r'(?P<id>\$/[^/]+/[^/]+/{1}|@{0}/{0}|(?!@){0})'.format(LBRYBaseIE._OPT_CLAIM_ID, LBRYBaseIE._CLAIM_ID_REGEX)
+    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + r'(?P<id>\$/(?!playlist)[^/]+/[^/]+/{1}|@{0}/{0}|(?!@|\$){0})'.format(LBRYBaseIE._OPT_CLAIM_ID, LBRYBaseIE._CLAIM_ID_REGEX)
     _TESTS = [{
         # Video
         'url': 'https://lbry.tv/@Mantega:1/First-day-LBRY:1',

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -348,21 +348,16 @@ class LBRYChannelIE(LBRYBaseIE):
                 'url': self._permanent_url(url, stream_claim_name, stream_claim_id),
             }
 
-    def _fetch_playlist_items(self, claim_id):
-        page_params = {
-            'claim_ids': [claim_id],
-            'no_totals': True,
-            'page': 1,
-            'page_size': self._PAGE_SIZE,
-        }
-        return self._call_api_proxy('claim_search', claim_id, page_params, 'playlist')
-
     def _real_extract(self, url):
         playlist_id = self._match_valid_url(url).group('id2')
         if playlist_id:
             is_playlist = True
-            r = self._fetch_playlist_items(playlist_id)
-            result = r.get('items', [])[0]
+            result = traverse_obj(self._call_api_proxy('claim_search', playlist_id, {
+                'claim_ids': [playlist_id],
+                'no_totals': True,
+                'page': 1,
+                'page_size': self._PAGE_SIZE,
+            }, 'playlist'), ('items', 0))
             claim_ids = result.get('value', {}).get('claims', [])
         else:
             is_playlist = False

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -84,18 +84,16 @@ class LBRYBaseIE(InfoExtractor):
             'no_totals': True,
             'page': page,
             'page_size': self._PAGE_SIZE,
+            **params,
         }
-        page_params.update(params)
         result = self._call_api_proxy(
             'claim_search', display_id, page_params, f'page {page}')
         for item in traverse_obj(result, ('items', lambda _, v: v['name'] and v['claim_id'])):
-            stream_claim_id = item['claim_id']
-
             yield {
                 **self._parse_stream(item, url),
                 '_type': 'url',
-                'id': stream_claim_id,
-                'url': self._permanent_url(url, item['name'], stream_claim_id),
+                'id': item['claim_id'],
+                'url': self._permanent_url(url, item['name'], item['claim_id']),
             }
 
     def _playlist_entries(self, url, display_id, claim_param, metadata):

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -334,7 +334,7 @@ class LBRYChannelIE(LBRYBaseIE):
         }
         page_params.update(params)
         result = self._call_api_proxy(
-            'claim_search', claim_ids, page_params, 'page %d' % page)
+            'claim_search', claim_ids, page_params, f'page {page}')
         for item in (result.get('items') or []):
             stream_claim_name = item.get('name')
             stream_claim_id = item.get('claim_id')

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -358,7 +358,8 @@ class LBRYChannelIE(LBRYBaseIE):
         return self._call_api_proxy('claim_search', claim_id, page_params, 'playlist')
 
     def _real_extract(self, url):
-        if playlist_id := self._match_valid_url(url).group('id2'):
+        playlist_id = self._match_valid_url(url).group('id2')
+        if playlist_id:
             is_playlist = True
             r = self._fetch_playlist_items(playlist_id)
             result = r.get('items', [])[0]

--- a/yt_dlp/extractor/lbry.py
+++ b/yt_dlp/extractor/lbry.py
@@ -22,10 +22,11 @@ from ..utils import (
 
 
 class LBRYBaseIE(InfoExtractor):
-    _BASE_URL_REGEX = r'(?:https?://(?:www\.)?(?:lbry\.tv|odysee\.com)/|lbry://)'
+    _BASE_URL_REGEX = r'(?x)(?:https?://(?:www\.)?(?:lbry\.tv|odysee\.com)/|lbry://)'
     _CLAIM_ID_REGEX = r'[0-9a-f]{1,40}'
-    _OPT_CLAIM_ID = '[^:/?#&]+(?:[:#]%s)?' % _CLAIM_ID_REGEX
+    _OPT_CLAIM_ID = '[^$@:/?#&]+(?:[:#]%s)?' % _CLAIM_ID_REGEX
     _SUPPORTED_STREAM_TYPES = ['video', 'audio']
+    _PAGE_SIZE = 50
 
     def _call_api_proxy(self, method, display_id, params, resource):
         headers = {'Content-Type': 'application/json-rpc'}
@@ -77,10 +78,72 @@ class LBRYBaseIE(InfoExtractor):
 
         return info
 
+    def _fetch_page(self, display_id, url, params, page):
+        page += 1
+        page_params = {
+            'no_totals': True,
+            'page': page,
+            'page_size': self._PAGE_SIZE,
+        }
+        page_params.update(params)
+        result = self._call_api_proxy(
+            'claim_search', display_id, page_params, f'page {page}')
+        for item in traverse_obj(result, ('items', lambda _, v: v['name'] and v['claim_id'])):
+            stream_claim_id = item['claim_id']
+
+            yield {
+                **self._parse_stream(item, url),
+                '_type': 'url',
+                'id': stream_claim_id,
+                'url': self._permanent_url(url, item['name'], stream_claim_id),
+            }
+
+    def _playlist_entries(self, url, display_id, claim_param, metadata):
+        qs = parse_qs(url)
+        content = qs.get('content', [None])[0]
+        params = {
+            'fee_amount': qs.get('fee_amount', ['>=0'])[0],
+            'order_by': {
+                'new': ['release_time'],
+                'top': ['effective_amount'],
+                'trending': ['trending_group', 'trending_mixed'],
+            }[qs.get('order', ['new'])[0]],
+            'claim_type': 'stream',
+            'stream_types': [content] if content in ['audio', 'video'] else self._SUPPORTED_STREAM_TYPES,
+            **claim_param,
+        }
+        duration = qs.get('duration', [None])[0]
+        if duration:
+            params['duration'] = {
+                'long': '>=1200',
+                'short': '<=240',
+            }[duration]
+        language = qs.get('language', ['all'])[0]
+        if language != 'all':
+            languages = [language]
+            if language == 'en':
+                languages.append('none')
+            params['any_languages'] = languages
+
+        entries = OnDemandPagedList(
+            functools.partial(self._fetch_page, display_id, url, params),
+            self._PAGE_SIZE)
+
+        return self.playlist_result(
+            entries, display_id, **traverse_obj(metadata, ('value', {
+                'title': 'title',
+                'description': 'description',
+            })))
+
 
 class LBRYIE(LBRYBaseIE):
     IE_NAME = 'lbry'
-    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + r'(?P<id>\$/(?!playlist)[^/]+/[^/]+/{1}|@{0}/{0}|(?!@|\$){0})'.format(LBRYBaseIE._OPT_CLAIM_ID, LBRYBaseIE._CLAIM_ID_REGEX)
+    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + rf'''
+        (?:\$/(?:download|embed)/)?
+        (?P<id>
+            [^$@:/?#]+/{LBRYBaseIE._CLAIM_ID_REGEX}
+            |(?:@{LBRYBaseIE._OPT_CLAIM_ID}/)?{LBRYBaseIE._OPT_CLAIM_ID}
+        )'''
     _TESTS = [{
         # Video
         'url': 'https://lbry.tv/@Mantega:1/First-day-LBRY:1',
@@ -149,7 +212,7 @@ class LBRYIE(LBRYBaseIE):
             'channel': 'Gardening In Canada',
             'channel_id': 'b8be0e93b423dad221abe29545fbe8ec36e806bc',
             'channel_url': 'https://odysee.com/@gardeningincanada:b8be0e93b423dad221abe29545fbe8ec36e806bc',
-            'formats': 'mincount:3',
+            'formats': 'mincount:3',  # FIXME
             'thumbnail': 'https://thumbnails.lbry.com/AgHSc_HzrrE',
             'license': 'Copyrighted (contact publisher)',
         }
@@ -184,12 +247,12 @@ class LBRYIE(LBRYBaseIE):
             'id': '41fbfe805eb73c8d3012c0c49faa0f563274f634',
             'ext': 'mp4',
             'title': 'Biotechnological Invasion of Skin (April 2023)',
-            'description': 'md5:709a2f4c07bd8891cda3a7cc2d6fcf5c',
+            'description': 'md5:fe28689db2cb7ba3436d819ac3ffc378',
             'channel': 'Wicked Truths',
             'channel_id': '23d2bbf856b0ceed5b1d7c5960bcc72da5a20cb0',
             'channel_url': 'https://odysee.com/@wickedtruths:23d2bbf856b0ceed5b1d7c5960bcc72da5a20cb0',
-            'timestamp': 1685790036,
-            'upload_date': '20230603',
+            'timestamp': 1695114347,
+            'upload_date': '20230919',
             'release_timestamp': 1685617473,
             'release_date': '20230601',
             'duration': 1063,
@@ -229,10 +292,10 @@ class LBRYIE(LBRYBaseIE):
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
-        if display_id.startswith('$/'):
-            display_id = display_id.split('/', 2)[-1].replace('/', ':')
-        else:
+        if display_id.startswith('@'):
             display_id = display_id.replace(':', '#')
+        else:
+            display_id = display_id.replace('/', ':')
         display_id = urllib.parse.unquote(display_id)
         uri = 'lbry://' + display_id
         result = self._resolve_url(uri, display_id, 'stream')
@@ -299,7 +362,7 @@ class LBRYIE(LBRYBaseIE):
 
 class LBRYChannelIE(LBRYBaseIE):
     IE_NAME = 'lbry:channel'
-    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + r'(?:(?P<id>@%s)|\$/playlist/(?P<id2>[0-9a-f]+))/?(?:[?&]|$)' % LBRYBaseIE._OPT_CLAIM_ID
+    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + rf'(?P<id>@{LBRYBaseIE._OPT_CLAIM_ID})/?(?:[?&]|$)'
     _TESTS = [{
         'url': 'https://lbry.tv/@LBRYFoundation:0',
         'info_dict': {
@@ -309,92 +372,56 @@ class LBRYChannelIE(LBRYBaseIE):
         },
         'playlist_mincount': 29,
     }, {
-        'url': 'https://odysee.com/$/playlist/ffef782f27486f0ac138bde8777f72ebdd0548c2',
-        'info_dict': {
-            "id": "7f614a383d0663da1ade80d2962e91e94d1d91b6",
-            "title": "Théâtre Classique",
-            "description": "Théâtre Classique",
-            "_type": "playlist",
-        }
-    }, {
         'url': 'https://lbry.tv/@LBRYFoundation',
         'only_matching': True,
     }, {
         'url': 'lbry://@lbry#3f',
         'only_matching': True,
     }]
-    _PAGE_SIZE = 50
-
-    def _fetch_page(self, claim_ids, url, params, page):
-        page += 1
-        page_params = {
-            'no_totals': True,
-            'page': page,
-            'page_size': self._PAGE_SIZE,
-        }
-        page_params.update(params)
-        result = self._call_api_proxy(
-            'claim_search', claim_ids, page_params, f'page {page}')
-        for item in (result.get('items') or []):
-            stream_claim_name = item.get('name')
-            stream_claim_id = item.get('claim_id')
-            if not (stream_claim_name and stream_claim_id):
-                continue
-
-            yield {
-                **self._parse_stream(item, url),
-                '_type': 'url',
-                'id': stream_claim_id,
-                'url': self._permanent_url(url, stream_claim_name, stream_claim_id),
-            }
 
     def _real_extract(self, url):
-        playlist_id = self._match_valid_url(url).group('id2')
-        if playlist_id:
-            is_playlist = True
-            result = traverse_obj(self._call_api_proxy('claim_search', playlist_id, {
-                'claim_ids': [playlist_id],
-                'no_totals': True,
-                'page': 1,
-                'page_size': self._PAGE_SIZE,
-            }, 'playlist'), ('items', 0))
-            claim_ids = result.get('value', {}).get('claims', [])
-        else:
-            is_playlist = False
-            display_id = self._match_id(url).replace(':', '#')
-            result = self._resolve_url(
-                'lbry://' + display_id, display_id, 'channel')
-            claim_ids = [result['claim_id']]
-        qs = parse_qs(url)
-        content = qs.get('content', [None])[0]
-        params = {
-            'fee_amount': qs.get('fee_amount', ['>=0'])[0],
-            'order_by': {
-                'new': ['release_time'],
-                'top': ['effective_amount'],
-                'trending': ['trending_group', 'trending_mixed'],
-            }[qs.get('order', ['new'])[0]],
-            'claim_type': 'stream',
-            'claim_ids' if is_playlist else 'channel_ids': claim_ids,
-            'stream_types': [content] if content in ['audio', 'video'] else self._SUPPORTED_STREAM_TYPES,
-        }
-        duration = qs.get('duration', [None])[0]
-        if duration:
-            params['duration'] = {
-                'long': '>=1200',
-                'short': '<=240',
-            }[duration]
-        language = qs.get('language', ['all'])[0]
-        if language != 'all':
-            languages = [language]
-            if language == 'en':
-                languages.append('none')
-            params['any_languages'] = languages
+        display_id = self._match_id(url).replace(':', '#')
+        result = self._resolve_url(f'lbry://{display_id}', display_id, 'channel')
+        claim_id = result['claim_id']
 
-        entries = OnDemandPagedList(
-            functools.partial(self._fetch_page, claim_ids, url, params),
-            self._PAGE_SIZE)
-        result_value = result.get('value') or {}
-        return self.playlist_result(
-            entries, claim_ids[0], result_value.get('title'),
-            result_value.get('description'))
+        return self._playlist_entries(url, claim_id, {'channel_ids': [claim_id]}, result)
+
+
+class LBRYPlaylistIE(LBRYBaseIE):
+    IE_NAME = 'lbry:playlist'
+    _VALID_URL = LBRYBaseIE._BASE_URL_REGEX + r'\$/(?:play)?list/(?P<id>[0-9a-f-]+)'
+    _TESTS = [{
+        'url': 'https://odysee.com/$/playlist/ffef782f27486f0ac138bde8777f72ebdd0548c2',
+        'info_dict': {
+            'id': 'ffef782f27486f0ac138bde8777f72ebdd0548c2',
+            'title': 'Théâtre Classique',
+            'description': 'Théâtre Classique',
+        },
+        'playlist_mincount': 4,
+    }, {
+        'url': 'https://odysee.com/$/list/9c6658b3dd21e4f2a0602d523a13150e2b48b770',
+        'info_dict': {
+            'id': '9c6658b3dd21e4f2a0602d523a13150e2b48b770',
+            'title': 'Social Media Exposed',
+            'description': 'md5:98af97317aacd5b85d595775ea37d80e',
+        },
+        'playlist_mincount': 34,
+    }, {
+        'url': 'https://odysee.com/$/playlist/938fb11d-215f-4d1c-ad64-723954df2184',
+        'info_dict': {
+            'id': '938fb11d-215f-4d1c-ad64-723954df2184',
+        },
+        'playlist_mincount': 1000,
+    }]
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+        result = traverse_obj(self._call_api_proxy('claim_search', display_id, {
+            'claim_ids': [display_id],
+            'no_totals': True,
+            'page': 1,
+            'page_size': self._PAGE_SIZE,
+        }, 'playlist'), ('items', 0))
+        claim_param = {'claim_ids': traverse_obj(result, ('value', 'claims', ..., {str}))}
+
+        return self._playlist_entries(url, display_id, claim_param, result)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Playlist support for lbry/odysee

Fixes #5982, Fixes #8204

But (at least) **one problem remains**, `LBRYIE` makes use of the following regexp `(?P<id>\$/[^/]+/[^/]+/[0-9a-f]{1,40})`:
https://github.com/yt-dlp/yt-dlp/blob/c54ddfba0f7d68034339426223d75373c5fc86df/yt_dlp/extractor/lbry.py#L83

This catches playlist short URL (like `$/playlist/abcd`), take over and eventually reject URLs that `LBRYChannelIE` would now otherwise support. Negative-look-ahead fanatics welcomed to amend this.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd3fc54</samp>

### Summary
🆕🛠️🧪

<!--
1.  🆕 - This emoji conveys the idea of adding new features or functionality, such as improving the support for LBRY URLs and extracting playlists.
2.  🛠️ - This emoji conveys the idea of fixing or improving something, such as refactoring some methods and handling multiple claim IDs.
3.  🧪 - This emoji conveys the idea of testing or experimenting, such as adding a new test case for playlist extraction.
-->
Improved LBRY playlist and channel extraction. The `LBRYIE` and `LBRYChannelIE` classes can now handle various URL formats and multiple claim IDs. Added a test case and refactored some code in `lbry.py`.

> _We are the rebels of the web, we defy the central power_
> _We extract the playlists and the channels from the LBRY tower_
> _We support the different formats, we refactor and we test_
> _We are the masters of the `LBRYIE` and the `LBRYChannelIE`_

### Walkthrough
*  Modify `_VALID_URL` regex for `LBRYIE` class to support more types of LBRY URLs and simplify the pattern ([link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L83-R83))
*  Modify `_VALID_URL` regex for `LBRYChannelIE` class to support playlist URLs and add a new named group `id2` for playlist claim ID ([link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L302-R302))
*  Add a test case for `LBRYChannelIE` class to check playlist URL extraction in `yt_dlp/extractor/lbry.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8R312-R319))
*  Modify `_fetch_page` method of `LBRYChannelIE` class to accept a list of claim IDs instead of a single one and remove unnecessary parameters from `page_params` dictionary ([link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L320-R330), [link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L331-R337))
*  Modify `_real_extract` method of `LBRYChannelIE` class to handle both channel and playlist URLs and use different API parameters accordingly ([link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L345-R371), [link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8R381-R382), [link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L373-R403))
*  Add a new method `_fetch_playlist_items` to `LBRYChannelIE` class to retrieve playlist metadata and claim IDs from the API ([link](https://github.com/yt-dlp/yt-dlp/pull/8213/files?diff=unified&w=0#diff-64c082b4efe2e91db77dc41e4db23319ad4cef533ab0ac782a831a489c0eeba8L345-R371))



</details>
