### PR TITLE
[nova.py] Added support for mediatn embed URLs.

### DIFF
--- a/yt_dlp/extractor/nova.py
+++ b/yt_dlp/extractor/nova.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class NovaEmbedIE(InfoExtractor):
-    _VALID_URL = r'https?://media\.cms\.nova\.cz/embed/(?P<id>[^/?#&]+)'
+    _VALID_URL = r'https?://media(?:tn)?\.cms\.nova\.cz/embed/(?P<id>[^/?#&]+)'
     _TESTS = [{
         'url': 'https://media.cms.nova.cz/embed/8o0n0r?autoplay=1',
         'info_dict': {
@@ -35,6 +35,16 @@ class NovaEmbedIE(InfoExtractor):
             'title': 'Borhyová oslavila 60? Soutěžící z pořadu odboural moderátora Ondřeje Sokola',
             'thumbnail': r're:^https?://.*\.jpg',
             'duration': 114,
+        },
+        'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://mediatn.cms.nova.cz/embed/EU5ELEsmOHt?autoplay=1',
+        'info_dict': {
+            'id': 'EU5ELEsmOHt',
+            'ext': 'mp4',
+            'title': 'Haptické křeslo, bionická ruka nebo roboti. Reportérka se podívala na Týden inovací',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'duration': 1780,
         },
         'params': {'skip_download': 'm3u8'},
     }]


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

The `nova.py` extractor did not support embed URLs of type https://mediatn.cms.nova.cz/embed/EU5ELEsmOHt?autoplay=1 . This PR fixes that by allowing an optional `tn` suffix for the `media` lowest level domain name part.

Fixes no reported bug - I'm directly submitting a fix for something that didn't work for me.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 475fddd</samp>

### Summary
🌐🧪🎞️

<!--
1.  🌐 - This emoji represents the addition of more subdomains to the extractor, which expands its scope and coverage of the Nova.cz website.
2.  🧪 - This emoji represents the addition of a test case, which improves the quality and reliability of the extractor and ensures that it works as expected.
3.  🎞️ - This emoji represents the media content that the extractor handles, which is the main purpose and output of the extractor.
-->
Improved Nova.cz extractor and added a test. The extractor can now handle more subdomains of `cms.nova.cz` and a new test case covers a `mediatn` URL.

> _Sing, O Muse, of the skillful coder who updated_
> _The `Nova.cz` extractor, expanding its domain_
> _To capture more URLs from `media` and `mediatn`_
> _And added a test case, like a wise and prudent guard._

### Walkthrough
* Update the URL pattern to match both `media` and `mediatn` subdomains ([link](https://github.com/yt-dlp/yt-dlp/pull/8368/files?diff=unified&w=0#diff-40b6c060bb11c740ec5d129c78c95f5f6ce426dc8f9b1effd540ce732728210fL16-R16))
* Add a test case for a `mediatn` URL with expected fields and skip download ([link](https://github.com/yt-dlp/yt-dlp/pull/8368/files?diff=unified&w=0#diff-40b6c060bb11c740ec5d129c78c95f5f6ce426dc8f9b1effd540ce732728210fR40-R49))



</details>
