### PR TITLE
[ie/theatercomplextown] Add extractors

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1902,6 +1902,8 @@ from .srmediathek import SRMediathekIE
 from .stacommu import (
     StacommuLiveIE,
     StacommuVODIE,
+    TheaterComplexTownVODIE,
+    TheaterComplexTownPPVIE,
 )
 from .stanfordoc import StanfordOpenClassroomIE
 from .startv import StarTVIE

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -38,6 +38,45 @@ class StacommuBaseIE(WrestleUniverseBaseIE):
             return None
         return traverse_obj(encryption_data, {'key': ('key', {decrypt}), 'iv': ('iv', {decrypt})})
 
+    def _extract_vod(self, url):
+        video_id = self._match_id(url)
+        video_info = self._download_metadata(
+            url, video_id, 'ja', ('dehydratedState', 'queries', 0, 'state', 'data'))
+        hls_info, decrypt = self._call_encrypted_api(
+            video_id, ':watch', 'stream information', data={'method': 1})
+
+        return {
+            'id': video_id,
+            'formats': self._get_formats(hls_info, ('protocolHls', 'url', {url_or_none}), video_id),
+            'hls_aes': self._extract_hls_key(hls_info, 'protocolHls', decrypt),
+            **traverse_obj(video_info, {
+                'title': ('displayName', {str}),
+                'description': ('description', {str}),
+                'timestamp': ('watchStartTime', {int_or_none}),
+                'thumbnail': ('keyVisualUrl', {url_or_none}),
+                'cast': ('casts', ..., 'displayName', {str}),
+                'duration': ('duration', {int}),
+            }),
+        }
+
+    def _extract_ppv(self, url):
+        video_id = self._match_id(url)
+        video_info = self._call_api(video_id, msg='video information', query={'al': 'ja'}, auth=False)
+        hls_info, decrypt = self._call_encrypted_api(
+            video_id, ':watchArchive', 'stream information', data={'method': 1})
+
+        return {
+            'id': video_id,
+            'formats': self._get_formats(hls_info, ('hls', 'urls', ..., {url_or_none}), video_id),
+            'hls_aes': self._extract_hls_key(hls_info, 'hls', decrypt),
+            **traverse_obj(video_info, {
+                'title': ('displayName', {str}),
+                'timestamp': ('startTime', {int_or_none}),
+                'thumbnail': ('keyVisualUrl', {url_or_none}),
+                'duration': ('duration', {int_or_none}),
+            }),
+        }
+
 
 class StacommuVODIE(StacommuBaseIE):
     _VALID_URL = r'https?://www\.stacommu\.jp/videos/episodes/(?P<id>[\da-zA-Z]+)'
@@ -84,25 +123,7 @@ class StacommuVODIE(StacommuBaseIE):
     _API_PATH = 'videoEpisodes'
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        video_info = self._download_metadata(
-            url, video_id, 'ja', ('dehydratedState', 'queries', 0, 'state', 'data'))
-        hls_info, decrypt = self._call_encrypted_api(
-            video_id, ':watch', 'stream information', data={'method': 1})
-
-        return {
-            'id': video_id,
-            'formats': self._get_formats(hls_info, ('protocolHls', 'url', {url_or_none}), video_id),
-            'hls_aes': self._extract_hls_key(hls_info, 'protocolHls', decrypt),
-            **traverse_obj(video_info, {
-                'title': ('displayName', {str}),
-                'description': ('description', {str}),
-                'timestamp': ('watchStartTime', {int_or_none}),
-                'thumbnail': ('keyVisualUrl', {url_or_none}),
-                'cast': ('casts', ..., 'displayName', {str}),
-                'duration': ('duration', {int}),
-            }),
-        }
+        return self._extract_vod(url)
 
 
 class StacommuLiveIE(StacommuBaseIE):
@@ -130,19 +151,75 @@ class StacommuLiveIE(StacommuBaseIE):
     _API_PATH = 'events'
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        video_info = self._call_api(video_id, msg='video information', query={'al': 'ja'}, auth=False)
-        hls_info, decrypt = self._call_encrypted_api(
-            video_id, ':watchArchive', 'stream information', data={'method': 1})
+        return self._extract_ppv(url)
 
-        return {
-            'id': video_id,
-            'formats': self._get_formats(hls_info, ('hls', 'urls', ..., {url_or_none}), video_id),
-            'hls_aes': self._extract_hls_key(hls_info, 'hls', decrypt),
-            **traverse_obj(video_info, {
-                'title': ('displayName', {str}),
-                'timestamp': ('startTime', {int_or_none}),
-                'thumbnail': ('keyVisualUrl', {url_or_none}),
-                'duration': ('duration', {int_or_none}),
-            }),
-        }
+
+class TheaterComplexTownBaseIE(StacommuBaseIE):
+    _NETRC_MACHINE = 'theatercomplextown'
+    _API_HOST = 'api.theater-complex.town'
+    _LOGIN_QUERY = {'key': 'AIzaSyAgNCqToaIz4a062EeIrkhI_xetVfAOrfc'}
+    _LOGIN_HEADERS = {
+        'Accept': '*/*',
+        'Content-Type': 'application/json',
+        'X-Client-Version': 'Chrome/JsCore/9.9.4/FirebaseCore-web',
+        'Referer': 'https://www.theater-complex.town/',
+        'Origin': 'https://www.theater-complex.town',
+    }
+
+
+class TheaterComplexTownVODIE(TheaterComplexTownBaseIE):
+    _VALID_URL = r'https?://(?:www\.)?theater-complex\.town/(?:en/)?videos/episodes/(?P<id>\w+)'
+    IE_NAME = 'theatercomplextown:vod'
+    _TESTS = [{
+        'url': 'https://www.theater-complex.town/videos/episodes/hoxqidYNoAn7bP92DN6p78',
+        'info_dict': {
+            'id': 'hoxqidYNoAn7bP92DN6p78',
+            'ext': 'mp4',
+            'title': '演劇ドラフトグランプリ2023　劇団『恋のぼり』〜劇団名決定秘話ラジオ',
+            'description': 'md5:a7e2e9cf570379ea67fb630f345ff65d',
+            'cast': ['玉城 裕規', '石川 凌雅'],
+            'thumbnail': 'https://image.theater-complex.town/5URnXX6KCeDysuFrPkP38o/5URnXX6KCeDysuFrPkP38o',
+            'upload_date': '20231103',
+            'timestamp': 1699016400,
+            'duration': 868,
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }, {
+        'url': 'https://www.theater-complex.town/en/videos/episodes/6QT7XYwM9dJz5Gf9VB6K5y',
+        'only_matching': True,
+    }]
+
+    _API_PATH = 'videoEpisodes'
+
+    def _real_extract(self, url):
+        return self._extract_ppv(url)
+
+
+class TheaterComplexTownPPVIE(TheaterComplexTownBaseIE):
+    _VALID_URL = r'https?://(?:www\.)?theater-complex\.town/(?:en/)?ppv/(?P<id>\w+)'
+    IE_NAME = 'theatercomplextown:ppv'
+    _TESTS = [{
+        'url': 'https://www.theater-complex.town/ppv/wytW3X7khrjJBUpKuV3jen',
+        'info_dict': {
+            'id': 'wytW3X7khrjJBUpKuV3jen',
+            'ext': 'mp4',
+            'title': 'BREAK FREE STARS　11月5日（日）12:30千秋楽公演',
+            'thumbnail': 'https://image.theater-complex.town/5GWEB31JcTUfjtgdeV5t6o/5GWEB31JcTUfjtgdeV5t6o',
+            'upload_date': '20231105',
+            'timestamp': 1699155000,
+            'duration': 8378,
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }, {
+        'url': 'https://www.theater-complex.town/en/ppv/wytW3X7khrjJBUpKuV3jen',
+        'only_matching': True,
+    }]
+
+    _API_PATH = 'events'
+
+    def _real_extract(self, url):
+        return self._extract_vod(url)

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -167,7 +167,7 @@ class TheaterComplexTownBaseIE(StacommuBaseIE):
     _LOGIN_HEADERS = {
         'Accept': '*/*',
         'Content-Type': 'application/json',
-        'X-Client-Version': 'Chrome/JsCore/9.9.4/FirebaseCore-web',
+        'X-Client-Version': 'Chrome/JsCore/9.23.0/FirebaseCore-web',
         'Referer': 'https://www.theater-complex.town/',
         'Origin': 'https://www.theater-complex.town',
     }

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -79,7 +79,7 @@ class StacommuBaseIE(WrestleUniverseBaseIE):
 
 
 class StacommuVODIE(StacommuBaseIE):
-    _VALID_URL = r'https?://www\.stacommu\.jp/videos/episodes/(?P<id>[\da-zA-Z]+)'
+    _VALID_URL = r'https?://www\.stacommu\.jp/(?:en/)?videos/episodes/(?P<id>[\da-zA-Z]+)'
     _TESTS = [{
         # not encrypted
         'url': 'https://www.stacommu.jp/videos/episodes/aXcVKjHyAENEjard61soZZ',
@@ -118,6 +118,9 @@ class StacommuVODIE(StacommuBaseIE):
         'params': {
             'skip_download': 'm3u8',
         },
+    }, {
+        'url': 'https://www.stacommu.jp/en/videos/episodes/aXcVKjHyAENEjard61soZZ',
+        'only_matching': True,
     }]
 
     _API_PATH = 'videoEpisodes'
@@ -127,7 +130,7 @@ class StacommuVODIE(StacommuBaseIE):
 
 
 class StacommuLiveIE(StacommuBaseIE):
-    _VALID_URL = r'https?://www\.stacommu\.jp/live/(?P<id>[\da-zA-Z]+)'
+    _VALID_URL = r'https?://www\.stacommu\.jp/(?:en/)?live/(?P<id>[\da-zA-Z]+)'
     _TESTS = [{
         'url': 'https://www.stacommu.jp/live/d2FJ3zLnndegZJCAEzGM3m',
         'info_dict': {
@@ -146,6 +149,9 @@ class StacommuLiveIE(StacommuBaseIE):
         'params': {
             'skip_download': 'm3u8',
         },
+    }, {
+        'url': 'https://www.stacommu.jp/en/live/d2FJ3zLnndegZJCAEzGM3m',
+        'only_matching': True,
     }]
 
     _API_PATH = 'events'

--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -200,7 +200,7 @@ class TheaterComplexTownVODIE(TheaterComplexTownBaseIE):
     _API_PATH = 'videoEpisodes'
 
     def _real_extract(self, url):
-        return self._extract_ppv(url)
+        return self._extract_vod(url)
 
 
 class TheaterComplexTownPPVIE(TheaterComplexTownBaseIE):
@@ -228,4 +228,4 @@ class TheaterComplexTownPPVIE(TheaterComplexTownBaseIE):
     _API_PATH = 'events'
 
     def _real_extract(self, url):
-        return self._extract_vod(url)
+        return self._extract_ppv(url)


### PR DESCRIPTION
theater-complex.town is a subscription/PPV service that streams Japanese theater productions. Its web API is *identical* to that of StaCommu, another Japanese subscription-based streaming service.
(The G Play store says that both sites' Android apps are developed by "CyberAgent Inc.", which is likely the same company as "CyberFight Inc." that develops the Wrestle-Universe app.)

Because of the carbon copy API, I didn't have to do much here: just moved some methods to the Stacommu baseclass and plugged in a different API key and hostname

Closes #8491


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f7dbeb7</samp>

### Summary
🎭🎬♻️

<!--
1.  🎭 - This emoji represents theater and drama, which is the main theme of the website theater-complex.town. It also conveys the idea of streaming and watching performances online.
2.  🎬 - This emoji represents video production and editing, which is related to the extraction of video on demand and pay-per-view content. It also suggests the quality and variety of the content available on the website.
3.  ♻️ - This emoji represents recycling and reuse, which is related to the refactoring of the stacommu extractors. It also implies improvement and optimization of the code.
-->
Refactor and add extractors for stacommu and theater-complex.town. The change improves the code structure and reusability of the stacommu extractors and adds support for a new site that offers theater streaming. The change affects the files `yt_dlp/extractor/stacommu.py`, `yt_dlp/extractor/theatercomplextown.py`, and `yt_dlp/extractor/_extractors.py`.

> _Oh we are the coders of yt-dlp_
> _We scrape the sites for video clips_
> _We add new extractors to the list_
> _And refactor the old ones with a twist_

### Walkthrough
*  Add support for theater-complex.town, a Japanese platform for streaming theater performances, by creating two new extractor classes: `TheaterComplexTownVODIE` for video on demand content and `TheaterComplexTownPPVIE` for pay-per-view content ([link](https://github.com/yt-dlp/yt-dlp/pull/8560/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1905-R1906))
*  Move the base class `StacommuBaseIE` from `yt_dlp/extractor/stacommu.py` to `yt_dlp/extractor/_extractors.py` to avoid circular imports and enable inheritance by the new classes ([link](https://github.com/yt-dlp/yt-dlp/pull/8560/files?diff=unified&w=0#diff-94b8992ff07a35dde39e76f8f14191afa898e2802527664a84b40ad48cef8fd5L41-R80))
*  Simplify the extraction of video on demand content from stacommu.jp by calling the `_extract_vod` method of `StacommuBaseIE` in the `_real_extract` method of `StacommuVODIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/8560/files?diff=unified&w=0#diff-94b8992ff07a35dde39e76f8f14191afa898e2802527664a84b40ad48cef8fd5L87-R128))
*  Simplify the extraction of pay-per-view content from stacommu.jp by calling the `_extract_ppv` method of `StacommuBaseIE` in the `_real_extract` method of `StacommuLiveIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/8560/files?diff=unified&w=0#diff-94b8992ff07a35dde39e76f8f14191afa898e2802527664a84b40ad48cef8fd5L133-R225))



</details>
