### PR TITLE
[extractor/weverse] Fix username check for invalid accounts

### DIFF
--- a/yt_dlp/extractor/weverse.py
+++ b/yt_dlp/extractor/weverse.py
@@ -46,8 +46,8 @@ class WeverseBaseIE(InfoExtractor):
             'x-clog-user-device-id': str(uuid.uuid4()),
         }
         check_username = self._download_json(
-            f'{self._ACCOUNT_API_BASE}/signup/email/status', None,
-            note='Checking username', query={'email': username}, headers=headers)
+            f'{self._ACCOUNT_API_BASE}/signup/email/status', None, note='Checking username',
+            query={'email': username}, headers=headers, expected_status=(200, 400, 404))
         if not check_username.get('hasPassword'):
             raise ExtractorError('Invalid username provided', expected=True)
 

--- a/yt_dlp/extractor/weverse.py
+++ b/yt_dlp/extractor/weverse.py
@@ -45,10 +45,10 @@ class WeverseBaseIE(InfoExtractor):
             'x-acc-trace-id': str(uuid.uuid4()),
             'x-clog-user-device-id': str(uuid.uuid4()),
         }
-        check_username = self._download_json(
+        valid_username = traverse_obj(self._download_json(
             f'{self._ACCOUNT_API_BASE}/signup/email/status', None, note='Checking username',
-            query={'email': username}, headers=headers, expected_status=(200, 400, 404))
-        if not check_username.get('hasPassword'):
+            query={'email': username}, headers=headers, expected_status=(400, 404)), 'hasPassword')
+        if not valid_username:
             raise ExtractorError('Invalid username provided', expected=True)
 
         headers['content-type'] = 'application/json'


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The username check currently fails if the username is invalid due to the API now returning a status code of 400 or 404 instead of 200 for invalid and unregistered accounts respectively.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c9cb638</samp>

### Summary
🛠️📥🚦

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the function was modified to solve a problem or improve its functionality.
2.  📥 - This emoji represents an inbox or a download, and can be used to indicate that the function involves downloading data from an API endpoint or a server.
3.  🚦 - This emoji represents a traffic light or a status, and can be used to indicate that the function handles different HTTP status codes or checks the validity of the input.
-->
Fix login issue for some users in `weverse.py` by handling different API status codes. Add `expected_status` parameter to `_download_json` function.

> _`_perform_login` changed_
> _API status codes vary_
> _Autumn of errors_

### Walkthrough
* Allow different HTTP status codes for username check in `_perform_login` ([link](https://github.com/yt-dlp/yt-dlp/pull/8458/files?diff=unified&w=0#diff-267a5b7aa508e0099ef609aad0ce38e0371f77515bdf56f4ad244143aaf59d60L49-R50))
* Add `expected_status` parameter to `_download_json` call in `_perform_login` ([link](https://github.com/yt-dlp/yt-dlp/pull/8458/files?diff=unified&w=0#diff-267a5b7aa508e0099ef609aad0ce38e0371f77515bdf56f4ad244143aaf59d60L49-R50))
* Fix login issue for some users with valid usernames ([link](https://github.com/yt-dlp/yt-dlp/pull/8458/files?diff=unified&w=0#diff-267a5b7aa508e0099ef609aad0ce38e0371f77515bdf56f4ad244143aaf59d60L49-R50))



</details>
