### PR TITLE
Various radiko enhancements

### DIFF
--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -14,6 +14,7 @@ from ..utils import (
 
 
 class RadikoBaseIE(InfoExtractor):
+    _GEO_BYPASS = False
     _FULL_KEY = None
     _HOSTS_FOR_TIME_FREE_FFMPEG_UNSUPPORTED = (
         'https://c-rpaa.smartstream.ne.jp',
@@ -58,6 +59,9 @@ class RadikoBaseIE(InfoExtractor):
                 'x-radiko-authtoken': auth_token,
                 'x-radiko-partialkey': partial_key,
             }).split(',')[0]
+
+        if area_id == 'OUT':
+            self.raise_geo_restricted(countries=['JP'])
 
         auth_data = (auth_token, area_id)
         self.cache.store('radiko', 'auth_data', auth_data)

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -1,4 +1,5 @@
 import base64
+import secrets
 import urllib.parse
 
 from .common import InfoExtractor
@@ -114,7 +115,7 @@ class RadikoBaseIE(InfoExtractor):
                 'station_id': station,
                 **query,
                 'l': '15',
-                'lsid': '88ecea37e968c1f17d5413312d9f8003',
+                'lsid': secrets.token_hex(16),
                 'type': 'b',
             })
             if playlist_url in found:

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -127,7 +127,7 @@ class RadikoBaseIE(InfoExtractor):
             pcu = element.text
             if pcu in found:
                 continue
-           found.add(pcu)
+            found.add(pcu)
             playlist_url = update_url_query(pcu, {
                 'station_id': station,
                 **query,

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -1,5 +1,4 @@
 import base64
-import secrets
 import urllib.parse
 
 from .common import InfoExtractor
@@ -70,9 +69,9 @@ class RadikoBaseIE(InfoExtractor):
     def _auth_client(self):
         cachedata = self.cache.load('radiko', 'auth_data')
         if cachedata is not None:
-            response = self._download_webpage('https://radiko.jp/v2/api/auth_check', None,
-                                              'Checking cached token', expected_status=401,
-                                              headers={'X-Radiko-AuthToken': cachedata[0], 'X-Radiko-AreaId': cachedata[1]})
+            response = self._download_webpage(
+                'https://radiko.jp/v2/api/auth_check', None, 'Checking cached token', expected_status=401,
+                headers={'X-Radiko-AuthToken': cachedata[0], 'X-Radiko-AreaId': cachedata[1]})
             if response == 'OK':
                 return cachedata
         return self._negotiate_token()
@@ -128,13 +127,12 @@ class RadikoBaseIE(InfoExtractor):
             pcu = element.text
             if pcu in found:
                 continue
-            else:
-                found.add(pcu)
+           found.add(pcu)
             playlist_url = update_url_query(pcu, {
                 'station_id': station,
                 **query,
                 'l': '15',
-                'lsid': secrets.token_hex(16),
+                'lsid': ''.join(random.choices('0123456789abcdef', k=32)),
                 'type': 'b',
             })
 
@@ -183,6 +181,7 @@ class RadikoIE(RadikoBaseIE):
         prog, station_program, ft, radio_begin, radio_end = self._find_program(video_id, station, vid_int)
 
         auth_token, area_id = self._auth_client()
+
         return {
             'id': video_id,
             'title': try_call(lambda: prog.find('title').text),

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -76,7 +76,7 @@ class RadikoBaseIE(InfoExtractor):
 
         if full_key:
             full_key = full_key.encode()
-        else:  # use full key ever known
+        else:  # use only full key ever known
             full_key = b'bcd151073c03b352e1ef2fd66c32209da9ca0afa'
 
         self._FULL_KEY = full_key

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -1,4 +1,5 @@
 import base64
+import random
 import urllib.parse
 
 from .common import InfoExtractor

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -116,7 +116,7 @@ class RadikoBaseIE(InfoExtractor):
 
     def _extract_formats(self, video_id, station, is_onair, ft, cursor, auth_token, area_id, query):
         m3u8_playlist_data = self._download_xml(
-            f'https://radiko.jp/v3/station/stream/pc_html5/{station}.xml', video_id,
+            f'https://radiko.jp/v3/station/stream/aSmartPhone7a/{station}.xml', video_id,
             note='Downloading stream information')
 
         formats = []
@@ -143,7 +143,7 @@ class RadikoBaseIE(InfoExtractor):
             domain = urllib.parse.urlparse(playlist_url).netloc
             subformats = self._extract_m3u8_formats(
                 playlist_url, video_id, ext='m4a',
-                live=True, fatal=False, m3u8_id=domain,
+                fatal=False, m3u8_id=domain,
                 note=f'Downloading m3u8 information from {domain}',
                 headers={
                     'X-Radiko-AreaId': area_id,
@@ -190,7 +190,7 @@ class RadikoIE(RadikoBaseIE):
             'uploader': try_call(lambda: station_program.find('.//name').text),
             'uploader_id': station,
             'timestamp': vid_int,
-            'is_live': True,
+            'live_status': 'was_live',
             'formats': self._extract_formats(
                 video_id=video_id, station=station, is_onair=False,
                 ft=ft, cursor=vid_int, auth_token=auth_token, area_id=area_id,

--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -116,7 +116,7 @@ class RadikoBaseIE(InfoExtractor):
 
     def _extract_formats(self, video_id, station, is_onair, ft, cursor, auth_token, area_id, query):
         m3u8_playlist_data = self._download_xml(
-            f'https://radiko.jp/v3/station/stream/aSmartPhone7a/{station}.xml', video_id,
+            f'https://radiko.jp/v3/station/stream/pc_html5/{station}.xml', video_id,
             note='Downloading stream information')
 
         formats = []
@@ -143,7 +143,7 @@ class RadikoBaseIE(InfoExtractor):
             domain = urllib.parse.urlparse(playlist_url).netloc
             subformats = self._extract_m3u8_formats(
                 playlist_url, video_id, ext='m4a',
-                fatal=False, m3u8_id=domain,
+                live=True, fatal=False, m3u8_id=domain,
                 note=f'Downloading m3u8 information from {domain}',
                 headers={
                     'X-Radiko-AreaId': area_id,
@@ -190,7 +190,7 @@ class RadikoIE(RadikoBaseIE):
             'uploader': try_call(lambda: station_program.find('.//name').text),
             'uploader_id': station,
             'timestamp': vid_int,
-            'live_status': 'was_live',
+            'is_live': True,
             'formats': self._extract_formats(
                 video_id=video_id, station=station, is_onair=False,
                 ft=ft, cursor=vid_int, auth_token=auth_token, area_id=area_id,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

These patches improve the `radiko` extractor using things I've learnt while developing my plugin [yt-dlp-rajiko](https://github.com/garret1317/yt-dlp-rajiko).
Hopefully the commit messages explain each change well enough, feel free to ask if not.

e9117f0bab990ad43c1a94b3c388bc7d10437b6b sort-of-fixes #6090, since the new format downloads with yt-dlp's hls downloader rather than ffmpeg.
However it could possibly break someone's workflow, as the extractor now extracts completely different formats. This commit can be skipped if you'd like.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e9117f0</samp>

### Summary
🌐🕒🔑

<!--
1.  🌐 for geo-restriction checks
2.  🕒 for timefree streams
3.  🔑 for authentication and decryption simplification
-->
Enhance the `radiko.py` extractor to handle different types of streams, check geo-restrictions, and streamline the code.

> _`Radiko` is the sound of doom, the voice of the oppressed_
> _We break the chains of geo-restriction, we stream the timefree past_
> _We simplify the code of darkness, we decrypt the hidden light_
> _We fix the flaws of format extraction, we make the metadata right_

### Walkthrough
*  Disable geo-bypass and raise error for out-of-Japan users ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fR17), [link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL61-R79))
*  Rename and move `_auth_client` method to `_negotiate_token` ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL35-R37))
*  Use different XML endpoint and filter URLs by `timefree` attribute for live and timefree streams ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL104-R139), [link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL141-R157))
*  Generate random `lsid` parameter for playlist URL ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fR2), [link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL104-R139))
*  Remove `live` argument from `_extract_m3u8_formats` method call ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL130-R146))
*  Simplify token and area ID extraction and return formats early ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL169-R194), [link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL180-R204))
*  Add comment to clarify hardcoded full key fallback ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL78-R93))
*  Change `is_live` key to `live_status` and set it to `was_live` for timefree streams ([link](https://github.com/yt-dlp/yt-dlp/pull/8221/files?diff=unified&w=0#diff-0b9132bf887faf956d81399a6a1e08e33718c64eb4021379f3d3468f76b2355fL180-R204))



</details>