### PR TITLE
[fd/fragments] Refactor and improve progress calculation

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -274,8 +274,8 @@ class FragmentFD(FileDownloader):
                 progress.thread_reset()
 
             state['downloaded_bytes'] = ctx['complete_frags_downloaded_bytes'] = progress.downloaded
-            ctx['speed'] = state['speed'] = progress.smooth_speed
-            state['eta'] = progress.smooth_eta
+            state['speed'] = ctx['speed'] = progress.speed.smooth
+            state['eta'] = progress.eta.smooth
 
             self._hook_progress(state, info_dict)
 

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -257,6 +257,7 @@ class FragmentFD(FileDownloader):
             frag_total_bytes = s.get('total_bytes') or 0
             s['fragment_info_dict'] = s.pop('info_dict', {})
 
+            # XXX: Fragment resume is not accounted for here
             if not ctx['live']:
                 estimated_size = (
                     (ctx['complete_frags_downloaded_bytes'] + frag_total_bytes)

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -14,6 +14,7 @@ from ..networking import Request
 from ..networking.exceptions import HTTPError, IncompleteRead
 from ..utils import DownloadError, RetryManager, encodeFilename, traverse_obj
 from ..utils.networking import HTTPHeaderDict
+from ..utils.progress import ProgressCalculator
 
 
 class HttpQuietDownloader(HttpFD):
@@ -226,8 +227,7 @@ class FragmentFD(FileDownloader):
         resume_len = ctx['complete_frags_downloaded_bytes']
         total_frags = ctx['total_frags']
         ctx_id = ctx.get('ctx_id')
-        # This dict stores the download progress, it's updated by the progress
-        # hook
+        # Stores the download progress, updated by the progress hook
         state = {
             'status': 'downloading',
             'downloaded_bytes': resume_len,
@@ -237,14 +237,8 @@ class FragmentFD(FileDownloader):
             'tmpfilename': ctx['tmpfilename'],
         }
 
-        start = time.time()
-        ctx.update({
-            'started': start,
-            'fragment_started': start,
-            # Amount of fragment's bytes downloaded by the time of the previous
-            # frag progress hook invocation
-            'prev_frag_downloaded_bytes': 0,
-        })
+        ctx['started'] = time.time()
+        progress = ProgressCalculator(resume_len)
 
         def frag_progress_hook(s):
             if s['status'] not in ('downloading', 'finished'):
@@ -259,38 +253,35 @@ class FragmentFD(FileDownloader):
             state['max_progress'] = ctx.get('max_progress')
             state['progress_idx'] = ctx.get('progress_idx')
 
-            time_now = time.time()
-            state['elapsed'] = time_now - start
+            state['elapsed'] = progress.elapsed
             frag_total_bytes = s.get('total_bytes') or 0
             s['fragment_info_dict'] = s.pop('info_dict', {})
+
             if not ctx['live']:
                 estimated_size = (
                     (ctx['complete_frags_downloaded_bytes'] + frag_total_bytes)
                     / (state['fragment_index'] + 1) * total_frags)
-                state['total_bytes_estimate'] = estimated_size
+                progress.total = estimated_size
+                progress.update(s['downloaded_bytes'])
+                state['total_bytes_estimate'] = progress.total
+            else:
+                progress.update(s['downloaded_bytes'])
 
             if s['status'] == 'finished':
                 state['fragment_index'] += 1
                 ctx['fragment_index'] = state['fragment_index']
-                state['downloaded_bytes'] += frag_total_bytes - ctx['prev_frag_downloaded_bytes']
-                ctx['complete_frags_downloaded_bytes'] = state['downloaded_bytes']
-                ctx['speed'] = state['speed'] = self.calc_speed(
-                    ctx['fragment_started'], time_now, frag_total_bytes)
-                ctx['fragment_started'] = time.time()
-                ctx['prev_frag_downloaded_bytes'] = 0
+                state['downloaded_bytes'] = ctx['complete_frags_downloaded_bytes'] = progress.downloaded
+                ctx['speed'] = state['speed'] = progress.speed
             else:
-                frag_downloaded_bytes = s['downloaded_bytes']
-                state['downloaded_bytes'] += frag_downloaded_bytes - ctx['prev_frag_downloaded_bytes']
-                ctx['speed'] = state['speed'] = self.calc_speed(
-                    ctx['fragment_started'], time_now, frag_downloaded_bytes - ctx.get('frag_resume_len', 0))
-                if not ctx['live']:
-                    state['eta'] = self.calc_eta(state['speed'], estimated_size - state['downloaded_bytes'])
-                ctx['prev_frag_downloaded_bytes'] = frag_downloaded_bytes
+                state['downloaded_bytes'] = progress.downloaded
+                ctx['speed'] = state['speed'] = progress.speed
+                state['eta'] = progress.eta
+
             self._hook_progress(state, info_dict)
 
         ctx['dl'].add_progress_hook(frag_progress_hook)
 
-        return start
+        return ctx['started']
 
     def _finish_frag_download(self, ctx, info_dict):
         ctx['dest_stream'].close()
@@ -500,7 +491,6 @@ class FragmentFD(FileDownloader):
                 download_fragment(fragment, ctx_copy)
                 return fragment, fragment['frag_index'], ctx_copy.get('fragment_filename_sanitized')
 
-            self.report_warning('The download speed shown is only of one thread. This is a known issue')
             with tpe or concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
                 try:
                     for fragment, frag_index, frag_filename in pool.map(_download_fragment, fragments):

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -262,13 +262,14 @@ class FragmentFD(FileDownloader):
                     (ctx['complete_frags_downloaded_bytes'] + frag_total_bytes)
                     / (state['fragment_index'] + 1) * total_frags)
                 progress.total = estimated_size
-                progress.update(s['downloaded_bytes'])
+                progress.update(s.get('downloaded_bytes'))
                 state['total_bytes_estimate'] = progress.total
             else:
-                progress.update(s['downloaded_bytes'])
+                progress.update(s.get('downloaded_bytes'))
 
             if s['status'] == 'finished':
                 state['fragment_index'] += 1
+                progress.thread_reset()
                 ctx['fragment_index'] = state['fragment_index']
                 state['downloaded_bytes'] = ctx['complete_frags_downloaded_bytes'] = progress.downloaded
                 ctx['speed'] = state['speed'] = progress.speed

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -270,14 +270,12 @@ class FragmentFD(FileDownloader):
 
             if s['status'] == 'finished':
                 state['fragment_index'] += 1
-                progress.thread_reset()
                 ctx['fragment_index'] = state['fragment_index']
-                state['downloaded_bytes'] = ctx['complete_frags_downloaded_bytes'] = progress.downloaded
-                ctx['speed'] = state['speed'] = progress.speed
-            else:
-                state['downloaded_bytes'] = progress.downloaded
-                ctx['speed'] = state['speed'] = progress.speed
-                state['eta'] = progress.eta
+                progress.thread_reset()
+
+            state['downloaded_bytes'] = ctx['complete_frags_downloaded_bytes'] = progress.downloaded
+            ctx['speed'] = state['speed'] = progress.smooth_speed
+            state['eta'] = progress.eta
 
             self._hook_progress(state, info_dict)
 

--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -275,7 +275,7 @@ class FragmentFD(FileDownloader):
 
             state['downloaded_bytes'] = ctx['complete_frags_downloaded_bytes'] = progress.downloaded
             ctx['speed'] = state['speed'] = progress.smooth_speed
-            state['eta'] = progress.eta
+            state['eta'] = progress.smooth_eta
 
             self._hook_progress(state, info_dict)
 

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -21,6 +21,7 @@ class ProgressCalculator:
         self.speed: float = 0
         self.smooth_speed: int = 0
         self.eta: float | None = None
+        self.smooth_eta: int | None = None
 
         self._total = None
         self._start_time = time.monotonic_ns()
@@ -89,7 +90,11 @@ class ProgressCalculator:
 
         self.smooth_speed = int(self.SMOOTHING * self.speed + (1 - self.SMOOTHING) * self.smooth_speed)
 
-        if not self.total:
-            self.eta = None
-        elif self.speed:
+        if self.total and self.speed:
             self.eta = (self.total - self.downloaded) / self.speed
+            if not self.smooth_eta:
+                self.smooth_eta = self.eta  # type: ignore
+            self.smooth_eta = int(self.SMOOTHING * self.eta + (1 - self.SMOOTHING) * self.smooth_eta)
+        else:
+            self.eta = None
+            self.smooth_eta = None

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -77,6 +77,10 @@ class ProgressCalculator:
         offset = bisect.bisect_left(self._times, current_time - self.SAMPLING_WINDOW)
         del self._times[:offset]
         del self._downloaded[:offset]
+        if len(self._times) < 2:
+            self.speed = self.smooth_speed = 0
+            self.eta = self.smooth_eta = None
+            return
 
         download_time = current_time - self._times[0]
         if not download_time:

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -29,9 +29,7 @@ class ProgressCalculator:
         self._last_update = self._start_time
 
         self._times: list[float] = []
-        self._speeds: list[int] = []
-
-        self._thread_updates: dict[int, float] = {}
+        self._downloaded: list[int] = []
         self._thread_sizes: dict[int, int] = {}
 
     @property
@@ -52,7 +50,6 @@ class ProgressCalculator:
         current_thread = threading.get_ident()
         with self._lock:
             self._thread_sizes[current_thread] = 0
-            self._thread_updates[current_thread] = TIME_PROVIDER()
 
     def update(self, size: int | None):
         if not size:
@@ -61,39 +58,45 @@ class ProgressCalculator:
         current_thread = threading.get_ident()
 
         with self._lock:
-            current_time = TIME_PROVIDER()
-            last_size = self._thread_sizes.get(current_thread) or 0
-            last_update = self._thread_updates.get(current_thread) or self._start_time
-            chunk = size - last_size
-            print(f'    [{threading.get_ident()}] {last_update} -> {current_time} ({chunk}B)')
-
-            update_time = self._update(chunk, current_time, last_update)
-            if update_time:
-                self._thread_updates[current_thread] = current_time
+            last_size = self._thread_sizes.get(current_thread, 0)
             self._thread_sizes[current_thread] = size
+            self._update(size - last_size)
 
-    def _update(self, size, current_time, last_update):
+    def _update(self, size):
+        current_time = TIME_PROVIDER()
+
         self.downloaded += size
         self.elapsed = current_time - self._start_time
         if self.total is not None and self.downloaded > self.total:
             self._total = self.downloaded
 
         self._times.append(current_time)
-        self._speeds.append(size / (current_time - last_update))
+        self._downloaded.append(self.downloaded)
 
-        if current_time - self.UPDATE_TIME <= last_update:
+        if current_time - self.UPDATE_TIME <= self._last_update:
             return
         self._last_update = current_time
 
         offset = bisect.bisect_left(self._times, current_time - self.WINDOW_SIZE)
         del self._times[:offset]
-        del self._speeds[:offset]
+        del self._downloaded[:offset]
+        assert self._times, "A current entry should have been added above"
+        assert self._downloaded, "A current entry should have been added above"
 
-        weights = tuple(1 + (point - current_time) / self.WINDOW_SIZE for point in self._times)
-        # Same as `statistics.fmean(self.data_points, weights)`, but weights is >=3.11
-        self.speed = sum(map(float.__mul__, self._speeds, weights)) / sum(weights)
+        time_delta = self._times[-1] - self._times[0]
+        if not time_delta:
+            return
+
+        downloaded_bytes = self._downloaded[-1] - self._downloaded[0]
+        speed = downloaded_bytes / time_delta
+
+        # TODO: Add linear moving average
+        # weights = tuple(1 + (point - current_time) / self.WINDOW_SIZE for point in self._times)
+        # # Same as `statistics.fmean(self.data_points, weights)`, but weights is >=3.11
+        # self.speed = sum(map(float.__mul__, self._downloaded, weights)) / sum(weights)
+        self.speed = speed
 
         if not self.total:
             self.eta = None
-        else:
+        elif self.speed:
             self.eta = (self.total - self.downloaded) / self.speed

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import bisect
+# import operator
+import statistics
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class ThreadInfo:
+    speed: float
+    last_update: float
+    last_size: int
+    times: list[float]
+    speeds: list[float]
+
+
+class ProgressCalculator:
+    # Time to calculate the average over (in seconds)
+    WINDOW_SIZE = 2.0
+    # Minimum time before we add another datapoint (in seconds)
+    # This is *NOT* the same as the time between a progress change
+    UPDATE_TIME = 0.2
+
+    def __init__(self, initial):
+        self.downloaded = initial if initial else 0
+
+        self.elapsed = 0
+        self.speed = None
+        self.eta = None
+        self._total = None
+
+        self._start_time = time.monotonic()
+        self._thread_infos: dict[int, ThreadInfo] = {}
+
+    @property
+    def total(self):
+        return self._total
+
+    @total.setter
+    def total(self, value):
+        if not value or value <= 0.01:
+            value = None
+        elif value < self.downloaded:
+            value = self.downloaded
+
+        self._total = value
+
+    def update(self, size):
+        current_thread = threading.get_ident()
+        thread_info = self._thread_infos.get(current_thread)
+        if not thread_info:
+            thread_info = ThreadInfo(self._start_time, 0, 0, [], [])
+            self._thread_infos[current_thread] = thread_info
+
+        last_size = thread_info.last_size
+        if size < last_size:
+            chunk = size
+        elif size > last_size:
+            chunk = size - last_size
+        else:
+            return
+        self.downloaded += chunk
+        if self.total and self.downloaded > self.total:
+            self._total = self.downloaded
+        thread_info.last_size = size
+
+        current_time = time.monotonic()
+        self.elapsed = current_time - self._start_time
+
+        last_update = thread_info.last_update
+        if current_time - self.UPDATE_TIME <= last_update:
+            return
+        thread_info.last_update = current_time
+
+        offset = bisect.bisect_left(thread_info.times, current_time - self.WINDOW_SIZE)
+        del thread_info.times[:offset]
+        del thread_info.speeds[:offset]
+        thread_info.times.append(current_time)
+        thread_info.speeds.append(size / (current_time - last_update))
+
+        # weights = tuple(1 + (point - current_time) / self.WINDOW_SIZE for point in thread_info.times)
+        # Same as `statistics.fmean(self.data_points, weights)`, but weights is >=3.11
+        # thread_info.speed = sum(map(operator.mul, thread_info.speeds, weights)) / sum(weights)
+        thread_info.speed = statistics.fmean(thread_info.speeds)
+        self.speed = sum(info.speed for info in self._thread_infos.values())
+
+        if not self.total:
+            self.eta = None
+        else:
+            self.eta = (self.total - self.downloaded) / self.speed

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -23,7 +23,7 @@ class ProgressCalculator:
         self.eta: float | None = None
         self.smooth_eta: int | None = None
 
-        self._total = None
+        self._total = 0
         self._start_time = time.monotonic_ns()
 
         self._lock = threading.Lock()
@@ -39,9 +39,7 @@ class ProgressCalculator:
     @total.setter
     def total(self, value: int | None):
         with self._lock:
-            if not value:
-                value = None
-            elif value < self.downloaded:
+            if value is not None and value < self.downloaded:
                 value = self.downloaded
 
             self._total = value

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -8,9 +8,9 @@ import time
 
 class ProgressCalculator:
     # Time to calculate the speed over (in nanoseconds)
-    WINDOW_SIZE = 1_000_000_000
+    WINDOW_SIZE = 2_000_000_000
     # Time to smooth the speed over (in nanoseconds)
-    SPEED_WINDOW = 1_000_000_000
+    SPEED_WINDOW = 100_000_000
 
     def __init__(self, initial):
         self.downloaded = initial or 0
@@ -27,6 +27,7 @@ class ProgressCalculator:
         self._thread_sizes: dict[int, int] = {}
 
         self._downloaded = _DataPoints()
+        self._downloaded.add_point(self._start_time, self.downloaded)
         self._speeds = _DataPoints()
 
     @property
@@ -36,7 +37,7 @@ class ProgressCalculator:
     @total.setter
     def total(self, value):
         with self._lock:
-            if not value or value <= 0.01:
+            if not value:
                 value = None
             elif value < self.downloaded:
                 value = self.downloaded

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import bisect
-import operator
 import threading
 import time
 
@@ -9,14 +8,14 @@ import time
 class ProgressCalculator:
     # Time to calculate the speed over (in nanoseconds)
     SAMPLING_WINDOW = 1_000_000_000
-    # Time to smooth the speed over (in nanoseconds)
-    SMOOTHING_WINDOW = 100_000_000
+    # Factor for the exponential moving average (from 0 = prev to 1 = current)
+    SMOOTHING_FACTOR = 0.3
 
     def __init__(self, initial: int):
         self.downloaded = initial or 0
 
         self.elapsed: float = 0
-        self.speed: int | None = None
+        self.speed: int = 0
         self.eta: float | None = None
 
         self._total = None
@@ -26,9 +25,8 @@ class ProgressCalculator:
         self._lock = threading.Lock()
         self._thread_sizes: dict[int, int] = {}
 
-        self._downloaded = _DataPoints()
-        self._downloaded.add_point(self._start_time, self.downloaded)
-        self._speeds = _DataPoints()
+        self._times = [self._start_time]
+        self._downloaded = [self.downloaded]
 
     @property
     def total(self):
@@ -68,56 +66,25 @@ class ProgressCalculator:
         if self.total is not None and self.downloaded > self.total:
             self._total = self.downloaded
 
-        self._downloaded.add_point(current_time, self.downloaded)
+        self._times.append(current_time)
+        self._downloaded.append(self.downloaded)
 
         if current_time <= self._last_update:
             return
         self._last_update = current_time
 
-        self._downloaded.trim(current_time - self.SAMPLING_WINDOW)
-        download_time, download_bytes = self._downloaded.ranges()
+        offset = bisect.bisect_left(self._times, current_time - self.SAMPLING_WINDOW)
+        del self._times[:offset]
+        del self._downloaded[:offset]
+        download_time = current_time - self._times[0]
         if not download_time:
             return
-        speed = round(download_bytes * 1_000_000_000 / download_time)
+        downloaded_bytes = self.downloaded - self._downloaded[0]
+        speed = round(downloaded_bytes * 1_000_000_000 / download_time)
 
-        self._speeds.add_point(current_time, speed)
-        self._speeds.trim(current_time - self.SMOOTHING_WINDOW)
-        speed_time = self._speeds.ranges()[0] or 1
-
-        weights = tuple(1 + (point - current_time) / speed_time for point in self._speeds.times)
-        # Same as `statistics.fmean(self.data_points, weights)`, but weights is >=3.11
-        self.speed = int(sum(map(operator.mul, self._speeds.values, weights)) / sum(weights))
+        self.speed = int(self.SMOOTHING_FACTOR * speed + (1 - self.SMOOTHING_FACTOR) * self.speed)
 
         if not self.total:
             self.eta = None
         elif self.speed:
             self.eta = (self.total - self.downloaded) / self.speed
-
-
-class _DataPoints:
-    def __init__(self):
-        self.times: list[int] = []
-        self.values: list[int] = []
-
-    def add_point(self, time: int, value: int):
-        """Add a point to the dataset"""
-        self.times.append(time)
-        self.values.append(value)
-
-    def trim(self, start_time: int):
-        """Remove expired data points"""
-        offset = bisect.bisect_left(self.times, start_time)
-        del self.times[:offset]
-        del self.values[:offset]
-
-        return offset
-
-    def ranges(self):
-        """Return the range of both the time and data"""
-        if not self.times:
-            return 0, 0
-
-        return self.times[-1] - self.times[0], self.values[-1] - self.values[0]
-
-    def __len__(self):
-        return len(self.times)

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -12,8 +12,10 @@ class ProgressCalculator:
     SAMPLING_RATE = 50_000_000
     # Time until we show smoothed speed and eta (nanoseconds)
     GRACE_PERIOD = 1_000_000_000
-    # Factor for the exponential moving average (from 0 = prev to 1 = current)
-    SMOOTHING = 0.1
+    # Smoothing factor for the speed EMA (from 0 = prev to 1 = current)
+    SPEED_SMOOTHING = 0.3
+    # Smoothing factor for the ETA EMA (from 0 = prev to 1 = current)
+    ETA_SMOOTHING = 0.05
 
     def __init__(self, initial: int):
         self._initial = initial or 0
@@ -97,13 +99,13 @@ class ProgressCalculator:
             self.smooth_speed = int(self.speed)
             return
 
-        self.smooth_speed = int(self.SMOOTHING * self.speed + (1 - self.SMOOTHING) * self.smooth_speed)
+        self.smooth_speed = int(self.SPEED_SMOOTHING * self.speed + (1 - self.SPEED_SMOOTHING) * self.smooth_speed)
 
         if self.total and self.speed:
             self.eta = (self.total - self.downloaded) / self.speed
             if not self.smooth_eta:
                 self.smooth_eta = self.eta  # type: ignore
-            self.smooth_eta = int(self.SMOOTHING * self.eta + (1 - self.SMOOTHING) * self.smooth_eta)
+            self.smooth_eta = int(self.ETA_SMOOTHING * self.eta + (1 - self.ETA_SMOOTHING) * self.smooth_eta)
         else:
             self.eta = None
             self.smooth_eta = None

--- a/yt_dlp/utils/progress.py
+++ b/yt_dlp/utils/progress.py
@@ -1,22 +1,14 @@
 from __future__ import annotations
 
 import bisect
-# import operator
-import statistics
 import threading
 import time
-from dataclasses import dataclass
+
+# FIXME: monotonic has terrible resolution on Windows
+TIME_PROVIDER = time.perf_counter
 
 
-@dataclass
-class ThreadInfo:
-    speed: float
-    last_update: float
-    last_size: int
-    times: list[float]
-    speeds: list[float]
-
-
+# XXX: Fragment resume is not accounted for here
 class ProgressCalculator:
     # Time to calculate the average over (in seconds)
     WINDOW_SIZE = 2.0
@@ -32,9 +24,15 @@ class ProgressCalculator:
         self.eta = None
         self._total = None
 
-        self._start_time = time.monotonic()
-        self._thread_infos: dict[int, ThreadInfo] = {}
         self._lock = threading.Lock()
+        self._start_time = TIME_PROVIDER()
+        self._last_update = self._start_time
+
+        self._times: list[float] = []
+        self._speeds: list[int] = []
+
+        self._thread_updates: dict[int, float] = {}
+        self._thread_sizes: dict[int, int] = {}
 
     @property
     def total(self):
@@ -50,48 +48,50 @@ class ProgressCalculator:
 
             self._total = value
 
-    def update(self, size):
-        with self._lock:
-            return self._update(size)
-
-    def _update(self, size):
+    def thread_reset(self):
         current_thread = threading.get_ident()
-        thread_info = self._thread_infos.get(current_thread)
-        if not thread_info:
-            thread_info = ThreadInfo(self._start_time, 0, 0, [], [])
-            self._thread_infos[current_thread] = thread_info
+        with self._lock:
+            self._thread_sizes[current_thread] = 0
+            self._thread_updates[current_thread] = TIME_PROVIDER()
 
-        last_size = thread_info.last_size
-        if size < last_size:
-            chunk = size
-        elif size > last_size:
-            chunk = size - last_size
-        else:
+    def update(self, size: int | None):
+        if not size:
             return
-        self.downloaded += chunk
-        if self.total and self.downloaded > self.total:
-            self._total = self.downloaded
-        thread_info.last_size = size
 
-        current_time = time.monotonic()
+        current_thread = threading.get_ident()
+
+        with self._lock:
+            current_time = TIME_PROVIDER()
+            last_size = self._thread_sizes.get(current_thread) or 0
+            last_update = self._thread_updates.get(current_thread) or self._start_time
+            chunk = size - last_size
+            print(f'    [{threading.get_ident()}] {last_update} -> {current_time} ({chunk}B)')
+
+            update_time = self._update(chunk, current_time, last_update)
+            if update_time:
+                self._thread_updates[current_thread] = current_time
+            self._thread_sizes[current_thread] = size
+
+    def _update(self, size, current_time, last_update):
+        self.downloaded += size
         self.elapsed = current_time - self._start_time
+        if self.total is not None and self.downloaded > self.total:
+            self._total = self.downloaded
 
-        last_update = thread_info.last_update
+        self._times.append(current_time)
+        self._speeds.append(size / (current_time - last_update))
+
         if current_time - self.UPDATE_TIME <= last_update:
             return
-        thread_info.last_update = current_time
+        self._last_update = current_time
 
-        offset = bisect.bisect_left(thread_info.times, current_time - self.WINDOW_SIZE)
-        del thread_info.times[:offset]
-        del thread_info.speeds[:offset]
-        thread_info.times.append(current_time)
-        thread_info.speeds.append(size / (current_time - last_update))
+        offset = bisect.bisect_left(self._times, current_time - self.WINDOW_SIZE)
+        del self._times[:offset]
+        del self._speeds[:offset]
 
-        # weights = tuple(1 + (point - current_time) / self.WINDOW_SIZE for point in thread_info.times)
+        weights = tuple(1 + (point - current_time) / self.WINDOW_SIZE for point in self._times)
         # Same as `statistics.fmean(self.data_points, weights)`, but weights is >=3.11
-        # thread_info.speed = sum(map(operator.mul, thread_info.speeds, weights)) / sum(weights)
-        thread_info.speed = statistics.fmean(thread_info.speeds)
-        self.speed = sum(info.speed for info in self._thread_infos.values())
+        self.speed = sum(map(float.__mul__, self._speeds, weights)) / sum(weights)
 
         if not self.total:
             self.eta = None


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds a exponential moving average with a threadsafe interface for updating progress.
While currently only implemented for fragmented downloaders, it can be used tor every download.

Supersedes #3345
In preparation for #2197


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 20204b8</samp>

### Summary
📊🚀🔒

<!--
1.  📊 This emoji represents the data analysis and calculation aspect of the `ProgressCalculator` class, which uses various formulas and algorithms to compute the download progress and speed.
2.  🚀 This emoji represents the speed and performance improvement of the fragment downloads, which benefit from the sliding window and weighted average methods of the `ProgressCalculator` class, as well as the removal of redundant calculations and warnings.
3.  🔒 This emoji represents the thread-safety and synchronization feature of the `ProgressCalculator` class, which uses a lock to ensure that the progress data is updated and accessed atomically and consistently across multiple threads.
-->
This pull request introduces a new `ProgressCalculator` class that handles the download progress and speed calculations for fragment downloads. It also refactors the `yt_dlp/downloader/fragment.py` module to use this class and simplify the code. The new class improves the accuracy and consistency of the download speed and eta estimates.

> _Sing, O Muse, of the cunning `ProgressCalculator`,_
> _The dataclass that measured the swift downloads of fragments,_
> _And stored the bytes and speed in a sliding window of time,_
> _Secured by a lock from the strife of threading errors._

### Walkthrough
*  Add `ProgressCalculator` class to `utils.progress` module to handle download progress calculation for each thread and total download ([link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-fd5b4e8623a0743764d60ffa6850f59d8a8cc09a8ed5ae447eefde08a8c05c63R1-R99))
* Import `ProgressCalculator` class in `downloader.fragment` module and use it to replace manual calculation of speed, eta, and progress ([link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1R17), [link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L240-R241), [link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L262-R284))
* Simplify comment and logic for `state` dict that stores progress information for each fragment ([link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L229-R230), [link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L262-R284))
* Remove unused and unnecessary keys and variables from `ctx` dict and `frag_progress_hook` function ([link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L240-R241), [link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L262-R284))
* Remove warning message about download speed with multiple threads, as it is no longer relevant ([link](https://github.com/yt-dlp/yt-dlp/pull/8241/files?diff=unified&w=0#diff-766dc6665bc33238983e3ccbe955ebe6d80a8f7008340a6aa49d84a4397edeb1L503))



</details>
