### PR TITLE
[cleanup] Misc

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # CPython 3.11 is in quick-test
-        python-version: ['3.8', '3.9', '3.10', '3.12-dev', pypy-3.7, pypy-3.8, pypy-3.10]
+        python-version: ['3.8', '3.9', '3.10', '3.12', pypy-3.7, pypy-3.8, pypy-3.10]
         run-tests-ext: [sh]
         include:
         # atleast one of each CPython/PyPy tests must be in windows
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.7'
           run-tests-ext: bat
         - os: windows-latest
-          python-version: '3.12-dev'
+          python-version: '3.12'
           run-tests-ext: bat
         - os: windows-latest
           python-version: pypy-3.9

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.10', 3.11-dev, pypy-3.7, pypy-3.8]
+        python-version: ['3.7', '3.10', '3.12', pypy-3.7, pypy-3.8, pypy-3.10]
         run-tests-ext: [sh]
         include:
         # atleast one of each CPython/PyPy tests must be in windows

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -1687,7 +1687,7 @@ class InfoExtractor:
     def _search_nuxt_data(self, webpage, video_id, context_name='__NUXT__', *, fatal=True, traverse=('data', 0)):
         """Parses Nuxt.js metadata. This works as long as the function __NUXT__ invokes is a pure function"""
         rectx = re.escape(context_name)
-        FUNCTION_RE = r'\(function\((?P<arg_keys>.*?)\){(?:.*?)return\s+(?P<js>{.*?})\s*;?\s*}\((?P<arg_vals>.*?)\)'
+        FUNCTION_RE = r'\(function\((?P<arg_keys>.*?)\){.*?\breturn\s+(?P<js>{.*?})\s*;?\s*}\((?P<arg_vals>.*?)\)'
         js, arg_keys, arg_vals = self._search_regex(
             (rf'<script>\s*window\.{rectx}={FUNCTION_RE}\s*\)\s*;?\s*</script>', rf'{rectx}\(.*?{FUNCTION_RE}'),
             webpage, context_name, group=('js', 'arg_keys', 'arg_vals'),

--- a/yt_dlp/extractor/tmz.py
+++ b/yt_dlp/extractor/tmz.py
@@ -8,158 +8,160 @@ from ..utils import (
 
 
 class TMZIE(InfoExtractor):
-    _VALID_URL = r"https?://(?:www\.)?tmz\.com/.*"
+    _VALID_URL = r'https?://(?:www\.)?tmz\.com/.*'
     _TESTS = [
         {
-            "url": "http://www.tmz.com/videos/0-cegprt2p/",
-            "info_dict": {
-                "id": "http://www.tmz.com/videos/0-cegprt2p/",
-                "ext": "mp4",
-                "title": "No Charges Against Hillary Clinton? Harvey Says It Ain't Over Yet",
-                "description": "Harvey talks about Director Comey’s decision not to prosecute Hillary Clinton.",
-                "timestamp": 1467831837,
-                "uploader": "TMZ Staff",
-                "upload_date": "20160706",
-                "thumbnail": "https://imagez.tmz.com/image/5e/4by3/2016/07/06/5eea7dc01baa5c2e83eb06930c170e46_xl.jpg",
-                "duration": 772.0,
+            'url': 'http://www.tmz.com/videos/0-cegprt2p/',
+            'info_dict': {
+                'id': 'http://www.tmz.com/videos/0-cegprt2p/',
+                'ext': 'mp4',
+                'title': 'No Charges Against Hillary Clinton? Harvey Says It Ain\'t Over Yet',
+                'description': 'Harvey talks about Director Comey’s decision not to prosecute Hillary Clinton.',
+                'timestamp': 1467831837,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20160706',
+                'thumbnail': 'https://imagez.tmz.com/image/5e/4by3/2016/07/06/5eea7dc01baa5c2e83eb06930c170e46_xl.jpg',
+                'duration': 772.0,
             },
         },
         {
-            "url": "https://www.tmz.com/videos/071119-chris-morgan-women-4590005-0-zcsejvcr/",
-            "info_dict": {
-                "id": "https://www.tmz.com/videos/071119-chris-morgan-women-4590005-0-zcsejvcr/",
-                "ext": "mp4",
-                "title": "Angry Bagel Shop Guy Says He Doesn't Trust Women",
-                "description": "The enraged man who went viral for ranting about women on dating sites before getting ragdolled in a bagel shop is defending his misogyny ... he says it's women's fault in the first place.",
-                "timestamp": 1562889485,
-                "uploader": "TMZ Staff",
-                "upload_date": "20190711",
-                "thumbnail": "https://imagez.tmz.com/image/a8/4by3/2019/07/12/a85480d27b2f50a7bfea2322151d67a5_xl.jpg",
-                "duration": 123.0,
+            'url': 'https://www.tmz.com/videos/071119-chris-morgan-women-4590005-0-zcsejvcr/',
+            'info_dict': {
+                'id': 'https://www.tmz.com/videos/071119-chris-morgan-women-4590005-0-zcsejvcr/',
+                'ext': 'mp4',
+                'title': 'Angry Bagel Shop Guy Says He Doesn\'t Trust Women',
+                'description': 'The enraged man who went viral for ranting about women on dating sites before getting ragdolled in a bagel shop is defending his misogyny ... he says it\'s women\'s fault in the first place.',
+                'timestamp': 1562889485,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20190711',
+                'thumbnail': 'https://imagez.tmz.com/image/a8/4by3/2019/07/12/a85480d27b2f50a7bfea2322151d67a5_xl.jpg',
+                'duration': 123.0,
             },
         },
         {
-            "url": "http://www.tmz.com/2015/04/19/bobby-brown-bobbi-kristina-awake-video-concert",
-            "md5": "5429c85db8bde39a473a56ca8c4c5602",
-            "info_dict": {
-                "id": "http://www.tmz.com/2015/04/19/bobby-brown-bobbi-kristina-awake-video-concert",
-                "ext": "mp4",
-                "title": "Bobby Brown Tells Crowd ... Bobbi Kristina is Awake",
-                "description": 'Bobby Brown stunned his audience during a concert Saturday night, when he told the crowd, "Bobbi is awake.  She\'s watching me."',
-                "timestamp": 1429467813,
-                "uploader": "TMZ Staff",
-                "upload_date": "20150419",
-                "duration": 29.0,
-                "thumbnail": "https://imagez.tmz.com/image/15/4by3/2015/04/20/1539c7ae136359fc979236fa6a9449dd_xl.jpg",
+            'url': 'http://www.tmz.com/2015/04/19/bobby-brown-bobbi-kristina-awake-video-concert',
+            'md5': '5429c85db8bde39a473a56ca8c4c5602',
+            'info_dict': {
+                'id': 'http://www.tmz.com/2015/04/19/bobby-brown-bobbi-kristina-awake-video-concert',
+                'ext': 'mp4',
+                'title': 'Bobby Brown Tells Crowd ... Bobbi Kristina is Awake',
+                'description': 'Bobby Brown stunned his audience during a concert Saturday night, when he told the crowd, "Bobbi is awake.  She\'s watching me."',
+                'timestamp': 1429467813,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20150419',
+                'duration': 29.0,
+                'thumbnail': 'https://imagez.tmz.com/image/15/4by3/2015/04/20/1539c7ae136359fc979236fa6a9449dd_xl.jpg',
             },
         },
         {
-            "url": "http://www.tmz.com/2015/09/19/patti-labelle-concert-fan-stripping-kicked-out-nicki-minaj/",
-            "info_dict": {
-                "id": "http://www.tmz.com/2015/09/19/patti-labelle-concert-fan-stripping-kicked-out-nicki-minaj/",
-                "ext": "mp4",
-                "title": "Patti LaBelle -- Goes Nuclear On Stripping Fan",
-                "description": "Patti LaBelle made it known loud and clear last night ... NO "
-                "ONE gets on her stage and strips down.",
-                "timestamp": 1442683746,
-                "uploader": "TMZ Staff",
-                "upload_date": "20150919",
-                "duration": 104.0,
-                "thumbnail": "https://imagez.tmz.com/image/5e/4by3/2015/09/20/5e57d7575062528082994e18ac3f0f48_xl.jpg",
+            'url': 'http://www.tmz.com/2015/09/19/patti-labelle-concert-fan-stripping-kicked-out-nicki-minaj/',
+            'info_dict': {
+                'id': 'http://www.tmz.com/2015/09/19/patti-labelle-concert-fan-stripping-kicked-out-nicki-minaj/',
+                'ext': 'mp4',
+                'title': 'Patti LaBelle -- Goes Nuclear On Stripping Fan',
+                'description': 'Patti LaBelle made it known loud and clear last night ... NO '
+                'ONE gets on her stage and strips down.',
+                'timestamp': 1442683746,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20150919',
+                'duration': 104.0,
+                'thumbnail': 'https://imagez.tmz.com/image/5e/4by3/2015/09/20/5e57d7575062528082994e18ac3f0f48_xl.jpg',
             },
         },
         {
-            "url": "http://www.tmz.com/2016/01/28/adam-silver-sting-drake-blake-griffin/",
-            "info_dict": {
-                "id": "http://www.tmz.com/2016/01/28/adam-silver-sting-drake-blake-griffin/",
-                "ext": "mp4",
-                "title": "NBA's Adam Silver -- Blake Griffin's a Great Guy ... He'll Learn from This",
-                "description": "Two pretty parts of this video with NBA Commish Adam Silver.",
-                "timestamp": 1454010989,
-                "uploader": "TMZ Staff",
-                "upload_date": "20160128",
-                "duration": 59.0,
-                "thumbnail": "https://imagez.tmz.com/image/38/4by3/2016/01/29/3856e83e0beb57059ec412122b842fb1_xl.jpg",
+            'url': 'http://www.tmz.com/2016/01/28/adam-silver-sting-drake-blake-griffin/',
+            'info_dict': {
+                'id': 'http://www.tmz.com/2016/01/28/adam-silver-sting-drake-blake-griffin/',
+                'ext': 'mp4',
+                'title': 'NBA\'s Adam Silver -- Blake Griffin\'s a Great Guy ... He\'ll Learn from This',
+                'description': 'Two pretty parts of this video with NBA Commish Adam Silver.',
+                'timestamp': 1454010989,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20160128',
+                'duration': 59.0,
+                'thumbnail': 'https://imagez.tmz.com/image/38/4by3/2016/01/29/3856e83e0beb57059ec412122b842fb1_xl.jpg',
             },
         },
         {
-            "url": "http://www.tmz.com/2016/10/27/donald-trump-star-vandal-arrested-james-otis/",
-            "info_dict": {
-                "id": "http://www.tmz.com/2016/10/27/donald-trump-star-vandal-arrested-james-otis/",
-                "ext": "mp4",
-                "title": "Trump Star Vandal -- I'm Not Afraid of Donald or the Cops!",
-                "description": "James Otis is the the guy who took a pickaxe to Donald Trump's star on the Walk of Fame, and he tells TMZ .. he's ready and willing to go to jail for the crime.",
-                "timestamp": 1477500095,
-                "uploader": "TMZ Staff",
-                "upload_date": "20161026",
-                "thumbnail": "https://imagez.tmz.com/image/0d/4by3/2016/10/27/0d904814d4a75dcf9cc3b8cfd1edc1a3_xl.jpg",
-                "duration": 128.0,
+            'url': 'http://www.tmz.com/2016/10/27/donald-trump-star-vandal-arrested-james-otis/',
+            'info_dict': {
+                'id': 'http://www.tmz.com/2016/10/27/donald-trump-star-vandal-arrested-james-otis/',
+                'ext': 'mp4',
+                'title': 'Trump Star Vandal -- I\'m Not Afraid of Donald or the Cops!',
+                'description': 'James Otis is the the guy who took a pickaxe to Donald Trump\'s star on the Walk of Fame, and he tells TMZ .. he\'s ready and willing to go to jail for the crime.',
+                'timestamp': 1477500095,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20161026',
+                'thumbnail': 'https://imagez.tmz.com/image/0d/4by3/2016/10/27/0d904814d4a75dcf9cc3b8cfd1edc1a3_xl.jpg',
+                'duration': 128.0,
             },
         },
         {
-            "url": "https://www.tmz.com/videos/2020-10-31-103120-beverly-hills-protest-4878209/",
-            "info_dict": {
-                "id": "https://www.tmz.com/videos/2020-10-31-103120-beverly-hills-protest-4878209/",
-                "ext": "mp4",
-                "title": "Cops Use Billy Clubs Against Pro-Trump and Anti-Fascist "
-                "Demonstrators",
-                "description": "Beverly Hills may be an omen of what's coming next week, "
-                "because things got crazy on the streets and cops started "
-                "swinging their billy clubs at both Anti-Fascist and Pro-Trump "
-                "demonstrators.",
-                "timestamp": 1604182772,
-                "uploader": "TMZ Staff",
-                "upload_date": "20201031",
-                "duration": 96.0,
-                "thumbnail": "https://imagez.tmz.com/image/f3/4by3/2020/10/31/f37bd5a8aef84497866f425130c58be3_xl.jpg",
+            'url': 'https://www.tmz.com/videos/2020-10-31-103120-beverly-hills-protest-4878209/',
+            'info_dict': {
+                'id': 'https://www.tmz.com/videos/2020-10-31-103120-beverly-hills-protest-4878209/',
+                'ext': 'mp4',
+                'title': 'Cops Use Billy Clubs Against Pro-Trump and Anti-Fascist '
+                'Demonstrators',
+                'description': 'Beverly Hills may be an omen of what\'s coming next week, '
+                'because things got crazy on the streets and cops started '
+                'swinging their billy clubs at both Anti-Fascist and Pro-Trump '
+                'demonstrators.',
+                'timestamp': 1604182772,
+                'uploader': 'TMZ Staff',
+                'upload_date': '20201031',
+                'duration': 96.0,
+                'thumbnail': 'https://imagez.tmz.com/image/f3/4by3/2020/10/31/f37bd5a8aef84497866f425130c58be3_xl.jpg',
             },
         },
         {
-            "url": "https://www.tmz.com/2020/11/05/gervonta-davis-car-crash-hit-and-run-police/",
-            "info_dict": {
-                "id": "Dddb6IGe-ws",
-                "ext": "mp4",
-                "title": "SICK LAMBO GERVONTA DAVIS IN HIS NEW RIDE RIGHT AFTER KO AFTER LEO  EsNews Boxing",
-                "uploader": "ESNEWS",
-                "description": "md5:49675bc58883ccf80474b8aa701e1064",
-                "upload_date": "20201102",
-                "uploader_id": "ESNEWS",
-                "uploader_url": "http://www.youtube.com/user/ESNEWS",
-                "like_count": int,
-                "channel_id": "UCI-Oq7oFGakzSzHFlTtsUsQ",
-                "channel": "ESNEWS",
-                "view_count": int,
-                "duration": 225,
-                "live_status": "not_live",
-                "thumbnail": "https://i.ytimg.com/vi_webp/Dddb6IGe-ws/maxresdefault.webp",
-                "channel_url": "https://www.youtube.com/channel/UCI-Oq7oFGakzSzHFlTtsUsQ",
-                "channel_follower_count": int,
-                "playable_in_embed": True,
-                "categories": ["Sports"],
-                "age_limit": 0,
-                "tags": "count:10",
-                "availability": "public",
+            'url': 'https://www.tmz.com/2020/11/05/gervonta-davis-car-crash-hit-and-run-police/',
+            'info_dict': {
+                'id': 'Dddb6IGe-ws',
+                'ext': 'mp4',
+                'title': 'SICK LAMBO GERVONTA DAVIS IN HIS NEW RIDE RIGHT AFTER KO AFTER LEO  EsNews Boxing',
+                'uploader': 'ESNEWS',
+                'description': 'md5:49675bc58883ccf80474b8aa701e1064',
+                'upload_date': '20201102',
+                'uploader_id': '@ESNEWS',
+                'uploader_url': 'https://www.youtube.com/@ESNEWS',
+                'like_count': int,
+                'channel_id': 'UCI-Oq7oFGakzSzHFlTtsUsQ',
+                'channel': 'ESNEWS',
+                'view_count': int,
+                'duration': 225,
+                'live_status': 'not_live',
+                'thumbnail': 'https://i.ytimg.com/vi_webp/Dddb6IGe-ws/maxresdefault.webp',
+                'channel_url': 'https://www.youtube.com/channel/UCI-Oq7oFGakzSzHFlTtsUsQ',
+                'channel_follower_count': int,
+                'playable_in_embed': True,
+                'categories': ['Sports'],
+                'age_limit': 0,
+                'tags': 'count:10',
+                'availability': 'public',
+                'comment_count': int,
             },
         },
         {
-            "url": "https://www.tmz.com/2020/11/19/conor-mcgregor-dustin-poirier-contract-fight-ufc-257-fight-island/",
-            "info_dict": {
-                "id": "1329450007125225473",
-                "ext": "mp4",
-                "title": "The Mac Life - BREAKING: Conor McGregor (@thenotoriousmma) has signed his bout agreement for his rematch with Dustin Poirier for January 23.",
-                "uploader": "The Mac Life",
-                "description": "md5:56e6009bbc3d12498e10d08a8e1f1c69",
-                "upload_date": "20201119",
-                "uploader_id": "TheMacLife",
-                "timestamp": 1605800556,
-                "thumbnail": "https://pbs.twimg.com/media/EnMmfT8XYAExgxJ.jpg?name=small",
-                "like_count": int,
-                "duration": 11.812,
-                "uploader_url": "https://twitter.com/TheMacLife",
-                "age_limit": 0,
-                "repost_count": int,
-                "tags": [],
-                "comment_count": int,
+            'url': 'https://www.tmz.com/2020/11/19/conor-mcgregor-dustin-poirier-contract-fight-ufc-257-fight-island/',
+            'info_dict': {
+                'id': '1329448013937471491',
+                'ext': 'mp4',
+                'title': 'The Mac Life - BREAKING: Conor McGregor (@thenotoriousmma) has signed his bout agreement for his rematch with Dustin Poirier for January 23.',
+                'uploader': 'The Mac Life',
+                'description': 'md5:56e6009bbc3d12498e10d08a8e1f1c69',
+                'upload_date': '20201119',
+                'display_id': '1329450007125225473',
+                'uploader_id': 'TheMacLife',
+                'timestamp': 1605800556,
+                'thumbnail': 'https://pbs.twimg.com/media/EnMmfT8XYAExgxJ.jpg?name=small',
+                'like_count': int,
+                'duration': 11.812,
+                'uploader_url': 'https://twitter.com/TheMacLife',
+                'age_limit': 0,
+                'repost_count': int,
+                'tags': [],
+                'comment_count': int,
             },
         },
     ]
@@ -167,25 +169,25 @@ class TMZIE(InfoExtractor):
     def _real_extract(self, url):
         webpage = self._download_webpage(url, url)
         jsonld = self._search_json_ld(webpage, url)
-        if not jsonld or "url" not in jsonld:
+        if not jsonld or 'url' not in jsonld:
             # try to extract from YouTube Player API
             # see https://developers.google.com/youtube/iframe_api_reference#Video_Queueing_Functions
             match_obj = re.search(r'\.cueVideoById\(\s*(?P<quote>[\'"])(?P<id>.*?)(?P=quote)', webpage)
             if match_obj:
-                res = self.url_result(match_obj.group("id"))
+                res = self.url_result(match_obj.group('id'))
                 return res
             # try to extract from twitter
-            blockquote_el = get_element_by_attribute("class", "twitter-tweet", webpage)
+            blockquote_el = get_element_by_attribute('class', 'twitter-tweet', webpage)
             if blockquote_el:
                 matches = re.findall(
                     r'<a[^>]+href=\s*(?P<quote>[\'"])(?P<link>.*?)(?P=quote)',
                     blockquote_el)
                 if matches:
                     for _, match in matches:
-                        if "/status/" in match:
+                        if '/status/' in match:
                             res = self.url_result(match)
                             return res
-            raise ExtractorError("No video found!")
+            raise ExtractorError('No video found!')
         if id not in jsonld:
-            jsonld["id"] = url
+            jsonld['id'] = url
         return jsonld


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Some cleanup:
- `_search_nuxt_data` regex fix from @dirkf (https://github.com/yt-dlp/yt-dlp/commit/904a19ee93195ce0bd4b08bd22b186120afb5b17#commitcomment-129343041)
- Update test targets
- Update `tmz.py` quotes and tests from @gamer191

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ced55f</samp>

### Summary
🔄🩹🚀

<!--
1.  🔄 for moving the download workflow to the core workflow and updating the python-version matrix.
2.  🩹 for simplifying the regex pattern for parsing Nuxt.js metadata in the common extractor.
3.  🚀 for using the stable version of Python 3.12 in the core workflow.
-->
This pull request updates the core workflow to use Python 3.12, removes the download workflow, and improves the Nuxt.js metadata extraction. These changes aim to enhance compatibility, efficiency, and accuracy.

> _We are the core, we rule the workflow_
> _We crush the redundancy, we optimize the matrix_
> _We parse the metadata, we flex the regex_
> _We use the stable Python, we shun the dev version_

### Walkthrough
*  Simplify Nuxt.js metadata regex in common extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8300/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L1690-R1690))
*  Update python-version matrix to use '3.12' instead of '3.12-dev' in core workflow ([link](https://github.com/yt-dlp/yt-dlp/pull/8300/files?diff=unified&w=0#diff-a86bb2175b62f05d86a7f7fe0f3fd6d6c44e2cdfd0f4e4a92759c817d7959d96L16-R16), [link](https://github.com/yt-dlp/yt-dlp/pull/8300/files?diff=unified&w=0#diff-a86bb2175b62f05d86a7f7fe0f3fd6d6c44e2cdfd0f4e4a92759c817d7959d96L24-R24))



</details>
