### PR TITLE
[ie/brilliantpala] Fix login detection when using Cookies

### DIFF
--- a/yt_dlp/extractor/brilliantpala.py
+++ b/yt_dlp/extractor/brilliantpala.py
@@ -14,17 +14,17 @@ class BrilliantpalaBaseIE(InfoExtractor):
 
     def _initialize_pre_login(self):
         self._HOMEPAGE = f'https://{self._DOMAIN}'
-        self._LOGIN_API = f'{self._HOMEPAGE}/login/'
+        self._LOGIN_API = f'{self._HOMEPAGE}/login/?next='
         self._LOGOUT_DEVICES_API = f'{self._HOMEPAGE}/logout_devices/?next=/'
         self._CONTENT_API = f'{self._HOMEPAGE}/api/v2.4/contents/{{content_id}}/'
         self._HLS_AES_URI = f'{self._HOMEPAGE}/api/v2.5/video_contents/{{content_id}}/key/'
 
     def _get_logged_in_username(self, url, video_id):
         webpage, urlh = self._download_webpage_handle(url, video_id)
-        if self._LOGIN_API == urlh.url:
+        if urlh.url.startswith(self._LOGIN_API):
             self.raise_login_required()
         return self._html_search_regex(
-            r'"username"\s*:\s*"(?P<username>[^"]+)"', webpage, 'stream page info', 'username')
+            r'"username"\s*:\s*"(?P<username>[^"]+)"', webpage, 'logged-in username')
 
     def _perform_login(self, username, password):
         login_form = self._hidden_inputs(self._download_webpage(

--- a/yt_dlp/extractor/brilliantpala.py
+++ b/yt_dlp/extractor/brilliantpala.py
@@ -14,7 +14,7 @@ class BrilliantpalaBaseIE(InfoExtractor):
 
     def _initialize_pre_login(self):
         self._HOMEPAGE = f'https://{self._DOMAIN}'
-        self._LOGIN_API = f'{self._HOMEPAGE}/login/?next='
+        self._LOGIN_API = f'{self._HOMEPAGE}/login/'
         self._LOGOUT_DEVICES_API = f'{self._HOMEPAGE}/logout_devices/?next=/'
         self._CONTENT_API = f'{self._HOMEPAGE}/api/v2.4/contents/{{content_id}}/'
         self._HLS_AES_URI = f'{self._HOMEPAGE}/api/v2.5/video_contents/{{content_id}}/key/'


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Hello!

The original implementation did not work with Cookies, but username and password only.

I fixed it.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8a4bc38</samp>

### Summary
🐛🧠📱

<!--
1.  🐛 - This emoji is commonly used to indicate a bug fix, and it fits well with the login bug that was resolved.
2.  🧠 - This emoji could represent the improved regex method, as it suggests intelligence, logic, or creativity. Alternatively, one could use 🧵 to indicate the use of regular expressions, or 🚀 to indicate a performance improvement.
3.  📱 - This emoji could represent the multiple devices that can now log in, as it suggests mobile or web access. Alternatively, one could use 🔑 to indicate the login feature, or 🛠 to indicate a general improvement.
-->
Fixed login and regex issues in `brilliantpala` extractor. This allows users to access more content from the Brilliant Pala website.

> _The `brilliantpala` extractor_
> _Had a login bug that perplexed her_
> _She improved the regex_
> _To handle more contexts_
> _And renamed the argument `textor`_

### Walkthrough
* Fix login bug and improve logged-in username extraction in `brilliantpala` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8352/files?diff=unified&w=0#diff-a1e46b84b9c3eb281cb8aea36a626f9a0b232e385ac1298f3c63593e3a58d698L17-R17), [link](https://github.com/yt-dlp/yt-dlp/pull/8352/files?diff=unified&w=0#diff-a1e46b84b9c3eb281cb8aea36a626f9a0b232e385ac1298f3c63593e3a58d698L24-R27))
  - Append `?next=` query parameter to `_LOGIN_API` to redirect to original URL after login ([link](https://github.com/yt-dlp/yt-dlp/pull/8352/files?diff=unified&w=0#diff-a1e46b84b9c3eb281cb8aea36a626f9a0b232e385ac1298f3c63593e3a58d698L17-R17))
  - Use `startswith` instead of `==` to check if URL is login URL, to account for additional query parameters ([link](https://github.com/yt-dlp/yt-dlp/pull/8352/files?diff=unified&w=0#diff-a1e46b84b9c3eb281cb8aea36a626f9a0b232e385ac1298f3c63593e3a58d698L24-R27))
  - Rename second argument of `_html_search_regex` call to 'logged-in username' for clarity ([link](https://github.com/yt-dlp/yt-dlp/pull/8352/files?diff=unified&w=0#diff-a1e46b84b9c3eb281cb8aea36a626f9a0b232e385ac1298f3c63593e3a58d698L24-R27))



</details>
