### PR TITLE
Rewrite OnDemandKorea Extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1387,7 +1387,10 @@ from .oftv import (
 from .oktoberfesttv import OktoberfestTVIE
 from .olympics import OlympicsReplayIE
 from .on24 import On24IE
-from .ondemandkorea import OnDemandKoreaIE
+from .ondemandkorea import (
+    OnDemandKoreaIE,
+    OnDemandKoreaProgramIE,
+)
 from .onefootball import OneFootballIE
 from .onenewsnz import OneNewsNZIE
 from .oneplace import OnePlacePodcastIE

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -65,6 +65,9 @@ class OnDemandKoreaIE(InfoExtractor):
             'thumbnail': r're:^https?://.*\.(jpg|jpeg|png)',
             'age_limit': 18,
         },
+    }, {
+        'url': 'https://www.ondemandkorea.com/en/player/vod/capture-the-moment-how-is-that-possible?contentId=1605006',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -5,10 +5,10 @@ from .common import InfoExtractor
 from ..networking import HEADRequest
 from ..utils import (
     ExtractorError,
+    OnDemandPagedList,
     float_or_none,
     int_or_none,
     join_nonempty,
-    OnDemandPagedList,
     parse_age_limit,
     parse_qs,
     random_uuidv4,

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -29,7 +29,7 @@ class OnDemandKoreaIE(InfoExtractor):
             'id': '686471',
             'ext': 'mp4',
             'title': 'Ask Us Anything: Jung Sung-ho, Park Seul-gi, Kim Bo-min, Yang Seung-won',
-            'thumbnail': 'https://sp.ondemandkorea.com/wp-content/themes/ondemandkorea/uploads/thumbnail/1891035_20220924_1.jpg',
+            'thumbnail': r're:^https?://.*\.(jpg|jpeg|png)',
             'duration': 5486.955,
             'release_date': '20220924',
             'series': 'Ask Us Anything',
@@ -38,16 +38,31 @@ class OnDemandKoreaIE(InfoExtractor):
             'episode': 'Jung Sung-ho, Park Seul-gi, Kim Bo-min, Yang Seung-won',
         },
     }, {
-        'url': 'https://www.ondemandkorea.com/en/player/vod/joint-security-area?contentId=464622',
+        'url': 'https://www.ondemandkorea.com/player/vod/breakup-probation-a-week?contentId=1595796',
         'md5': '44e274d2b04977e03fc7f3941fbcb355',
         'info_dict': {
-            'id': '464622',
+            'id': '1595796',
             'ext': 'mp4',
-            'title': 'Joint Security Area: Main Movie',
-            'thumbnail': 'https://sp.ondemandkorea.com/wp-content/themes/ondemandkorea/uploads/thumbnail/jsa.1080p.4896k_3410.901645.jpg',
-            'age_limit': 15,
-            'duration': 6525.0,
-            'release_date': '20200114',
+            'title': 'Breakup Probation, A Week: E08',
+            'thumbnail': r're:^https?://.*\.(jpg|jpeg|png)',
+            'duration': 1586.0,
+            'release_date': '20231001',
+            'series': 'Breakup Probation, A Week',
+            'series_id': 22912,
+            'episode_number': 8,
+            'episode': 'E08',
+        },
+    }, {
+        'url': 'https://www.ondemandkorea.com/player/vod/the-outlaws?contentId=369531',
+        'md5': 'fa5523b87aa1f6d74fc622a97f2b47cd',
+        'info_dict': {
+            'id': '369531',
+            'ext': 'mp4',
+            'release_date': '20220519',
+            'duration': 7267.0,
+            'title': 'The Outlaws: Main Movie',
+            'thumbnail': r're:^https?://.*\.(jpg|jpeg|png)',
+            'age_limit': 18,
         },
     }]
 
@@ -56,11 +71,11 @@ class OnDemandKoreaIE(InfoExtractor):
 
         data = self._download_json(f'https://odkmedia.io/odx/api/v3/playback/{video_id}/', video_id,
                                    fatal=False, headers={'service-name': 'odk'},
-                                   query={'did': random_uuidv4()}, expected_status=403)
+                                   query={'did': random_uuidv4()}, expected_status=(403, 404))
         if not data.get('result'):
             raise ExtractorError(traverse_obj(data, ('messages', '__default'), 'title'), expected=True)
 
-        potential_urls = traverse_obj(data, ('result', 'sources', ..., 'url'), ('result', 'manifests', ..., 'url'))
+        potential_urls = traverse_obj(data, ('result', ('sources', 'manifest'), ..., 'url'))
         # Try to bypass geo-restricted ad proxy
         potential_urls = [
             alt_url if (alt_url := traverse_obj(url, ({parse_qs}, 'stream_url', 0, {url_or_none}))) else url
@@ -115,13 +130,13 @@ class OnDemandKoreaProgramIE(InfoExtractor):
         'info_dict': {
             'id': 'uskn-news',
         },
-        'playlist_count': 755,
+        'playlist_mincount': 755,
     }, {
-        'url': 'https://www.ondemandkorea.com/en/player/vod/joint-security-area',
+        'url': 'https://www.ondemandkorea.com/en/player/vod/the-land',
         'info_dict': {
-            'id': 'joint-security-area',
+            'id': 'the-land',
         },
-        'playlist_count': 2,
+        'playlist_count': 52,
     }]
 
     _PAGE_SIZE = 100

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -157,7 +157,7 @@ class OnDemandKoreaProgramIE(InfoExtractor):
             headers={'service-name': 'odk'}, query={
                 'page': page,
                 'page_size': self._PAGE_SIZE,
-            }, note=f'Downloading page {page}')
+            }, note=f'Downloading page {page}', expected_status=404)
         for episode in traverse_obj(page_data, ('result', 'results', ...)):
             yield self.url_result(
                 f'https://www.ondemandkorea.com/player/vod/{display_id}?contentId={episode["id"]}',

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -90,12 +90,9 @@ class OnDemandKoreaIE(InfoExtractor):
                 HEADRequest(mod_url), video_id, note='Checking for higher quality format',
                 errnote='No higher quality format found', fatal=False) else url
 
-        potential_urls = traverse_obj(
-            data, (('sources', 'manifest'), ..., 'url', {url_or_none}, {try_geo_bypass}, {try_upgrade_quality}))
-
         formats = []
-        for url in potential_urls:
-            formats.extend(self._extract_m3u8_formats(url, video_id, fatal=False))
+        for m3u8_url in traverse_obj(data, (('sources', 'manifest'), ..., 'url', {url_or_none}, {try_geo_bypass}):
+            formats.extend(self._extract_m3u8_formats(try_upgrade_quality(m3u8_url), video_id, fatal=False))
 
         subtitles = {}
         for track in traverse_obj(data, ('text_tracks', lambda _, v: url_or_none(v['url']))):

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -12,7 +12,6 @@ from ..utils import (
     join_nonempty,
     parse_age_limit,
     parse_qs,
-    random_uuidv4,
     unified_strdate,
     url_or_none,
 )

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -107,7 +107,7 @@ class OnDemandKoreaIE(InfoExtractor):
 
 
 class OnDemandKoreaProgramIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?ondemandkorea\.com/(?:en/)?player/vod/(?P<id>[a-z0-9-]+)(?:$|[?#])'
+    _VALID_URL = r'https?://(?:www\.)?ondemandkorea\.com/(?:en/)?player/vod/(?P<id>[a-z0-9-]+)(?:$|#)'
     _GEO_COUNTRIES = ['US', 'CA']
 
     _TESTS = [{

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -91,7 +91,7 @@ class OnDemandKoreaIE(InfoExtractor):
                 errnote='No higher quality format found', fatal=False) else url
 
         formats = []
-        for m3u8_url in traverse_obj(data, (('sources', 'manifest'), ..., 'url', {url_or_none}, {try_geo_bypass}):
+        for m3u8_url in traverse_obj(data, (('sources', 'manifest'), ..., 'url', {url_or_none}, {try_geo_bypass})):
             formats.extend(self._extract_m3u8_formats(try_upgrade_quality(m3u8_url), video_id, fatal=False))
 
         subtitles = {}

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -56,7 +56,7 @@ class OnDemandKoreaIE(InfoExtractor):
 
         data = self._download_json(f'https://odkmedia.io/odx/api/v3/playback/{video_id}/', video_id,
                                    fatal=False, headers={'service-name': 'odk'},
-                                   query={'did': random_uuidv4()}, expected_status=(200, 403))
+                                   query={'did': random_uuidv4()}, expected_status=403)
         if not data.get('result'):
             raise ExtractorError(traverse_obj(data, ('messages', '__default'), 'title'), expected=True)
 

--- a/yt_dlp/extractor/ondemandkorea.py
+++ b/yt_dlp/extractor/ondemandkorea.py
@@ -1,87 +1,149 @@
+import functools
 import re
 
 from .common import InfoExtractor
+from ..networking import HEADRequest
 from ..utils import (
     ExtractorError,
-    js_to_json,
+    float_or_none,
+    int_or_none,
+    join_nonempty,
+    OnDemandPagedList,
+    parse_age_limit,
+    parse_qs,
+    random_uuidv4,
+    unified_strdate,
+    url_or_none,
 )
+from ..utils.traversal import traverse_obj
 
 
 class OnDemandKoreaIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?ondemandkorea\.com/(?P<id>[^/]+)\.html'
+    _VALID_URL = r'https?://(?:www\.)?ondemandkorea\.com/(?:en/)?player/vod/[a-z0-9-]+\?(?:[^#]+&)?contentId=(?P<id>\d+)'
     _GEO_COUNTRIES = ['US', 'CA']
+
     _TESTS = [{
-        'url': 'https://www.ondemandkorea.com/ask-us-anything-e351.html',
+        'url': 'https://www.ondemandkorea.com/player/vod/ask-us-anything?contentId=686471',
+        'md5': 'e2ff77255d989e3135bde0c5889fbce8',
         'info_dict': {
-            'id': 'ask-us-anything-e351',
+            'id': '686471',
             'ext': 'mp4',
-            'title': 'Ask Us Anything : Jung Sung-ho, Park Seul-gi, Kim Bo-min, Yang Seung-won - 09/24/2022',
-            'description': 'A talk show/game show with a school theme where celebrity guests appear as “transfer students.”',
-            'thumbnail': r're:^https?://.*\.jpg$',
+            'title': 'Ask Us Anything: Jung Sung-ho, Park Seul-gi, Kim Bo-min, Yang Seung-won',
+            'thumbnail': 'https://sp.ondemandkorea.com/wp-content/themes/ondemandkorea/uploads/thumbnail/1891035_20220924_1.jpg',
+            'duration': 5486.955,
+            'release_date': '20220924',
+            'series': 'Ask Us Anything',
+            'series_id': 11790,
+            'episode_number': 351,
+            'episode': 'Jung Sung-ho, Park Seul-gi, Kim Bo-min, Yang Seung-won',
         },
-        'params': {
-            'skip_download': 'm3u8 download'
-        }
     }, {
-        'url': 'https://www.ondemandkorea.com/work-later-drink-now-e1.html',
+        'url': 'https://www.ondemandkorea.com/en/player/vod/joint-security-area?contentId=464622',
+        'md5': '44e274d2b04977e03fc7f3941fbcb355',
         'info_dict': {
-            'id': 'work-later-drink-now-e1',
+            'id': '464622',
             'ext': 'mp4',
-            'title': 'Work Later, Drink Now : E01',
-            'description': 'Work Later, Drink First follows three women who find solace in a glass of liquor at the end of the day. So-hee, who gets comfort from a cup of soju af',
-            'thumbnail': r're:^https?://.*\.png$',
-            'subtitles': {
-                'English': 'mincount:1',
-            },
+            'title': 'Joint Security Area: Main Movie',
+            'thumbnail': 'https://sp.ondemandkorea.com/wp-content/themes/ondemandkorea/uploads/thumbnail/jsa.1080p.4896k_3410.901645.jpg',
+            'age_limit': 15,
+            'duration': 6525.0,
+            'release_date': '20200114',
         },
-        'params': {
-            'skip_download': 'm3u8 download'
-        }
     }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id, fatal=False)
 
-        if not webpage:
-            # Page sometimes returns captcha page with HTTP 403
-            raise ExtractorError(
-                'Unable to access page. You may have been blocked.',
-                expected=True)
+        data = self._download_json(f'https://odkmedia.io/odx/api/v3/playback/{video_id}/', video_id,
+                                   fatal=False, headers={'service-name': 'odk'},
+                                   query={'did': random_uuidv4()}, expected_status=(200, 403))
+        if not data.get('result'):
+            raise ExtractorError(traverse_obj(data, ('messages', '__default'), 'title'), expected=True)
 
-        if 'msg_block_01.png' in webpage:
-            self.raise_geo_restricted(
-                msg='This content is not available in your region',
-                countries=self._GEO_COUNTRIES)
+        potential_urls = traverse_obj(data, ('result', 'sources', ..., 'url'), ('result', 'manifests', ..., 'url'))
+        # Try to bypass geo-restricted ad proxy
+        potential_urls = [
+            alt_url if (alt_url := traverse_obj(url, ({parse_qs}, 'stream_url', 0, {url_or_none}))) else url
+            for url in potential_urls
+        ]
+        # Try to upgrade quality
+        potential_urls = [
+            mod_url if self._request_webpage(
+                HEADRequest(mod_url := re.sub(r'_720(p?)\.m3u8', r'_1080\1.m3u8', url)), video_id,
+                note='Checking if higher quality format is available', fatal=False) else url
+            for url in potential_urls
+        ]
 
-        if 'This video is only available to ODK PLUS members.' in webpage:
-            raise ExtractorError(
-                'This video is only available to ODK PLUS members.',
-                expected=True)
+        formats = []
+        for url in potential_urls:
+            formats.extend(self._extract_m3u8_formats(url, video_id, fatal=False))
 
-        if 'ODK PREMIUM Members Only' in webpage:
-            raise ExtractorError(
-                'This video is only available to ODK PREMIUM members.',
-                expected=True)
+        subtitles = {}
+        for track in traverse_obj(data, ('result', 'text_tracks', lambda _, v: url_or_none(v['url']))):
+            subtitles.setdefault(track.get('language', 'und'), []).append({
+                'url': track['url'],
+                'ext': track.get('codec'),
+                'name': track.get('label'),
+            })
 
-        title = self._search_regex(
-            r'class=["\']episode_title["\'][^>]*>([^<]+)',
-            webpage, 'episode_title', fatal=False) or self._og_search_title(webpage)
+        return {
+            'id': video_id,
+            'title': join_nonempty(
+                ('result', 'episode', 'program', 'title'),
+                ('result', 'episode', 'title'), from_dict=data, delim=': '),
+            **traverse_obj(data, ('result', {
+                'thumbnail': ('episode', 'images', 'thumbnail', {url_or_none}),
+                'release_date': ('episode', 'release_date', {lambda x: x.replace('-', '')}, {unified_strdate}),
+                'duration': ('duration', {functools.partial(float_or_none, scale=1000)}),
+                'age_limit': ('age_rating', 'name', {lambda x: x.replace('R', '')}, {parse_age_limit}),
+                'series': ('episode', {lambda x: x['program'] if x['kind'] == 'series' else None}, 'title'),
+                'series_id': ('episode', {lambda x: x['program'] if x['kind'] == 'series' else None}, 'id'),
+                'episode': ('episode', {lambda x: x['title'] if x['kind'] == 'series' else None},),
+                'episode_number': ('episode', {lambda x: x['number'] if x['kind'] == 'series' else None}, {int_or_none}),
+            }), get_all=False),
+            'formats': formats,
+            'subtitles': subtitles,
+        }
 
-        jw_config = self._parse_json(
-            self._search_regex((
-                r'(?P<options>{\s*[\'"]tracks[\'"].*?})[)\];]+$',
-                r'playlist\s*=\s*\[(?P<options>.+)];?$',
-                r'odkPlayer\.init.*?(?P<options>{[^;]+}).*?;',
-            ), webpage, 'jw config', flags=re.MULTILINE | re.DOTALL, group='options'),
-            video_id, transform_source=js_to_json)
-        info = self._parse_jwplayer_data(
-            jw_config, video_id, require_title=False, m3u8_id='hls',
-            base_url=url)
 
-        info.update({
-            'title': title,
-            'description': self._og_search_description(webpage),
-            'thumbnail': self._og_search_thumbnail(webpage)
-        })
-        return info
+class OnDemandKoreaProgramIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?ondemandkorea\.com/(?:en/)?player/vod/(?P<id>[a-z0-9-]+)(?:$|[?#])'
+    _GEO_COUNTRIES = ['US', 'CA']
+
+    _TESTS = [{
+        'url': 'https://www.ondemandkorea.com/player/vod/uskn-news',
+        'info_dict': {
+            'id': 'uskn-news',
+        },
+        'playlist_count': 755,
+    }, {
+        'url': 'https://www.ondemandkorea.com/en/player/vod/joint-security-area',
+        'info_dict': {
+            'id': 'joint-security-area',
+        },
+        'playlist_count': 2,
+    }]
+
+    _PAGE_SIZE = 100
+
+    def _fetch_page(self, display_id, page):
+        page += 1
+        page_data = self._download_json(
+            f'https://odkmedia.io/odx/api/v3/program/{display_id}/episodes/', display_id,
+            headers={'service-name': 'odk'}, query={
+                'page': page,
+                'page_size': self._PAGE_SIZE,
+            }, note=f'Downloading page {page}')
+        for episode in traverse_obj(page_data, ('result', 'results')):
+            yield self.url_result(
+                f'https://www.ondemandkorea.com/player/vod/{display_id}?contentId={episode["id"]}',
+                ie=OnDemandKoreaIE, video_title=episode.get('title')
+            )
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+
+        entries = OnDemandPagedList(functools.partial(
+            self._fetch_page, display_id), self._PAGE_SIZE)
+
+        return self.playlist_result(entries, display_id)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

~~Requires Python 3.8 due to the use of the walrus operator.
Not entirely sure if the series check inside `traverse_obj` is the most elegant way to write this.~~
Both were addressed in review.

Fixes #8374


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 19aa313</samp>

### Summary
🆕🔄✨

<!--
1.  🆕 for importing the new `OnDemandKoreaProgramIE` extractor class.
2.  🔄 for replacing the entire code of the `ondemandkorea.py` module with a new implementation.
3.  ✨ for adding more features, error handling, and tests.
-->
Add a new extractor class for OnDemandKorea programs and rewrite the existing extractor class for OnDemandKorea videos. The new classes use a different API endpoint, support more features and formats, and handle errors better. Update the tests and the import statement in `_extractors.py` accordingly.

> _`ondemandkorea.py`_
> _New API, more features_
> _Autumn of improvement_

### Walkthrough
* Import and register new extractor class for OnDemandKorea programs ([link](https://github.com/yt-dlp/yt-dlp/pull/8386/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L1390-R1393))
* Rewrite extractor classes for OnDemandKorea videos and programs using a different API endpoint and URL pattern ([link](https://github.com/yt-dlp/yt-dlp/pull/8386/files?diff=unified&w=0#diff-150926927f6f2c0af97b75d2d0c581fd0bd86010f317c272983af2b40c2455a9L1-R149))



</details>
