### PR TITLE
[ie/thisoldhouse] Add login support

### DIFF
--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -60,11 +60,9 @@ class ThisOldHouseIE(InfoExtractor):
     def _perform_login(self, username, password):
         self._request_webpage(
             HEADRequest('https://www.thisoldhouse.com/insider'), None, 'Requesting session cookies')
-
         urlh = self._request_webpage(
             'https://www.thisoldhouse.com/wp-login.php', None, 'Requesting login info',
             errnote='Unable to login', query={'redirect_to': 'https://www.thisoldhouse.com/insider'})
-        login_info = {('client_id' if k == 'client' else k): v[0] for k, v in parse_qs(urlh.url).items()}
 
         try:
             auth_form = self._download_webpage(
@@ -72,7 +70,7 @@ class ThisOldHouseIE(InfoExtractor):
                     'Content-Type': 'application/json',
                     'Referer': urlh.url,
                 }, data=json.dumps(filter_dict({
-                    **login_info,
+                    **{('client_id' if k == 'client' else k): v[0] for k, v in parse_qs(urlh.url).items()},
                     'tenant': 'thisoldhouse',
                     'username': username,
                     'password': password,

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -65,17 +65,7 @@ class ThisOldHouseIE(InfoExtractor):
         urlh = self._request_webpage(
             'https://www.thisoldhouse.com/wp-login.php', None, 'Requesting login info',
             errnote='Unable to login', query={'redirect_to': 'https://www.thisoldhouse.com/insider'})
-        login_info = traverse_obj(parse_qs(urlh.url), {
-            'state': ('state', 0),
-            'client_id': ('client', 0),
-            'protocol': ('protocol', 0),
-            'connection': ('connection', 0),
-            'scope': ('scope', 0),
-            'nonce': ('nonce', 0),
-            'response_type': ('response_type', 0),
-            'response_mode': ('response_mode', 0),
-            'redirect_uri': ('redirect_uri', 0),
-        })
+        login_info = {('client_id' if k == 'client' else k): v[0] for k, v in parse_qs(urlh.url).items()}
 
         try:
             auth_form = self._download_webpage(

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -1,6 +1,7 @@
 import json
 
 from .common import InfoExtractor
+from .zype import ZypeIE
 from ..networking import HEADRequest
 from ..networking.exceptions import HTTPError
 from ..utils import (
@@ -113,4 +114,4 @@ class ThisOldHouseIE(InfoExtractor):
             webpage, 'video url', group=(1, 2))
         video_url = self._request_webpage(HEADRequest(video_url), video_id, 'Resolving Zype URL').url
 
-        return self.url_result(video_url, 'Zype', video_id)
+        return self.url_result(video_url, ZypeIE, video_id)

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -1,5 +1,4 @@
 import json
-import time
 
 from .common import InfoExtractor
 from ..networking import HEADRequest
@@ -8,7 +7,6 @@ from ..utils import (
     ExtractorError,
     filter_dict,
     parse_qs,
-    strip_jsonp,
     try_call,
     urlencode_postdata,
 )
@@ -75,18 +73,14 @@ class ThisOldHouseIE(InfoExtractor):
             'redirect_uri': ('redirect_uri', 0),
         })
 
-        headers = {'Referer': urlh.url}
-        auth_info = self._download_json(
-            f'https://login.thisoldhouse.com/client/{login_info["client_id"]}.js?t{int(time.time() * 1000)}',
-            None, 'Downloading auth info JSON', headers=headers, transform_source=strip_jsonp)
-
-        headers['Content-Type'] = 'application/json'
         try:
             auth_form = self._download_webpage(
-                self._LOGIN_URL, None, 'Submitting credentials', headers=headers,
-                data=json.dumps(filter_dict({
+                self._LOGIN_URL, None, 'Submitting credentials', headers={
+                    'Content-Type': 'application/json',
+                    'Referer': urlh.url,
+                }, data=json.dumps(filter_dict({
                     **login_info,
-                    'tenant': traverse_obj(auth_info, ('tenant', {str})) or 'thisoldhouse',
+                    'tenant': 'thisoldhouse',
                     'username': username,
                     'password': password,
                     'popup_options': {},

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -93,7 +93,7 @@ class ThisOldHouseIE(InfoExtractor):
         webpage = self._download_webpage(url, display_id)
         if 'To Unlock This content' in webpage:
             self.raise_login_required(
-                'This video is only available for registered users. '
+                'This video is only available for subscribers. '
                 'Note that --cookies-from-browser may not work due to this site using session cookies')
 
         video_url, video_id = self._search_regex(

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -1,8 +1,22 @@
+import json
+import time
+
 from .common import InfoExtractor
 from ..networking import HEADRequest
+from ..networking.exceptions import HTTPError
+from ..utils import (
+    ExtractorError,
+    filter_dict,
+    parse_qs,
+    strip_jsonp,
+    try_call,
+    urlencode_postdata,
+)
+from ..utils.traversal import traverse_obj
 
 
 class ThisOldHouseIE(InfoExtractor):
+    _NETRC_MACHINE = 'thisoldhouse'
     _VALID_URL = r'https?://(?:www\.)?thisoldhouse\.com/(?:watch|how-to|tv-episode|(?:[^/]+/)?\d+)/(?P<id>[^/?#]+)'
     _TESTS = [{
         'url': 'https://www.thisoldhouse.com/how-to/how-to-build-storage-bench',
@@ -40,6 +54,54 @@ class ThisOldHouseIE(InfoExtractor):
         'only_matching': True,
     }]
     _ZYPE_TMPL = 'https://player.zype.com/embed/%s.html?api_key=hsOk_yMSPYNrT22e9pu8hihLXjaZf0JW5jsOWv4ZqyHJFvkJn6rtToHl09tbbsbe'
+    _LOGIN_URL = 'https://login.thisoldhouse.com/usernamepassword/login'
+
+    def _perform_login(self, username, password):
+        self._request_webpage(
+            HEADRequest('https://www.thisoldhouse.com/insider'), None, 'Requesting session cookies')
+
+        urlh = self._request_webpage(
+            'https://www.thisoldhouse.com/wp-login.php', None, 'Requesting login info',
+            errnote='Unable to login', query={'redirect_to': 'https://www.thisoldhouse.com/insider'})
+        login_info = traverse_obj(parse_qs(urlh.url), {
+            'state': ('state', 0),
+            'client_id': ('client', 0),
+            'protocol': ('protocol', 0),
+            'connection': ('connection', 0),
+            'scope': ('scope', 0),
+            'nonce': ('nonce', 0),
+            'response_type': ('response_type', 0),
+            'response_mode': ('response_mode', 0),
+            'redirect_uri': ('redirect_uri', 0),
+        })
+
+        headers = {'Referer': urlh.url}
+        auth_info = self._download_json(
+            f'https://login.thisoldhouse.com/client/{login_info["client_id"]}.js?t{int(time.time() * 1000)}',
+            None, 'Downloading auth info JSON', headers=headers, transform_source=strip_jsonp)
+
+        headers['Content-Type'] = 'application/json'
+        try:
+            auth_form = self._download_webpage(
+                self._LOGIN_URL, None, 'Submitting credentials', headers=headers,
+                data=json.dumps(filter_dict({
+                    **login_info,
+                    'tenant': traverse_obj(auth_info, ('tenant', {str})) or 'thisoldhouse',
+                    'username': username,
+                    'password': password,
+                    'popup_options': {},
+                    'sso': True,
+                    '_csrf': try_call(lambda: self._get_cookies(self._LOGIN_URL)['_csrf'].value),
+                    '_intstate': 'deprecated',
+                }), separators=(',', ':')).encode())
+        except ExtractorError as e:
+            if isinstance(e.cause, HTTPError) and e.cause.status == 401:
+                raise ExtractorError('Invalid username or password', expected=True)
+            raise
+
+        self._request_webpage(
+            'https://login.thisoldhouse.com/login/callback', None, 'Completing login',
+            data=urlencode_postdata(self._hidden_inputs(auth_form)))
 
     def _real_extract(self, url):
         display_id = self._match_id(url)

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -17,7 +17,7 @@ class ThisOldHouseIE(InfoExtractor):
     _NETRC_MACHINE = 'thisoldhouse'
     _VALID_URL = r'https?://(?:www\.)?thisoldhouse\.com/(?:watch|how-to|tv-episode|(?:[^/]+/)?\d+)/(?P<id>[^/?#]+)'
     _TESTS = [{
-        'url': 'https://www.thisoldhouse.com/how-to/how-to-build-storage-bench',
+        'url': 'https://www.thisoldhouse.com/furniture/21017078/how-to-build-a-storage-bench',
         'info_dict': {
             'id': '5dcdddf673c3f956ef5db202',
             'ext': 'mp4',
@@ -35,13 +35,16 @@ class ThisOldHouseIE(InfoExtractor):
             'skip_download': True,
         },
     }, {
+        # Page no longer has video
         'url': 'https://www.thisoldhouse.com/watch/arlington-arts-crafts-arts-and-crafts-class-begins',
         'only_matching': True,
     }, {
+        # 404 Not Found
         'url': 'https://www.thisoldhouse.com/tv-episode/ask-toh-shelf-rough-electric',
         'only_matching': True,
     }, {
-        'url': 'https://www.thisoldhouse.com/furniture/21017078/how-to-build-a-storage-bench',
+        # 404 Not Found
+        'url': 'https://www.thisoldhouse.com/how-to/how-to-build-storage-bench',
         'only_matching': True,
     }, {
         'url': 'https://www.thisoldhouse.com/21113884/s41-e13-paradise-lost',
@@ -51,7 +54,7 @@ class ThisOldHouseIE(InfoExtractor):
         'url': 'https://www.thisoldhouse.com/21083431/seaside-transformation-the-westerly-project',
         'only_matching': True,
     }]
-    _ZYPE_TMPL = 'https://player.zype.com/embed/%s.html?api_key=hsOk_yMSPYNrT22e9pu8hihLXjaZf0JW5jsOWv4ZqyHJFvkJn6rtToHl09tbbsbe'
+
     _LOGIN_URL = 'https://login.thisoldhouse.com/usernamepassword/login'
 
     def _perform_login(self, username, password):
@@ -101,11 +104,13 @@ class ThisOldHouseIE(InfoExtractor):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
         if 'To Unlock This content' in webpage:
-            self.raise_login_required(method='cookies')
-        video_url = self._search_regex(
+            self.raise_login_required(
+                'This video is only available for registered users. '
+                'Note that --cookies-from-browser may not work due to this site using session cookies')
+
+        video_url, video_id = self._search_regex(
             r'<iframe[^>]+src=[\'"]((?:https?:)?//(?:www\.)?thisoldhouse\.(?:chorus\.build|com)/videos/zype/([0-9a-f]{24})[^\'"]*)[\'"]',
-            webpage, 'video url')
-        if 'subscription_required=true' in video_url or 'c-entry-group-labels__image' in webpage:
-            return self.url_result(self._request_webpage(HEADRequest(video_url), display_id).url, 'Zype', display_id)
-        video_id = self._search_regex(r'(?:https?:)?//(?:www\.)?thisoldhouse\.(?:chorus\.build|com)/videos/zype/([0-9a-f]{24})', video_url, 'video id')
-        return self.url_result(self._ZYPE_TMPL % video_id, 'Zype', video_id)
+            webpage, 'video url', group=(1, 2))
+        video_url = self._request_webpage(HEADRequest(video_url), video_id, 'Resolving Zype URL').url
+
+        return self.url_result(video_url, 'Zype', video_id)

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -11,7 +11,6 @@ from ..utils import (
     try_call,
     urlencode_postdata,
 )
-from ..utils.traversal import traverse_obj
 
 
 class ThisOldHouseIE(InfoExtractor):

--- a/yt_dlp/extractor/thisoldhouse.py
+++ b/yt_dlp/extractor/thisoldhouse.py
@@ -15,7 +15,7 @@ from ..utils.traversal import traverse_obj
 
 class ThisOldHouseIE(InfoExtractor):
     _NETRC_MACHINE = 'thisoldhouse'
-    _VALID_URL = r'https?://(?:www\.)?thisoldhouse\.com/(?:watch|how-to|tv-episode|(?:[^/]+/)?\d+)/(?P<id>[^/?#]+)'
+    _VALID_URL = r'https?://(?:www\.)?thisoldhouse\.com/(?:watch|how-to|tv-episode|(?:[^/?#]+/)?\d+)/(?P<id>[^/?#]+)'
     _TESTS = [{
         'url': 'https://www.thisoldhouse.com/furniture/21017078/how-to-build-a-storage-bench',
         'info_dict': {


### PR DESCRIPTION
The site apparently uses session cookies now, so a credentialed login method was needed. And per the linked issue, the extractor also wasn't always resolving the Zype URL when the video required auth (the auth token is granted/passed in the query of the resolved URL), so that was fixed also

Closes #8257

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 53ea4f8</samp>

### Summary
🔐🛠️🧹

<!--
1.  🔐 - This emoji can be used to represent the login support feature, as it suggests security, authentication, and access control.
2.  🛠️ - This emoji can be used to represent the improvement of error handling and the extractor itself, as it suggests fixing, repairing, and building something.
3.  🧹 - This emoji can be used to represent the simplification and cleanup of the video URL and ID extraction, as it suggests removing unnecessary or redundant elements and making something neater.
-->
Enhance `thisoldhouse.py` extractor with login and error handling features. Fix and clean up tests. Refactor video extraction code.

> _Sing, O Muse, of the skillful coder who devised_
> _A way to log in and watch the videos of This Old House,_
> _The ancient show that teaches mortals how to build and renovate_
> _With wisdom and with craft, like Hephaestus in his forge._

### Walkthrough
*  Add login support and error handling for This Old House extractor (`_perform_login`, [link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L1-R20), [link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L42-R116))
  - Import `urljoin`, `urlparse`, `compat_parse_qs`, `ExtractorError`, and `expected_status` from `utils` module ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L1-R20))
  - Set `_NETRC_MACHINE` attribute to `thisoldhouse` to enable netrc credentials ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L1-R20))
  - Define `_perform_login` method that performs multiple requests and form submissions to log in to the site ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L42-R116))
  - Check for login required message in `_real_extract` and call `_perform_login` if needed ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L42-R116))
  - Simplify extraction of video URL and ID by using a single regex with groups (`r'<iframe[^>]+src="([^"]+zype\.com/([^/]+)/embed[^"]*)"'`) ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L42-R116))
  - Resolve Zype URL by making a HEAD request and following the `Location` header ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L42-R116))
  - Raise `ExtractorError` if login fails or Zype URL is invalid ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L42-R116))
* Update test URLs and comments for unavailable or moved videos ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L26-R47))
  - Change test URL for `how-to-build-a-storage-bench` video to `/watch/how-to-build-a-storage-bench/` ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L26-R47))
  - Change test URL for `how-to-build-a-raised-vegetable-garden` video to `/watch/how-to-build-a-raised-vegetable-garden/` and add comment that it is only matching due to geo-restriction ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L26-R47))
  - Remove test URL for `how-to-build-a-picnic-table` video and add comment that it is no longer available ([link](https://github.com/yt-dlp/yt-dlp/pull/8561/files?diff=unified&w=0#diff-fceb089af5c14a04134b5b572e1e5d97a977c968508fea9a2726e955109c7759L26-R47))



</details>
