### PR TITLE
Add `NO_COLOR` environment variable support

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -625,15 +625,16 @@ class YoutubeDL:
                     'Overwriting params from "color" with "no_color"')
             self.params['color'] = 'no_color'
 
-        term_allow_color = os.getenv('TERM', '').lower() != 'dumb' and not os.getenv('NO_COLOR')
+        term_allow_color = os.getenv('TERM', '').lower() != 'dumb'
+        no_color = bool(os.getenv('NO_COLOR'))
 
         def process_color_policy(stream):
             stream_name = {sys.stdout: 'stdout', sys.stderr: 'stderr'}[stream]
             policy = traverse_obj(self.params, ('color', (stream_name, None), {str}), get_all=False)
             if policy in ('auto', None):
-                return term_allow_color and supports_terminal_sequences(stream)
-            assert policy in ('always', 'never', 'no_color'), policy
-            return {'always': True, 'never': False}.get(policy, policy)
+                if term_allow_color and supports_terminal_sequences(stream):
+                    return 'no_color' if no_color else True
+                return False
 
         self._allow_colors = Namespace(**{
             name: process_color_policy(stream)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -625,7 +625,7 @@ class YoutubeDL:
                     'Overwriting params from "color" with "no_color"')
             self.params['color'] = 'no_color'
 
-        term_allow_color = os.environ.get('TERM', '').lower() != 'dumb' and not os.getenv('NO_COLOR')
+        term_allow_color = os.getenv('TERM', '').lower() != 'dumb' and not os.getenv('NO_COLOR')
 
         def process_color_policy(stream):
             stream_name = {sys.stdout: 'stdout', sys.stderr: 'stderr'}[stream]

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -625,7 +625,7 @@ class YoutubeDL:
                     'Overwriting params from "color" with "no_color"')
             self.params['color'] = 'no_color'
 
-        term_allow_color = os.environ.get('TERM', '').lower() != 'dumb'
+        term_allow_color = os.environ.get('TERM', '').lower() != 'dumb' and not os.getenv('NO_COLOR')
 
         def process_color_policy(stream):
             stream_name = {sys.stdout: 'stdout', sys.stderr: 'stderr'}[stream]

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -635,6 +635,8 @@ class YoutubeDL:
                 if term_allow_color and supports_terminal_sequences(stream):
                     return 'no_color' if no_color else True
                 return False
+            assert policy in ('always', 'never', 'no_color'), policy
+            return {'always': True, 'never': False}.get(policy, policy)
 
         self._allow_colors = Namespace(**{
             name: process_color_policy(stream)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information
This enables support for the `NO_COLOR` environment variable, which has become widely-used in order to automatically disable colored output to the terminal. There was already a flag within this program to suppress colors (`--no-colors`, and `‐‐color no_color`), all this patch does is extend the range of what to look for to when considering if colors should be disabled to an environment variable.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e8c62f</samp>

### Summary
🎨🌐🙅

<!--
1.  🎨 - This emoji is often used to indicate changes related to color, style, or appearance of the output or interface. It is suitable for this change because it directly affects the color output of yt-dlp.
2.  🌐 - This emoji is often used to indicate changes related to internationalization, localization, or compatibility with different environments or platforms. It is suitable for this change because it follows a widely adopted standard (NO_COLOR) that is used by many other tools and users across different operating systems and terminals.
3.  🙅 - This emoji is often used to indicate changes that prevent, disable, or reject something. It is suitable for this change because it allows the user to opt out of color output if they do not want it or if it causes issues with their terminal.
-->
Respect `NO_COLOR` environment variable in `yt_dlp/YoutubeDL.py`. This allows users to disable color output in any terminal by setting this variable.

> _`NO_COLOR` env var_
> _A standard way to opt out_
> _Of colorful spring_

### Walkthrough
*  Respect `NO_COLOR` environment variable to disable color output ([link](https://github.com/yt-dlp/yt-dlp/pull/8385/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bL628-R628))



</details>
