### PR TITLE
[ie/generic] Improve direct video link ext detection

### DIFF
--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -34,6 +34,7 @@ from ..utils import (
     unified_timestamp,
     unsmuggle_url,
     update_url_query,
+    urlhandle_detect_ext,
     url_or_none,
     urljoin,
     variadic,
@@ -2459,7 +2460,7 @@ class GenericIE(InfoExtractor):
             self.report_detected('direct video link')
             headers = smuggled_data.get('http_headers', {})
             format_id = str(m.group('format_id'))
-            ext = determine_ext(url)
+            ext = determine_ext(url, default_ext=None) or urlhandle_detect_ext(full_response)
             subtitles = {}
             if format_id.endswith('mpegurl') or ext == 'm3u8':
                 formats, subtitles = self._extract_m3u8_formats_and_subtitles(url, video_id, 'mp4', headers=headers)
@@ -2471,6 +2472,7 @@ class GenericIE(InfoExtractor):
                 formats = [{
                     'format_id': format_id,
                     'url': url,
+                    'ext': ext,
                     'vcodec': 'none' if m.group('type') == 'audio' else None
                 }]
                 info_dict['direct'] = True


### PR DESCRIPTION
Closes #8265


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe274d3</samp>

### Summary
📁🔎📝

<!--
1.  📁 - This emoji represents files or folders, and can be used to indicate the improvement of file extension detection for the generic extractor.
2.  🔎 - This emoji represents a magnifying glass, and can be used to indicate the use of the `urlhandle_detect_ext` function, which performs a more thorough search for the file extension in the URL or the content type header.
3.  📝 - This emoji represents a document or a note, and can be used to indicate the passing of the `ext` to the format dictionary, which allows the generic extractor to use the detected extension for naming the output file.
-->
Improved file extension detection for generic extractor by using a helper function and passing the detected extension to the format info. This affects the file `yt_dlp/extractor/generic.py`.

> _`urlhandle_detect_ext` is the key to our salvation_
> _We pass the `ext` to the format and unleash the extraction_
> _No more generic errors, no more false detections_
> _We improved the file extension detection_

### Walkthrough
* Import `urlhandle_detect_ext` function from `utils.py` to detect file extension from URL response ([link](https://github.com/yt-dlp/yt-dlp/pull/8340/files?diff=unified&w=0#diff-28ac72db5ec9cbb295cfe1f162c6947893d6f348cb3ce76b90a6459194770892R37))
* Modify `determine_ext` function to accept `default_ext` argument and return `None` if URL has no clear extension ([link](https://github.com/yt-dlp/yt-dlp/pull/8340/files?diff=unified&w=0#diff-28ac72db5ec9cbb295cfe1f162c6947893d6f348cb3ce76b90a6459194770892L2462-R2463))
* Call `urlhandle_detect_ext` function with `full_response` object to get more accurate extension from response headers or content type ([link](https://github.com/yt-dlp/yt-dlp/pull/8340/files?diff=unified&w=0#diff-28ac72db5ec9cbb295cfe1f162c6947893d6f348cb3ce76b90a6459194770892L2462-R2463))
* Add `ext` variable to `f` dictionary to pass extension information to downloader ([link](https://github.com/yt-dlp/yt-dlp/pull/8340/files?diff=unified&w=0#diff-28ac72db5ec9cbb295cfe1f162c6947893d6f348cb3ce76b90a6459194770892R2475))



</details>
