### PR TITLE
[extractor/substack] Fix embed URL extraction

### DIFF
--- a/yt_dlp/extractor/substack.py
+++ b/yt_dlp/extractor/substack.py
@@ -50,7 +50,7 @@ class SubstackIE(InfoExtractor):
         if not re.search(r'<script[^>]+src=["\']https://substackcdn.com/[^"\']+\.js', webpage):
             return
 
-        mobj = re.search(r'{[^}]*["\']subdomain["\']\s*:\s*["\'](?P<subdomain>[^"]+)', webpage)
+        mobj = re.search(r'{[^}]*\\?["\']subdomain\\?["\']\s*:\s*\\?["\'](?P<subdomain>[^\\"]+)', webpage)
         if mobj:
             parsed = urllib.parse.urlparse(url)
             yield parsed._replace(netloc=f'{mobj.group("subdomain")}.substack.com').geturl()

--- a/yt_dlp/extractor/substack.py
+++ b/yt_dlp/extractor/substack.py
@@ -50,7 +50,7 @@ class SubstackIE(InfoExtractor):
         if not re.search(r'<script[^>]+src=["\']https://substackcdn.com/[^"\']+\.js', webpage):
             return
 
-        mobj = re.search(r'{[^}]*\\?["\']subdomain\\?["\']\s*:\s*\\?["\'](?P<subdomain>[^\\"]+)', webpage)
+        mobj = re.search(r'{[^}]*\\?["\']subdomain\\?["\']\s*:\s*\\?["\'](?P<subdomain>[^\\"\']+)', webpage)
         if mobj:
             parsed = urllib.parse.urlparse(url)
             yield parsed._replace(netloc=f'{mobj.group("subdomain")}.substack.com').geturl()


### PR DESCRIPTION
### Description of your *pull request* and other information

The format of the JSON payload being extracted has changed to a JSON.parse("...")-style format. This PR fixes the extraction process so that it ignores the added slashes.

There's a theoretical possibility of the extracted string being too short if it contains an escape sequence (which would contain a slash thus not matching the `[^\"]+` part). In practice, a valid DNS name is unlikely to get escaped by a sensible JSON encoder. I have searched for uses of `_search_json` and `_parse_json` and found none, so I opted for a fix to the regular expression. 

Regarding tests, there are two in `generic.py` which should have actually been failing. If I try them manually using `yt-dlp -j`, the result seems to match, but I don't know how to run specific download tests in a generic way.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6cfb6a0</samp>

### Summary
🐛🔧🧪

<!--
1.  🐛 - This emoji represents a bug fix, since the original pattern had a flaw that caused some substack posts to be missed by the extractor.
2.  🔧 - This emoji represents a tool or configuration change, since the pattern is part of the extractor's configuration and affects how it works.
3.  🧪 - This emoji represents a test or experiment, since the change may need to be verified by testing different substack posts and checking the results.
-->
Fixed substack extractor to handle backslashes in subdomain names. Modified regex pattern in `yt_dlp/extractor/substack.py`.

> _Substack posts vary_
> _Escape backslashes in regex_
> _Winter bug is fixed_

### Walkthrough
*  Escape backslashes in subdomain pattern ([link](https://github.com/yt-dlp/yt-dlp/pull/8218/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL53-R53)) to fix extraction of some substack posts in `yt_dlp/extractor/substack.py`



</details>
