### PR TITLE
[DRTV extractor] Fix drtv.py

### DIFF
--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -73,7 +73,6 @@ class DRTVIE(InfoExtractor):
             'id': '00951930010',
             'ext': 'mp4',
             'title': 'Frank & Kastaniegaarden',
-            'alt_title': None,
             'description': 'md5:974e1780934cf3275ef10280204bccb0',
             'release_timestamp': 1546545600,
             'release_date': '20190103',
@@ -313,6 +312,7 @@ class DRTVSeasonIE(InfoExtractor):
             'title': 'Frank & Kastaniegaarden',
             'series': 'Frank & Kastaniegaarden',
             'season_number': 2008,
+            'alt_title': 'Season 2008',
         },
         'playlist_mincount': 8
     }, {
@@ -323,6 +323,7 @@ class DRTVSeasonIE(InfoExtractor):
             'title': 'Frank & Kastaniegaarden',
             'series': 'Frank & Kastaniegaarden',
             'season_number': 2009,
+            'alt_title': 'Season 2009',
         },
         'playlist_mincount': 19
     }]
@@ -367,6 +368,7 @@ class DRTVSeriesIE(InfoExtractor):
             'display_id': 'frank-and-kastaniegaarden',
             'title': 'Frank & Kastaniegaarden',
             'series': 'Frank & Kastaniegaarden',
+            'alt_title': '',
         },
         'playlist_mincount': 15
     }]

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -126,17 +126,18 @@ class DRTVIE(InfoExtractor):
         'only_matching': True,
     }]
 
-    _TOKEN = None
-
     SUBTITLE_LANGS = {
         'DanishLanguageSubtitles': 'da',
         'ForeignLanguageSubtitles': 'da_foreign',
         'CombinedLanguageSubtitles': 'da_combined',
     }
 
+    _TOKEN = None
+
     def _real_initialize(self):
         if self._TOKEN:
             return
+
         token_response = self._download_json(
             'https://production.dr-massive.com/api/authorization/anonymous-sso', None,
             note='Downloading anonymous token', headers={

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -222,6 +222,9 @@ class DRTVIE(InfoExtractor):
                     'ext': mimetype2ext(sub_track.get('format')) or 'vtt'
                 })
 
+        if not formats and traverse_obj(item, ('season', 'customFields', 'IsGeoRestricted')):
+            self.raise_geo_restricted(countries=self._GEO_COUNTRIES)
+
         return {
             'id': video_id,
             'formats': formats,

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -228,7 +228,7 @@ class DRTVIE(InfoExtractor):
             'subtitles': subtitles,
             **traverse_obj(item, {
                 'title': 'title',
-                'alt_title': 'contextualTitle',                
+                'alt_title': 'contextualTitle',
                 'description': 'description',
                 'thumbnail': ('images', 'wallpaper'),
                 'release_timestamp': ('customFields', 'BroadcastTimeDK', {parse_iso8601}),

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -68,11 +68,12 @@ class DRTVIE(InfoExtractor):
         },
         'skip': 'this video has been removed',
     }, {
-        'url': 'https://www.dr.dk/drtv/se/bonderoeven_71769',
+        'url': 'https://www.dr.dk/drtv/se/frank-and-kastaniegaarden_71769',
         'info_dict': {
             'id': '00951930010',
             'ext': 'mp4',
             'title': 'Frank & Kastaniegaarden',
+            'alt_title': None,
             'description': 'md5:974e1780934cf3275ef10280204bccb0',
             'release_timestamp': 1546545600,
             'release_date': '20190103',
@@ -97,6 +98,7 @@ class DRTVIE(InfoExtractor):
             'ext': 'mp4',
             'episode_number': 1,
             'title': 'Spise med Price: Pasta Selv',
+            'alt_title': '1. Pasta Selv',
             'release_date': '20230807',
             'description': 'md5:2da9060524fed707810d71080b3d0cd8',
             'duration': 1750,

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -184,7 +184,7 @@ class DRTVIE(InfoExtractor):
                 'DanishLanguageSubtitles': 'da',
             }
 
-            for subs in fmt['subtitles']:
+            for subs in fmt.get('subtitles', []):
                 if not isinstance(subs, dict):
                     continue
                 sub_uri = url_or_none(subs.get('link'))

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -176,8 +176,8 @@ class DRTVIE(InfoExtractor):
         formats = []
         subtitles = {}
         for fmt in data:
-            formatId = fmt['format'] or 'na'
-            accessService = fmt['accessService']
+            format_id = fmt.get('format', 'na')
+            access_service = fmt.get('accessService')
             preference = None
             if accessService in ('SpokenSubtitles', 'SignLanguage', 'VisuallyInterpreted'):
                 preference = -1

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -200,11 +200,11 @@ class DRTVIE(InfoExtractor):
             format_id = fmt.get('format', 'na')
             access_service = fmt.get('accessService')
             preference = None
-            subtitle_sufix = ''
+            subtitle_suffix = ''
             if access_service in ('SpokenSubtitles', 'SignLanguage', 'VisuallyInterpreted'):
                 preference = -1
                 format_id += f'-{access_service}'
-                subtitle_sufix = f'-{access_service}'
+                subtitle_suffix = f'-{access_service}'
             elif access_service == 'StandardVideo':
                 preference = 1
             fmts, subs = self._extract_m3u8_formats_and_subtitles(
@@ -217,7 +217,7 @@ class DRTVIE(InfoExtractor):
 
             for sub_track in api_subtitles:
                 lang = sub_track.get('language') or 'da'
-                subtitles.setdefault(self.SUBTITLE_LANGS.get(lang, lang) + subtitle_sufix, []).append({
+                subtitles.setdefault(self.SUBTITLE_LANGS.get(lang, lang) + subtitle_suffix, []).append({
                     'url': sub_track['link'],
                     'ext': mimetype2ext(sub_track.get('format')) or 'vtt'
                 })

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -3,6 +3,7 @@ import uuid
 
 from .common import InfoExtractor
 from ..utils import (
+    ExtractorError,
     int_or_none,
     mimetype2ext,
     parse_iso8601,
@@ -153,6 +154,8 @@ class DRTVIE(InfoExtractor):
 
         self._TOKEN = traverse_obj(
             token_response, (lambda _, x: x['type'] == 'UserAccount', 'value', {str}), get_all=False)
+        if not self._TOKEN:
+            raise ExtractorError('Unable to get anonymous token')
 
     def _real_extract(self, url):
         url_slug = self._match_id(url)

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 import binascii
 import hashlib
 import json
@@ -7,16 +8,21 @@ import uuid
 from .common import InfoExtractor
 from ..aes import aes_cbc_decrypt_bytes, unpad_pkcs7
 from ..compat import compat_etree_fromstring, compat_urllib_parse_unquote
+=======
+import datetime
+import json
+
+from .common import InfoExtractor
+>>>>>>> Stashed changes
 from ..utils import (
     ExtractorError,
-    float_or_none,
     int_or_none,
     mimetype2ext,
     str_or_none,
     traverse_obj,
-    unified_timestamp,
     update_url_query,
     url_or_none,
+    random_uuidv4
 )
 
 SERIES_API = 'https://production-cdn.dr-massive.com/api/page?device=web_browser&item_detail_expand=all&lang=da&max_list_prefetch=3&path=%s'
@@ -55,38 +61,24 @@ class DRTVIE(InfoExtractor):
         'expected_warnings': ['Unable to download f4m manifest'],
         'skip': 'this video has been removed',
     }, {
-        # embed
-        'url': 'https://www.dr.dk/nyheder/indland/live-christianias-rydning-af-pusher-street-er-i-gang',
-        'info_dict': {
-            'id': 'urn:dr:mu:programcard:57c926176187a50a9c6e83c6',
-            'ext': 'mp4',
-            'title': 'christiania pusher street ryddes drdkrjpo',
-            'description': 'md5:2a71898b15057e9b97334f61d04e6eb5',
-            'timestamp': 1472800279,
-            'upload_date': '20160902',
-            'duration': 131.4,
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'expected_warnings': ['Unable to download f4m manifest'],
-    }, {
         # with SignLanguage formats
-        'url': 'https://www.dr.dk/tv/se/historien-om-danmark/-/historien-om-danmark-stenalder',
+        'url': 'https://www.dr.dk/drtv/se/tegnsprogsmagasinet-udsyn_365039',
         'info_dict': {
-            'id': '00831690010',
+            'id': '00922307010',
             'ext': 'mp4',
-            'title': 'Historien om Danmark: Stenalder',
-            'description': 'md5:8c66dcbc1669bbc6f873879880f37f2a',
-            'timestamp': 1546628400,
-            'upload_date': '20190104',
-            'duration': 3504.619,
-            'formats': 'mincount:20',
-            'release_year': 2017,
-            'season_id': 'urn:dr:mu:bundle:5afc03ad6187a4065ca5fd35',
+            'title': '1. episode',
+            'description': 'md5:a94679ee27debca33655986b78e2f8e5',
+            'timestamp': 1674842400,
+            'upload_date': '20230127',
+            'duration': 1816,
+            'formats': 'mincount:10',
+            'release_year': 2023,
+            'season_id': 365038,
             'season_number': 1,
-            'season': 'Historien om Danmark',
-            'series': 'Historien om Danmark',
+            'season': 'Tegnsprogsmagasinet Udsyn',
+            'series': 'Tegnsprogsmagasinet Udsyn',
+            'episode': 'Tegnsprogsmagasinet Udsyn',
+            'episode_number': 1
         },
         'params': {
             'skip_download': True,
@@ -95,22 +87,22 @@ class DRTVIE(InfoExtractor):
         'url': 'https://www.dr.dk/lyd/p4kbh/regionale-nyheder-kh4/p4-nyheder-2019-06-26-17-30-9',
         'only_matching': True,
     }, {
-        'url': 'https://www.dr.dk/drtv/se/bonderoeven_71769',
+        'url': 'https://www.dr.dk/drtv/se/spise-med-price_-pasta-selv_397445',
         'info_dict': {
-            'id': '00951930010',
+            'id': '00212301010',
             'ext': 'mp4',
-            'title': 'Bonderøven 2019 (1:8)',
-            'description': 'md5:b6dcfe9b6f0bea6703e9a0092739a5bd',
-            'timestamp': 1654856100,
-            'upload_date': '20220610',
-            'duration': 2576.6,
-            'season': 'Bonderøven 2019',
-            'season_id': 'urn:dr:mu:bundle:5c201667a11fa01ca4528ce5',
-            'release_year': 2019,
-            'season_number': 2019,
-            'series': 'Frank & Kastaniegaarden',
+            'title': '1. Pasta Selv',
+            'description': 'md5:2da9060524fed707810d71080b3d0cd8',
+            'timestamp': 1691373600,
+            'upload_date': '20230807',
+            'duration': 1750,
+            'season': 'Spise med Price',
+            'season_id': 397440,
+            'release_year': 2022,
+            'season_number': 15,
+            'series': 'Spise med Price',
             'episode_number': 1,
-            'episode': 'Episode 1',
+            'episode': 'Spise med Price: Pasta Selv',
         },
         'params': {
             'skip_download': True,
@@ -124,50 +116,40 @@ class DRTVIE(InfoExtractor):
     }, {
         'url': 'https://www.dr.dk/drtv/program/jagten_220924',
         'only_matching': True,
-    }, {
-        'url': 'https://www.dr.dk/lyd/p4aarhus/regionale-nyheder-ar4/regionale-nyheder-2022-05-05-12-30-3',
-        'info_dict': {
-            'id': 'urn:dr:mu:programcard:6265cb2571401424d0360113',
-            'title': "Regionale nyheder",
-            'ext': 'mp4',
-            'duration': 120.043,
-            'series': 'P4 Østjylland regionale nyheder',
-            'timestamp': 1651746600,
-            'season': 'Regionale nyheder',
-            'release_year': 0,
-            'season_id': 'urn:dr:mu:bundle:61c26889539f0201586b73c5',
-            'description': '',
-            'upload_date': '20220505',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'skip': 'this video has been removed',
-    }, {
-        'url': 'https://www.dr.dk/lyd/p4kbh/regionale-nyheder-kh4/regionale-nyheder-2023-03-14-10-30-9',
-        'info_dict': {
-            'ext': 'mp4',
-            'id': '14802310112',
-            'timestamp': 1678786200,
-            'duration': 120.043,
-            'season_id': 'urn:dr:mu:bundle:63a4f7c87140143504b6710f',
-            'series': 'P4 København regionale nyheder',
-            'upload_date': '20230314',
-            'release_year': 0,
-            'description': 'Hør seneste regionale nyheder fra P4 København.',
-            'season': 'Regionale nyheder',
-            'title': 'Regionale nyheder',
-        },
     }]
 
+    def _get_token(self, video_id):
+        return self._download_json(
+            'https://isl.dr-massive.com/api/authorization/anonymous-sso?device=web_browser&ff=idp%2Cldp&lang=da',
+            video_id,
+            headers={
+                'Content-Type': 'application/json'
+            },
+            query={
+                'device': 'web_browser',
+                'ff': 'idp,ldp,rpt',
+                'lang': 'da',
+                'supportFallbackToken': 'true',
+            },
+            data=json.dumps({
+                'deviceId': str(random_uuidv4()),
+                'scopes': ['Catalog'],
+                'optout': True
+            }).encode('utf-8'))[0]['value']
+
     def _real_extract(self, url):
+<<<<<<< Updated upstream
         raw_video_id, is_radio_url = self._match_valid_url(url).group('id', 'radio')
+=======
+        raw_video_id = self._match_valid_url(url).group('id')
+>>>>>>> Stashed changes
         webpage = self._download_webpage(url, raw_video_id)
         if '>Programmet er ikke længere tilgængeligt' in webpage:
             raise ExtractorError(
                 'Video %s is not available' % raw_video_id, expected=True)
         json_data = self._search_json(r'window\.__data\s*=', webpage, 'data', raw_video_id)
         item = traverse_obj(json_data, ('cache', 'page', Ellipsis, (None, ('entries', 0)), 'item'), get_all=False)
+<<<<<<< Updated upstream
         itemId = item.get('id')
         videoId = item['customId'].split(':')[-1]
         deviceId = uuid.uuid1()
@@ -175,10 +157,33 @@ class DRTVIE(InfoExtractor):
         data = self._download_json('https://production.dr-massive.com/api/account/items/{0}/videos?delivery=stream&device=web_browser&ff=idp%2Cldp%2Crpt&lang=da&resolution=HD-1080&sub=Anonymous'.format(itemId), videoId, headers={'authorization': 'Bearer {0}'.format(token)})
         formats = []
         subtitles = {}
+=======
+        item_id = item.get('id')
+        video_id = item['customId'].split(':')[-1]
+        season = item.get('season')
+        show = season.get('show') if season is not None else None
+        season_number = int_or_none(season.get('seasonNumber') if season is not None else None)
+        # episodes_in_season = int_or_none(season.get('episodeCount') if season is not None else None)
+        available_from_str = item.get('customFields').get('AvailableFrom')
+        available_from_dt = datetime.datetime.strptime(available_from_str[:-2], '%Y-%m-%dT%H:%M:%S.%f')
+        available_from_unix = available_from_dt.timestamp()
+        available_from_date = available_from_dt.strftime('%Y%m%d')
+        token = self._get_token(video_id)
+        data = self._download_json(
+            'https://production.dr-massive.com/api/account/items/{0}/videos?delivery=stream&device=web_browser&ff=idp%2Cldp%2Crpt&lang=da&resolution=HD-1080&sub=Anonymous'.format(item_id),
+            video_id,
+            headers={
+                'authorization': 'Bearer {0}'.format(token)
+            })
+        formats = []
+        subtitles = {}
+
+>>>>>>> Stashed changes
         for fmt in data:
             format_id = fmt.get('format', 'na')
             access_service = fmt.get('accessService')
             preference = None
+<<<<<<< Updated upstream
             if accessService in ('SpokenSubtitles', 'SignLanguage', 'VisuallyInterpreted'):
                 preference = -1
                 formatId += '-%s' % accessService
@@ -190,6 +195,20 @@ class DRTVIE(InfoExtractor):
             LANGS = {
                 'Danish': 'da',
             }
+=======
+            if access_service in ('SpokenSubtitles', 'SignLanguage', 'VisuallyInterpreted'):
+                preference = -1
+                format_id += '-%s' % access_service
+            elif access_service == 'StandardVideo':
+                preference = 1
+            fmts, subs = self._extract_m3u8_formats_and_subtitles(fmt['url'], video_id, 'mp4', entry_protocol='m3u8_native', preference=preference, m3u8_id=format_id, fatal=False)
+            formats.extend(fmts)
+            self._merge_subtitles(subs, target=subtitles)
+            LANGS = {
+                'DanishLanguageSubtitles': 'da',
+            }
+
+>>>>>>> Stashed changes
             for subs in fmt['subtitles']:
                 if not isinstance(subs, dict):
                     continue
@@ -201,6 +220,7 @@ class DRTVIE(InfoExtractor):
                     'url': sub_uri,
                     'ext': mimetype2ext(subs.get('format')) or 'vtt'
                 })
+<<<<<<< Updated upstream
             
         return {
             'id': videoId,
@@ -208,6 +228,25 @@ class DRTVIE(InfoExtractor):
             'description': item.get('description'),
             'formats': formats,
             'subtitles': subtitles,
+=======
+
+        return {
+            'id': video_id,
+            'title': item.get('contextualTitle'),
+            'description': item.get('description'),
+            'formats': formats,
+            'subtitles': subtitles,
+            'duration': item.get('duration'),
+            'release_year': int_or_none(item.get('releaseYear')),
+            'timestamp': available_from_unix,
+            'upload_date': available_from_date,
+            'series': str_or_none(show.get('title') if show is not None else None),
+            'season': str_or_none(season.get('title') if season is not None else None),
+            'season_number': season_number,
+            'season_id': int_or_none(season.get('id') if season is not None else None),
+            'episode': str_or_none(item.get('episodeName')),
+            'episode_number': item.get('episodeNumber')
+>>>>>>> Stashed changes
         }
 
 class DRTVLiveIE(InfoExtractor):

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -228,6 +228,7 @@ class DRTVIE(InfoExtractor):
             'subtitles': subtitles,
             **traverse_obj(item, {
                 'title': 'title',
+                'alt_title': 'contextualTitle',                
                 'description': 'description',
                 'thumbnail': ('images', 'wallpaper'),
                 'release_timestamp': ('customFields', 'BroadcastTimeDK', {parse_iso8601}),
@@ -333,6 +334,7 @@ class DRTVSeasonIE(InfoExtractor):
             'url': f'https://www.dr.dk/drtv{episode["path"]}',
             'ie_key': DRTVIE.ie_key(),
             'title': episode.get('title'),
+            'alt_title': episode.get('contextualTitle'),
             'episode': episode.get('episodeName'),
             'description': episode.get('shortDescription'),
             'series': traverse_obj(data, ('entries', 0, 'item', 'title')),
@@ -345,6 +347,7 @@ class DRTVSeasonIE(InfoExtractor):
             'id': season_id,
             'display_id': display_id,
             'title': traverse_obj(data, ('entries', 0, 'item', 'title')),
+            'alt_title': traverse_obj(data, ('entries', 0, 'item', 'contextualTitle')),
             'series': traverse_obj(data, ('entries', 0, 'item', 'title')),
             'entries': entries,
             'season_number': traverse_obj(data, ('entries', 0, 'item', 'seasonNumber'))
@@ -375,6 +378,7 @@ class DRTVSeriesIE(InfoExtractor):
             'url': f'https://www.dr.dk/drtv{season.get("path")}',
             'ie_key': DRTVSeasonIE.ie_key(),
             'title': season.get('title'),
+            'alt_title': season.get('contextualTitle'),
             'series': traverse_obj(data, ('entries', 0, 'item', 'title')),
             'season_number': traverse_obj(data, ('entries', 0, 'item', 'seasonNumber'))
         } for season in traverse_obj(data, ('entries', 0, 'item', 'show', 'seasons', 'items'))]
@@ -384,6 +388,7 @@ class DRTVSeriesIE(InfoExtractor):
             'id': series_id,
             'display_id': display_id,
             'title': traverse_obj(data, ('entries', 0, 'item', 'title')),
+            'alt_title': traverse_obj(data, ('entries', 0, 'item', 'contextualTitle')),
             'series': traverse_obj(data, ('entries', 0, 'item', 'title')),
             'entries': entries
         }

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -98,41 +98,6 @@ class DRTVIE(InfoExtractor):
     }, {
         'url': 'https://www.dr.dk/drtv/program/jagten_220924',
         'only_matching': True,
-    }, {
-        'url': 'https://www.dr.dk/lyd/p4aarhus/regionale-nyheder-ar4/regionale-nyheder-2022-05-05-12-30-3',
-        'info_dict': {
-            'id': 'urn:dr:mu:programcard:6265cb2571401424d0360113',
-            'title': 'Regionale nyheder',
-            'ext': 'mp4',
-            'duration': 120.043,
-            'series': 'P4 Østjylland regionale nyheder',
-            'timestamp': 1651746600,
-            'season': 'Regionale nyheder',
-            'release_year': 0,
-            'season_id': 'urn:dr:mu:bundle:61c26889539f0201586b73c5',
-            'description': '',
-            'upload_date': '20220505',
-        },
-        'params': {
-            'skip_download': True,
-        },
-        'skip': 'this video has been removed',
-    }, {
-        'url': 'https://www.dr.dk/lyd/p4kbh/regionale-nyheder-kh4/regionale-nyheder-2023-03-14-10-30-9',
-        'info_dict': {
-            'ext': 'mp4',
-            'id': '14802310112',
-            'timestamp': 1678786200,
-            'duration': 120.043,
-            'season_id': 'urn:dr:mu:bundle:63a4f7c87140143504b6710f',
-            'series': 'P4 København regionale nyheder',
-            'upload_date': '20230314',
-            'release_year': 0,
-            'description': 'Hør seneste regionale nyheder fra P4 København.',
-            'season': 'Regionale nyheder',
-            'title': 'Regionale nyheder',
-        },
-        'skip': 'this video has been removed',
     }]
 
     _TOKEN = None

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -193,9 +193,9 @@ class DRTVIE(InfoExtractor):
 
         formats = []
         subtitles = {}
-        for fmt in traverse_obj(stream_data, (lambda _, x: x['url'])):
-            format_id = fmt.get('format', 'na')
-            access_service = fmt.get('accessService')
+        for stream in traverse_obj(stream_data, (lambda _, x: x['url'])):
+            format_id = stream.get('format', 'na')
+            access_service = stream.get('accessService')
             preference = None
             subtitle_suffix = ''
             if access_service in ('SpokenSubtitles', 'SignLanguage', 'VisuallyInterpreted'):
@@ -205,10 +205,10 @@ class DRTVIE(InfoExtractor):
             elif access_service == 'StandardVideo':
                 preference = 1
             fmts, subs = self._extract_m3u8_formats_and_subtitles(
-                fmt.get('url'), video_id, preference=preference, m3u8_id=format_id, fatal=False)
+                stream.get('url'), video_id, preference=preference, m3u8_id=format_id, fatal=False)
             formats.extend(fmts)
 
-            api_subtitles = traverse_obj(fmt, ('subtitles', lambda _, v: url_or_none(v['link']), {dict}))
+            api_subtitles = traverse_obj(stream, ('subtitles', lambda _, v: url_or_none(v['link']), {dict}))
             if not api_subtitles:
                 self._merge_subtitles(subs, target=subtitles)
 

--- a/yt_dlp/extractor/drtv.py
+++ b/yt_dlp/extractor/drtv.py
@@ -19,7 +19,7 @@ class DRTVIE(InfoExtractor):
     _VALID_URL = r'''(?x)
                     https?://
                         (?:
-                            (?:www\.)?dr\.dk/?tv/se(?:/ondemand)?/(?:[^/]+/)*|
+                            (?:www\.)?dr\.dk/tv/se(?:/ondemand)?/(?:[^/]+/)*|
                             (?:www\.)?(?:dr\.dk|dr-massive\.com)/drtv/(?:se|episode|program)/
                         )
                         (?P<id>[\da-z_-]+)


### PR DESCRIPTION
### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Changed code to be able to download from dr.dk's new format.

Fixes #8298

Code taken from https://gist.github.com/lyngklip/3be04b1cf380536f76713cd09d4ac61a

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e8efd7c</samp>

### Summary
🔄🗑️🔢

<!--
1.  🔄 Rewrite: This emoji indicates that the extraction logic has been rewritten using a new API endpoint and JSON data structure, and that the code has been updated to reflect the new format and fields of the data.
2.  🗑️ Remove: This emoji indicates that unused code, such as the old API endpoint, the old data structure, and the old extractors, have been removed from the file, as they are no longer needed or relevant.
3.  🔢 Reorder: This emoji indicates that the extractors have been reordered to match the new data structure, and to group related fields and methods together. For example, the video id, title, description, and thumbnail are extracted first, followed by the formats, subtitles, and duration.
-->
Update DRTV extractor to use new API and JSON format. Simplify and clean up the code.

> _`DRTV` videos_
> _New endpoint, JSON data_
> _Old code falls like leaves_

### Walkthrough
* Rewrite extraction logic for DRTV videos using a different API endpoint and JSON data structure ([link](https://github.com/yt-dlp/yt-dlp/pull/8484/files?diff=unified&w=0#diff-0363d92c142b50b88cfc0b912879c30a0dfb720feb57f35ae1d2e2073e9d226bL164-R212))
* Add imports of `json`, `uuid`, and `compat_etree_fromstring` for the new extraction logic ([link](https://github.com/yt-dlp/yt-dlp/pull/8484/files?diff=unified&w=0#diff-0363d92c142b50b88cfc0b912879c30a0dfb720feb57f35ae1d2e2073e9d226bL3-R9))
* Remove unused constant and helper functions that were based on the deprecated and encrypted API endpoint ([link](https://github.com/yt-dlp/yt-dlp/pull/8484/files?diff=unified&w=0#diff-0363d92c142b50b88cfc0b912879c30a0dfb720feb57f35ae1d2e2073e9d226bL22))
* Move `DRTVLiveIE` class to the end of the file to follow alphabetical order of extractors ([link](https://github.com/yt-dlp/yt-dlp/pull/8484/files?diff=unified&w=0#diff-0363d92c142b50b88cfc0b912879c30a0dfb720feb57f35ae1d2e2073e9d226bL403))



</details>
