### PR TITLE
Don't skip if unplayable formats are allowed by the user

### DIFF
--- a/yt_dlp/extractor/npo.py
+++ b/yt_dlp/extractor/npo.py
@@ -255,7 +255,8 @@ class NPOIE(InfoExtractor):
             if not stream_url or stream_url in format_urls:
                 continue
             format_urls.add(stream_url)
-            if stream.get('protection') is not None or stream.get('keySystemOptions') is not None:
+            if (stream.get('protection') is not None or stream.get('keySystemOptions') is not None
+                and not self.get_param('allow_unplayable_formats')):
                 drm = True
                 continue
             stream_type = stream.get('type')

--- a/yt_dlp/extractor/npo.py
+++ b/yt_dlp/extractor/npo.py
@@ -255,10 +255,10 @@ class NPOIE(InfoExtractor):
             if not stream_url or stream_url in format_urls:
                 continue
             format_urls.add(stream_url)
-            if (stream.get('protection') is not None or stream.get('keySystemOptions') is not None
-                and not self.get_param('allow_unplayable_formats')):
+            if stream.get('protection') is not None or stream.get('keySystemOptions') is not None:
                 drm = True
-                continue
+                if not self.get_param('allow_unplayable_formats'):
+                    continue
             stream_type = stream.get('type')
             stream_ext = determine_ext(stream_url)
             if stream_type == 'application/dash+xml' or stream_ext == 'mpd':


### PR DESCRIPTION
Currently the NPO extractor skips downloads when DRM is detected, even if the user requested to also download unplayable formats. This fixes that. Now the unplayable formats will be downloaded if the user wants that..

Depends on the fix in #8413 to be merged as well.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at feee098</samp>

### Summary
:unlock::video_camera::netherlands:

<!--
1.  :unlock: This emoji represents the unlocking of DRM-protected streams for users who have the option enabled. It also conveys the idea of giving more freedom and choice to the users.
2.  :video_camera: This emoji represents the video streams that are affected by the change. It also conveys the idea of improving the video quality and availability for the users.
3.  :netherlands: This emoji represents the NPO service that is the main target of the pull request. It also conveys the idea of supporting more regional and local content for the users.
-->
Allow downloading DRM-protected streams from NPO with `allow_unplayable_formats` option. Modify `yt_dlp/extractor/npo.py` to skip DRM check if option is enabled.

> _`allow_unplayable`_
> _A new option for NPO_
> _Winter of DRM_

### Walkthrough
* Add a condition to skip DRM-protected streams only if `allow_unplayable_formats` is not enabled ([link](https://github.com/yt-dlp/yt-dlp/pull/8449/files?diff=unified&w=0#diff-a5299353c140db0f81e158e6437b8410f792e4dbb2cb87371e0e6a955387d6e0L258-R259))



</details>
