### PR TITLE
[ie/orf] Add extractor for sound.orf.at podcasts

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1416,6 +1416,7 @@ from .orf import (
     ORFTVthekIE,
     ORFFM4StoryIE,
     ORFRadioIE,
+    ORFPodcastIE,
     ORFIPTVIE,
 )
 from .outsidetv import OutsideTVIE

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -339,7 +339,7 @@ class ORFPodcastIE(InfoExtractor):
 
     _STATION_RE = 'noe|wie|bgl|ooe|stm|ktn|sbg|tir|vbg|oe3|oe1|tv'
 
-    _VALID_URL = f'https?://sound\.orf\.at/podcast/(?P<station>{_STATION_RE})/(?P<show>[a-zA-Z0-9_-]+)/(?P<id>[a-zA-Z0-9_-]+)'
+    _VALID_URL = f'https?://sound.orf.at/podcast/(?P<station>{_STATION_RE})/(?P<show>[a-zA-Z0-9_-]+)/(?P<id>[a-zA-Z0-9_-]+)'
 
     _TESTS = [{
         'url': 'https://sound.orf.at/podcast/oe3/fruehstueck-bei-mir/nicolas-stockhammer-15102023',

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -4,15 +4,16 @@ import re
 from .common import InfoExtractor
 from ..networking import HEADRequest
 from ..utils import (
+    InAdvancePagedList,
     clean_html,
     determine_ext,
     float_or_none,
-    InAdvancePagedList,
     int_or_none,
     join_nonempty,
+    make_archive_id,
+    mimetype2ext,
     orderedSet,
     remove_end,
-    make_archive_id,
     smuggle_url,
     strip_jsonp,
     try_call,
@@ -20,7 +21,6 @@ from ..utils import (
     unified_strdate,
     unsmuggle_url,
     url_or_none,
-    mimetype2ext,
 )
 from ..utils.traversal import traverse_obj
 

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -20,6 +20,7 @@ from ..utils import (
     unified_strdate,
     unsmuggle_url,
     url_or_none,
+    mimetype2ext,
 )
 from ..utils.traversal import traverse_obj
 
@@ -337,11 +338,10 @@ class ORFRadioIE(InfoExtractor):
 
 class ORFPodcastIE(InfoExtractor):
     IE_NAME = 'orf:podcast'
-
-    _STATION_RE = 'noe|wie|bgl|ooe|stm|ktn|sbg|tir|vbg|oe3|oe1|fm4|tv'
-
+    _STATION_RE = '|'.join(map(re.escape, (
+        'bgl', 'fm4', 'ktn', 'noe', 'oe1', 'oe3',
+        'ooe', 'sbg', 'stm', 'tir', 'tv', 'vbg', 'wie')))
     _VALID_URL = rf'https?://sound\.orf\.at/podcast/(?P<station>{_STATION_RE})/(?P<show>[\w-]+)/(?P<id>[\w-]+)'
-
     _TESTS = [{
         'url': 'https://sound.orf.at/podcast/oe3/fruehstueck-bei-mir/nicolas-stockhammer-15102023',
         'md5': '526a5700e03d271a1505386a8721ab9b',
@@ -366,6 +366,7 @@ class ORFPodcastIE(InfoExtractor):
             'vcodec': 'none',
             **traverse_obj(data, ('payload', {
                 'url': ('enclosures', 0, 'url'),
+                'ext': ('enclosures', 0, 'type', {mimetype2ext}),
                 'title': 'title',
                 'description': ('description', {clean_html}),
                 'duration': ('duration', {functools.partial(float_or_none, scale=1000)}),

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -334,6 +334,42 @@ class ORFRadioIE(InfoExtractor):
             self._entries(data, station or station2), show_id, data.get('title'), clean_html(data.get('subtitle')))
 
 
+class ORFPodcastIE(InfoExtractor):
+    IE_NAME = 'orf:podcast'
+
+    _STATION_RE = 'noe|wie|bgl|ooe|stm|ktn|sbg|tir|vbg|oe3|oe1|tv'
+
+    _VALID_URL = f'https?://sound\.orf\.at/podcast/(?P<station>{_STATION_RE})/(?P<show>[a-zA-Z0-9_-]+)/(?P<id>[a-zA-Z0-9_-]+)'
+
+    _TESTS = [{
+        'url': 'https://sound.orf.at/podcast/oe3/fruehstueck-bei-mir/nicolas-stockhammer-15102023',
+        'md5': '526a5700e03d271a1505386a8721ab9b',
+        'info_dict': {
+            'id': 'nicolas-stockhammer-15102023',
+            'ext': 'mp3',
+            'title': 'Nicolas Stockhammer (15.10.2023)',
+            'duration': 3396.0,
+            'series': 'Frühstück bei mir',
+        },
+        'skip': 'ORF podcasts are only available for a limited time'
+    }]
+
+    def _real_extract(self, url):
+        station, show, show_id = self._match_valid_url(url).group('station', 'show', 'id')
+        data = self._download_json(
+            f'https://audioapi.orf.at/radiothek/api/2.0/podcast/{station}/{show}/{show_id}', show_id)
+
+        return {
+            'id': show_id,
+            'url': data.get('payload').get('enclosures')[0]['url'],
+            'ext': 'mp3',
+            'title': data.get('payload').get('title'),
+            'description': clean_html(data.get('payload').get('description')),
+            'duration': data.get('payload').get('duration') / 1000,
+            'series': data.get('payload').get('podcast').get('title'),
+        }
+
+
 class ORFIPTVIE(InfoExtractor):
     IE_NAME = 'orf:iptv'
     IE_DESC = 'iptv.ORF.at'


### PR DESCRIPTION
### Add orf extractor for podcasts

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This adds support for downloading podcasts from `https://sound.orf.at/podcast/sender`.

Partly Fixes #5265


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e50d532</samp>

### Summary
🎙️🇦🇹➕

<!--
1.  🎙️ - This emoji represents podcasts, audio programs, and broadcasting, which are the main features of the ORF podcasts and the new extractor class.
2.  🇦🇹 - This emoji represents Austria, the country of origin of the ORF podcasts and the public broadcaster that produces them.
3.  ➕ - This emoji represents adding, creating, or supporting something new, which is what the change does by adding a new extractor class and supporting a new URL format.
-->
Add a new extractor class `ORFPodcastIE` for ORF podcasts in the `orf.py` module and register it in the `_extractors.py` module. This allows yt-dlp to download audio programs from the Austrian public broadcaster.

> _New `ORFPodcastIE`_
> _Extracts audio from ORF_
> _Listen in winter_

### Walkthrough
*  Add support for ORF podcasts with a new extractor class ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1419), [link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-9434d3584a6d02a95cf46967e794cf7d024be50957816605e711c18bd646234fR337-R372))
   * Define the `ORFPodcastIE` class in `orf.py` that inherits from `InfoExtractor` ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-9434d3584a6d02a95cf46967e794cf7d024be50957816605e711c18bd646234fR337-R372))
   * Implement the `_VALID_URL` pattern to match the ORF podcast URLs ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-9434d3584a6d02a95cf46967e794cf7d024be50957816605e711c18bd646234fR337-R372))
   * Implement the `_TESTS` list to provide an example URL and expected metadata ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-9434d3584a6d02a95cf46967e794cf7d024be50957816605e711c18bd646234fR337-R372))
   * Implement the `_real_extract` method to download the JSON data from the ORF API and extract the audio URL, title, description, duration, and series name ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-9434d3584a6d02a95cf46967e794cf7d024be50957816605e711c18bd646234fR337-R372))
   * Use the `clean_html` helper function to remove HTML tags from the description ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-9434d3584a6d02a95cf46967e794cf7d024be50957816605e711c18bd646234fR337-R372))
   * Register the new extractor class in the `_extractors.py` module ([link](https://github.com/yt-dlp/yt-dlp/pull/8486/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1419))



</details>
