### PR TITLE
Add jtbc.co.kr extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -896,6 +896,10 @@ from .jeuxvideo import JeuxVideoIE
 from .jove import JoveIE
 from .joj import JojIE
 from .jstream import JStreamIE
+from .jtbc import (
+    JTBCIE,
+    JTBCProgramIE,
+)
 from .jwplatform import JWPlatformIE
 from .kakao import KakaoIE
 from .kaltura import KalturaIE

--- a/yt_dlp/extractor/jtbc.py
+++ b/yt_dlp/extractor/jtbc.py
@@ -2,8 +2,10 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
+    int_or_none,
     parse_duration,
     traverse_obj,
+    url_or_none,
 )
 
 
@@ -92,10 +94,9 @@ class JTBCIE(InfoExtractor):
             subtitles.setdefault(sub.get('label', 'und'), []).append({'url': sub['file']})
 
         formats = []
-        for format_id, stream in traverse_obj(playback_data, ('sources', 'HLS', lambda _, v: v['file'], {dict.items}, ...)):
+        for stream in traverse_obj(playback_data, ('sources', 'HLS', lambda _, v: v['file'])):
             m3u8_url = re.sub(r'/playlist(?:_pd\d+)?\.m3u8', '/index.m3u8', stream['file'])
-            formats.extend(self._extract_m3u8_formats(
-                m3u8_url, video_id, m3u8_id=format_id, fatal=False))
+            formats.extend(self._extract_m3u8_formats(m3u8_url, video_id, fatal=False))
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/jtbc.py
+++ b/yt_dlp/extractor/jtbc.py
@@ -94,8 +94,8 @@ class JTBCIE(InfoExtractor):
             subtitles.setdefault(sub.get('label', 'und'), []).append({'url': sub['file']})
 
         formats = []
-        for stream in traverse_obj(playback_data, ('sources', 'HLS', lambda _, v: v['file'])):
-            m3u8_url = re.sub(r'/playlist(?:_pd\d+)?\.m3u8', '/index.m3u8', stream['file'])
+        for stream_url in traverse_obj(playback_data, ('sources', 'HLS', ..., 'file')):
+            m3u8_url = re.sub(r'/playlist(?:_pd\d+)?\.m3u8', '/index.m3u8', stream_url)
             formats.extend(self._extract_m3u8_formats(m3u8_url, video_id, fatal=False))
 
         return {

--- a/yt_dlp/extractor/jtbc.py
+++ b/yt_dlp/extractor/jtbc.py
@@ -94,9 +94,9 @@ class JTBCIE(InfoExtractor):
             subtitles.setdefault(sub.get('label', 'und'), []).append({'url': sub['file']})
 
         formats = []
-        for stream_url in traverse_obj(playback_data, ('sources', 'HLS', ..., 'file')):
-            m3u8_url = re.sub(r'/playlist(?:_pd\d+)?\.m3u8', '/index.m3u8', stream_url)
-            formats.extend(self._extract_m3u8_formats(m3u8_url, video_id, fatal=False))
+        for stream_url in traverse_obj(playback_data, ('sources', 'HLS', ..., 'file', {url_or_none})):
+            stream_url = re.sub(r'/playlist(?:_pd\d+)?\.m3u8', '/index.m3u8', stream_url)
+            formats.extend(self._extract_m3u8_formats(stream_url, video_id, fatal=False))
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/jtbc.py
+++ b/yt_dlp/extractor/jtbc.py
@@ -144,6 +144,6 @@ class JTBCProgramIE(InfoExtractor):
             })
 
         entries = [self.url_result(f'https://vod.jtbc.co.kr/player/program/{video_id}', JTBCIE, video_id)
-                   for video_id in traverse_obj(vod_list, ('programReplayVodList', ... 'episodeId'))]
+                   for video_id in traverse_obj(vod_list, ('programReplayVodList', ..., 'episodeId'))]
 
         return self.playlist_result(entries, program_id)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Added extractor for [JTBC](https://jtbc.co.kr/) a Korean TV network.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 36e17a0</samp>

### Summary
:sparkles::tv::kr:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the case for adding new extractors for the JTBC website.
2.  :tv: This emoji represents the media or entertainment theme of the changes, which is related to the JTBC TV network and its video content.
3.  :kr: This emoji represents the country or region of the changes, which is South Korea, where the JTBC website is based and where most of its content is produced.
-->
Add support for downloading videos and playlists from the JTBC website, a Korean TV network. Add two new extractors, `JTBCIE` and `JTBCProgramIE`, in the `jtbc.py` module and register them in `_extractors.py`. Add test cases for the new extractors.

> _`JTBCIE` extracts_
> _videos from Korean network_
> _autumn leaves streaming_

### Walkthrough
*  Add `jtbc.py` module that defines extractors for JTBC website (`yt_dlp/extractor/jtbc.py`)



</details>
