### PR TITLE
[eltrecetv] Add new extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -565,6 +565,7 @@ from .ellentube import (
 )
 from .elonet import ElonetIE
 from .elpais import ElPaisIE
+from .eltrecetv import ElTreceTVIE
 from .embedly import EmbedlyIE
 from .engadget import EngadgetIE
 from .epicon import (

--- a/yt_dlp/extractor/eltrecetv.py
+++ b/yt_dlp/extractor/eltrecetv.py
@@ -6,6 +6,16 @@ class ElTreceTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?eltrecetv.com.ar/(?:[\w\-]+)/capitulos/temporada-(?:\d+)/(?P<id>[\w\-]+)/?'
     _TESTS = [
         {
+            'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-260923/',
+            'md5': '255436bcb48de9ef5cafda999acab437',
+            'info_dict': {
+                'id': 'AHCA25092023173459249708796',
+                'ext': 'mp4',
+                'title': 'AHORA CAIGO - Programa 26/09/23',
+                'thumbnail': 'https://thumbs.vodgc.net/AHCA25092023173459249708796.png?793338',
+            }
+        },
+        {
             'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-280823/',
             'md5': 'e0a2033e020f423c0e620ec8471b54f3',
             'info_dict': {
@@ -52,13 +62,22 @@ class ElTreceTVIE(InfoExtractor):
 
         title = config.get('title')
         thumbnail = config.get('thumbnail')
+        url = config.get('m3u8')
 
-        video_id = self._search_regex(r'/([A-Z0-9]+).jpg', thumbnail, 'video_id')
-        url = 'https://vod.vodgc.net/gid1/vod/Artear/Eltrece/75/%s_720P.mp4' % video_id
+        video_id = self._search_regex(r'/([A-Z0-9]+).(?:jpg|png)', thumbnail, 'video_id')
+
+        formats = self._extract_m3u8_formats(url, video_id, ext='mp4', entry_protocol='http')
+
+        for f in formats:
+            # Edit url if points to a segment playlist to point to actual video
+            f['url'] = f['url'].replace('/tracks-v1a1/index.m3u8', '')
+
+        # hide 1080p format because it's not really available
+        formats = [f for f in formats if f['height'] != 1080]
 
         return {
             'id': video_id,
             'title': title,
-            'url': url,
             'thumbnail': thumbnail,
+            'formats': formats,
         }

--- a/yt_dlp/extractor/eltrecetv.py
+++ b/yt_dlp/extractor/eltrecetv.py
@@ -3,37 +3,21 @@ from .common import InfoExtractor
 
 class ElTreceTVIE(InfoExtractor):
     IE_DESC = 'El Trece TV (Argentina)'
-    _VALID_URL = r'https?://(?:www\.)?eltrecetv.com.ar/(?:[\w\-]+)/capitulos/temporada-(?:\d+)/(?P<id>[\w\-]+)/?'
+    _VALID_URL = r'https?://(?:www\.)?eltrecetv\.com\.ar/[\w-]+/capitulos/temporada-\d+/(?P<id>[\w-]+)'
     _TESTS = [
         {
-            'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-260923/',
-            'md5': '255436bcb48de9ef5cafda999acab437',
+            'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-061023/',
+            'md5': '71a66673dc63f9a5939d97bfe4b311ba',
             'info_dict': {
-                'id': 'AHCA25092023173459249708796',
+                'id': 'AHCA05102023145553329621094',
                 'ext': 'mp4',
-                'title': 'AHORA CAIGO - Programa 26/09/23',
-                'thumbnail': 'https://thumbs.vodgc.net/AHCA25092023173459249708796.png?793338',
-            }
-        },
-        {
-            'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-280823/',
-            'md5': 'e0a2033e020f423c0e620ec8471b54f3',
-            'info_dict': {
-                'id': 'AHCA25082023145927244603575',
-                'ext': 'mp4',
-                'title': 'AHORA CAIGO - Programa 28/08/23',
-                'thumbnail': 'https://thumbs.vodgc.net/AHCA25082023145927244603575.jpg?377333',
+                'title': 'AHORA CAIGO - Programa 06/10/23',
+                'thumbnail': 'https://thumbs.vodgc.net/AHCA05102023145553329621094.JPG?649339',
             }
         },
         {
             'url': 'https://www.eltrecetv.com.ar/poco-correctos/capitulos/temporada-2023/programa-del-250923-invitada-dalia-gutmann/',
-            'md5': 'c6066e6ea4a4b7d11a8c4cc8cb5a0c85',
-            'info_dict': {
-                'id': '804C6158638F598B4903394E9707B6EB129',
-                'ext': 'mp4',
-                'title': 'POCO CORRECTOS - Programa 25/09/23',
-                'thumbnail': 'https://thumbs.vodgc.net/804C6158638F598B4903394E9707B6EB129.jpg?194429',
-            }
+            'only_matching': True,
         },
         {
             'url': 'https://www.eltrecetv.com.ar/argentina-tierra-de-amor-y-venganza/capitulos/temporada-2023/atav-2-capitulo-121-del-250923/',
@@ -57,27 +41,24 @@ class ElTreceTVIE(InfoExtractor):
         slug = self._match_id(url)
         webpage = self._download_webpage(url, slug)
 
-        json_all = self._search_json(r'Fusion.globalContent\s*=', webpage, 'content', slug)
-        config = json_all.get('promo_items').get('basic').get('embed').get('config')
+        config = self._search_json(r'Fusion.globalContent\s*=', webpage, 'content', slug)['promo_items']['basic']['embed']['config']
 
-        title = config.get('title')
-        thumbnail = config.get('thumbnail')
-        url = config.get('m3u8')
+        video_url = config['m3u8']
 
-        video_id = self._search_regex(r'/([A-Z0-9]+).(?:jpg|png)', thumbnail, 'video_id')
+        video_id = self._search_regex(r'/(\w+)\.m3u8', video_url, 'video id', default=slug)
 
-        formats = self._extract_m3u8_formats(url, video_id, ext='mp4', entry_protocol='http')
-
-        for f in formats:
-            # Edit url if points to a segment playlist to point to actual video
-            f['url'] = f['url'].replace('/tracks-v1a1/index.m3u8', '')
-
-        # hide 1080p format because it's not really available
-        formats = [f for f in formats if f['height'] != 1080]
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4', m3u8_id='hls')
+        formats.extend([{
+            'url': f['url'][:-23],
+            'format_id': f['format_id'].replace('hls', 'http'),
+            'width': f.get('width'),
+            'height': f.get('height'),
+        } for f in formats if f['url'].endswith('/tracks-v1a1/index.m3u8') and f.get('height') != 1080])
 
         return {
             'id': video_id,
-            'title': title,
-            'thumbnail': thumbnail,
+            'title': config.get('title'),
+            'thumbnail': config.get('thumbnail'),
             'formats': formats,
+            'subtitles': subtitles,
         }

--- a/yt_dlp/extractor/eltrecetv.py
+++ b/yt_dlp/extractor/eltrecetv.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class ElTreceTVIE(InfoExtractor):
+    IE_DESC = 'El Trece TV (Argentina)'
+    _VALID_URL = r'https?://(?:www\.)?eltrecetv.com.ar/([\w\-]+)/capitulos/temporada-(\d+)/(?P<id>[\w\-]+)/?'
+    _TESTS = [
+        {
+            'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-280823/',
+            'md5': 'e0a2033e020f423c0e620ec8471b54f3',
+            'info_dict': {
+                'id': 'AHCA25082023145927244603575',
+                'ext': 'mp4',
+                'title': 'AHORA CAIGO - Programa 28/08/23',
+                'thumbnail': 'https://thumbs.vodgc.net/AHCA25082023145927244603575.jpg',
+            }
+        },
+        {
+            'url': 'https://www.eltrecetv.com.ar/poco-correctos/capitulos/temporada-2023/programa-del-250923-invitada-dalia-gutmann/',
+            'md5': 'c6066e6ea4a4b7d11a8c4cc8cb5a0c85',
+            'info_dict': {
+                'id': '804C6158638F598B4903394E9707B6EB129',
+                'ext': 'mp4',
+                'title': 'POCO CORRECTOS - Programa 25/09/23',
+                'thumbnail': 'https://thumbs.vodgc.net/804C6158638F598B4903394E9707B6EB129.jpg',
+            }
+        },
+        {
+            'url': 'https://www.eltrecetv.com.ar/argentina-tierra-de-amor-y-venganza/capitulos/temporada-2023/atav-2-capitulo-121-del-250923/',
+            'only_matching': True,
+        },
+        {
+            'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-250923/',
+            'only_matching': True,
+        },
+        {
+            'url': 'https://www.eltrecetv.com.ar/pasaplatos/capitulos/temporada-2023/pasaplatos-el-restaurante-del-250923/',
+            'only_matching': True,
+        },
+        {
+            'url': 'https://www.eltrecetv.com.ar/el-galpon/capitulos/temporada-2023/programa-del-160923-invitado-raul-lavie/',
+            'only_matching': True,
+        }
+    ]
+
+    def _real_extract(self, url):
+        slug = self._match_id(url)
+        webpage = self._download_webpage(url, slug)
+
+        video_id = self._search_regex(r'https://vod\.vodgc\.net/manifest/([A-Z0-9]+)\.m3u8', webpage, 'video_id')
+        title = self._search_regex(r',"title":"(.+?)",', webpage, 'title')
+
+        return {
+            'id': video_id,
+            'title': title,
+            'url': 'https://vod.vodgc.net/gid1/vod/Artear/Eltrece/75/%s_720P.mp4' % video_id,
+            'thumbnail': 'https://thumbs.vodgc.net/%s.jpg' % video_id,
+        }

--- a/yt_dlp/extractor/eltrecetv.py
+++ b/yt_dlp/extractor/eltrecetv.py
@@ -40,11 +40,9 @@ class ElTreceTVIE(InfoExtractor):
     def _real_extract(self, url):
         slug = self._match_id(url)
         webpage = self._download_webpage(url, slug)
-
-        config = self._search_json(r'Fusion.globalContent\s*=', webpage, 'content', slug)['promo_items']['basic']['embed']['config']
-
+        config = self._search_json(
+            r'Fusion.globalContent\s*=', webpage, 'content', slug)['promo_items']['basic']['embed']['config']
         video_url = config['m3u8']
-
         video_id = self._search_regex(r'/(\w+)\.m3u8', video_url, 'video id', default=slug)
 
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4', m3u8_id='hls')

--- a/yt_dlp/extractor/eltrecetv.py
+++ b/yt_dlp/extractor/eltrecetv.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-from __future__ import unicode_literals
-
 from .common import InfoExtractor
 
 
@@ -15,7 +12,7 @@ class ElTreceTVIE(InfoExtractor):
                 'id': 'AHCA25082023145927244603575',
                 'ext': 'mp4',
                 'title': 'AHORA CAIGO - Programa 28/08/23',
-                'thumbnail': 'https://thumbs.vodgc.net/AHCA25082023145927244603575.jpg',
+                'thumbnail': 'https://thumbs.vodgc.net/AHCA25082023145927244603575.jpg?377333',
             }
         },
         {
@@ -25,7 +22,7 @@ class ElTreceTVIE(InfoExtractor):
                 'id': '804C6158638F598B4903394E9707B6EB129',
                 'ext': 'mp4',
                 'title': 'POCO CORRECTOS - Programa 25/09/23',
-                'thumbnail': 'https://thumbs.vodgc.net/804C6158638F598B4903394E9707B6EB129.jpg',
+                'thumbnail': 'https://thumbs.vodgc.net/804C6158638F598B4903394E9707B6EB129.jpg?194429',
             }
         },
         {
@@ -50,12 +47,18 @@ class ElTreceTVIE(InfoExtractor):
         slug = self._match_id(url)
         webpage = self._download_webpage(url, slug)
 
-        video_id = self._search_regex(r'https://vod\.vodgc\.net/manifest/([A-Z0-9]+)\.m3u8', webpage, 'video_id')
-        title = self._search_regex(r',"title":"(.+?)",', webpage, 'title')
+        json_all = self._search_json(r'Fusion.globalContent\s*=', webpage, 'content', slug)
+        config = json_all.get('promo_items').get('basic').get('embed').get('config')
+
+        title = config.get('title')
+        thumbnail = config.get('thumbnail')
+
+        video_id = self._search_regex(r'/([A-Z0-9]+).jpg', thumbnail, 'video_id')
+        url = 'https://vod.vodgc.net/gid1/vod/Artear/Eltrece/75/%s_720P.mp4' % video_id
 
         return {
             'id': video_id,
             'title': title,
-            'url': 'https://vod.vodgc.net/gid1/vod/Artear/Eltrece/75/%s_720P.mp4' % video_id,
-            'thumbnail': 'https://thumbs.vodgc.net/%s.jpg' % video_id,
+            'url': url,
+            'thumbnail': thumbnail,
         }

--- a/yt_dlp/extractor/eltrecetv.py
+++ b/yt_dlp/extractor/eltrecetv.py
@@ -6,7 +6,7 @@ from .common import InfoExtractor
 
 class ElTreceTVIE(InfoExtractor):
     IE_DESC = 'El Trece TV (Argentina)'
-    _VALID_URL = r'https?://(?:www\.)?eltrecetv.com.ar/([\w\-]+)/capitulos/temporada-(\d+)/(?P<id>[\w\-]+)/?'
+    _VALID_URL = r'https?://(?:www\.)?eltrecetv.com.ar/(?:[\w\-]+)/capitulos/temporada-(?:\d+)/(?P<id>[\w\-]+)/?'
     _TESTS = [
         {
             'url': 'https://www.eltrecetv.com.ar/ahora-caigo/capitulos/temporada-2023/programa-del-280823/',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Add extractor for eltrecetv.com.ar, the second biggest TV network in Argentina

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 76c9268</samp>

### Summary
📦📺🕵️‍♂️

<!--
1.  📦 - This emoji can represent the import statement, which imports the `ElTreceTVIE` class from another file. It can also suggest the idea of packaging or modularizing the code into separate files.
2.  📺 - This emoji can represent the El Trece TV website, which is a TV channel that offers online streaming of its shows. It can also suggest the idea of video or media content.
3.  🕵️‍♂️ - This emoji can represent the `InfoExtractor` base class, which is a common superclass for all extractors that scrape information from webpages. It can also suggest the idea of searching or finding data.
-->
Add a new extractor for El Trece TV website. The extractor is defined in the `eltrecetv.py` file and imported in the `_extractors.py` file. It can handle URLs of the format `https://www.eltrecetv.com.ar/[show-name]/capitulos/temporada-[season-number]/[episode-slug]/` and extract the video ID, title, URL and thumbnail.

> _`ElTreceTVIE` class_
> _extracts video info from_
> _Argentine website_

### Walkthrough
*  Add a new extractor for El Trece TV website (`yt_dlp/extractor/eltrecetv.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/8216/files?diff=unified&w=0#diff-b2f74866cbd030f5f6395355d7f4180228dc6d7a2a5b99f51569fa0c15bcb808R1-R61))
*  Import the `ElTreceTVIE` class in the extractors module (`yt_dlp/extractor/_extractors.py`, [link](https://github.com/yt-dlp/yt-dlp/pull/8216/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R568))



</details>
