### PR TITLE
[extractor/substack] Return canonical URLs

### DIFF
--- a/yt_dlp/extractor/substack.py
+++ b/yt_dlp/extractor/substack.py
@@ -56,10 +56,10 @@ class SubstackIE(InfoExtractor):
             yield parsed._replace(netloc=f'{mobj.group("subdomain")}.substack.com').geturl()
             raise cls.StopExtraction()
 
-    def _extract_video_formats(self, video_id, username):
+    def _extract_video_formats(self, video_id, url):
         formats, subtitles = [], {}
         for video_format in ('hls', 'mp4'):
-            video_url = f'https://{username}.substack.com/api/v1/video/upload/{video_id}/src?type={video_format}'
+            video_url = urllib.parse.urljoin(url, f'/api/v1/video/upload/{video_id}/src?type={video_format}')
 
             if video_format == 'hls':
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(video_url, video_id, 'mp4', fatal=False)
@@ -81,12 +81,17 @@ class SubstackIE(InfoExtractor):
             r'window\._preloads\s*=\s*JSON\.parse\(', webpage, 'json string',
             display_id, transform_source=js_to_json, contains_pattern=r'"{(?s:.+)}"'), display_id)
 
+        canonical_url = url
+        domain = traverse_obj(webpage_info, ('domainInfo', 'customDomain'))
+        if domain is not None:
+            canonical_url = urllib.parse.urlparse(url)._replace(netloc=domain).geturl()
+
         post_type = webpage_info['post']['type']
         formats, subtitles = [], {}
         if post_type == 'podcast':
             formats, subtitles = [{'url': webpage_info['post']['podcast_url']}], {}
         elif post_type == 'video':
-            formats, subtitles = self._extract_video_formats(webpage_info['post']['videoUpload']['id'], username)
+            formats, subtitles = self._extract_video_formats(webpage_info['post']['videoUpload']['id'], canonical_url)
         else:
             self.raise_no_formats(f'Page type "{post_type}" is not supported')
 
@@ -99,4 +104,6 @@ class SubstackIE(InfoExtractor):
             'thumbnail': traverse_obj(webpage_info, ('post', 'cover_image')),
             'uploader': traverse_obj(webpage_info, ('pub', 'name')),
             'uploader_id': str_or_none(traverse_obj(webpage_info, ('post', 'publication_id'))),
+            'webpage_url': canonical_url,
+            'original_url': canonical_url,
         }

--- a/yt_dlp/extractor/substack.py
+++ b/yt_dlp/extractor/substack.py
@@ -82,8 +82,8 @@ class SubstackIE(InfoExtractor):
             display_id, transform_source=js_to_json, contains_pattern=r'"{(?s:.+)}"'), display_id)
 
         canonical_url = url
-        domain = traverse_obj(webpage_info, ('domainInfo', 'customDomain'))
-        if domain is not None:
+        domain = traverse_obj(webpage_info, ('domainInfo', 'customDomain', {str}))
+        if domain:
             canonical_url = urllib.parse.urlparse(url)._replace(netloc=domain).geturl()
 
         post_type = webpage_info['post']['type']
@@ -105,5 +105,4 @@ class SubstackIE(InfoExtractor):
             'uploader': traverse_obj(webpage_info, ('pub', 'name')),
             'uploader_id': str_or_none(traverse_obj(webpage_info, ('post', 'publication_id'))),
             'webpage_url': canonical_url,
-            'original_url': canonical_url,
         }


### PR DESCRIPTION
### Description of your *pull request* and other information

The URL passed to _real_extract is of format "{username}.substack.com", but for blogs with custom domains the canonical URL would use the custom domain. Because of the wrong URL, the cookies in the resulting info dict come from the wrong domain, which breaks subscriber content extraction.

This isn't really testable because for whatever reason yt-dlp itself doesn't have any trouble downloading such content; however, `yt-dlp -j` consumers are broken without this change because of how the `cookies` field is populated.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fa51465</samp>

### Summary
🎥🛠️🔗

<!--
1.  🎥 - This emoji represents the video URLs and metadata that the extractor handles, as well as the custom domains that some Substack users have for their video content.
2.  🛠️ - This emoji represents the improvement and modification of the extractor functions, as well as the use of the `canonical_url` variable to handle different domains.
3.  🔗 - This emoji represents the addition of the `webpage_url` and `original_url` fields to the video metadata, which provide more information and context for the video sources.
-->
Enhanced the Substack extractor to support custom domains. Used `canonical_url` instead of `username` for video extraction and added more metadata fields.

> _Substack extractor_
> _`canonical_url` for videos_
> _Autumn leaves falling_

### Walkthrough
*  Modify `_extract_video_formats` function to use `url` instead of `username` and `urllib.parse.urljoin` to construct video URL ([link](https://github.com/yt-dlp/yt-dlp/pull/8219/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL59-R62))
*  Modify `_real_extract` function to get `domain` value from `webpage_info` and use it to set `canonical_url` with custom domain if applicable ([link](https://github.com/yt-dlp/yt-dlp/pull/8219/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aR84-R88))
*  Pass `canonical_url` instead of `username` to `_extract_video_formats` function in `_real_extract` function ([link](https://github.com/yt-dlp/yt-dlp/pull/8219/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aL89-R94))
*  Add `webpage_url` and `original_url` fields to metadata dictionary in `_real_extract` function, using `canonical_url` as the value ([link](https://github.com/yt-dlp/yt-dlp/pull/8219/files?diff=unified&w=0#diff-ac510ca323ee529ede929329f2c855ed2323608fc856c00594005f864590623aR107-R108))



</details>
