### PR TITLE
[ie] Extract info from <media> elements in SMIL manifest

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2339,7 +2339,9 @@ class InfoExtractor:
         imgs_count = 0
 
         srcs = set()
-        media = [el for arg in ['.//video', './/audio', './/media'] for el in smil.findall(self._xpath_ns(arg, namespace))]
+        media = itertools.chain.from_iterable(
+            smil.findall(self._xpath_ns(arg, namespace))
+            for arg in ['.//video', './/audio', './/media'])
         for medium in media:
             src = medium.get('src')
             if not src or src in srcs:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2339,7 +2339,7 @@ class InfoExtractor:
         imgs_count = 0
 
         srcs = set()
-        media = smil.findall(self._xpath_ns('.//video', namespace)) + smil.findall(self._xpath_ns('.//audio', namespace))
+        media = [el for arg in ['.//video', './/audio', './/media'] for el in smil.findall(self._xpath_ns(arg, namespace))]
         for medium in media:
             src = medium.get('src')
             if not src or src in srcs:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Currently, the SMIL parser only extracts media streams from `<audio>` and `<video>` elements.
While as far as I can tell not spec compliant, in practice `<media>` elements are also sometimes used.
Looking around this seems to be something Microsoft likes to do, for example in [Windows Media Player Playlists](https://en.wikipedia.org/wiki/Windows_Media_Player_Playlist) and [Windows Media Services](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/dd873962(v=vs.85)).

Needed for proper SMIL parsing in https://github.com/yt-dlp/yt-dlp/pull/7790


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe9b464</samp>

### Summary
🎬🛠️🇳🇴

<!--
1.  🎬 This emoji represents the media element, which is the main focus of the change. It also suggests the video and audio elements that are already supported by the extractor.
2.  🛠️ This emoji represents the fix or improvement that the change provides to the extractor. It also suggests that the change is part of a larger pull request that addresses some issues with the NRK TV website.
3.  🇳🇴 This emoji represents the NRK TV website, which is the specific source that the change affects. It also suggests the Norwegian origin of the website and the extractor.
-->
Add support for SMIL files with `<media>` tags in `common.py`. This fixes the extraction of some NRK TV videos.

> _`<media>` tag found_
> _SMIL extraction improved_
> _Winter of content_

### Walkthrough
* Support SMIL files with `<media>` tags by extending the media element XPath ([link](https://github.com/yt-dlp/yt-dlp/pull/8504/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2342-R2342))



</details>
