### PR TITLE
Improve argument handling for aria2c

### DIFF
--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -335,7 +335,7 @@ class Aria2cFD(ExternalFD):
         cmd += ['--auto-file-renaming=false']
 
         if 'fragments' in info_dict:
-            cmd += ['--file-allocation=none', '--uri-selector=inorder']
+            cmd += ['--uri-selector=inorder']
             url_list_file = '%s.frag.urls' % tmpfilename
             url_list = []
             for frag_index, fragment in enumerate(info_dict['fragments']):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Currently the argument handling of aria2c has several issues:

1) It uses `--no-conf`, thus ignoring user's `aria2.conf` config file. There is no inherit reason yt-dlp requires this to work, because if an option is specified both in config file and in argument, the argument (which yt-dlp uses) takes priority.

2) It forces `--file-allocation=none`, twice, while the aria2c offers [subjectively better choices](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-file-allocation). I suggest we don't force if it's not necessary.

3) It hard codes concurrent download segments/splits to 16, instead of respecting yt-dlp's own `--concurrent-fragments`. In the [commit introducing these hardcodes](https://github.com/yt-dlp/yt-dlp/commit/5219cb3e7567143ea704d299ebe6e7135341ebc1), the author didn't mention any reason why he put in such numbers.

Note that the current `--concurrent-fragments` default value is 1. Therefore, after this change, user might observe huge slowdown for site supporting multiple concurrent connections from single IP. It could also give user tool to fix cases when a site would ban IP that makes multi-connections.

4) The existing respected non-boolean options are missing the '=' separator, making them being ignored by aria2c altogether. For example, `cmd += self._option('--max-overall-download-limit', 'ratelimit')` generates something like `--max-overall-download-limit 1M`, while aria2c [requires `--max-overall-download-limit=1M`](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-max-overall-download-limit).

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 94480ae</samp>

### Summary
🛠️🚀🆕

<!--
1.  🛠️ - This emoji represents fixing or improving something, which is what the changes to the `Aria2cFD` class do by removing or changing options that were not optimal or caused errors.
2.  🚀 - This emoji represents speed or performance, which is what the changes to the concurrency and segmentation options aim to achieve by allowing the user to customize how many connections and chunks are used for downloading.
3.  🆕 - This emoji represents adding something new or introducing a feature, which is what the `separator` argument of the `_option` method does by allowing different external downloaders to use different formats for their options.
-->
Improved aria2c integration and option handling in `yt_dlp/downloader/external.py`. Added concurrency and segmentation options for aria2c and a `separator` argument for external downloaders.

> _Sing, O Muse, of the skillful coder who refined_
> _The `Aria2cFD` class, a swift and powerful tool_
> _To download from the web with options well-defined_
> _And avoid the errors of the ignorant and the fool._

### Walkthrough
*  Modify `_option` method of `ExternalFD` class to accept `separator` argument for different command option formats ([link](https://github.com/yt-dlp/yt-dlp/pull/8332/files?diff=unified&w=0#diff-045340cd706a52a49d1614a44d092c244144486fdd4101f4b56ae644ac9fdd04L119-R120))
*  Simplify and improve `_make_cmd` method of `Aria2cFD` class by removing redundant, unnecessary, or conflicting options and adding options for concurrent downloads, connections, and segments ([link](https://github.com/yt-dlp/yt-dlp/pull/8332/files?diff=unified&w=0#diff-045340cd706a52a49d1614a44d092c244144486fdd4101f4b56ae644ac9fdd04L297-R298), [link](https://github.com/yt-dlp/yt-dlp/pull/8332/files?diff=unified&w=0#diff-045340cd706a52a49d1614a44d092c244144486fdd4101f4b56ae644ac9fdd04L310-R314), [link](https://github.com/yt-dlp/yt-dlp/pull/8332/files?diff=unified&w=0#diff-045340cd706a52a49d1614a44d092c244144486fdd4101f4b56ae644ac9fdd04L338-R340))



</details>
