### PR TITLE
Fix #4521: If `os.path.getsize` throws `FileNotFoundError`, set the retry to resume from 0.

### DIFF
--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -237,8 +237,13 @@ class HttpFD(FileDownloader):
 
             def retry(e):
                 close_stream()
-                ctx.resume_len = (byte_counter if ctx.tmpfilename == '-'
-                                  else os.path.getsize(encodeFilename(ctx.tmpfilename)))
+                if ctx.tmpfilename == '-':
+                    ctx.resume_len = byte_counter
+                else:
+                    try:
+                        ctx.resume_len = os.path.getsize(encodeFilename(ctx.tmpfilename))
+                    except FileNotFoundError:
+                        ctx.resume_len = 0
                 raise RetryDownload(e)
 
             while True:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

As of 2023.10.13 and master@4e38e2ae9d7380015349e6aee59c78bb3938befd, when yt-dlp encounters an incomplete read while downloading a WebVTT stream, it may not have created the file for that fragment yet, in which case its attempt to set the resume length on the retry (to the file's length) fails with `FileNotFoundError`.

This patch catches `FileNotFoundError` and sets the resume length to 0 in that case.

Fixes #4521.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0d37aa9</samp>

### Summary
🔄🗑️🐛

<!--
1.  🔄 This emoji can be used to indicate that the change is related to resuming or restarting something, such as a download. It can also suggest a circular or retry logic.
2.  🗑️ This emoji can be used to indicate that the change is related to handling the case where a file is deleted or missing, such as the temporary file. It can also suggest garbage collection or cleanup.
3.  🐛 This emoji can be used to indicate that the change is related to fixing a bug or an issue, such as the exception that was raised before. It can also suggest debugging or testing.
-->
Handle missing temporary file when resuming download in `yt_dlp/downloader/http.py`. Set resume length to zero instead of raising an error.

> _`tempfile` missing_
> _resume length becomes zero_
> _autumn leaves falling_

### Walkthrough
*  Handle missing temporary file when resuming download ([link](https://github.com/yt-dlp/yt-dlp/pull/8399/files?diff=unified&w=0#diff-b6fae2631bea3c5c9cd221f2b4d793b6af0f0f2e363fe7a852a0380314526945L240-R246))



</details>
