### PR TITLE
Add mbn.co.kr extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1051,6 +1051,7 @@ from .markiza import (
 from .massengeschmacktv import MassengeschmackTVIE
 from .masters import MastersIE
 from .matchtv import MatchTVIE
+from .mbn import MBNIE
 from .mdr import MDRIE
 from .medaltv import MedalTVIE
 from .mediaite import MediaiteIE

--- a/yt_dlp/extractor/mbn.py
+++ b/yt_dlp/extractor/mbn.py
@@ -3,9 +3,9 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     int_or_none,
-	traverse_obj,
+    traverse_obj,
     unified_strdate,
-	url_or_none,
+    url_or_none,
 )
 
 

--- a/yt_dlp/extractor/mbn.py
+++ b/yt_dlp/extractor/mbn.py
@@ -67,13 +67,13 @@ class MBNIE(InfoExtractor):
             })
 
         formats = []
-        for stream_url in traverse_obj(media_info, ('movie_list', ..., 'url')):
-            location = re.sub(r'/(?:chunk|play)list(?:_pd\d+)?\.m3u8', '/manifest.m3u8', stream_url)
-            m3u8_url = url_or_none(self._download_webpage(
-                f'https://www.mbn.co.kr/player/mbnStreamAuth_new_vod.mbn?vod_url={location}',
+        for stream_url in traverse_obj(media_info, ('movie_list', ..., 'url', {url_or_none})):
+            stream_url = re.sub(r'/(?:chunk|play)list(?:_pd\d+)?\.m3u8', '/manifest.m3u8', stream_url)
+            final_url = url_or_none(self._download_webpage(
+                f'https://www.mbn.co.kr/player/mbnStreamAuth_new_vod.mbn?vod_url={stream_url}',
                 content_id, note='Fetching authenticated m3u8 url'))
 
-            formats.extend(self._extract_m3u8_formats(m3u8_url, content_id, fatal=False))
+            formats.extend(self._extract_m3u8_formats(final_url, content_id, fatal=False))
 
         return {
             'id': content_id,

--- a/yt_dlp/extractor/mbn.py
+++ b/yt_dlp/extractor/mbn.py
@@ -67,8 +67,8 @@ class MBNIE(InfoExtractor):
             })
 
         formats = []
-        for stream in traverse_obj(media_info, ('movie_list', lambda _, v: v['url'])):
-            location = re.sub(r'/(?:chunk|play)list(?:_pd\d+)?\.m3u8', '/manifest.m3u8', stream['url'])
+        for stream_url in traverse_obj(media_info, ('movie_list', ..., 'url')):
+            location = re.sub(r'/(?:chunk|play)list(?:_pd\d+)?\.m3u8', '/manifest.m3u8', stream_url)
             m3u8_url = url_or_none(self._download_webpage(
                 f'https://www.mbn.co.kr/player/mbnStreamAuth_new_vod.mbn?vod_url={location}',
                 content_id, note='Fetching authenticated m3u8 url'))

--- a/yt_dlp/extractor/mbn.py
+++ b/yt_dlp/extractor/mbn.py
@@ -1,0 +1,82 @@
+import re
+
+from .common import InfoExtractor
+from ..utils import (
+    int_or_none,
+    unified_strdate,
+)
+
+
+class MBNIE(InfoExtractor):
+    IE_DESC = 'mbn.co.kr (매일방송)'
+    _VALID_URL = r'https?://(?:www\.)?mbn\.co\.kr/vod/programContents/(?:previewlist|preview)/[0-9]+/[0-9]+/(?P<id>[0-9]+)'
+    _TESTS = [{
+        'url': 'https://mbn.co.kr/vod/programContents/previewlist/861/5433/1276155',
+        'md5': '85e1694e5b247c04d1386b7e3c90fd76',
+        'info_dict': {
+            'id': '1276155',
+            'ext': 'mp4',
+            'title': '결국 사로잡힌 권유리, 그녀를 목숨 걸고 구하려는 정일우!',
+            'duration': 3891,
+            'release_date': '20210703',
+            'thumbnail': 'http://img.vod.mbn.co.kr/mbnvod2img/861/2021/07/03/20210703230811_20_861_1276155_360_7_0.jpg',
+            'series': '보쌈 - 운명을 훔치다',
+            'episode': 'Episode 19',
+            'episode_number': 19,
+        },
+    }, {
+        'url': 'https://www.mbn.co.kr/vod/programContents/previewlist/835/5294/1084744',
+        'md5': 'fc65d3aac85e85e0b5056f4ef99cde4a',
+        'info_dict': {
+            'id': '1084744',
+            'ext': 'mp4',
+            'title': '김정은♥최원영, 제자리를 찾은 위험한 부부! ＂결혼은 투쟁이면서, 어려운 방식이야..＂',
+            'duration': 93,
+            'release_date': '20201124',
+            'thumbnail': 'http://img.vod.mbn.co.kr/mbnvod2img/835/2020/11/25/20201125000221_21_835_1084744_360_7_0.jpg',
+            'series': '나의 위험한 아내',
+        },
+    }, {
+        'url': 'https://www.mbn.co.kr/vod/programContents/preview/952/6088/1054797?next=1',
+        'md5': 'c711103c72aeac8323a5cf1751f10097',
+        'info_dict': {
+            'id': '1054797',
+            'ext': 'mp4',
+            'title': '[2차 티저] MBN 주말 미니시리즈 <완벽한 결혼의 정석> l 그녀에게 주어진 두 번째 인생',
+            'duration': 65,
+            'release_date': '20231028',
+            'thumbnail': 'http://img.vod.mbn.co.kr/vod2/952/2023/09/11/20230911130223_22_952_1054797_1080_7.jpg',
+            'series': '완벽한 결혼의 정석',
+        },
+    }]
+
+    def _real_extract(self, url):
+        content_id = self._match_id(url)
+        webpage = self._download_webpage(url, content_id)
+
+        content_cls_cd = self._search_regex(r'"\?content_cls_cd=(\d+)&', webpage, 'content_cls_cd', default='20')
+        media_info = self._download_json(
+            f'https://www.mbn.co.kr/player/mbnVodPlayer_2020.mbn?content_cls_cd={content_cls_cd}&content_id={content_id}&relay_type=1',
+            content_id, note='Fetching playback data')
+
+        formats = []
+        for stream in media_info.get('movie_list'):
+            if not stream.get('url'):
+                continue
+            location = re.sub(r'/(?:chunklist|playlist)(?:_pd180000)?\.m3u8', '/manifest.m3u8', stream['url'])
+            m3u8_url = self._download_webpage(
+                f'https://www.mbn.co.kr/player/mbnStreamAuth_new_vod.mbn?vod_url={location}',
+                content_id, note='Generating authenticated m3u8 url')
+
+            formats.extend(self._extract_m3u8_formats(m3u8_url, content_id))
+
+        return {
+            'id': content_id,
+            'title': media_info.get('movie_title'),
+            'duration': int_or_none(media_info.get('play_sec')),
+            'release_date': unified_strdate(media_info.get('bcast_date').replace('.', '')),
+            'thumbnail': media_info.get('movie_start_Img'),
+            'series': media_info.get('prog_nm'),
+            'episode_number': int_or_none(media_info.get('ad_contentnumber')),
+            'formats': formats,
+        }

--- a/yt_dlp/extractor/mbn.py
+++ b/yt_dlp/extractor/mbn.py
@@ -3,7 +3,9 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     int_or_none,
+	traverse_obj,
     unified_strdate,
+	url_or_none,
 )
 
 

--- a/yt_dlp/extractor/mbn.py
+++ b/yt_dlp/extractor/mbn.py
@@ -3,10 +3,10 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     int_or_none,
-    traverse_obj,
     unified_strdate,
     url_or_none,
 )
+from ..utils.traversal import traverse_obj
 
 
 class MBNIE(InfoExtractor):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Added extractor for [MBN](https://www.mbn.co.kr/) a Korean TV network.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb63487</samp>

### Summary
:sparkles::tv::kr:

<!--
1.  :sparkles: This emoji is often used to indicate the addition of a new feature or functionality, such as a new extractor class for a website. In this case, the MBNIE class is a new feature that enables downloading videos from the mbn.co.kr website.
2.  :tv: This emoji is often used to indicate the involvement of media or entertainment, such as a TV network or a video-on-demand service. In this case, the mbn.co.kr website is a TV network that offers video-on-demand content, so the emoji is relevant to the change.
3.  :kr: This emoji is often used to indicate the country or region of origin or relevance for a change, such as a website or a language. In this case, the mbn.co.kr website is a Korean TV network, so the emoji is appropriate to indicate the Korean context of the change.
-->
Add support for mbn.co.kr extractor. Import MBNIE class from `mbn.py` and define methods for extracting video information and formats from the website.

> _`MBNIE` extracts_
> _video from Korean site_
> _autumn request done_

### Walkthrough
*  Add support for downloading videos from mbn.co.kr website ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1054), [link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
  * Import MBNIE class from `mbn.py` file in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1054))
  * Define MBNIE class in `mbn.py` file as a subclass of InfoExtractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
    * Set IE_DESC and _VALID_URL attributes to describe the extractor and match the video URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
    * Define _TESTS attribute to provide test cases for the extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
    * Implement _real_extract method to extract video information and formats from the website ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
      * Use _download_webpage and _download_json to fetch HTML and JSON data from the video URL and the API URL ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
      * Use _search_regex to extract content_cls_cd and content_id from the HTML data ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
      * Use content_cls_cd and content_id to construct the API URL and query parameters ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
      * Use movie_list field from the JSON data to get the video URL and the movie_title field to get the title ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))
      * Use _extract_m3u8_formats to extract the video formats from the video URL ([link](https://github.com/yt-dlp/yt-dlp/pull/8312/files?diff=unified&w=0#diff-756b4ede0c2a3c74d4741b144a9ef8f3a9fa0cb6d4b590ef031be7f32476c527R1-R82))



</details>
