### PR TITLE
[ytdownload] Increased read timeout

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2572,3 +2572,4 @@ from .zingmp3 import (
 )
 from .zoom import ZoomIE
 from .zype import ZypeIE
+from .ytdownload import ytdownloadIE

--- a/yt_dlp/extractor/ytdownload.py
+++ b/yt_dlp/extractor/ytdownload.py
@@ -1,0 +1,35 @@
+from .common import InfoExtractor
+
+
+class ytdownloadIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?yourextractor\.com/watch/(?P<id>[0-9]+)'
+    _TESTS = [{
+        'url': 'https://yourextractor.com/watch/42',
+        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
+        'info_dict': {
+            'id': '42',
+            'ext': 'mp4',
+            'title': 'Video title goes here',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            # TODO more properties, either as:
+            # * A value
+            # * MD5 checksum; start the string with md5:
+            # * A regular expression; start the string with re:
+            # * Any Python type, e.g. int or float
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        # TODO more code goes here, for example ...
+        title = self._html_search_regex(r'<h1>(.+?)</h1>', webpage, 'title')
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': self._og_search_description(webpage),
+            'uploader': self._search_regex(r'<div[^>]+id="uploader"[^>]*>([^<]+)<', webpage, 'uploader', fatal=False),
+            # TODO more properties (see yt_dlp/extractor/common.py)
+        }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--Tried to increase timeout so to bypass read timeout error

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADD DESCRIPTION HERE

Fixes #8468 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [ x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb65a67</samp>

### Summary
:sparkles::truck::construction:

<!--
1.  :sparkles: This emoji is used to indicate that a new feature or functionality has been added to the project. In this case, the new feature is the support for a new website.
2.  :truck: This emoji is used to indicate that files or code have been moved or renamed within the project. In this case, the file `ytdownload.py` has been created and the class `ytdownloadIE` has been imported from it.
3.  :construction: This emoji is used to indicate that the work is still in progress or incomplete. In this case, the code for the new extractor class is still missing some logic and data.
-->
Add a new extractor module `ytdownload.py` for a website `yourextractor.com` and import it in `_extractors.py`. The new extractor class `ytdownloadIE` is still a work in progress and needs to be completed with the website-specific logic and data.

> _New `ytdownloadIE`_
> _Extracts from yourextractor_
> _Code is not finished_

### Walkthrough
* Create a new module `ytdownload.py` that defines a new extractor class for `yourextractor.com` ([link](https://github.com/yt-dlp/yt-dlp/pull/8472/files?diff=unified&w=0#diff-9fe0e05c08beee29596d701d0cde747643470055b81dc8a7ac032e7bcea00fbdL1-R34))
* Import and register the new extractor class in the main extractor module `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8472/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L2575-L2573))



</details>
