### PR TITLE
__init__.py: remove unnecessary f-string

### DIFF
--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -2,7 +2,7 @@ try:
     import contextvars  # noqa: F401
 except Exception:
     raise Exception(
-        f'You are using an unsupported version of Python. Only Python versions 3.7 and above are supported by yt-dlp')  # noqa: F541
+        'You are using an unsupported version of Python. Only Python versions 3.7 and above are supported by yt-dlp')
 
 __license__ = 'Public Domain'
 


### PR DESCRIPTION
When the python runtime version is < 3.7, an Exception is raised. The message contained in that version contained an f-string with no placeholders.

This triggered a warning in pyflakes, that was subsequently silenced with a F541 directive.

We can simply use a plain string and get rid of the "noqa" directive.
