### PR TITLE
Change to POST request in the NPO extractor

### DIFF
--- a/yt_dlp/extractor/npo.py
+++ b/yt_dlp/extractor/npo.py
@@ -245,8 +245,7 @@ class NPOIE(InfoExtractor):
                     'quality': 'npoplus',
                     'tokenId': player_token,
                     'streamType': 'broadcast',
-                },
-                data=b'')  # by posting empty data we force a POST request
+                }, data=b'')
             if not streams:
                 continue
             stream = streams.get('stream')

--- a/yt_dlp/extractor/npo.py
+++ b/yt_dlp/extractor/npo.py
@@ -245,7 +245,8 @@ class NPOIE(InfoExtractor):
                     'quality': 'npoplus',
                     'tokenId': player_token,
                     'streamType': 'broadcast',
-                })
+                },
+                data=b'')  # by posting empty data we force a POST request
             if not streams:
                 continue
             stream = streams.get('stream')

--- a/yt_dlp/extractor/npo.py
+++ b/yt_dlp/extractor/npo.py
@@ -245,7 +245,7 @@ class NPOIE(InfoExtractor):
                     'quality': 'npoplus',
                     'tokenId': player_token,
                     'streamType': 'broadcast',
-                }, data=b'')
+                }, data=b'')  # endpoint requires POST
             if not streams:
                 continue
             stream = streams.get('stream')


### PR DESCRIPTION
### Description of your *pull request* and other information
The server probably changed and now returns a HTTP 405 "Method not allowed" if we send GET requests to it.
The actual data is still in the GET parameters, and has not moved to the payload.

Closes #6398 

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a7c8f9e</samp>

### Summary
🛠️📬🎥

<!--
1.  🛠️ - This emoji represents a fix or a repair, which is the main purpose of the change.
2.  📬 - This emoji represents a post or a mail, which is the type of request that is now used by the change.
3.  🎥 - This emoji represents a video or a movie, which is the type of content that is affected by the change.
-->
Fix NPO extraction by using POST requests for some streams. Modify `yt_dlp/extractor/npo.py` to pass `data=b''` to `self._download_json`.

> _`data=b''` added_
> _To force a POST request_
> _NPO streams fixed now_

### Walkthrough
* Force POST request for NPO API by adding `data=b''` argument ([link](https://github.com/yt-dlp/yt-dlp/pull/8413/files?diff=unified&w=0#diff-a5299353c140db0f81e158e6437b8410f792e4dbb2cb87371e0e6a955387d6e0L248-R249))



</details>
