### PR TITLE
[ie/bbc] extract more formats

### DIFF
--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -320,11 +320,11 @@ class BBCCoUkIE(InfoExtractor):
         formats, subtitles = [], {}
         for media_set in self._MEDIA_SETS:
             try:
-                fmts, sttls = self._download_media_selector_url(
+                fmts, subs = self._download_media_selector_url(
                     self._MEDIA_SELECTOR_URL_TEMPL % (media_set, programme_id), programme_id)
                 formats.extend(fmts)
-                if sttls:
-                    subtitles = self._merge_subtitles(subtitles, sttls)
+                if subs:
+                    self._merge_subtitles(subs, target=subtitles)
             except BBCCoUkIE.MediaSelectionError as e:
                 if e.id in ('notukerror', 'geolocation', 'selectionunavailable'):
                     last_exception = e
@@ -332,8 +332,7 @@ class BBCCoUkIE(InfoExtractor):
                 self._raise_extractor_error(e)
         if last_exception:
             if formats or subtitles:
-                self.report_warning(
-                    '%s returned error: %s' % (self.IE_NAME, last_exception.id))
+                self.report_warning(f'{self.IE_NAME} returned error: {last_exception.id}')
             else:
                 self._raise_extractor_error(last_exception)
         return formats, subtitles


### PR DESCRIPTION
This fetches the higher-resolution SD streams.

Taken from
https://github.com/yt-dlp/yt-dlp/issues/4902#issuecomment-1244298806 by @dirkf.

Fixes https://github.com/yt-dlp/yt-dlp/issues/4902

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This adds additional parsing of formats, to deliver the higher-resolution, and also higher-quality, SD streams. Notably, this discovers the 540p streams, over the previous maximum resolution of 396p.

The "Author" tag of the commit credits @dirkf, who provided the diff in the named comment.

Some of the links from the ticket were tested manually, both for finding the formats and for actual download of the media.

The IEs' tests should not be invalidated, as none of them use content MD5 sums. Many tests fail for me anyway, they didn't seem of much use. (Requires clean-up.)

Fixes #4902

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 42c0547</samp>

### Summary
🌐🎞️⚠️

<!--
1.  🌐 - This emoji represents the geo-restricted or unavailable media sets, as it is a globe with meridians that indicate different regions or zones of the world.
2.  🎞️ - This emoji represents the formats and subtitles that are collected from different media sets, as it is a film strip that suggests various types of media content.
3.  ⚠️ - This emoji represents the warning instead of an error that is reported if some media sets fail, as it is a triangular sign that indicates caution or potential danger.
-->
Enhance `bbc.py` extractor to handle media set failures more gracefully and collect more formats and subtitles.

> _When the BBC extractor runs_
> _It may encounter media shuns_
> _But instead of an error_
> _It shows some more terror_
> _By collecting all formats and `subs`_

### Walkthrough
* Collect and return all formats and subtitles from different media sets in `_download_media_selector` ([link](https://github.com/yt-dlp/yt-dlp/pull/8321/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57L320-R327), [link](https://github.com/yt-dlp/yt-dlp/pull/8321/files?diff=unified&w=0#diff-0abdd53ffd6c2083b41d6d68bf14219a98fb7f4dcf0199af518592fa89439f57L329-R339))



</details>
