### PR TITLE
[RadioComercial] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -23,7 +23,6 @@ from .youtube import (  # Youtube is moved to the top to improve performance
     YoutubeShortsAudioPivotIE,
     YoutubeConsentRedirectIE,
 )
-
 from .abc import (
     ABCIE,
     ABCIViewIE,
@@ -1577,6 +1576,10 @@ from .radiko import RadikoIE, RadikoRadioIE
 from .radiocanada import (
     RadioCanadaIE,
     RadioCanadaAudioVideoIE,
+)
+from .radiocomercial import (
+    RadioComercialIE,
+    RadioComercialPlaylistIE,
 )
 from .radiode import RadioDeIE
 from .radiojavan import RadioJavanIE

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -23,6 +23,7 @@ from .youtube import (  # Youtube is moved to the top to improve performance
     YoutubeShortsAudioPivotIE,
     YoutubeConsentRedirectIE,
 )
+
 from .abc import (
     ABCIE,
     ABCIViewIE,

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -17,55 +17,70 @@ from ..utils.traversal import traverse_obj
 
 
 class RadioComercialIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/]+/\w(?P<season>\d+)/(?P<id>[-\w]+)/*$'
-    _TESTS = [{
-        'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
-        'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',
-        'info_dict': {
-            'id': 'taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
-            'ext': 'mp3',
-            'title': 'Taylor Swift entranhando-se que nem uma espada no ventre dos fãs.',
-            'description': '',
-            'release_date': '20231025',
-            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-            'season': 6
-        }
-    },
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/]+/\D*(?P<season>\d+)/(?P<id>[\w-]+)'
+    _TESTS = [
         {
-        'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3/convenca-me-num-minuto-que-os-lobisomens-existem',
-        'md5': '47e96c273aef96a8eb160cd6cf46d782',
-        'info_dict': {
-            'id': 'convenca-me-num-minuto-que-os-lobisomens-existem',
-            'ext': 'mp3',
-            'title': 'Convença-me num minuto que os lobisomens existem',
-            'description': '',
-            'release_date': '20231026',
-            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-            'season': 3
-        }
-    },
+            'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
+            'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',
+            'info_dict': {
+                'id': 'taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
+                'ext': 'mp3',
+                'title': 'Taylor Swift entranhando-se que nem uma espada no ventre dos fãs.',
+                'description': None,
+                'release_date': '20231025',
+                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+                'season': 6
+            }
+        },
         {
-        'url': 'https://radiocomercial.pt/podcasts/inacreditavel-by-ines-castel-branco/t2/o-desastre-de-aviao',
-        'md5': '69be64255420fec23b7259955d771e54',
-        'info_dict': {
-            'id': 'o-desastre-de-aviao',
-            'ext': 'mp3',
-            'title': 'O desastre de avião',
-            'description': 'md5:8a82beeb372641614772baab7246245f',
-            'release_date': '20231101',
-            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-            'season': 2
-        }
-    },
+            'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3/convenca-me-num-minuto-que-os-lobisomens-existem',
+            'md5': '47e96c273aef96a8eb160cd6cf46d782',
+            'info_dict': {
+                'id': 'convenca-me-num-minuto-que-os-lobisomens-existem',
+                'ext': 'mp3',
+                'title': 'Convença-me num minuto que os lobisomens existem',
+                'description': None,
+                'release_date': '20231026',
+                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+                'season': 3
+            }
+        },
+        {
+            'url': 'https://radiocomercial.pt/podcasts/inacreditavel-by-ines-castel-branco/t2/o-desastre-de-aviao',
+            'md5': '69be64255420fec23b7259955d771e54',
+            'info_dict': {
+                'id': 'o-desastre-de-aviao',
+                'ext': 'mp3',
+                'title': 'O desastre de avião',
+                'description': 'md5:8a82beeb372641614772baab7246245f',
+                'release_date': '20231101',
+                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+                'season': 2
+            }
+        },
+        {
+            'url': 'https://radiocomercial.pt/podcasts/tnt-todos-no-top/2023/t-n-t-29-de-outubro',
+            'md5': '91d32d4d4b1407272068b102730fc9fa',
+            'info_dict': {
+                'id': 't-n-t-29-de-outubro',
+                'ext': 'mp3',
+                'title': 'T.N.T 29 de outubro',
+                'description': None,
+                'release_date': '20231029',
+                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+                'season': 2023
+            }
+        },
     ]
 
     def _real_extract(self, url):
         video_id, season = self._match_valid_url(url).group('id', 'season')
         webpage = self._download_webpage(url, video_id)
+        print(self._og_search_description(webpage, default=None))
         return {
             'id': video_id,
             'title': self._html_extract_title(webpage),
-            'description': self._og_search_description(webpage, default=''),
+            'description': self._og_search_description(webpage, default=None),
             'release_date': unified_strdate(
                 get_element_by_class('date', get_element_html_by_class('descriptions', webpage))),
             'thumbnail': self._og_search_thumbnail(webpage),
@@ -75,49 +90,52 @@ class RadioComercialIE(InfoExtractor):
 
 
 class RadioComercialPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[-\w]+)[/\w\d+]*$'
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[\w-]+)(?:\D*(?P<season>\d+))?'
     _PAGE_SIZE = 19
-    _TESTS = [{
-        'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',
-        'info_dict': {
-            'id': 'convenca-me-num-minuto',
-            'title': 'Convença-me num Minuto - Temporada 3',
+    _TESTS = [
+        {
+            'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',
+            'info_dict': {
+                'id': 'convenca-me-num-minuto',
+                'title': 'Convença-me num Minuto - Temporada 3',
+            },
+            'playlist_mincount': 32
         },
-        'playlist_mincount': 32
-    }, {
-        'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao',
-        'info_dict': {
-            'id': 'o-homem-que-mordeu-o-cao',
-            'title': 'O Homem Que Mordeu o Cão',
+        {
+            'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao',
+            'info_dict': {
+                'id': 'o-homem-que-mordeu-o-cao',
+                'title': 'O Homem Que Mordeu o Cão',
+            },
+            'playlist_mincount': 19
         },
-        'playlist_mincount': 19
-    }, {
-        'url': 'https://radiocomercial.pt/podcasts/as-minhas-coisas-favoritas',
-        'info_dict': {
-            'id': 'as-minhas-coisas-favoritas',
-            'title': 'As Minhas Coisas Favoritas',
-        },
-        'playlist_mincount': 131
-    },
+        {
+            'url': 'https://radiocomercial.pt/podcasts/as-minhas-coisas-favoritas',
+            'info_dict': {
+                'id': 'as-minhas-coisas-favoritas',
+                'title': 'As Minhas Coisas Favoritas',
+            },
+            'playlist_mincount': 131
+        }
     ]
 
-    def _fetch_page(self, url, season, page):
+    def _fetch_page(self, podcast, season, page):
         page += 1
-        next_page = f'{url}{"/" + str(page) if page > 1 else ""}'
-        webpage = self._download_webpage(next_page, season, headers={'X-Requested-With': 'XMLHttpRequest'},
-                                         note=f'Downloading page: {next_page}')
+        url = f'https://radiocomercial.pt/podcasts/{podcast}' + (f'/t{season}' if season else '') + f'/{page}'
+        playlist_id = join_nonempty(podcast, season, delim='_')
+        webpage = self._download_webpage(url, playlist_id, note=f'Downloading page: {page}')
+
         episodes = set(traverse_obj(get_elements_html_by_class('tm-ouvir-podcast', webpage),
                                     (..., {extract_attributes}, 'href')))
         for entry in episodes:
             yield self.url_result(f'https://radiocomercial.pt{entry}', RadioComercialIE)
 
     def _real_extract(self, url):
-        podcast = self._match_id(url)
+        podcast, season = self._match_valid_url(url).group('id', 'season')
         webpage = self._download_webpage(url, podcast)
 
         name = try_call(lambda: get_element_text_and_html_by_tag('h1', webpage)[0])
-        season = self._html_extract_title(webpage)
-        title = name if name == season else join_nonempty(name, season, delim=' - ')
+        title = name if name == season else join_nonempty(name, season, delim=' - Temporada ')
 
-        return self.playlist_result(OnDemandPagedList(functools.partial(self._fetch_page, url, season),
+        return self.playlist_result(OnDemandPagedList(functools.partial(self._fetch_page, podcast, season),
                                                       self._PAGE_SIZE), podcast, title)

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -57,7 +57,10 @@ class RadioComercialIE(InfoExtractor):
                 'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
                 'season': 2
             },
-            'skip': 'inconsistent md5',
+            'params': {
+                # inconsistant md5
+                'skip_download': True,
+            },
         },
         {
             'url': 'https://radiocomercial.pt/podcasts/tnt-todos-no-top/2023/t-n-t-29-de-outubro',

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -20,7 +20,7 @@ from ..utils.traversal import traverse_obj
 
 
 class RadioComercialIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/?#]+/t?(?P<season>\d+)/(?P<id>[\w-]+)/?(?:$|[?#])'
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/?#]+/t?(?P<season>\d+)/(?P<id>[\w-]+)'
     _TESTS = [{
         'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas#page-content-wrapper',
         'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -88,7 +88,7 @@ class RadioComercialIE(InfoExtractor):
 
 
 class RadioComercialPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[\w-]+)(?:\D*(?P<season>\d+))?/*$'
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[\w-]+)(?:/\D*(?P<season>\d+))?/?(?:$|[?#])'
     _PAGE_SIZE = 19
     _TESTS = [{
         'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -20,7 +20,7 @@ from ..utils.traversal import traverse_obj
 
 
 class RadioComercialIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/?#]+/t?(?P<season>\d+)/(?P<id>[\w-]+)(?:$|[?#])'
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/?#]+/t?(?P<season>\d+)/(?P<id>[\w-]+)/?(?:$|[?#])'
     _TESTS = [{
         'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas#page-content-wrapper',
         'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',
@@ -122,15 +122,16 @@ class RadioComercialPlaylistIE(InfoExtractor):
     def _entries(self, url, playlist_id):
         for page in itertools.count(1):
             try:
-                webpage, urlh = self._download_webpage_handle(
+                webpage = self._download_webpage(
                     f'{url}/{page}', playlist_id, f'Downloading page {page}')
             except ExtractorError as e:
                 if isinstance(e.cause, HTTPError) and e.cause.status == 404:
                     break
                 raise
-            if 'radiocomercial.pt/podcasts' not in urlh.url:
-                break
+
             episodes = get_elements_html_by_class('tm-ouvir-podcast', webpage)
+            if not episodes:
+                break
             for url_path in traverse_obj(episodes, (..., {extract_attributes}, 'href')):
                 episode_url = urljoin(url, url_path)
                 if RadioComercialIE.suitable(episode_url):

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -18,64 +18,59 @@ from ..utils.traversal import traverse_obj
 
 class RadioComercialIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/]+/\D*(?P<season>\d+)/(?P<id>[\w-]+)'
-    _TESTS = [
-        {
-            'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
-            'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',
-            'info_dict': {
-                'id': 'taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
-                'ext': 'mp3',
-                'title': 'Taylor Swift entranhando-se que nem uma espada no ventre dos fãs.',
-                'description': None,
-                'release_date': '20231025',
-                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-                'season': 6
-            }
+    _TESTS = [{
+        'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
+        'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',
+        'info_dict': {
+            'id': 'taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
+            'ext': 'mp3',
+            'title': 'Taylor Swift entranhando-se que nem uma espada no ventre dos fãs.',
+            'description': None,
+            'release_date': '20231025',
+            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+            'season': 6
+        }
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3/convenca-me-num-minuto-que-os-lobisomens-existem',
+        'md5': '47e96c273aef96a8eb160cd6cf46d782',
+        'info_dict': {
+            'id': 'convenca-me-num-minuto-que-os-lobisomens-existem',
+            'ext': 'mp3',
+            'title': 'Convença-me num minuto que os lobisomens existem',
+            'description': None,
+            'release_date': '20231026',
+            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+            'season': 3
+        }
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/inacreditavel-by-ines-castel-branco/t2/o-desastre-de-aviao',
+        'md5': '69be64255420fec23b7259955d771e54',
+        'info_dict': {
+            'id': 'o-desastre-de-aviao',
+            'ext': 'mp3',
+            'title': 'O desastre de avião',
+            'description': 'md5:8a82beeb372641614772baab7246245f',
+            'release_date': '20231101',
+            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+            'season': 2
         },
-        {
-            'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3/convenca-me-num-minuto-que-os-lobisomens-existem',
-            'md5': '47e96c273aef96a8eb160cd6cf46d782',
-            'info_dict': {
-                'id': 'convenca-me-num-minuto-que-os-lobisomens-existem',
-                'ext': 'mp3',
-                'title': 'Convença-me num minuto que os lobisomens existem',
-                'description': None,
-                'release_date': '20231026',
-                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-                'season': 3
-            }
+        'params': {
+            # inconsistant md5
+            'skip_download': True,
         },
-        {
-            'url': 'https://radiocomercial.pt/podcasts/inacreditavel-by-ines-castel-branco/t2/o-desastre-de-aviao',
-            'md5': '69be64255420fec23b7259955d771e54',
-            'info_dict': {
-                'id': 'o-desastre-de-aviao',
-                'ext': 'mp3',
-                'title': 'O desastre de avião',
-                'description': 'md5:8a82beeb372641614772baab7246245f',
-                'release_date': '20231101',
-                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-                'season': 2
-            },
-            'params': {
-                # inconsistant md5
-                'skip_download': True,
-            },
-        },
-        {
-            'url': 'https://radiocomercial.pt/podcasts/tnt-todos-no-top/2023/t-n-t-29-de-outubro',
-            'md5': '91d32d4d4b1407272068b102730fc9fa',
-            'info_dict': {
-                'id': 't-n-t-29-de-outubro',
-                'ext': 'mp3',
-                'title': 'T.N.T 29 de outubro',
-                'description': None,
-                'release_date': '20231029',
-                'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
-                'season': 2023
-            }
-        },
-    ]
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/tnt-todos-no-top/2023/t-n-t-29-de-outubro',
+        'md5': '91d32d4d4b1407272068b102730fc9fa',
+        'info_dict': {
+            'id': 't-n-t-29-de-outubro',
+            'ext': 'mp3',
+            'title': 'T.N.T 29 de outubro',
+            'description': None,
+            'release_date': '20231029',
+            'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
+            'season': 2023
+        }
+    }]
 
     def _real_extract(self, url):
         video_id, season = self._match_valid_url(url).group('id', 'season')
@@ -95,32 +90,28 @@ class RadioComercialIE(InfoExtractor):
 class RadioComercialPlaylistIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[\w-]+)(?:\D*(?P<season>\d+))?'
     _PAGE_SIZE = 19
-    _TESTS = [
-        {
-            'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',
-            'info_dict': {
-                'id': 'convenca-me-num-minuto',
-                'title': 'Convença-me num Minuto - Temporada 3',
-            },
-            'playlist_mincount': 32
+    _TESTS = [{
+        'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',
+        'info_dict': {
+            'id': 'convenca-me-num-minuto',
+            'title': 'Convença-me num Minuto - Temporada 3',
         },
-        {
-            'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao',
-            'info_dict': {
-                'id': 'o-homem-que-mordeu-o-cao',
-                'title': 'O Homem Que Mordeu o Cão',
-            },
-            'playlist_mincount': 19
+        'playlist_mincount': 32
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao',
+        'info_dict': {
+            'id': 'o-homem-que-mordeu-o-cao',
+            'title': 'O Homem Que Mordeu o Cão',
         },
-        {
-            'url': 'https://radiocomercial.pt/podcasts/as-minhas-coisas-favoritas',
-            'info_dict': {
-                'id': 'as-minhas-coisas-favoritas',
-                'title': 'As Minhas Coisas Favoritas',
-            },
-            'playlist_mincount': 131
-        }
-    ]
+        'playlist_mincount': 19
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/as-minhas-coisas-favoritas',
+        'info_dict': {
+            'id': 'as-minhas-coisas-favoritas',
+            'title': 'As Minhas Coisas Favoritas',
+        },
+        'playlist_mincount': 131
+    }]
 
     def _fetch_page(self, podcast, season, page):
         page += 1

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -1,0 +1,141 @@
+import re
+from collections import namedtuple
+
+from .common import InfoExtractor
+from ..utils import (
+    int_or_none,
+)
+
+
+class RadioComercialBaseExtractor(InfoExtractor):
+    def _extract_page_content(self, url):
+        video_id = RadioComercialIE._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        title = self._html_search_regex(r'<title>(.+?)</title>', webpage, 'title')
+        url = self._html_search_regex(r'<a.+?isExclusivePlay=.+?href="(.+?)">', webpage, 'url')
+        date = self._html_search_regex(r'<div[^"]+"date">(\d{4}-\d{2}-\d{2})</div>', webpage, 'date')
+        thumbnail = self._html_search_regex(r'<source[^"]+"image/jpeg[^/]+(.+?)\">', webpage, 'thumbnail')
+        season = int_or_none(self._html_search_regex(r'<h2>\w+\s(\d+)</h2>', webpage, 'season'))
+        episode_id = int_or_none(self._html_search_regex(r'episodeid=(\d+)&', url, 'episode_id'))
+
+        return {
+            'id': video_id,
+            'title': title,
+            'date': date,
+            'thumbnail': thumbnail,
+            'season': season,
+            'episode_id': episode_id,
+            'url': url
+        }
+
+
+class RadioComercialIE(RadioComercialBaseExtractor):
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/[^/]+/\w\d+/(?P<id>[-\w]+)/*$'
+    _TESTS = [{
+        'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao/t6/taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
+        'md5': '5f4fe8e485b29d2e8fd495605bc2c7e4',
+        'info_dict': {
+            'id': 'taylor-swift-entranhando-se-que-nem-uma-espada-no-ventre-dos-fas',
+            'ext': 'mp3',
+            'title': 'Taylor Swift entranhando-se que nem uma espada no ventre dos fãs.',
+            'date': '2023-10-25',
+            'thumbnail': r're:/upload/[^.]+.jpg',
+            'season': 6,
+            'episode_id': 220899
+        }
+    },
+        {
+        'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3/convenca-me-num-minuto-que-os-lobisomens-existem',
+        'md5': '47e96c273aef96a8eb160cd6cf46d782',
+        'info_dict': {
+            'id': 'convenca-me-num-minuto-que-os-lobisomens-existem',
+            'ext': 'mp3',
+            'title': 'Convença-me num minuto que os lobisomens existem',
+            'date': '2023-10-26',
+            'thumbnail': r're:/upload/[^.]+.jpg',
+            'season': 3,
+            'episode_id': 221210
+        }
+    },
+    ]
+
+    def _real_extract(self, url):
+        return self._extract_page_content(url)
+
+
+class RadioComercialPlaylistIE(RadioComercialBaseExtractor):
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[-\w]+)[/\w\d+]*$'
+    _TESTS = [{
+        'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',
+        'info_dict': {
+            'id': 'convenca-me-num-minuto',
+            'title': 'Convença-me num Minuto - Temporada 3',
+        },
+        'playlist_mincount': 32
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/o-homem-que-mordeu-o-cao',
+        'info_dict': {
+            'id': 'o-homem-que-mordeu-o-cao',
+            'title': 'O Homem Que Mordeu o Cão',
+        },
+        'playlist_mincount': 19
+    }, {
+        'url': 'https://radiocomercial.pt/podcasts/as-minhas-coisas-favoritas',
+        'info_dict': {
+            'id': 'as-minhas-coisas-favoritas',
+            'title': 'As Minhas Coisas Favoritas',
+        },
+        'playlist_mincount': 100
+    },
+    ]
+
+    NextPage = namedtuple('NextPage', ['path', 'page', 'add_one'])
+
+    def _extract_next_url_details(self, source):
+        regex = re.compile(
+            r'\sclass="pagination__next"\shref="(?P<path>/podcasts/[^/]+?[/\w\d+/]+?/)(?P<page>\d+)/*(?P<add_one>\d*)')
+        match = regex.search(source)
+        if match:
+            return self.NextPage(match.group('path'),
+                                 int_or_none(match.group('page')), int_or_none(match.group('add_one')))
+        return self.NextPage(None, None, None)
+
+    def _get_next_page(self, webpage):
+        next_page = self._extract_next_url_details(webpage)
+        if not next_page.path or not next_page.page:
+            return None
+        number_section = f'{next_page.page if not next_page.add_one else next_page.page + 1}'
+        next_page = f'https://radiocomercial.pt{next_page.path}{number_section}'
+        video_id = self._match_id(next_page)
+        return self._download_webpage(next_page, video_id, headers={'X-Requested-With': 'XMLHttpRequest'})
+
+    def _collect_hrefs(self, webpage):
+        regex = re.compile(r'rounded-site-bottom"><a class="tm-ouvir-podcast" href="([^"]+)"')
+        matches = regex.finditer(webpage)
+        for match in matches:
+            yield f'https://radiocomercial.pt{match.group(1)}'
+
+    def _generate_sorted_entries(self, list_of_podcasts):
+        entries = [self._extract_page_content(item) for item in list_of_podcasts]
+        sorted_entries = sorted(entries, key=lambda x: x['date'], reverse=True)
+        for entry in sorted_entries:
+            yield entry
+
+    def _real_extract(self, url):
+        podcast = self._match_id(url)
+        webpage = self._download_webpage(url, podcast)
+
+        podcast_name = self._html_search_regex(r'<h1>(.+?)</h1>', webpage, 'name')
+        podcast_season = self._html_search_regex(r'<title>(.+?)</title>', webpage, 'season')
+        podcast_title = podcast_name if podcast_name == podcast_season else f'{podcast_name} - {podcast_season}'
+
+        list_of_podcasts = set()
+        while True:
+            get_entries = self._collect_hrefs(webpage)
+            if get_entries:
+                list_of_podcasts.update(get_entries)
+            webpage = self._get_next_page(webpage)
+            if not webpage:
+                break
+
+        return self.playlist_result(self._generate_sorted_entries(list_of_podcasts), podcast, podcast_title)

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -77,7 +77,6 @@ class RadioComercialIE(InfoExtractor):
     def _real_extract(self, url):
         video_id, season = self._match_valid_url(url).group('id', 'season')
         webpage = self._download_webpage(url, video_id)
-        print(self._og_search_description(webpage, default=None))
         return {
             'id': video_id,
             'title': self._html_extract_title(webpage),

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -2,18 +2,18 @@ import functools
 
 from .common import InfoExtractor
 from ..utils import (
-    int_or_none,
-    unified_strdate,
+    OnDemandPagedList,
+    extract_attributes,
     get_element_by_class,
     get_element_html_by_class,
-    extract_attributes,
-    try_call,
     get_element_text_and_html_by_tag,
-    join_nonempty,
     get_elements_html_by_class,
-    traverse_obj,
-    OnDemandPagedList
+    int_or_none,
+    join_nonempty,
+    try_call,
+    unified_strdate,
 )
+from ..utils.traversal import traverse_obj
 
 
 class RadioComercialIE(InfoExtractor):

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -56,7 +56,8 @@ class RadioComercialIE(InfoExtractor):
                 'release_date': '20231101',
                 'thumbnail': r're:https://radiocomercial.pt/upload/[^.]+.jpg',
                 'season': 2
-            }
+            },
+            'skip': 'inconsistent md5',
         },
         {
             'url': 'https://radiocomercial.pt/podcasts/tnt-todos-no-top/2023/t-n-t-29-de-outubro',

--- a/yt_dlp/extractor/radiocomercial.py
+++ b/yt_dlp/extractor/radiocomercial.py
@@ -88,7 +88,7 @@ class RadioComercialIE(InfoExtractor):
 
 
 class RadioComercialPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[\w-]+)(?:\D*(?P<season>\d+))?'
+    _VALID_URL = r'https?://(?:www\.)?radiocomercial\.pt/podcasts/(?P<id>[\w-]+)(?:\D*(?P<season>\d+))?/*$'
     _PAGE_SIZE = 19
     _TESTS = [{
         'url': 'https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This extractor was created specifically for the Portuguese radio station ``Radio Comercial``.
Its main function is to fetch and download podcast episodes.

Presently, it offers two extract functions:
- Downloading individual podcast episodes by directly using their URL links.
- Downloading all the episodes of a specified season for a particular podcast, utilizing the `playlist concept.

Valid URLs that are covered by this extractor:
- Single episode: ``https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3/convenca-me-num-minuto-que-os-lobisomens-existem``
- Entire podcast playlist: ``https://radiocomercial.pt/podcasts/as-minhas-coisas-favoritas``
- Playlist specific to a particular season of a podcast: ``https://radiocomercial.pt/podcasts/convenca-me-num-minuto/t3``


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [X] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd9904c</samp>

### Summary
🎙️📻🎧

<!--
1.  🎙️ - This emoji represents the audio and podcast content that the new extractors can download from Radio Comercial. It also suggests the theme of radio broadcasting and communication, which is relevant for the source website.
2.  📻 - This emoji represents the radio station itself, as well as the medium of radio in general. It also indicates that the new extractors are specific to Radio Comercial and not other radio websites.
3.  🎧 - This emoji represents the listening experience and the enjoyment of the audio content that the new extractors provide. It also suggests the quality and variety of the podcasts and shows that Radio Comercial offers.
-->
This pull request adds two new extractors for `yt-dlp`, `RadioComercialIE` and `RadioComercialPlaylistIE`, which enable downloading audio and playlists from the Portuguese radio station Radio Comercial. It also fixes a minor formatting issue in `_extractors.py`.

> _Oh we are the coders of the sea_
> _And we write extractors with glee_
> _We pull the audio from `RadioComercial`_
> _On the count of three, heave ho, heave ho!_

### Walkthrough
*  Add support for Radio Comercial extractors ([link](https://github.com/yt-dlp/yt-dlp/pull/8508/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1580-R1583), [link](https://github.com/yt-dlp/yt-dlp/pull/8508/files?diff=unified&w=0#diff-1e19ea63575bf6d4862897095d1b9e9362bcdca2f4cd9af94926fb911bc7cc0fR1-R141))
   * Import new classes `RadioComercialIE` and `RadioComercialPlaylistIE` from `radiocomercial.py` in `_extractors.py` ([link](https://github.com/yt-dlp/yt-dlp/pull/8508/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1580-R1583))
   * Define new classes in `radiocomercial.py` that inherit from `RadioComercialBaseExtractor` ([link](https://github.com/yt-dlp/yt-dlp/pull/8508/files?diff=unified&w=0#diff-1e19ea63575bf6d4862897095d1b9e9362bcdca2f4cd9af94926fb911bc7cc0fR1-R141))
* Remove an empty line from `_extractors.py` for formatting consistency ([link](https://github.com/yt-dlp/yt-dlp/pull/8508/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3L26))



</details>
