### PR TITLE
[fd/dash] Force native downloader for `--live-from-start`

### DIFF
--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -15,12 +15,15 @@ class DashSegmentsFD(FragmentFD):
     FD_NAME = 'dashsegments'
 
     def real_download(self, filename, info_dict):
-        if info_dict.get('is_live') and set(info_dict['protocol'].split('+')) != {'http_dash_segments_generator'}:
+        if set(info_dict['protocol'].split('+')) == {'http_dash_segments_generator'}:
+            real_downloader = None
+        elif info_dict.get('is_live'):
             self.report_error('Live DASH videos are not supported')
+        else:
+            real_downloader = get_suitable_downloader(
+                info_dict, self.params, None, protocol='dash_frag_urls', to_stdout=(filename == '-'))
 
         real_start = time.time()
-        real_downloader = get_suitable_downloader(
-            info_dict, self.params, None, protocol='dash_frag_urls', to_stdout=(filename == '-'))
 
         requested_formats = [{**info_dict, **fmt} for fmt in info_dict.get('requested_formats', [])]
         args = []

--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -16,7 +16,7 @@ class DashSegmentsFD(FragmentFD):
 
     def real_download(self, filename, info_dict):
         if set(info_dict['protocol'].split('+')) == {'http_dash_segments_generator'}:
-            real_downloader = None
+            real_downloader = None  # No external FD can support --live-from-start
         else:
             if info_dict.get('is_live'):
                 self.report_error('Live DASH videos are not supported')

--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -15,7 +15,7 @@ class DashSegmentsFD(FragmentFD):
     FD_NAME = 'dashsegments'
 
     def real_download(self, filename, info_dict):
-        if set(info_dict['protocol'].split('+')) == {'http_dash_segments_generator'}:
+        if 'http_dash_segments_generator' in info_dict['protocol'].split('+'):
             real_downloader = None  # No external FD can support --live-from-start
         else:
             if info_dict.get('is_live'):

--- a/yt_dlp/downloader/dash.py
+++ b/yt_dlp/downloader/dash.py
@@ -17,9 +17,9 @@ class DashSegmentsFD(FragmentFD):
     def real_download(self, filename, info_dict):
         if set(info_dict['protocol'].split('+')) == {'http_dash_segments_generator'}:
             real_downloader = None
-        elif info_dict.get('is_live'):
-            self.report_error('Live DASH videos are not supported')
         else:
+            if info_dict.get('is_live'):
+                self.report_error('Live DASH videos are not supported')
             real_downloader = get_suitable_downloader(
                 info_dict, self.params, None, protocol='dash_frag_urls', to_stdout=(filename == '-'))
 


### PR DESCRIPTION
Description from linked issue:

> aria2c can't support `--live-from-start` downloads of ongoing livestreams. aria2c ***can*** support downloading **post-live** streams with `--live-from-start`, because those have an endpoint, and it won't take minutes/hours/days/forever to generate the fragment URLs. But I don't think it was ever intended that the user should be able to hand off ongoing livestream `--live-from-start` downloads to aria2c. So this is a bug.
> 
> It looks like there was a check added in `yt_dlp/downloader/__init__.py` for this, but that check is negated later in `yt_dlp/downloader/dash.py`, where `get_suitable_downloader` is called again with a protocol of `dash_frag_urls`.

Closes #8212


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 772e925</samp>

### Summary
🚚🚫🧹

<!--
1.  🚚  This emoji can represent the act of moving or relocating something, such as a variable, to a different place or scope. In this case, the `real_downloader` variable is moved inside an `else` block.
2.  🚫  This emoji can represent the act of preventing or avoiding something, such as an unnecessary operation or a potential error. In this case, the `real_downloader` variable is avoided when the protocol is `http_dash_segments_generator`, which could cause an exception or a wrong behavior.
3.  🧹  This emoji can represent the act of cleaning or simplifying something, such as a codebase or a logic. In this case, the `DashSegmentsFD` class is simplified by removing redundant code and making the logic more clear and concise.
-->
Refactor `DashSegmentsFD` class in `yt_dlp/downloader/dash.py` to simplify logic and avoid unnecessary variables.

> _`real_downloader`_
> _only in `else` block now_
> _refactoring dash_

### Walkthrough
* Refactor the `DashSegmentsFD` class to simplify the logic and avoid redundant code ([link](https://github.com/yt-dlp/yt-dlp/pull/8339/files?diff=unified&w=0#diff-be726c7557b840218a1b9ebd2bc0f9510a1832bb68ea87a8863530c3cbc8b302L18-R26),                            



</details>
