### PR TITLE
NHK metadata fixes/improvements

### DIFF
--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -4,6 +4,7 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     clean_html,
+    get_element_by_class,
     int_or_none,
     join_nonempty,
     parse_duration,
@@ -286,11 +287,11 @@ class NhkVodProgramIE(NhkBaseIE):
             entries.append(self._extract_episode_info(
                 urljoin(url, episode_path), episode))
 
-        program_title = None
-        if entries:
-            program_title = entries[0].get('series')
+        html = self._download_webpage(url, program_id)
+        program_title = clean_html(get_element_by_class('p-programDetail__title', html))
+        program_description = clean_html(get_element_by_class('p-programDetail__text', html))
 
-        return self.playlist_result(entries, program_id, program_title)
+        return self.playlist_result(entries, program_id, program_title, program_description)
 
 
 class NhkForSchoolBangumiIE(InfoExtractor):

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -181,7 +181,7 @@ class NhkVodIE(NhkBaseIE):
             'ext': 'm4a',
             'title': 'Living in Japan - Tips for Travelers to Japan / Ramen Vending Machines',
             'series': 'Living in Japan',
-            'description': 'md5:850611969932874b4a3309e0cae06c2f',
+            'description': 'md5:0a0e2077d8f07a03071e990a6f51bfab',
             'thumbnail': 'md5:960622fb6e06054a4a1a0c97ea752545',
             'episode': 'Tips for Travelers to Japan / Ramen Vending Machines'
         },
@@ -224,14 +224,13 @@ class NhkVodIE(NhkBaseIE):
         },
         'skip': 'expires 2023-10-15',
     }, {
+        # a one-off (single-episode series). title from the api is just '<p></p>'
         'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/3004952/',
         'info_dict': {
             'id': 'nw_vod_v_en_3004_952_20230723091000_01_1690074552',
             'ext': 'mp4',
-            'title': 'Barakan Discovers AMAMI OSHIMA: Isson\'s Treasure Island - <p></p>',
+            'title': 'Barakan Discovers AMAMI OSHIMA: Isson\'s Treasure Island',
             'description': 'md5:5db620c46a0698451cc59add8816b797',
-            'series': 'Barakan Discovers AMAMI OSHIMA: Isson\'s Treasure Island',
-            'episode': '<p></p>',
             'thumbnail': 'md5:67d9ff28009ba379bfa85ad1aaa0e2bd',
         },
     }]

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -477,6 +477,7 @@ class NhkRadiruIE(InfoExtractor):
         'skip': 'Episode expired on 2023-04-16',
         'info_dict': {
             'channel': 'NHK-FM',
+            'uploader': 'NHK-FM',
             'description': 'md5:94b08bdeadde81a97df4ec882acce3e9',
             'ext': 'm4a',
             'id': '0449_01_3853544',
@@ -497,6 +498,7 @@ class NhkRadiruIE(InfoExtractor):
             'title': 'ベストオブクラシック',
             'description': '世界中の上質な演奏会をじっくり堪能する本格派クラシック番組。',
             'channel': 'NHK-FM',
+            'uploader': 'NHK-FM',
             'thumbnail': 'https://www.nhk.or.jp/prog/img/458/g458.jpg',
         },
         'playlist_mincount': 3,
@@ -510,6 +512,7 @@ class NhkRadiruIE(InfoExtractor):
             'title': '有島武郎「一房のぶどう」',
             'description': '朗読：川野一宇（ラジオ深夜便アンカー）\r\n\r\n（2016年12月8日放送「ラジオ深夜便『アンカー朗読シリーズ』」より）',
             'channel': 'NHKラジオ第1、NHK-FM',
+            'uploader': 'NHKラジオ第1、NHK-FM',
             'timestamp': 1635757200,
             'thumbnail': 'https://www.nhk.or.jp/radioondemand/json/F300/img/corner/box_109_thumbnail.jpg',
             'release_date': '20161207',
@@ -525,6 +528,7 @@ class NhkRadiruIE(InfoExtractor):
             'id': 'F261_01_3855109',
             'ext': 'm4a',
             'channel': 'NHKラジオ第1',
+            'uploader': 'NHKラジオ第1',
             'timestamp': 1681635900,
             'release_date': '20230416',
             'series': 'NHKラジオニュース',
@@ -598,6 +602,7 @@ class NhkRadioNewsPageIE(InfoExtractor):
             'thumbnail': 'https://www.nhk.or.jp/radioondemand/json/F261/img/RADIONEWS_640.jpg',
             'description': 'md5:bf2c5b397e44bc7eb26de98d8f15d79d',
             'channel': 'NHKラジオ第1',
+            'uploader': 'NHKラジオ第1',
             'title': 'NHKラジオニュース',
         }
     }]

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -569,6 +569,7 @@ class NhkRadiruIE(InfoExtractor):
         series_meta = traverse_obj(meta, {
             'title': 'program_name',
             'channel': 'media_name',
+            'uploader': 'media_name',
             'thumbnail': (('thumbnail_c', 'thumbnail_p'), {url_or_none}),
         }, get_all=False)
 

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -65,13 +65,6 @@ class NhkBaseIE(InfoExtractor):
             stream_url = traverse_obj(
                 meta, ('movie_url', ('mb_auto', 'auto_sp', 'auto_pc'), {url_or_none}), get_all=False)
 
-            info = traverse_obj(meta, {
-                'duration': 'duration',
-                'timestamp': ('publication_date', {unified_timestamp}),
-                'release_timestamp': ('insert_date', {unified_timestamp}),
-                'modified_timestamp': ('update_date', {unified_timestamp}),
-            })
-
             if stream_url:
                 formats, subtitles = self._extract_m3u8_formats_and_subtitles(stream_url, vod_id)
                 return {

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -212,6 +212,17 @@ class NhkVodIE(NhkBaseIE):
             'description': 'md5:9c1d6cbeadb827b955b20e99ab920ff0',
         },
         'skip': 'expires 2023-10-15',
+    }, {
+        'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/video/3004952/',
+        'info_dict': {
+            'id': 'nw_vod_v_en_3004_952_20230723091000_01_1690074552',
+            'ext': 'mp4',
+            'title': 'Barakan Discovers AMAMI OSHIMA: Isson\'s Treasure Island - <p></p>',
+            'description': 'md5:5db620c46a0698451cc59add8816b797',
+            'series': 'Barakan Discovers AMAMI OSHIMA: Isson\'s Treasure Island',
+            'episode': '<p></p>',
+            'thumbnail': 'md5:67d9ff28009ba379bfa85ad1aaa0e2bd',
+        },
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -248,13 +248,15 @@ class NhkVodProgramIE(NhkBaseIE):
         'info_dict': {
             'id': 'sumo',
             'title': 'GRAND SUMO Highlights',
+            'description': 'md5:fc20d02dc6ce85e4b72e0273aa52fdbf',
         },
-        'playlist_mincount': 12,
+        'playlist_mincount': 0,
     }, {
         'url': 'https://www3.nhk.or.jp/nhkworld/en/ondemand/program/video/japanrailway',
         'info_dict': {
             'id': 'japanrailway',
             'title': 'Japan Railway Journal',
+            'description': 'md5:ea39d93af7d05835baadf10d1aae0e3f',
         },
         'playlist_mincount': 12,
     }, {
@@ -263,6 +265,7 @@ class NhkVodProgramIE(NhkBaseIE):
         'info_dict': {
             'id': 'japanrailway',
             'title': 'Japan Railway Journal',
+            'description': 'md5:ea39d93af7d05835baadf10d1aae0e3f',
         },
         'playlist_mincount': 5,
     }, {

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -169,6 +169,14 @@ class NhkVodIE(NhkBaseIE):
             'thumbnail': 'md5:51bcef4a21936e7fea1ff4e06353f463',
             'episode': 'The Tohoku Shinkansen: Full Speed Ahead',
             'series': 'Japan Railway Journal',
+            'modified_timestamp': 1694243656,
+            'timestamp': 1681428600,
+            'release_timestamp': 1693883728,
+            'duration': 1679,
+            'upload_date': '20230413',
+            'modified_date': '20230909',
+            'release_date': '20230905',
+
         },
     }, {
         # video clip
@@ -182,6 +190,13 @@ class NhkVodIE(NhkBaseIE):
             'thumbnail': 'md5:d6a4d9b6e9be90aaadda0bcce89631ed',
             'series': 'Dining with the Chef',
             'episode': 'Chef Saito\'s Family recipe: MENCHI-KATSU',
+            'duration': 148,
+            'upload_date': '20190816',
+            'release_date': '20230902',
+            'release_timestamp': 1693619292,
+            'modified_timestamp': 1694168033,
+            'modified_date': '20230908',
+            'timestamp': 1565997540,
         },
     }, {
         # radio
@@ -242,6 +257,13 @@ class NhkVodIE(NhkBaseIE):
             'title': 'Barakan Discovers AMAMI OSHIMA: Isson\'s Treasure Island',
             'description': 'md5:5db620c46a0698451cc59add8816b797',
             'thumbnail': 'md5:67d9ff28009ba379bfa85ad1aaa0e2bd',
+            'release_date': '20230905',
+            'timestamp': 1690103400,
+            'duration': 2939,
+            'release_timestamp': 1693898699,
+            'modified_timestamp': 1694223888,
+            'modified_date': '20230909',
+            'upload_date': '20230723',
         },
     }]
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fixes/improves NHK World's metadata extraction.
I've also snuck in a little change to NHK Radiru (domestic radio) while i'm here

---

The titles of one-off programmes, like https://www3.nhk.or.jp/nhkworld/en/ondemand/video/3004952/, were somewhat borked. The API returns the (sub)title as `<p></p>`, so the `title` the extractor returned was `Barakan Discovers AMAMI OSHIMA: Isson's Treasure Island - <p></p>`

the site doesn't handle it that well either tbh, note the ` - ` at the start
![browser showing the page title as " - Barakan Discovers AMAMI OSHIMA: Isson's Treasure Island | NHK WORLD-JAPAN On Demand"](https://github.com/yt-dlp/yt-dlp/assets/76261416/c0488953-1b12-4c12-9085-99514befcd13)

I've made it so that the `series` `Barakan Discovers AMAMI OSHIMA: Isson's Treasure Island` becomes the `title`, and the `series` becomes `None` - it's a one-off, so it's not really in a series.

In doing this, I changed the criteria for returning `series`/`episode` slightly. One-offs have no series. If there is no series, there can't be an episode of it, so `episode` isn't returned either.

----

If a programme had no entries, e.g. the sumo (first test), the extraction (or at least, the test) would fail, as it couldn't get the `series` from the nonexistent entries.

By extracting from the programme page instead, we prevent this, and gain the description "for free" as well

<details>
<summary>we could also get the thumbnail:</summary>

```python
thumbnail_div = get_element_by_class('p-programDetail__itemImg', html)
thumbnail = extract_attributes(thumbnail_div).get('src')  # the div contains nothing but an <img> tag
```
but it's a relative url, cba to urljoin it
\+ too much potential for fatalities/borking
</details>

---

The streams API has some other metadata, mostly related to timestamps.
I modified the `_extract_formats_and_subtitles` to extract this additional info as well.
It does rather ruin how nice and elegant it was before, i'm afraid
but got to get the metadata somehow

---

the radiru change
I've set the station name as `uploader` (in addition to `channel`, which it already is)

this is purely so i can have the station name embedded as the artist without changing my config
that commit can be skipped if thats not a valid enough reason

---

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 20ed3e0</samp>

### Summary
🌐🎧📺

<!--
1.  🌐 for improving the extraction of web-related information, such as titles, descriptions, thumbnails, and subtitles.
2.  🎧 for improving the extraction of audio-related information, such as formats, codecs, and quality.
3.  📺 for improving the extraction of video-related information, such as formats, codecs, and quality.
-->
This pull request enhances the support for downloading videos and audio from the NHK website and API. It fixes and updates the extraction of titles, descriptions, thumbnails, formats, subtitles, and other metadata for the `NhkVodIE`, `NhkVodProgramIE`, `NhkRadiruIE`, and `NhkRadioNewsPageIE` extractors. It also adds or updates tests for these extractors in the file `yt_dlp/extractor/nhk.py`.

> _`NhkVodIE` and more_
> _Extract fields from website, API_
> _Autumn tests updated_

### Walkthrough
*  Rename and modify `_extract_formats_and_subtitles` function to return additional stream information ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L48-R50), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L55-R75))
*  Use `clean_html` function to sanitize title, sub_title, and description fields in `_extract_episode_info` function ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L80-R94))
*  Handle missing or empty series and title fields in `_extract_episode_info` function and update info dictionary with stream information ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L99-R135))
*  Extract program title and description from HTML page in `NhkVodProgramIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L268-R328))
*  Extract uploader field from API response in `NhkRadiruIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R576))
*  Import `clean_html` and `get_element_by_class` functions from utils module ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R6-R7))
*  Add test cases for `NhkVodIE` extractor with additional fields and fix description typo ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R172-R179), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R193-R199), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L173-R209), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R251-R267))
*  Add description field and update playlist_mincount for test cases for `NhkVodProgramIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722L229-R284), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R290), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R299))
*  Add uploader field for test cases for `NhkRadiruIE` extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R480), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R501), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R515), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R531), [link](https://github.com/yt-dlp/yt-dlp/pull/8388/files?diff=unified&w=0#diff-5adc25ce69895042565846073090a631920a91ba6326b97b2357a097a6c2c722R605))



</details>
