### PR TITLE
[man] Wrap options in code spans

### DIFF
--- a/devscripts/prepare_manpage.py
+++ b/devscripts/prepare_manpage.py
@@ -80,7 +80,7 @@ def filter_options(readme):
         # Pandoc's definition_lists. See http://pandoc.org/README.html
         option = f'{option} *{metavar}*' if metavar else option
         description = f'{description}\n' if description else ''
-        options += f'\n{option}\n:   {description}'
+        options += f'\n`{option}`\n:   {description}'
         continue
 
     return readme.replace(section, options, 1)


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Manpage generator didn't mark options up as being code, so pandoc applied standard typography to them. In particular, it replaced -- by en-dashes, reducing clarity. (eg the following is a sample from the manpage on my system:
```
OPTIONS
  General Options:
      -h, –help
             Print this help text and exit

      –version
             Print program version and exit

      -U, –update
             Update this program to the latest version

      –no-update
             Do not check for updates (default)
```

Fixes: #7046


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 01aa84e</samp>

### Summary
:wrench::memo::sparkles:

<!--
1.  :wrench: This emoji could represent the change of formatting from emphasis to inline code, as it suggests a minor adjustment or tweak to the appearance of the text.
2.  :memo: This emoji could represent the change of documentation or writing style, as it suggests a revision or improvement of the text content or quality.
3.  :sparkles: This emoji could represent the change of adding some flair or polish to the text, as it suggests a enhancement or embellishment of the appearance or effect of the text.
-->
Use inline code formatting for option strings in man page. Update `prepare_manpage.py` script to wrap option strings in backticks instead of asterisks.

> _Man page formatting_
> _Backticks for option strings_
> _Winter clarity_

### Walkthrough
*  Use inline code formatting for option strings in the man page ([link](https://github.com/yt-dlp/yt-dlp/pull/8481/files?diff=unified&w=0#diff-3dfb75b8a4a940ba75c2081aa270bb129de8810d2092ba1ba48fadf54de2b348L83-R83))



</details>
