### PR TITLE
[ie/francetv] Add support for episode and season tagging

### DIFF
--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -1,14 +1,14 @@
 from .common import InfoExtractor
+from .dailymotion import DailymotionIE
 from ..utils import (
-    determine_ext,
     ExtractorError,
+    determine_ext,
     format_field,
+    int_or_none,
+    join_nonempty,
     parse_iso8601,
     parse_qs,
-    join_nonempty,
-    int_or_none,
 )
-from .dailymotion import DailymotionIE
 
 
 class FranceTVBaseInfoExtractor(InfoExtractor):

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -5,6 +5,8 @@ from ..utils import (
     format_field,
     parse_iso8601,
     parse_qs,
+    join_nonempty,
+    int_or_none,
 )
 from .dailymotion import DailymotionIE
 
@@ -98,8 +100,8 @@ class FranceTVIE(InfoExtractor):
         videos = []
         title = None
         subtitle = None
-        episode = None
-        series = None
+        episode_number = None
+        season_number = None
         image = None
         duration = None
         timestamp = None
@@ -115,8 +117,6 @@ class FranceTVIE(InfoExtractor):
 
             if not dinfo:
                 continue
-
-            print(dinfo)
 
             video = dinfo.get('video')
             if video:
@@ -134,7 +134,7 @@ class FranceTVIE(InfoExtractor):
                     title = meta.get('title')
                 # meta['pre_title'] contains season and episode number for series in format "S<ID> E<ID>"
                 season_number, episode_number = self._search_regex(
-                        r'S(\d+)\s*E(\d+)', meta.get('pre_title'), 'episode info', group=(1, 2), default=(None, None))
+                    r'S(\d+)\s*E(\d+)', meta.get('pre_title'), 'episode info', group=(1, 2), default=(None, None))
                 if subtitle is None:
                     subtitle = meta.get('additional_title')
                 if image is None:
@@ -215,7 +215,7 @@ class FranceTVIE(InfoExtractor):
 
         return {
             'id': video_id,
-            'title': (title + ' - %s' % subtitle if subtitle else title).strip(),
+            'title': join_nonempty(title, subtitle, delim=' - ').strip(),
             'thumbnail': image,
             'duration': duration,
             'timestamp': timestamp,
@@ -224,8 +224,8 @@ class FranceTVIE(InfoExtractor):
             'subtitles': subtitles,
             'episode': subtitle if episode_number else None,
             'series': title if episode_number else None,
-            'episode_number': int(episode_number) if episode_number else None,
-            'season_number': int(season_number) if season_number else None,
+            'episode_number': int_or_none(episode_number),
+            'season_number': int_or_none(season_number),
         }
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -49,22 +49,6 @@ class FranceTVIE(InfoExtractor):
             'upload_date': '20170813',
         },
     }, {
-        'url': 'https://www.france.tv/enfants/six-huit-ans/foot2rue/saison-1/3066387-duel-au-vieux-port.html',
-        'info_dict': {
-            'id': 'a9050959-eedd-4b4a-9b0d-de6eeaa73e44',
-            'ext': 'mp4',
-            'title': 'Foot2Rue - Duel au vieux port',
-            'episode': 'Duel au vieux port',
-            'series': 'Foot2Rue',
-            'episode_number': 1,
-            'season_number': 1,
-            'timestamp': 1642761360,
-            'upload_date': '20220121',
-            'season': 'Season 1',
-            'thumbnail': r're:^https?://.*\.jpg$',
-            'duration': 1441,
-        },
-    }, {
         # with catalog
         'url': 'https://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion=NI_1004933&catalogue=Zouzous&callback=_jsonp_loader_callback_request_4',
         'only_matching': True,
@@ -252,14 +236,32 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
             'id': 'ec217ecc-0733-48cf-ac06-af1347b849d1',
             'ext': 'mp4',
             'title': '13h15, le dimanche... - Les mystères de Jésus',
-            'description': 'md5:75efe8d4c0a8205e5904498ffe1e1a42',
+            # 'description': 'md5:75efe8d4c0a8205e5904498ffe1e1a42',
             'timestamp': 1502623500,
+            'duration': 2580,
+            'thumbnail': r're:^https?://.*\.jpg$',
             'upload_date': '20170813',
         },
         'params': {
             'skip_download': True,
         },
         'add_ie': [FranceTVIE.ie_key()],
+    }, {
+        'url': 'https://www.france.tv/enfants/six-huit-ans/foot2rue/saison-1/3066387-duel-au-vieux-port.html',
+        'info_dict': {
+            'id': 'a9050959-eedd-4b4a-9b0d-de6eeaa73e44',
+            'ext': 'mp4',
+            'title': 'Foot2Rue - Duel au vieux port',
+            'episode': 'Duel au vieux port',
+            'series': 'Foot2Rue',
+            'episode_number': 1,
+            'season_number': 1,
+            'timestamp': 1642761360,
+            'upload_date': '20220121',
+            'season': 'Season 1',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'duration': 1441,
+        },
     }, {
         # france3
         'url': 'https://www.france.tv/france-3/des-chiffres-et-des-lettres/139063-emission-du-mardi-9-mai-2017.html',

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -236,7 +236,6 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
             'id': 'ec217ecc-0733-48cf-ac06-af1347b849d1',
             'ext': 'mp4',
             'title': '13h15, le dimanche... - Les mystères de Jésus',
-            # 'description': 'md5:75efe8d4c0a8205e5904498ffe1e1a42',
             'timestamp': 1502623500,
             'duration': 2580,
             'thumbnail': r're:^https?://.*\.jpg$',


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This adds support for episode and season tagging for FranceTV extractor.
The FranceTV extractor didn't used the fields `pre_title`, which contains season and episode number.
If those fields are filled, this means that the media is part of a TV Show and the Title is the Show name, and subtitle
is the episode title.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6444c5d</samp>

### Summary
📺🇫🇷🔢

<!--
1.  📺 - This emoji represents television or TV shows, and can be used to indicate the feature of extracting and outputting season and episode information for series videos from francetv.
2.  🇫🇷 - This emoji represents the flag of France, and can be used to indicate the source of the videos, which is francetv, a French public broadcaster.
3.  🔢 - This emoji represents numbers or digits, and can be used to indicate the use of regular expressions to parse the `pre_title` field and assign the relevant values to the output dictionary.
-->
Added season and episode extraction for francetv series. Modified `yt_dlp/extractor/francetv.py` to parse `pre_title` metadata and output the corresponding fields.

> _`francetv` videos_
> _season and episode parsed_
> _autumn of series_

### Walkthrough
* Import the `re` module to use regular expressions for parsing season and episode numbers from the metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/8409/files?diff=unified&w=0#diff-98bf13c62ffce8c8b537462644191b374f9d44df4fa242a6da9e7ce49cac14caR10))
* Initialize variables to store the episode number, season number, episode title and series title of the video, if available ([link](https://github.com/yt-dlp/yt-dlp/pull/8409/files?diff=unified&w=0#diff-98bf13c62ffce8c8b537462644191b374f9d44df4fa242a6da9e7ce49cac14caR86-R89))
* Extract the season and episode numbers from the `pre_title` field of the metadata, if present, using regular expressions ([link](https://github.com/yt-dlp/yt-dlp/pull/8409/files?diff=unified&w=0#diff-98bf13c62ffce8c8b537462644191b374f9d44df4fa242a6da9e7ce49cac14caL115-R127))
* Assign the episode title and series title to the `episode` and `series` variables, respectively, if the video is an episode from a series ([link](https://github.com/yt-dlp/yt-dlp/pull/8409/files?diff=unified&w=0#diff-98bf13c62ffce8c8b537462644191b374f9d44df4fa242a6da9e7ce49cac14caR206-R210))
* Include the `episode`, `series`, `episode_number` and `season_number` fields in the output dictionary of the extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8409/files?diff=unified&w=0#diff-98bf13c62ffce8c8b537462644191b374f9d44df4fa242a6da9e7ce49cac14caR224-R227))



</details>
