### PR TITLE
[ie/altcensored] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -82,6 +82,10 @@ from .airtv import AirTVIE
 from .aitube import AitubeKZVideoIE
 from .aljazeera import AlJazeeraIE
 from .alphaporno import AlphaPornoIE
+from .altcensored import (
+    AltCensoredIE,
+    AltCensoredChannelIE,
+)
 from .amara import AmaraIE
 from .alura import (
     AluraIE,

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -1,7 +1,7 @@
 import re
 
-from .common import InfoExtractor
 from .archiveorg import ArchiveOrgIE
+from .common import InfoExtractor
 from ..utils import (
     InAdvancePagedList,
     int_or_none,

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -4,6 +4,7 @@ from .common import InfoExtractor
 from .archiveorg import ArchiveOrgIE
 from ..utils import (
     int_or_none,
+    str_to_int,
     orderedSet,
     urljoin,
     InAdvancePagedList,

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -53,6 +53,7 @@ class AltCensoredIE(InfoExtractor):
 
 
 class AltCensoredChannelIE(InfoExtractor):
+    IE_NAME = 'altcensored:channel'
     _VALID_URL = r'https?://(?:www\.)?altcensored\.com/channel/(?!page|table)(?P<id>[^/?#]+)'
     _PAGE_SIZE = 24
     _TESTS = [{

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -62,11 +62,10 @@ class AltCensoredChannelIE(InfoExtractor):
             r'<a[^>]+href="/channel/\w+/page/(\d+)">(?:\1)</a>', webpage, 'page count', default='1'))
 
         def page_func(page_num):
+            page_num += 1
             webpage = self._download_webpage(
-                'https://altcensored.com/channel/%s/page/%d' % (channel_id, page_num + 1),
-                channel_id, note='Download page #%d' % (page_num + 1),
-                errnote='Unable to get page #%d' % (page_num + 1),
-            )
+                f'https://altcensored.com/channel/{channel_id}/page/{page_num}',
+                channel_id, note=f'Downloading page {page_num}')
 
             items = re.findall(r'<a[^>]+href="(/watch\?v=[^"]+)', webpage)
             # deduplicate consecutive items (multiple <a> per video)

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -16,9 +16,9 @@ class AltCensoredIE(InfoExtractor):
     _TESTS = [{
         'url': 'https://www.altcensored.com/watch?v=k0srjLSkga8',
         'info_dict': {
-            "id": "youtube-k0srjLSkga8",
-            "ext": "webm",
-            "title": "QUELLES SONT LES CONSÉQUENCES DE L'HYPERSEXUALISATION DE LA SOCIÉTÉ ?",
+            'id': 'youtube-k0srjLSkga8',
+            'ext': 'webm',
+            'title': "QUELLES SONT LES CONSÉQUENCES DE L'HYPERSEXUALISATION DE LA SOCIÉTÉ ?",
             'display_id': 'k0srjLSkga8.webm',
             'release_date': '20180403',
             'creator': 'Virginie Vota',

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -1,0 +1,76 @@
+import re
+from itertools import groupby
+
+from .common import InfoExtractor
+from .archiveorg import ArchiveOrgIE
+from ..utils import (
+    InAdvancePagedList,
+)
+
+
+class AltCensoredIE(InfoExtractor):
+    IE_NAME = 'altcensored'
+    _VALID_URL = r'https?://(?:www\.)altcensored\.com/(?:watch\?v=|embed/)(?P<id>[^/?#]+)'
+    _TESTS = [{
+        'url': 'https://www.altcensored.com/watch?v=k0srjLSkga8',
+        'info_dict': {
+            "id": "youtube-k0srjLSkga8",
+            "ext": "webm",
+            "title": "QUELLES SONT LES CONSÉQUENCES DE L'HYPERSEXUALISATION DE LA SOCIÉTÉ ?",
+            'display_id': 'k0srjLSkga8.webm',
+            'release_date': '20180403',
+            'creator': 'Virginie Vota',
+            'release_year': 2018,
+            'upload_date': '20230318',
+            'uploader': 'admin@altcensored.com',
+            'description': 'md5:0b38a8fc04103579d5c1db10a247dc30',
+            'timestamp': 1679161343,
+            'track': 'k0srjLSkga8',
+            'duration': 926.09,
+            'thumbnail': 'https://archive.org/download/youtube-k0srjLSkga8/youtube-k0srjLSkga8.thumbs/k0srjLSkga8_000925.jpg',
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        res = self.url_result('https://archive.org/details/youtube-%s' % video_id, ArchiveOrgIE)
+        # Extractor indirection doesn't allow merging info from the original extractor.
+        # Youtube view count or thumbnail extracted from altcensored can't be merge back
+        # into underlying archive.org info json
+        return res
+
+class AltCensoredChannelIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)altcensored\.com/channel/(?P<id>[^/?#]+)'
+    _PAGE_SIZE = 24
+    _TESTS = [{
+        'url': 'https://www.altcensored.com/channel/UCFPTO55xxHqFqkzRZHu4kcw',
+        'info_dict': {
+            'title': 'Virginie Vota Channel (91 Censored Videos)',
+            'id': 'UCFPTO55xxHqFqkzRZHu4kcw',
+        },
+        'playlist_count': 91
+    }]
+
+
+    def _real_extract(self, url):
+        channel_id = self._match_id(url)
+
+        webpage = self._download_webpage(url, channel_id, note='Download channel info',
+                                         errnote='Unable to get channel info')
+        title = self._html_search_meta('og:title', webpage)
+        page_count = int(self._html_search_regex(r'<a href="/channel/\w+/page/(\d+)">(?:\1)</a>', webpage, 'page count'))
+
+        def page_func(page_num):
+            webpage = self._download_webpage(
+                'https://altcensored.com/channel/%s/page/%d' % (channel_id, page_num + 1),
+                channel_id, note='Download page #%d' % (page_num + 1),
+                errnote='Unable to get page #%d' % (page_num + 1),
+            )
+
+            items = re.findall(r'<a[^>]+href="(/watch\?v=[^"]+)', webpage)
+            # deduplicate consecutive items (multiple <a> per video)
+            items = [self.url_result('https://www.altcensored.com' + key, AltCensoredIE) for key, _group in groupby(items)]
+            return items
+
+        entries = InAdvancePagedList(page_func, page_count, self._PAGE_SIZE)
+        return self.playlist_result(entries, playlist_id=channel_id, playlist_title=title)

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -31,7 +31,7 @@ class AltCensoredIE(InfoExtractor):
             'track': 'k0srjLSkga8',
             'duration': 926.09,
             'thumbnail': 'https://archive.org/download/youtube-k0srjLSkga8/youtube-k0srjLSkga8.thumbs/k0srjLSkga8_000925.jpg',
-            'view_count': 30402,
+            'view_count': int,
             'categories': ['News & Politics'],
         }
     }]

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -40,8 +40,16 @@ class AltCensoredIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        return self.url_result(f'https://archive.org/details/youtube-{video_id}', ArchiveOrgIE, url_transparent=True,
-                               view_count=yt_views, categories=[category])
+        return {
+            '_type': 'url_transparent',
+            'url': f'https://archive.org/details/youtube-{video_id}',
+            'ie_key': ArchiveOrgIE.ie_key(),
+            'view_count': str_to_int(self._html_search_regex(
+                r'YouTube Views:(?:\s|&nbsp;)*([\d,]+)', webpage, 'view count', default=None))
+            'categories': self._html_search_regex(
+                r'<a href="/category/\d+">\s*\n?\s*([^<]+)</a>',
+                webpage, 'category', default='').split() or None
+        }
 
 
 class AltCensoredChannelIE(InfoExtractor):

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -41,7 +41,7 @@ class AltCensoredIE(InfoExtractor):
 
 
 class AltCensoredChannelIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)altcensored\.com/channel/(?P<id>[^/?#]+)'
+    _VALID_URL = r'https?://(?:www\.)altcensored\.com/channel/(?!page|table)(?P<id>[^/?#]+)'
     _PAGE_SIZE = 24
     _TESTS = [{
         'url': 'https://www.altcensored.com/channel/UCFPTO55xxHqFqkzRZHu4kcw',

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -39,8 +39,6 @@ class AltCensoredIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        yt_views = str_to_int(self._html_search_regex(r'YouTube Views:(?:\s|&nbsp;)*([\d,]+)', webpage, 'view count', default=''))
-        category = self._html_search_regex(r'<a href="/category/\d+">\s*\n?\s*([^<]+)</a>', webpage, 'category', fatal=False)
 
         return self.url_result(f'https://archive.org/details/youtube-{video_id}', ArchiveOrgIE, url_transparent=True,
                                view_count=yt_views, categories=[category])

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -68,9 +68,8 @@ class AltCensoredChannelIE(InfoExtractor):
                 channel_id, note=f'Downloading page {page_num}')
 
             items = re.findall(r'<a[^>]+href="(/watch\?v=[^"]+)', webpage)
-            # deduplicate consecutive items (multiple <a> per video)
-            items = [self.url_result('https://www.altcensored.com' + key, AltCensoredIE) for key, _group in groupby(items)]
-            return items
+            return [self.url_result(urljoin('https://www.altcensored.com', path), AltCensoredIE)
+                    for path in orderedSet(items)]
 
         return self.playlist_result(
             InAdvancePagedList(page_func, page_count, self._PAGE_SIZE),

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -74,12 +74,12 @@ class AltCensoredChannelIE(InfoExtractor):
 
     def _real_extract(self, url):
         channel_id = self._match_id(url)
-
-        webpage = self._download_webpage(url, channel_id, note='Download channel info',
-                                         errnote='Unable to get channel info')
+        webpage = self._download_webpage(
+            url, channel_id, 'Download channel webpage', 'Unable to get channel webpage')
         title = self._html_search_meta('altcen_title', webpage, 'title', fatal=False)
         page_count = int_or_none(self._html_search_regex(
-            r'<a[^>]+href="/channel/\w+/page/(\d+)">(?:\1)</a>', webpage, 'page count', default='1'))
+            r'<a[^>]+href="/channel/\w+/page/(\d+)">(?:\1)</a>',
+            webpage, 'page count', default='1'))
 
         def page_func(page_num):
             page_num += 1

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -72,5 +72,6 @@ class AltCensoredChannelIE(InfoExtractor):
             items = [self.url_result('https://www.altcensored.com' + key, AltCensoredIE) for key, _group in groupby(items)]
             return items
 
-        entries = InAdvancePagedList(page_func, page_count, self._PAGE_SIZE)
-        return self.playlist_result(entries, playlist_id=channel_id, playlist_title=title)
+        return self.playlist_result(
+            InAdvancePagedList(page_func, page_count, self._PAGE_SIZE),
+            playlist_id=channel_id, playlist_title=title)

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -31,8 +31,8 @@ class AltCensoredIE(InfoExtractor):
             'track': 'k0srjLSkga8',
             'duration': 926.09,
             'thumbnail': 'https://archive.org/download/youtube-k0srjLSkga8/youtube-k0srjLSkga8.thumbs/k0srjLSkga8_000925.jpg',
-            'yt_views': 30402,
-            'category': 'News & Politics',
+            'view_count': 30402,
+            'categories': ['News & Politics'],
         }
     }]
 

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -37,13 +37,10 @@ class AltCensoredIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        # Use most data from archive.org (extractor indirection)
-        # But try first to gather a couple of useful information from altcensored
         webpage = self._download_webpage(url, video_id)
-        yt_views = int_or_none(self._html_search_regex(
-            r'YouTube Views:.*?([0-9,.]+)', webpage, 'view count', default='0').replace(',', ''))
-        category = self._html_search_regex(r'<a href="/category/.*?\n\s+([^<]+)', webpage, 'category')
-        # Hardcoded (very unlikely to need a change in a foreseeable future)
+        yt_views = str_to_int(self._html_search_regex(r'YouTube Views:(?:\s|&nbsp;)*([\d,]+)', webpage, 'view count', default=''))
+        category = self._html_search_regex(r'<a href="/category/\d+">\s*\n?\s*([^<]+)</a>', webpage, 'category', fatal=False)
+
         return self.url_result(f'https://archive.org/details/youtube-{video_id}', ArchiveOrgIE, url_transparent=True,
                                view_count=yt_views, categories=[category])
 

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -44,9 +44,8 @@ class AltCensoredIE(InfoExtractor):
             r'YouTube Views:.*?([0-9,.]+)', webpage, 'view count', default='0').replace(',', ''))
         category = self._html_search_regex(r'<a href="/category/.*?\n\s+([^<]+)', webpage, 'category')
         # Hardcoded (very unlikely to need a change in a foreseeable future)
-        res = self.url_result(f'https://archive.org/details/youtube-{video_id}', ArchiveOrgIE, url_transparent=True,
-                              yt_views=yt_views, category=category)
-        return res
+        return self.url_result(f'https://archive.org/details/youtube-{video_id}', ArchiveOrgIE, url_transparent=True,
+                               view_count=yt_views, categories=[category])
 
 
 class AltCensoredChannelIE(InfoExtractor):

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -58,7 +58,8 @@ class AltCensoredChannelIE(InfoExtractor):
         webpage = self._download_webpage(url, channel_id, note='Download channel info',
                                          errnote='Unable to get channel info')
         title = self._html_search_meta('og:title', webpage)
-        page_count = int(self._html_search_regex(r'<a href="/channel/\w+/page/(\d+)">(?:\1)</a>', webpage, 'page count'))
+        page_count = int_or_none(self._html_search_regex(
+            r'<a[^>]+href="/channel/\w+/page/(\d+)">(?:\1)</a>', webpage, 'page count', default='1'))
 
         def page_func(page_num):
             webpage = self._download_webpage(

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -39,6 +39,7 @@ class AltCensoredIE(InfoExtractor):
         # into underlying archive.org info json
         return res
 
+
 class AltCensoredChannelIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)altcensored\.com/channel/(?P<id>[^/?#]+)'
     _PAGE_SIZE = 24
@@ -50,7 +51,6 @@ class AltCensoredChannelIE(InfoExtractor):
         },
         'playlist_count': 91
     }]
-
 
     def _real_extract(self, url):
         channel_id = self._match_id(url)

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -45,10 +45,10 @@ class AltCensoredIE(InfoExtractor):
             'url': f'https://archive.org/details/youtube-{video_id}',
             'ie_key': ArchiveOrgIE.ie_key(),
             'view_count': str_to_int(self._html_search_regex(
-                r'YouTube Views:(?:\s|&nbsp;)*([\d,]+)', webpage, 'view count', default=None))
+                r'YouTube Views:(?:\s|&nbsp;)*([\d,]+)', webpage, 'view count', default=None)),
             'categories': self._html_search_regex(
                 r'<a href="/category/\d+">\s*\n?\s*([^<]+)</a>',
-                webpage, 'category', default='').split() or None
+                webpage, 'category', default='').split() or None,
         }
 
 

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -3,11 +3,11 @@ import re
 from .common import InfoExtractor
 from .archiveorg import ArchiveOrgIE
 from ..utils import (
-    int_or_none,
-    str_to_int,
-    orderedSet,
-    urljoin,
     InAdvancePagedList,
+    int_or_none,
+    orderedSet,
+    str_to_int,
+    urljoin,
 )
 
 

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -57,7 +57,7 @@ class AltCensoredChannelIE(InfoExtractor):
 
         webpage = self._download_webpage(url, channel_id, note='Download channel info',
                                          errnote='Unable to get channel info')
-        title = self._html_search_meta('og:title', webpage)
+        title = self._html_search_meta('altcen_title', webpage, 'title', fatal=False)
         page_count = int_or_none(self._html_search_regex(
             r'<a[^>]+href="/channel/\w+/page/(\d+)">(?:\1)</a>', webpage, 'page count', default='1'))
 

--- a/yt_dlp/extractor/altcensored.py
+++ b/yt_dlp/extractor/altcensored.py
@@ -33,7 +33,7 @@ class AltCensoredIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        res = self.url_result('https://archive.org/details/youtube-%s' % video_id, ArchiveOrgIE)
+        res = self.url_result(f'https://archive.org/details/youtube-{video_id}', ArchiveOrgIE)
         # Extractor indirection doesn't allow merging info from the original extractor.
         # Youtube view count or thumbnail extracted from altcensored can't be merge back
         # into underlying archive.org info json


### PR DESCRIPTION
### Description of your *pull request* and other information

Add an extractor for https://www.altcensored.com

While the website uses archive.org as a backend, support is particularly useful to retrieve playlist from channels (as they used to exist on Youtube.com before removal)


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9028171</samp>

### Summary
🆕🌐🎥

<!--
1.  🆕 - This emoji represents the addition of a new feature or functionality, such as the support for altcensored.com.
2.  🌐 - This emoji represents the involvement of a web service or website, such as altcensored.com or archive.org.
3.  🎥 - This emoji represents the media content or format, such as videos or YouTube.
-->
Add support for downloading videos and channels from altcensored.com by adding `AltCensoredIE` and `AltCensoredChannelIE` classes in `altcensored.py` and importing them in `_extractors.py`.

> _`AltCensoredIE`_
> _Scrapes censored videos_
> _From archive.org_

### Walkthrough
*  Add support for downloading videos and channels from altcensored.com ([link](https://github.com/yt-dlp/yt-dlp/pull/8291/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R85-R88), [link](https://github.com/yt-dlp/yt-dlp/pull/8291/files?diff=unified&w=0#diff-1cf7cd61a8b2244fa824e5c876d364cf183c024cff438f88a440ca066b9ed3cbR1-R76))
   * Import `AltCensoredIE` and `AltCensoredChannelIE` classes from `altcensored.py` module in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8291/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R85-R88))
   * Define `AltCensoredIE` and `AltCensoredChannelIE` classes in `altcensored.py` module ([link](https://github.com/yt-dlp/yt-dlp/pull/8291/files?diff=unified&w=0#diff-1cf7cd61a8b2244fa824e5c876d364cf183c024cff438f88a440ca066b9ed3cbR1-R76))
      * `AltCensoredIE` delegates extraction to `ArchiveOrgIE` using the archive.org URL of the video ([link](https://github.com/yt-dlp/yt-dlp/pull/8291/files?diff=unified&w=0#diff-1cf7cd61a8b2244fa824e5c876d364cf183c024cff438f88a440ca066b9ed3cbR1-R76))
      * `AltCensoredChannelIE` scrapes the channel page and returns a playlist of video URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8291/files?diff=unified&w=0#diff-1cf7cd61a8b2244fa824e5c876d364cf183c024cff438f88a440ca066b9ed3cbR1-R76))



</details>
