### PR TITLE
Improve documentation and usage of release_year

### DIFF
--- a/README.md
+++ b/README.md
@@ -1296,6 +1296,7 @@ The available fields are:
  - `upload_date` (string): Video upload date in UTC (YYYYMMDD)
  - `release_timestamp` (numeric): UNIX timestamp of the moment the video was released
  - `release_date` (string): The date (YYYYMMDD) when the video was released in UTC
+ - `release_year` (numeric): Year (YYYY) when the video or album was released
  - `modified_timestamp` (numeric): UNIX timestamp of the moment the video was last modified
  - `modified_date` (string): The date (YYYYMMDD) when the video was last modified in UTC
  - `uploader_id` (string): Nickname or id of the video uploader
@@ -1369,7 +1370,6 @@ Available for the media that is a track or a part of a music album:
  - `album_type` (string): Type of the album
  - `album_artist` (string): List of all artists appeared on the album
  - `disc_number` (numeric): Number of the disc or other physical medium the track belongs to
- - `release_year` (numeric): Year (YYYY) when the album was released
 
 Available only when using `--download-sections` and for `chapter:` prefix when using `--split-chapters` for videos with internal chapters:
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -10,7 +10,7 @@ import types
 import yt_dlp.extractor
 from yt_dlp import YoutubeDL
 from yt_dlp.compat import compat_os_name
-from yt_dlp.utils import preferredencoding, write_string
+from yt_dlp.utils import preferredencoding, try_call, write_string
 
 if 'pytest' in sys.modules:
     import pytest
@@ -221,6 +221,10 @@ def sanitize_got_info_dict(got_dict):
     # display_id may be generated from id
     if test_info_dict.get('display_id') == test_info_dict.get('id'):
         test_info_dict.pop('display_id')
+
+    # release_year may be generated from release_date
+    if try_call(lambda: test_info_dict['release_year'] == int(test_info_dict['release_date'][:4])):
+        test_info_dict.pop('release_year')
 
     # Check url for flat entries
     if got_dict.get('_type', 'video') != 'video' and got_dict.get('url'):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2586,8 +2586,8 @@ class YoutubeDL:
                     upload_date = datetime.datetime.fromtimestamp(info_dict[ts_key], datetime.timezone.utc)
                     info_dict[date_key] = upload_date.strftime('%Y%m%d')
 
-        if info_dict.get('release_year') is None and info_dict.get('release_date') is not None:
-            info_dict['release_year'] = int_or_none(info_dict['release_date'][:4])
+        if not info_dict.get('release_year'):
+            info_dict['release_year'] = traverse_obj(info_dict, ('release_date', {lambda x: int(x[:4])}))
 
         live_keys = ('is_live', 'was_live')
         live_status = info_dict.get('live_status')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2586,6 +2586,9 @@ class YoutubeDL:
                     upload_date = datetime.datetime.fromtimestamp(info_dict[ts_key], datetime.timezone.utc)
                     info_dict[date_key] = upload_date.strftime('%Y%m%d')
 
+        if info_dict.get('release_year') is None and info_dict.get('release_date') is not None:
+            info_dict['release_year'] = int_or_none(info_dict['release_date'][:4])
+
         live_keys = ('is_live', 'was_live')
         live_status = info_dict.get('live_status')
         if live_status is None:

--- a/yt_dlp/extractor/archiveorg.py
+++ b/yt_dlp/extractor/archiveorg.py
@@ -52,7 +52,6 @@ class ArchiveOrgIE(InfoExtractor):
             'creator': 'SRI International',
             'uploader': 'laura@archive.org',
             'thumbnail': r're:https://archive\.org/download/.*\.jpg',
-            'release_year': 1968,
             'display_id': 'XD300-23_68HighlightsAResearchCntAugHumanIntellect.cdr',
             'track': 'XD300-23 68HighlightsAResearchCntAugHumanIntellect',
 
@@ -134,7 +133,6 @@ class ArchiveOrgIE(InfoExtractor):
             'album': '1977-05-08 - Barton Hall - Cornell University',
             'release_date': '19770508',
             'display_id': 'gd1977-05-08d01t07.flac',
-            'release_year': 1977,
             'track_number': 7,
         },
     }, {

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -286,6 +286,9 @@ class InfoExtractor:
                     If it is not clear whether to use timestamp or this, use the former
     release_date:   The date (YYYYMMDD) when the video was released in UTC.
                     If not explicitly set, calculated from release_timestamp
+    release_year:   Year (YYYY) as integer when the video or album was released.
+                    To be used if no exact release date is known.
+                    If not explicitly set, calculated from release_date.
     modified_timestamp: UNIX timestamp of the moment the video was last modified.
     modified_date:   The date (YYYYMMDD) when the video was last modified in UTC.
                     If not explicitly set, calculated from modified_timestamp
@@ -427,7 +430,6 @@ class InfoExtractor:
                     and compilations).
     disc_number:    Number of the disc or other physical medium the track belongs to,
                     as an integer.
-    release_year:   Year (YYYY) when the album was released.
     composer:       Composer of the piece
 
     The following fields should only be set for clips that should be cut from the original video:

--- a/yt_dlp/extractor/harpodeon.py
+++ b/yt_dlp/extractor/harpodeon.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from ..utils import unified_strdate
+from ..utils import int_or_none
 
 
 class HarpodeonIE(InfoExtractor):
@@ -14,7 +14,7 @@ class HarpodeonIE(InfoExtractor):
             'title': 'The Smoking Out of Bella Butts',
             'description': 'md5:47e16bdb41fc8a79c83ab83af11c8b77',
             'creator': 'Vitagraph Company of America',
-            'release_date': '19150101'
+            'release_year': 1915,
         }
     }, {
         'url': 'https://www.harpodeon.com/preview/The_Smoking_Out_of_Bella_Butts/268068288',
@@ -25,7 +25,7 @@ class HarpodeonIE(InfoExtractor):
             'title': 'The Smoking Out of Bella Butts',
             'description': 'md5:47e16bdb41fc8a79c83ab83af11c8b77',
             'creator': 'Vitagraph Company of America',
-            'release_date': '19150101'
+            'release_year': 1915,
         }
     }, {
         'url': 'https://www.harpodeon.com/preview/Behind_the_Screen/421838710',
@@ -36,7 +36,7 @@ class HarpodeonIE(InfoExtractor):
             'title': 'Behind the Screen',
             'description': 'md5:008972a3dc51fba3965ee517d2ba9155',
             'creator': 'Lone Star Corporation',
-            'release_date': '19160101'
+            'release_year': 1916,
         }
     }]
 
@@ -66,5 +66,5 @@ class HarpodeonIE(InfoExtractor):
             'http_headers': {'Referer': url},
             'description': self._html_search_meta('description', webpage, fatal=False),
             'creator': creator,
-            'release_date': unified_strdate(f'{release_year}0101')
+            'release_year': int_or_none(release_year),
         }

--- a/yt_dlp/extractor/monstercat.py
+++ b/yt_dlp/extractor/monstercat.py
@@ -24,7 +24,6 @@ class MonstercatIE(InfoExtractor):
             'title': 'The Secret Language of Trees',
             'id': '742779548009',
             'thumbnail': 'https://www.monstercat.com/release/742779548009/cover',
-            'release_year': 2023,
             'release_date': '20230711',
             'album': 'The Secret Language of Trees',
             'album_artist': 'BT',
@@ -71,7 +70,6 @@ class MonstercatIE(InfoExtractor):
             'thumbnail': f'https://www.monstercat.com/release/{url_id}/cover',
             'album_artist': try_call(
                 lambda: get_element_by_class('h-normal text-uppercase mb-desktop-medium mb-smallish', html)),
-            'release_year': int_or_none(date[:4]) if date else None,
             'release_date': date,
         }
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -2072,7 +2072,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 'track': 'Voyeur Girl',
                 'album': 'it\'s too much love to know my dear',
                 'release_date': '20190313',
-                'release_year': 2019,
                 'alt_title': 'Voyeur Girl',
                 'view_count': int,
                 'playable_in_embed': True,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

- Update docs to better reflect actual usage of release_year
- Auto generate release year if not present
- Fix `HarpodeonIE`, which reported an incorrect release date when only the year was known

Closes #7263

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cfea45e</samp>

### Summary
📅🎞️🛠️

<!--
1.  📅 - This emoji represents the addition of the `release_year` field and the logic to populate it from the `release_date` field. It also symbolizes the date-related metadata that yt-dlp can extract from various sources.
2. 🎞️ - This emoji represents the Harpodeon extractor, which specializes in extracting silent films and early cinema from the website harpodeon.com. It also symbolizes the video media that yt-dlp can download and process.
3. 🛠️ - This emoji represents the changes to the import statements, the test cases, and the extraction function in the Harpodeon extractor. It also symbolizes the maintenance and improvement of the code quality and functionality of yt-dlp.
-->
This pull request adds a new `release_year` field to the common metadata fields for extracted videos, and updates the Harpodeon extractor to use it. It also adds a logic to infer the `release_year` from the `release_date` if possible.

> _`release_year` field_
> _added to `InfoExtractor`_
> _autumn of metadata_

### Walkthrough
*  Add a new common field `release_year` to the `InfoExtractor` class and document its meaning and usage ([link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6R289-R291))
* Remove an outdated documentation line that referred to `release_year` as an album-specific field ([link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L430))
* Update the Harpodeon extractor to use the `release_year` field instead of the `release_date` field and convert the year to an integer or None ([link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-7306dcf6bd756ca38df76a9e9beeec34bc661983fc27364f0d8b2e68dc3fe2feL2-R2), [link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-7306dcf6bd756ca38df76a9e9beeec34bc661983fc27364f0d8b2e68dc3fe2feL69-R69))
* Update the test cases for the Harpodeon extractor to reflect the change from `release_date` to `release_year` and use integers instead of strings ([link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-7306dcf6bd756ca38df76a9e9beeec34bc661983fc27364f0d8b2e68dc3fe2feL17-R17), [link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-7306dcf6bd756ca38df76a9e9beeec34bc661983fc27364f0d8b2e68dc3fe2feL28-R28), [link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-7306dcf6bd756ca38df76a9e9beeec34bc661983fc27364f0d8b2e68dc3fe2feL39-R39))
* Add a logic to the `YoutubeDL` class to calculate the `release_year` field from the `release_date` field if not explicitly set by the extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8524/files?diff=unified&w=0#diff-d3ba8be45cae8dd7889a71c3360c9e4ac1160de8a5f3443b6e4a656395267f9bR2589-R2591))



</details>
