### PR TITLE
Fix https://github.com/yt-dlp/yt-dlp/issues/8363 by manually adding metadata during ffmpeg split chapters execution

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -1046,6 +1046,20 @@ class FFmpegSplitChaptersPP(FFmpegPostProcessor):
             destination,
             ['-ss', str(chapter['start_time']),
              '-t', str(chapter['end_time'] - chapter['start_time'])])
+    # FFmpeg adds metadata about all chapters from parent file to all split m4a files.
+    # This is incorrect since there must be only single chapter in each file after split.
+    # Such behavior confuses players who think multiple chapters present
+    def _set_out_opts(self, ext, chapter_title):
+        if ext == 'm4a':
+            return [
+                *self.stream_copy_opts(),
+                # For m4a ffmpeg copies all available parent track chapters to split tracks metadata
+                # And such behavior confuses players
+                # Wipe parent track metadata from split tracks and fill out only title
+                '-metadata', 'title={}'.format(chapter_title),
+                '-map_metadata','-1']
+        else:
+            return self.stream_copy_opts()   
 
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
@@ -1061,7 +1075,8 @@ class FFmpegSplitChaptersPP(FFmpegPostProcessor):
         self.to_screen('Splitting video by chapters; %d chapters found' % len(chapters))
         for idx, chapter in enumerate(chapters):
             destination, opts = self._ffmpeg_args_for_chapter(idx + 1, chapter, info)
-            self.real_run_ffmpeg([(in_file, opts)], [(destination, self.stream_copy_opts())])
+            out_file_opts = self._set_out_opts(info['ext'], chapter['title'])
+            self.real_run_ffmpeg([(in_file, opts)], [(destination, out_file_opts)])
         if in_file != info['filepath']:
             self._delete_downloaded_files(in_file, msg=None)
         return [], info


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes the bug https://github.com/yt-dlp/yt-dlp/issues/8363. 
--split-chapters with --add-metadata enabled produces incorrect metadata for m4a files

Fixes # 8363


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [ X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

copilot:all

</details>
