### PR TITLE
[ie/iqiyi] Fix extractor

### DIFF
--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -499,9 +499,10 @@ class IqIE(InfoExtractor):
                     'tm': tm,
                     'qdy': 'a',
                     'qds': 0,
-                    'k_ft1': 141287244169348,
-                    'k_ft4': 34359746564,
-                    'k_ft5': 1,
+                    'k_ft1': '143486267424900',
+                    'k_ft4': '1572868',
+                    'k_ft7': '4',
+                    'k_ft5': '1',
                     'bop': JSON.stringify({
                         'version': '10.0',
                         'dfp': dfp

--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -542,17 +542,10 @@ class IqIE(InfoExtractor):
             end_pattern=r'\[\w+\]\|\|\w+\)\+["\']\.', transform_source=js_to_json,
             fatal=False) or {}
 
-        webpack_map = {}
-        for key, value in webpack_map_hash.items():
-            if key in webpack_map_module:
-                new_key = webpack_map_module[key]
-                webpack_map[new_key] = value
-            else:
-                webpack_map[key] = value
-
         for module_index in reversed(webpack_map):
+            real_module = replacement_map.get(module_index) or module_index 
             module_js = self._download_webpage(
-                f'https://stc.iqiyipic.com/_next/static/chunks/{module_index}.{webpack_map[module_index]}.js',
+                f'https://stc.iqiyipic.com/_next/static/chunks/{real_module}.{webpack_map[module_index]}.js',
                 video_id, note=f'Downloading #{module_index} module JS', errnote='Unable to download module JS', fatal=False) or ''
             if 'vms request' in module_js:
                 self.cache.store('iq', 'player_js', module_js)

--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -538,7 +538,7 @@ class IqIE(InfoExtractor):
 
         replacement_map = self._search_json(
             r'["\']\s*\+\(\s*', webpack_js, 'replacement map', video_id,
-            contains_pattern=r'{\s*(?:\d+\s*:\s*["\'][\w-]+["\']\s*,?\s*)+}',
+            contains_pattern=r'{\s*(?:\d+\s*:\s*["\'][\w.-]+["\']\s*,?\s*)+}',
             end_pattern=r'\[\w+\]\|\|\w+\)\+["\']\.', transform_source=js_to_json,
             fatal=False) or {}
 

--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -531,15 +531,16 @@ class IqIE(InfoExtractor):
             r'<script src="((?:https?:)?//stc\.iqiyipic\.com/_next/static/chunks/webpack-\w+\.js)"', webpage, 'webpack URL'))
         webpack_js = self._download_webpage(webpack_js_url, video_id, note='Downloading webpack JS', errnote='Unable to download webpack JS')
 
-        webpack_map_module = self._search_json(
-            r'["\']\s*\+\(\s*', webpack_js, 'JS locations', video_id,
-            contains_pattern=r'{\s*(?:\d+\s*:\s*"[^"]+",?\s*)+\}',
-            end_pattern=r'\[e\]\|\|e\)', transform_source=js_to_json)
-
-        webpack_map_hash = self._search_json(
+        webpack_map = self._search_json(
             r'["\']\s*\+\s*', webpack_js, 'JS locations', video_id,
             contains_pattern=r'{\s*(?:\d+\s*:\s*["\'][\da-f]+["\']\s*,?\s*)+}',
             end_pattern=r'\[\w+\]\+["\']\.js', transform_source=js_to_json)
+
+        replacement_map = self._search_json(
+            r'["\']\s*\+\(\s*', webpack_js, 'replacement map', video_id,
+            contains_pattern=r'{\s*(?:\d+\s*:\s*["\'][\w-]+["\']\s*,?\s*)+}',
+            end_pattern=r'\[\w+\]\|\|\w+\)\+["\']\.', transform_source=js_to_json,
+            fatal=False) or {}
 
         webpack_map = {}
         for key, value in webpack_map_hash.items():

--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -543,7 +543,7 @@ class IqIE(InfoExtractor):
             fatal=False) or {}
 
         for module_index in reversed(webpack_map):
-            real_module = replacement_map.get(module_index) or module_index 
+            real_module = replacement_map.get(module_index) or module_index
             module_js = self._download_webpage(
                 f'https://stc.iqiyipic.com/_next/static/chunks/{real_module}.{webpack_map[module_index]}.js',
                 video_id, note=f'Downloading #{module_index} module JS', errnote='Unable to download module JS', fatal=False) or ''


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The JavaScript module's filename has been changed from `9491.95d5c8e43c7d8e44.js` to `middlekey.95d5c8e43c7d8e44.js`. As a result, we need to acquire the following two maps from webpack and update the module URL accordingly.

`https://stc.iqiyipic.com/_next/static/chunks/webpack-2b5033a75f5434df.js`

```
{
            1106: "ibdiq",
            1361: "lib-ibd-data-pc",
            1487: "lib-ibd-skin-mobile",
            1647: "ibd.datain",
            1650: "lib-ibd-http-mobile",
            2398: "ibd.httpin",
            2708: "lib-ibd-skin-mini",
            4753: "lib-ibd-http-mobile-debug",
            5482: "lib-middlekey",
            7045: "lib-ibd-skin-pc",
            9491: "middlekey",
}
```

```
{
            268: "e6c280426a8746e8",
            1106: "6591fd31131b3a66",
            1126: "697ce126de3c33bb",
            1361: "233b2da38728401d",
            1417: "fbcfbf8326847599",
            1487: "f14812f1a1255796",
            1647: "e014ce13cd7fafcf",
            1650: "ecee125e7bc512db",
            1903: "e170a1017928d974",
            2152: "05c86652ea379cd8",
            2248: "9fc66e61fe94b1a9",
            2274: "5dc16eb3979f5503",
            2398: "923e8ff2379fdcd3",
            2708: "bb1fd0428b882be9",
            2846: "051b1b4ca335dac2",
            2925: "5f78adcd0a33696c",
            3087: "535f9d451f7d7237",
            4182: "1d3a53100a901bf8",
            4403: "a2404ee0cb55fc58",
            4681: "855fd3d29ae62015",
            4753: "4af6cb51a511537e",
            4959: "e214027027515082",
            5189: "35247471a82442e3",
            5449: "a3f7bb4f560fd996",
            5465: "124930ad130f53a7",
            5482: "ec02153a04d5f6cb",
            7045: "07a132444951f7cb",
            8085: "c7b29bf1e0281ef8",
            8741: "f701991230f9b0a6",
            9491: "95d5c8e43c7d8e44",
            9839: "ae31ac0c557aeb34",
            9864: "a355a27f18dba3f5",
            9922: "644e79ec97062215",
            9943: "76be891a7dc1d1f5",
}
```

Fixes #8123

By modifying the query parameters, we can instruct the website to return the non-encrypted version instead.

```
'k_ft1': '143486267424900',
'k_ft4': '1572868',
'k_ft7': '4',
'k_ft5': '1',
```

Fixes #7734 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6628398</samp>

### Summary
🛠️🔐🗺️

<!--
1.  🛠️ - This emoji represents a fix or improvement to an existing feature or functionality, which is what the video URL encryption and webpack map parsing changes are.
2.  🔐 - This emoji represents security or encryption, which is relevant to the video URL encryption change that prevents unauthorized access to the video content.
3.  🗺️ - This emoji represents a map or navigation, which is related to the webpack map parsing change that helps locate the correct video URL from the website's code.
-->
Fixed iqiyi extraction by updating the encryption and map parsing logic in `IqIE`.

> _`IqIE` extractor_
> _Adapts to website changes_
> _Fixes errors in fall_

### Walkthrough
* Update encryption parameters for video URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8260/files?diff=unified&w=0#diff-ec8755f16af55626ad31306e661f23e103aaf1645e2e78053040d4901951c49bL502-R505))
* Handle new format of webpack map for JS modules ([link](https://github.com/yt-dlp/yt-dlp/pull/8260/files?diff=unified&w=0#diff-ec8755f16af55626ad31306e661f23e103aaf1645e2e78053040d4901951c49bL532-R551))



</details>
