### PR TITLE
NHK World regex fixes

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1273,6 +1273,7 @@ from .nfl import (
 )
 from .nhk import (
     NhkVodIE,
+    NhkVodAudioIE,
     NhkVodProgramIE,
     NhkForSchoolBangumiIE,
     NhkForSchoolSubjectIE,

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -138,30 +138,26 @@ class NhkVodIE(NhkBaseIE):
     # Content available only for a limited period of time. Visit
     # https://www3.nhk.or.jp/nhkworld/en/ondemand/ for working samples.
     _TESTS = [{
-        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/2061601/',
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/2049126/',
         'info_dict': {
-            'id': 'yd8322ch',
+            'id': 'nw_vod_v_en_2049_126_20230413233000_01_1681398302',
             'ext': 'mp4',
-            'description': 'md5:109c8b05d67a62d0592f2b445d2cd898',
-            'title': 'GRAND SUMO Highlights - [Recap] May Tournament Day 1 (Opening Day)',
-            'upload_date': '20230514',
-            'timestamp': 1684083791,
-            'series': 'GRAND SUMO Highlights',
-            'episode': '[Recap] May Tournament Day 1 (Opening Day)',
-            'thumbnail': 'https://mz-edge.stream.co.jp/thumbs/aid/t1684084443/4028649.jpg?w=1920&h=1080',
+            'title': 'Japan Railway Journal - The Tohoku Shinkansen: Full Speed Ahead',
+            'description': 'md5:49f7c5b206e03868a2fdf0d0814b92f6',
+            'thumbnail': 'md5:51bcef4a21936e7fea1ff4e06353f463',
+            'episode': 'The Tohoku Shinkansen: Full Speed Ahead',
+            'series': 'Japan Railway Journal',
         },
     }, {
         # video clip
         'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/9999011/',
-        'md5': '7a90abcfe610ec22a6bfe15bd46b30ca',
+        'md5': '153c3016dfd252ba09726588149cf0e7',
         'info_dict': {
-            'id': 'a95j5iza',
+            'id': 'lpZXIwaDE6_Z-976CPsFdxyICyWUzlT5',
             'ext': 'mp4',
             'title': "Dining with the Chef - Chef Saito's Family recipe: MENCHI-KATSU",
             'description': 'md5:5aee4a9f9d81c26281862382103b0ea5',
-            'timestamp': 1565965194,
-            'upload_date': '20190816',
-            'thumbnail': 'https://mz-edge.stream.co.jp/thumbs/aid/t1567086278/3715195.jpg?w=1920&h=1080',
+            'thumbnail': 'md5:d6a4d9b6e9be90aaadda0bcce89631ed',
             'series': 'Dining with the Chef',
             'episode': 'Chef Saito\'s Family recipe: MENCHI-KATSU',
         },
@@ -190,14 +186,16 @@ class NhkVodAudioIE(NhkBaseIE):
     _VALID_URL = r'%s/(?P<type>audio)/(?P<id>[^/]+?-\d{8}-[0-9a-z]+)/' % (NhkBaseIE._BASE_URL_REGEX)
     _TESTS = [{
         # audio clip
-        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/r_inventions-20201104-1/',
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/livinginjapan-20231001-1/',
         'info_dict': {
-            'id': 'r_inventions-20201104-1-en',
+            'id': 'livinginjapan-20231001-1-en',
             'ext': 'm4a',
-            'title': "Japan's Top Inventions - Miniature Video Cameras",
-            'description': 'md5:07ea722bdbbb4936fdd360b6a480c25b',
+            'title': "Living in Japan - Tips for Travelers to Japan / Ramen Vending Machines",
+            'series': 'Living in Japan',
+            'description': 'md5:850611969932874b4a3309e0cae06c2f',
+            'thumbnail': 'md5:960622fb6e06054a4a1a0c97ea752545',
+            'episode': 'Tips for Travelers to Japan / Ramen Vending Machines'
         },
-        'skip': '404 Not Found',
     }, {
         'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/plugin-20190404-1/',
         'only_matching': True,

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -123,12 +123,6 @@ class NhkBaseIE(InfoExtractor):
                     m3u8_id='hls', fatal=False)
                 for f in info['formats']:
                     f['language'] = lang
-            else:
-                info.update({
-                    '_type': 'url_transparent',
-                    'ie_key': NhkVodIE.ie_key(),
-                    'url': url,
-                })
         return info
 
 
@@ -213,7 +207,7 @@ class NhkVodAudioIE(NhkBaseIE):
 
 
 class NhkVodProgramIE(NhkBaseIE):
-    _VALID_URL = r'%s/program%s(?P<id>[0-9a-z]+)(?:.+?\btype=(?P<episode_type>clip|(?:radio|tv)Episode))?' % (NhkBaseIE._BASE_URL_REGEX, NhkBaseIE._TYPE_REGEX)
+    _VALID_URL = r'%s/program%s(?P<id>[0-9a-z_]+)(?:.+?\btype=(?P<episode_type>clip|(?:radio|tv)Episode))?' % (NhkBaseIE._BASE_URL_REGEX, NhkBaseIE._TYPE_REGEX)
     _TESTS = [{
         # video program episodes
         'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/program/video/sumo',
@@ -257,12 +251,10 @@ class NhkVodProgramIE(NhkBaseIE):
             episode_path = episode.get('url')
             if not episode_path:
                 continue
-            entries.append(self._extract_episode_info(
-                urljoin(url, episode_path), episode))
+            entries.append(self.url_result(
+                urljoin(url, episode_path)))
 
-        program_title = None
-        if entries:
-            program_title = entries[0].get('series')
+        program_title = traverse_obj(episodes, (0, 'series'))
 
         return self.playlist_result(entries, program_id, program_title)
 

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -68,11 +68,12 @@ class NhkBaseIE(InfoExtractor):
 
     def _extract_episode_info(self, url, episode=None):
         fetch_episode = episode is None
-        lang, m_type, episode_id = NhkVodIE._match_valid_url(url).groups()
-        if len(episode_id) == 7:
+        lang, m_type, episode_id = self._match_valid_url(url).groups()
+        is_video = m_type == 'video'
+
+        if is_video:
             episode_id = episode_id[:4] + '-' + episode_id[4:]
 
-        is_video = m_type == 'video'
         if fetch_episode:
             episode = self._call_api(
                 episode_id, lang, is_video, True, episode_id[:4] == '9999')[0]
@@ -133,7 +134,7 @@ class NhkBaseIE(InfoExtractor):
 
 class NhkVodIE(NhkBaseIE):
     # the 7-character IDs can have alphabetic chars too: assume [a-z] rather than just [a-f], eg
-    _VALID_URL = r'%s%s(?P<id>[0-9a-z]{7}|[^/]+?-\d{8}-[0-9a-z]+)' % (NhkBaseIE._BASE_URL_REGEX, NhkBaseIE._TYPE_REGEX)
+    _VALID_URL = r'%s/(?P<type>video)/(?P<id>[0-9a-z]+)/' % (NhkBaseIE._BASE_URL_REGEX)
     # Content available only for a limited period of time. Visit
     # https://www3.nhk.or.jp/nhkworld/en/ondemand/ for working samples.
     _TESTS = [{
@@ -165,28 +166,6 @@ class NhkVodIE(NhkBaseIE):
             'episode': 'Chef Saito\'s Family recipe: MENCHI-KATSU',
         },
     }, {
-        # audio clip
-        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/r_inventions-20201104-1/',
-        'info_dict': {
-            'id': 'r_inventions-20201104-1-en',
-            'ext': 'm4a',
-            'title': "Japan's Top Inventions - Miniature Video Cameras",
-            'description': 'md5:07ea722bdbbb4936fdd360b6a480c25b',
-        },
-        'skip': '404 Not Found',
-    }, {
-        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/2015173/',
-        'only_matching': True,
-    }, {
-        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/plugin-20190404-1/',
-        'only_matching': True,
-    }, {
-        'url': 'https://www3.nhk.or.jp/nhkworld/fr/ondemand/audio/plugin-20190404-1/',
-        'only_matching': True,
-    }, {
-        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/j_art-20150903-1/',
-        'only_matching': True,
-    }, {
         # video, alphabetic character in ID #29670
         'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/9999a34/',
         'info_dict': {
@@ -199,6 +178,35 @@ class NhkVodIE(NhkBaseIE):
             'timestamp': 1623722008,
         },
         'skip': '404 Not Found',
+    }, {
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/2015173/',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        return self._extract_episode_info(url)
+
+class NhkVodAudioIE(NhkBaseIE):
+    _VALID_URL = r'%s/(?P<type>audio)/(?P<id>[^/]+?-\d{8}-[0-9a-z]+)/' % (NhkBaseIE._BASE_URL_REGEX)
+    _TESTS = [{
+        # audio clip
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/r_inventions-20201104-1/',
+        'info_dict': {
+            'id': 'r_inventions-20201104-1-en',
+            'ext': 'm4a',
+            'title': "Japan's Top Inventions - Miniature Video Cameras",
+            'description': 'md5:07ea722bdbbb4936fdd360b6a480c25b',
+        },
+        'skip': '404 Not Found',
+    }, {
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/plugin-20190404-1/',
+        'only_matching': True,
+    }, {
+        'url': 'https://www3.nhk.or.jp/nhkworld/fr/ondemand/audio/plugin-20190404-1/',
+        'only_matching': True,
+    }, {
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/audio/j_art-20150903-1/',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -182,6 +182,7 @@ class NhkVodIE(NhkBaseIE):
     def _real_extract(self, url):
         return self._extract_episode_info(url)
 
+
 class NhkVodAudioIE(NhkBaseIE):
     _VALID_URL = r'%s/(?P<type>audio)/(?P<id>[^/]+?-\d{8}-[0-9a-z]+)/' % (NhkBaseIE._BASE_URL_REGEX)
     _TESTS = [{


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

> ```
> Split NHK World IEs in two to fix regex issues
> 
> radio was getting matched by a section of the regex meant for the video
> extractor, and japanese-language vods broke because their ids were too
> long.
> 
> this commit fixes NhkVodIE so it can extract japanese-language vods, by
> removing the explicit specification of the length of the ID. It also
> splits radio and tv into their own IEs, with separate regexes, so they
> don't conflict with each other.
> 
> closes #8303 and fixes radio extraction
> ```
also some modifications to NhkVodProgramIE because ^those changes broke it

Fixes #8303

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9d0c980</samp>

### Summary
:loud_sound::wrench::rocket:

<!--
1.  :loud_sound: This emoji represents the addition of audio support for NHK World, as well as the new extractor class for audio clips. It conveys the idea of sound and media.
2.  :wrench: This emoji represents the update and improvement of the existing code for the NHK World website, as well as the removal of obsolete code. It conveys the idea of fixing and enhancing something.
3.  :rocket: This emoji represents the performance and efficiency boost of the program extraction, as well as the new URL format and API response of the NHK World website. It conveys the idea of speed and innovation.
-->
This pull request adds support for downloading audio clips from the NHK World website, which has changed its URL format and API response. It updates the `nhk.py` module and adds a new extractor class `NhkVodAudioIE` to the `_extractors.py` module. It also removes redundant and obsolete code and improves performance and efficiency.

> _`yt-dlp` can fetch_
> _audio clips from NHK_
> _snowy winter news_

### Walkthrough
*  Add support for downloading audio clips from NHK World by creating a new extractor class `NhkVodAudioIE` that inherits from `NhkBaseIE` and overrides the `_real_extract` method ([link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1276), [link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R174-R193))
* Simplify and update the URL validation and extraction logic for video clips from NHK World by removing unnecessary groups and patterns from the `_VALID_URL` attribute and the `_TESTS` attribute of the `NhkVodIE` extractor class, and by using the `self._match_valid_url` method instead of the `NhkVodIE._match_valid_url` method in the `_extract_episode_info` method of the `NhkBaseIE` extractor class ([link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L71-R76), [link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L136-R168), [link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L189-L201))
* Remove redundant and unreachable code from the `_extract_episode_info` method of the `NhkBaseIE` extractor class that returned a URL transparent result for non-video and non-audio media types, since the `_match_valid_url` method only accepts video or audio as valid media types ([link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L125-L130))
* Fix a bug that prevented some programs from being recognized by the `NhkVodProgramIE` extractor class by adding an underscore to the character set for the program ID in the `_VALID_URL` attribute ([link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L209-R210))
* Improve the performance and efficiency of the `NhkVodProgramIE` extractor class by replacing the call to the `_extract_episode_info` method of the base class with a call to the `url_result` method of the `InfoExtractor` class, and by using the `traverse_obj` utility function to get the program title from the first episode in the list ([link](https://github.com/yt-dlp/yt-dlp/pull/8305/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L253-R257))



</details>
