### PR TITLE
extract nhk world's new stream provider

### DIFF
--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -29,12 +29,13 @@ class NhkBaseIE(InfoExtractor):
             m_id, query={'apikey': 'EJfK8jdS57GqlupFgAfAAwr573q01y6k'})['data']['episodes'] or []
 
     def _get_vod_api(self, vod_id):
-        movie_player_js = self._download_webpage('https://movie-a.nhk.or.jp/world/player/js/movie-player.js',
-                                                 vod_id, note='Downloading stream API information')
-        api_url = self._search_regex(r'prod:[^;]+apiUrl:\s*[\'"]([^\'"]+)[\'"]', movie_player_js,
-                                     vod_id, 'stream API url')
-        api_token = self._search_regex(r'prod:[^;]+token:\s*[\'"]([^\'"]+)[\'"]', movie_player_js,
-                                       vod_id, 'stream API token')
+        movie_player_js = self._download_webpage(
+            'https://movie-a.nhk.or.jp/world/player/js/movie-player.js', vod_id,
+            note='Downloading stream API information')
+        api_url = self._search_regex(
+            r'prod:[^;]+apiUrl:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, vod_id, 'stream API url')
+        api_token = self._search_regex(
+            r'prod:[^;]+token:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, vod_id, 'stream API token')
         return api_url, api_token
 
     def _extract_episode_info(self, url, episode=None):
@@ -81,14 +82,14 @@ class NhkBaseIE(InfoExtractor):
                 'token': api_token,
                 'type': 'json',
                 'optional_id': vod_id,
-                'active_flg': 1,  # dont know what this is but site sends it
+                'active_flg': 1,
             }, note='Downloading stream information')
-            stream_urls = traverse_obj(streams_json, ('meta', 0, 'movie_url'))
-            formats, subs = self._extract_m3u8_formats_and_subtitles(
-                stream_urls.get('mb_auto') or stream_urls.get('auto_sp') or stream_urls.get('auto_pc'),
-                vod_id)
+            stream_url = traverse_obj(streams_json, (
+                'meta', 0, 'movie_url', ('mb_auto', 'auto_sp', 'auto_pc'), {url_or_none}), get_all=False)
+            formats, subs = self._extract_m3u8_formats_and_subtitles(stream_url, vod_id)
 
             info.update({
+                'id': vod_id,
                 'formats': formats,
                 'subtitles': subs,
             })

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -54,7 +54,7 @@ class NhkBaseIE(InfoExtractor):
             api_url = api_info.pop('url')
             stream_url = traverse_obj(
                 self._download_json(
-                    api_url, vod_id, 'Downloading stream information', fatal=False, query={
+                    api_url, vod_id, 'Downloading stream url info', fatal=False, query={
                         **api_info,
                         'type': 'json',
                         'optional_id': vod_id,

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -47,11 +47,11 @@ class NhkBaseIE(InfoExtractor):
 
     def _extract_stream_info(self, api_url, api_token, vod_id):
         return self._download_json(api_url, vod_id, query={
-                'token': api_token,
-                'type': 'json',
-                'optional_id': vod_id,
-                'active_flg': 1,
-            }, note='Downloading stream information')
+            'token': api_token,
+            'type': 'json',
+            'optional_id': vod_id,
+            'active_flg': 1,
+        }, note='Downloading stream information')
 
     def _extract_episode_info(self, url, episode=None):
         fetch_episode = episode is None

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -28,14 +28,14 @@ class NhkBaseIE(InfoExtractor):
                 m_id, lang, '/all' if is_video else ''),
             m_id, query={'apikey': 'EJfK8jdS57GqlupFgAfAAwr573q01y6k'})['data']['episodes'] or []
 
-    def _get_vod_api(self, vod_id):
+    def _get_vod_api(self):
         movie_player_js = self._download_webpage(
-            'https://movie-a.nhk.or.jp/world/player/js/movie-player.js', vod_id,
+            'https://movie-a.nhk.or.jp/world/player/js/movie-player.js', None,
             note='Downloading stream API information')
         api_url = self._search_regex(
-            r'prod:[^;]+apiUrl:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, vod_id, 'stream API url')
+            r'prod:[^;]+apiUrl:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, None, 'stream API url')
         api_token = self._search_regex(
-            r'prod:[^;]+token:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, vod_id, 'stream API token')
+            r'prod:[^;]+token:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, None, 'stream API token')
         return api_url, api_token
 
     def _extract_episode_info(self, url, episode=None):
@@ -77,7 +77,7 @@ class NhkBaseIE(InfoExtractor):
         }
         if is_video:
             vod_id = episode['vod_id']
-            api_url, api_token = self._get_vod_api(vod_id)
+            api_url, api_token = self._get_vod_api()
             streams_json = self._download_json(api_url, vod_id, query={
                 'token': api_token,
                 'type': 'json',

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -28,7 +28,7 @@ class NhkBaseIE(InfoExtractor):
                 m_id, lang, '/all' if is_video else ''),
             m_id, query={'apikey': 'EJfK8jdS57GqlupFgAfAAwr573q01y6k'})['data']['episodes'] or []
 
-    def _get_vod_api(self):
+    def _extract_vod_api(self):
         movie_player_js = self._download_webpage(
             'https://movie-a.nhk.or.jp/world/player/js/movie-player.js', None,
             note='Downloading stream API information')
@@ -36,7 +36,22 @@ class NhkBaseIE(InfoExtractor):
             r'prod:[^;]+apiUrl:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, None, 'stream API url')
         api_token = self._search_regex(
             r'prod:[^;]+token:\s*[\'"]([^\'"]+)[\'"]', movie_player_js, None, 'stream API token')
+        self.cache.store('nhkworld', 'vod_api', {'url': api_url, 'token': api_token})
         return api_url, api_token
+
+    def _load_vod_api(self):
+        cachedata = self.cache.load('nhkworld', 'vod_api')
+        if cachedata is not None and url_or_none(cachedata.get('url')) is not None:
+            return cachedata['url'], cachedata.get('token')
+        return self._extract_vod_api()
+
+    def _extract_stream_info(self, api_url, api_token, vod_id):
+        return self._download_json(api_url, vod_id, query={
+                'token': api_token,
+                'type': 'json',
+                'optional_id': vod_id,
+                'active_flg': 1,
+            }, note='Downloading stream information')
 
     def _extract_episode_info(self, url, episode=None):
         fetch_episode = episode is None
@@ -77,13 +92,13 @@ class NhkBaseIE(InfoExtractor):
         }
         if is_video:
             vod_id = episode['vod_id']
-            api_url, api_token = self._get_vod_api()
-            streams_json = self._download_json(api_url, vod_id, query={
-                'token': api_token,
-                'type': 'json',
-                'optional_id': vod_id,
-                'active_flg': 1,
-            }, note='Downloading stream information')
+            api_url, api_token = self._load_vod_api()
+            streams_json = self._extract_stream_info(api_url, api_token, vod_id)
+            if streams_json.get('response_status') != '2000':
+                self.to_screen('Getting stream information failed, trying again with fresh API details')
+                api_url, api_token = self._extract_vod_api()
+                streams_json = self._extract_stream_info(api_url, api_token, vod_id)
+
             stream_url = traverse_obj(streams_json, (
                 'meta', 0, 'movie_url', ('mb_auto', 'auto_sp', 'auto_pc'), {url_or_none}), get_all=False)
             formats, subs = self._extract_m3u8_formats_and_subtitles(stream_url, vod_id)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

friendship ended with piksel
now stream.co.jp is my best friend
\- nhk, probably


I think it would be a good idea to cache the api url/token - they probably don't change at all
but grub4k said don't do that kind of thing in yt-dlp proper [in the discord](https://discord.com/channels/807245652072857610/1112613156934668338/1155774398918307870), so i won't

Fixes #8242 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 932e0a0</samp>

### Summary
🇯🇵📺🛠️

<!--
1.  🇯🇵 - This emoji represents Japan, the country where NHK is based and the main audience of its content. It also conveys the cultural and linguistic specificity of the website and the videos.
2.  📺 - This emoji represents television, the medium that NHK is best known for and the source of most of its video content. It also conveys the variety and quality of the programs that NHK offers, from news and documentaries to dramas and anime.
3.  🛠️ - This emoji represents tools, the symbol of improvement and fixing. It also conveys the technical aspect of the pull request, which involves modifying the code to use a different method of extraction and parsing.
-->
Improve NHK video extraction by using a new method to get and parse stream data. Fix `Piksel` extractor issue.

> _`Piksel` extractor_
> _fails for some NHK videos_
> _new method works well_

### Walkthrough
* Add a method to extract stream API url and token from JavaScript file (`_get_vod_api`, [link](https://github.com/yt-dlp/yt-dlp/pull/8249/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R31-R39))
* Use the new method to download and parse stream information as JSON (`_extract_episode_info`, [link](https://github.com/yt-dlp/yt-dlp/pull/8249/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L70-R95))
* Extract formats and subtitles from stream URLs using existing method (`_extract_m3u8_formats_and_subtitles`, [link](https://github.com/yt-dlp/yt-dlp/pull/8249/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L70-R95))
* Replace the use of `Piksel` extractor with the new approach (`_extract_episode_info`, [link](https://github.com/yt-dlp/yt-dlp/pull/8249/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L70-R95))



</details>
