### PR TITLE
[extractor/weibo] Fix visitor request

### DIFF
--- a/yt_dlp/extractor/weibo.py
+++ b/yt_dlp/extractor/weibo.py
@@ -1,3 +1,4 @@
+import json
 import random
 import itertools
 import urllib.parse


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #8445

Fix broken extractor due to change of guest token request.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8494b18</samp>

### Summary
🛠️🔄🗃️

<!--
1.  🛠️ - This emoji represents fixing or repairing something, and can be used to indicate that the video extraction was broken or not working before the change.
2.  🔄 - This emoji represents updating or refreshing something, and can be used to indicate that the method was changed to use a different or more current value for the referer header.
3.  🗃️ - This emoji represents a file cabinet or a box, and can be used to indicate that the data structure or storage was simplified or organized.
-->
Fix Weibo video extraction by updating cookie handling and data access. Modify `yt_dlp/extractor/weibo.py` to use the correct referer and simplify the `visitor_data` extraction.

> _We're scraping videos from Weibo, me hearties_
> _We need to update our cookies, aye_
> _We use the final URL as referer, on the count of three_
> _And simplify the `visitor_data`, heave ho_

### Walkthrough
* Fix Weibo video extraction by updating visitor cookies logic ([link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L21-R44), [link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L47-R53))
  - Add `visitor_url` parameter to `_update_visitor_cookies` method of `WeiboBaseIE` class ([link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L21-R44))
  - Use `visitor_url` as referer and Chrome version from user agent in requests to generate and run first-visit callback ([link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L21-R44))
  - Simplify access to `visitor_data` dictionary by removing unnecessary `['data']` key ([link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L21-R44))
  - Pass `urlh.url` as `visitor_url` to `_update_visitor_cookies` method in `_weibo_download_json` method of `WeiboBaseIE` class ([link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L47-R53))
  - Use `urlh.url` as final URL of webpage after following redirects, which may affect first-visit callback ([link](https://github.com/yt-dlp/yt-dlp/pull/8463/files?diff=unified&w=0#diff-8efa8d44e79fd9ae9cbe67344db2a31e224b9ce8fc2db9bcf309aced20a62dc7L47-R53))



</details>
