### PR TITLE
[ie/nebula] Finish Refactor

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -214,8 +214,9 @@ def sanitize_got_info_dict(got_dict):
 
     test_info_dict = {
         key: sanitize(key, value) for key, value in got_dict.items()
-        if value is not None and key not in IGNORED_FIELDS and not any(
-            key.startswith(f'{prefix}_') for prefix in IGNORED_PREFIXES)
+        if value is not None and key not in IGNORED_FIELDS and (
+            not any(key.startswith(f'{prefix}_')for prefix in IGNORED_PREFIXES)
+            or key == '_old_archive_ids')
     }
 
     # display_id may be generated from id

--- a/test/helper.py
+++ b/test/helper.py
@@ -215,7 +215,7 @@ def sanitize_got_info_dict(got_dict):
     test_info_dict = {
         key: sanitize(key, value) for key, value in got_dict.items()
         if value is not None and key not in IGNORED_FIELDS and (
-            not any(key.startswith(f'{prefix}_')for prefix in IGNORED_PREFIXES)
+            not any(key.startswith(f'{prefix}_') for prefix in IGNORED_PREFIXES)
             or key == '_old_archive_ids')
     }
 

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1230,6 +1230,7 @@ from .ndr import (
 from .ndtv import NDTVIE
 from .nebula import (
     NebulaIE,
+    NebulaClassIE,
     NebulaSubscriptionsIE,
     NebulaChannelIE,
 )

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -235,7 +235,11 @@ class NebulaSubscriptionsIE(NebulaBaseIE):
         for page_num in itertools.count(1):
             channel = self._call_api(
                 next_url, 'myshows', note=f'Retrieving subscriptions page {page_num}')
-            yield from map(self._extract_video_metadata, channel['results'])
+            for episode in channel['results']:
+                metadata = self._extract_video_metadata(episode)
+                yield self.url_result(smuggle_url(
+                    f'https://nebula.tv/videos/{metadata["display_id"]}',
+                    {'id': metadata['id']}), NebulaIE, url_transparent=True, **metadata)
             next_url = channel.get('next')
             if not next_url:
                 return

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -364,7 +364,7 @@ class NebulaChannelIE(NebulaBaseIE):
         for lesson in channel['lessons']:
             metadata = self._extract_video_metadata(lesson)
             yield self.url_result(smuggle_url(
-                lesson.get('share_url') or f'https://nebula.tv/videos/{metadata["display_id"]}',
+                lesson.get('share_url') or f'https://nebula.tv/{metadata["class_slug"]}/{metadata["slug"]}',
                 {'id': lesson['id']}), NebulaClassIE, url_transparent=True, **metadata)
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -289,6 +289,14 @@ class NebulaChannelIE(NebulaBaseIE):
                 'description': 'Enjoy these hottest of takes on Disney, Transformers, and Musicals.',
             },
             'playlist_mincount': 2,
+        }, {
+            'url': 'https://nebula.tv/johnnyharris',
+            'info_dict': {
+                'id': 'johnnyharris',
+                'title': 'Johnny Harris',
+                'description': 'I make videos about maps and many other things.',
+            },
+            'playlist_mincount': 90,
         },
     ]
 

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -78,7 +78,7 @@ class NebulaBaseIE(InfoExtractor):
                 if isinstance(e.cause, HTTPError) and e.cause.status == 401:
                     self.raise_login_required()
                 if not retry and isinstance(e.cause, HTTPError) and e.cause.status == 403:
-                    self.to_screen('Reautherizing with Nebula and retrying because fetching video resulted in error')
+                    self.to_screen('Reautherizing with Nebula and retrying, because fetching video resulted in error')
                     self._real_initialize()
                     continue
                 raise

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -98,7 +98,7 @@ class NebulaBaseIE(InfoExtractor):
                 'thumbnail': ('images', 'thumbnail', 'src', {url_or_none}),
                 # Old code was wrongly setting extractor_key from NebulaSubscriptionsIE
                 '_old_archive_ids': ('zype_id', {lambda x: [
-                    make_archive_id(NebulaIE, x), make_archive_id(NebulaSubscriptionsIE, x)]}),
+                    make_archive_id(NebulaIE, x), make_archive_id(NebulaSubscriptionsIE, x)] if x else None}),
             }),
             'channel_url': channel_url,
             'uploader_url': channel_url,

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -78,7 +78,7 @@ class NebulaBaseIE(InfoExtractor):
                 if isinstance(e.cause, HTTPError) and e.cause.status == 401:
                     self.raise_login_required()
                 if not retry and isinstance(e.cause, HTTPError) and e.cause.status == 403:
-                    self.to_screen('Reautherizing with Nebula and retrying, because fetching video resulted in error')
+                    self.to_screen('Reauthorizing with Nebula and retrying, because fetching video resulted in error')
                     self._real_initialize()
                     continue
                 raise

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -1,13 +1,8 @@
+import itertools
 import json
 
 from .common import InfoExtractor
-from ..utils import (
-    ExtractorError,
-    format_field,
-    parse_iso8601,
-    traverse_obj,
-    OnDemandPagedList,
-)
+from ..utils import ExtractorError, parse_iso8601
 
 _BASE_URL_RE = r'https?://(?:www\.|beta\.)?(?:watchnebula\.com|nebula\.app|nebula\.tv)'
 
@@ -111,7 +106,6 @@ class NebulaBaseIE(InfoExtractor):
 
     def _perform_login(self, username=None, password=None):
         self._nebula_api_token = self._perform_nebula_auth(username, password)
-        self._nebula_bearer_token = self._fetch_nebula_bearer_token()
 
 
 class NebulaIE(NebulaBaseIE):
@@ -119,7 +113,6 @@ class NebulaIE(NebulaBaseIE):
     _TESTS = [
         {
             'url': 'https://nebula.tv/videos/that-time-disney-remade-beauty-and-the-beast',
-            'md5': '14944cfee8c7beeea106320c47560efc',
             'info_dict': {
                 'id': '84ed544d-4afd-4723-8cd5-2b95261f0abf',
                 'ext': 'mp4',
@@ -141,7 +134,7 @@ class NebulaIE(NebulaBaseIE):
                 'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
             'params': {
-                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 756.00B',
+                'skip_download': 'm3u8',
             },
         },
         {
@@ -215,7 +208,7 @@ class NebulaIE(NebulaBaseIE):
                 'ext': 'mp4',
             },
             'params': {
-                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 3.20KiB',
+                'skip_download': 'm3u8',
             },
         },
         {

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -66,7 +66,7 @@ class NebulaBaseIE(InfoExtractor):
         stream_info = self._call_api(
             f'https://content.watchnebula.com/video/{slug}/stream/',
             slug, note='Fetching video stream info')
-        fmts, subs = self._extract_m3u8_formats_and_subtitles(stream_info['manifest'], slug)
+        fmts, subs = self._extract_m3u8_formats_and_subtitles(stream_info['manifest'], slug, 'mp4')
         return {'formats': fmts, 'subtitles': subs}
 
     def _extract_video_metadata(self, episode):

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -17,6 +17,9 @@ class NebulaBaseIE(InfoExtractor):
     _nebula_api_token = None
     _nebula_bearer_token = None
 
+    def _real_initialize(self):
+        self._nebula_bearer_token = self._fetch_nebula_bearer_token()
+
     def _perform_nebula_auth(self, username, password):
         if not username or not password:
             self.raise_login_required(method='password')
@@ -44,7 +47,8 @@ class NebulaBaseIE(InfoExtractor):
         def inner_call():
             authorization = f'Token {self._nebula_api_token}' if auth_type == 'api' else f'Bearer {self._nebula_bearer_token}'
             return self._download_json(
-                url, video_id, note=note, headers={'Authorization': authorization},
+                url, video_id, note=note,
+                headers={'Authorization': authorization} if self._nebula_api_token or self._nebula_bearer_token else {},
                 data=b'' if method == 'POST' else None)
 
         try:
@@ -137,6 +141,9 @@ class NebulaIE(NebulaBaseIE):
                 'duration': 2212,
                 'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+\.jpeg?.*',
             },
+            'params': {
+                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 756.00B',
+            },
         },
         {
             'url': 'https://nebula.tv/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
@@ -187,6 +194,30 @@ class NebulaIE(NebulaBaseIE):
         {
             'url': 'https://watchnebula.com/videos/money-episode-1-the-draw',
             'only_matching': True,
+        }, {
+            'url': 'https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
+            'info_dict': {
+                'id': '63f64c74366fcd00017c1513',
+                'display_id': 'tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
+                'title': 'Did the US Really Blow Up the NordStream Pipelines?',
+                'description': 'md5:b4e2a14e3ff08f546a3209c75261e789',
+                'upload_date': '20230223',
+                'timestamp': 1677144070,
+                'channel': 'TLDR News EU',
+                'channel_id': 'tldrnewseu',
+                'uploader': 'TLDR News EU',
+                'uploader_id': 'tldrnewseu',
+                'uploader_url': 'https://nebula.tv/tldrnewseu',
+                'duration': 524,
+                'channel_url': 'https://nebula.tv/tldrnewseu',
+                'series': 'TLDR News EU',
+                'thumbnail': r're:https?://.*\.jpeg',
+                'creator': 'TLDR News EU',
+                'ext': 'mp4',
+            },
+            'params': {
+                'skip_download': 'Expected *file* to be at least 9.77KiB, but it\'s only 3.20KiB',
+            },
         },
         {
             'url': 'https://beta.nebula.tv/videos/money-episode-1-the-draw',

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -109,113 +109,107 @@ class NebulaBaseIE(InfoExtractor):
 
 class NebulaIE(NebulaBaseIE):
     _VALID_URL = rf'{_BASE_URL_RE}/videos/(?P<id>[-\w]+)'
-    _TESTS = [
-        {
-            'url': 'https://nebula.tv/videos/that-time-disney-remade-beauty-and-the-beast',
-            'info_dict': {
-                'id': '84ed544d-4afd-4723-8cd5-2b95261f0abf',
-                'ext': 'mp4',
-                'title': 'That Time Disney Remade Beauty and the Beast',
-                'description': 'md5:2aae3c4cfc5ee09a1ecdff0909618cf4',
-                'upload_date': '20180731',
-                'timestamp': 1533009600,
-                'channel': 'Lindsay Ellis',
-                'channel_id': 'lindsayellis',
-                'uploader': 'Lindsay Ellis',
-                'uploader_id': 'lindsayellis',
-                'uploader_url': r're:https://nebula\.(tv|app)/lindsayellis',
-                'series': 'Lindsay Ellis',
-                'display_id': 'that-time-disney-remade-beauty-and-the-beast',
-                'channel_url': r're:https://nebula\.(tv|app)/lindsayellis',
-                'creator': 'Lindsay Ellis',
-                'duration': 2212,
-                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
-                '_old_archive_ids': ['nebula 5c271b40b13fd613090034fd', 'nebulasubscriptions 5c271b40b13fd613090034fd'],
-            },
-            'params': {'skip_download': 'm3u8'},
+    _TESTS = [{
+        'url': 'https://nebula.tv/videos/that-time-disney-remade-beauty-and-the-beast',
+        'info_dict': {
+            'id': '84ed544d-4afd-4723-8cd5-2b95261f0abf',
+            'ext': 'mp4',
+            'title': 'That Time Disney Remade Beauty and the Beast',
+            'description': 'md5:2aae3c4cfc5ee09a1ecdff0909618cf4',
+            'upload_date': '20180731',
+            'timestamp': 1533009600,
+            'channel': 'Lindsay Ellis',
+            'channel_id': 'lindsayellis',
+            'uploader': 'Lindsay Ellis',
+            'uploader_id': 'lindsayellis',
+            'uploader_url': r're:https://nebula\.(tv|app)/lindsayellis',
+            'series': 'Lindsay Ellis',
+            'display_id': 'that-time-disney-remade-beauty-and-the-beast',
+            'channel_url': r're:https://nebula\.(tv|app)/lindsayellis',
+            'creator': 'Lindsay Ellis',
+            'duration': 2212,
+            'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
+            '_old_archive_ids': ['nebula 5c271b40b13fd613090034fd', 'nebulasubscriptions 5c271b40b13fd613090034fd'],
         },
-        {
-            'url': 'https://nebula.tv/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
-            'md5': 'd05739cf6c38c09322422f696b569c23',
-            'info_dict': {
-                'id': '7e623145-1b44-4ca3-aa0b-ed25a247ea34',
-                'ext': 'mp4',
-                'title': 'Landing Craft - How The Allies Got Ashore',
-                'description': r're:^In this episode we explore the unsung heroes of D-Day, the landing craft.',
-                'upload_date': '20200327',
-                'timestamp': 1585348140,
-                'channel': 'Real Engineering — The Logistics of D-Day',
-                'channel_id': 'd-day',
-                'uploader': 'Real Engineering — The Logistics of D-Day',
-                'uploader_id': 'd-day',
-                'series': 'Real Engineering — The Logistics of D-Day',
-                'display_id': 'the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
-                'creator': 'Real Engineering — The Logistics of D-Day',
-                'duration': 841,
-                'channel_url': 'https://nebula.tv/d-day',
-                'uploader_url': 'https://nebula.tv/d-day',
-                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
-                '_old_archive_ids': ['nebula 5e7e78171aaf320001fbd6be', 'nebulasubscriptions 5e7e78171aaf320001fbd6be'],
-            },
-            'params': {'skip_download': 'm3u8'},
+        'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://nebula.tv/videos/the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
+        'md5': 'd05739cf6c38c09322422f696b569c23',
+        'info_dict': {
+            'id': '7e623145-1b44-4ca3-aa0b-ed25a247ea34',
+            'ext': 'mp4',
+            'title': 'Landing Craft - How The Allies Got Ashore',
+            'description': r're:^In this episode we explore the unsung heroes of D-Day, the landing craft.',
+            'upload_date': '20200327',
+            'timestamp': 1585348140,
+            'channel': 'Real Engineering — The Logistics of D-Day',
+            'channel_id': 'd-day',
+            'uploader': 'Real Engineering — The Logistics of D-Day',
+            'uploader_id': 'd-day',
+            'series': 'Real Engineering — The Logistics of D-Day',
+            'display_id': 'the-logistics-of-d-day-landing-craft-how-the-allies-got-ashore',
+            'creator': 'Real Engineering — The Logistics of D-Day',
+            'duration': 841,
+            'channel_url': 'https://nebula.tv/d-day',
+            'uploader_url': 'https://nebula.tv/d-day',
+            'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
+            '_old_archive_ids': ['nebula 5e7e78171aaf320001fbd6be', 'nebulasubscriptions 5e7e78171aaf320001fbd6be'],
         },
-        {
-            'url': 'https://nebula.tv/videos/money-episode-1-the-draw',
-            'md5': 'ebe28a7ad822b9ee172387d860487868',
-            'info_dict': {
-                'id': 'b96c5714-9e2b-4ec3-b3f1-20f6e89cc553',
-                'ext': 'mp4',
-                'title': 'Episode 1: The Draw',
-                'description': r'contains:There’s free money on offer… if the players can all work together.',
-                'upload_date': '20200323',
-                'timestamp': 1584980400,
-                'channel': 'Tom Scott Presents: Money',
-                'channel_id': 'tom-scott-presents-money',
-                'uploader': 'Tom Scott Presents: Money',
-                'uploader_id': 'tom-scott-presents-money',
-                'uploader_url': 'https://nebula.tv/tom-scott-presents-money',
-                'duration': 825,
-                'channel_url': 'https://nebula.tv/tom-scott-presents-money',
-                'series': 'Tom Scott Presents: Money',
-                'display_id': 'money-episode-1-the-draw',
-                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
-                'creator': 'Tom Scott Presents: Money',
-                '_old_archive_ids': ['nebula 5e779ebdd157bc0001d1c75a', 'nebulasubscriptions 5e779ebdd157bc0001d1c75a'],
-            },
-            'params': {'skip_download': 'm3u8'},
+        'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://nebula.tv/videos/money-episode-1-the-draw',
+        'md5': 'ebe28a7ad822b9ee172387d860487868',
+        'info_dict': {
+            'id': 'b96c5714-9e2b-4ec3-b3f1-20f6e89cc553',
+            'ext': 'mp4',
+            'title': 'Episode 1: The Draw',
+            'description': r'contains:There’s free money on offer… if the players can all work together.',
+            'upload_date': '20200323',
+            'timestamp': 1584980400,
+            'channel': 'Tom Scott Presents: Money',
+            'channel_id': 'tom-scott-presents-money',
+            'uploader': 'Tom Scott Presents: Money',
+            'uploader_id': 'tom-scott-presents-money',
+            'uploader_url': 'https://nebula.tv/tom-scott-presents-money',
+            'duration': 825,
+            'channel_url': 'https://nebula.tv/tom-scott-presents-money',
+            'series': 'Tom Scott Presents: Money',
+            'display_id': 'money-episode-1-the-draw',
+            'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
+            'creator': 'Tom Scott Presents: Money',
+            '_old_archive_ids': ['nebula 5e779ebdd157bc0001d1c75a', 'nebulasubscriptions 5e779ebdd157bc0001d1c75a'],
         },
-        {
-            'url': 'https://watchnebula.com/videos/money-episode-1-the-draw',
-            'only_matching': True,
-        }, {
-            'url': 'https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
-            'info_dict': {
-                'id': 'e389af9d-1dab-44f2-8788-ee24deb7ff0d',
-                'ext': 'mp4',
-                'display_id': 'tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
-                'title': 'Did the US Really Blow Up the NordStream Pipelines?',
-                'description': 'md5:b4e2a14e3ff08f546a3209c75261e789',
-                'upload_date': '20230223',
-                'timestamp': 1677144070,
-                'channel': 'TLDR News EU',
-                'channel_id': 'tldrnewseu',
-                'uploader': 'TLDR News EU',
-                'uploader_id': 'tldrnewseu',
-                'uploader_url': r're:https://nebula\.(tv|app)/tldrnewseu',
-                'duration': 524,
-                'channel_url': r're:https://nebula\.(tv|app)/tldrnewseu',
-                'series': 'TLDR News EU',
-                'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
-                'creator': 'TLDR News EU',
-                '_old_archive_ids': ['nebula 63f64c74366fcd00017c1513', 'nebulasubscriptions 63f64c74366fcd00017c1513'],
-            },
-            'params': {'skip_download': 'm3u8'},
+        'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://watchnebula.com/videos/money-episode-1-the-draw',
+        'only_matching': True,
+    }, {
+        'url': 'https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
+        'info_dict': {
+            'id': 'e389af9d-1dab-44f2-8788-ee24deb7ff0d',
+            'ext': 'mp4',
+            'display_id': 'tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
+            'title': 'Did the US Really Blow Up the NordStream Pipelines?',
+            'description': 'md5:b4e2a14e3ff08f546a3209c75261e789',
+            'upload_date': '20230223',
+            'timestamp': 1677144070,
+            'channel': 'TLDR News EU',
+            'channel_id': 'tldrnewseu',
+            'uploader': 'TLDR News EU',
+            'uploader_id': 'tldrnewseu',
+            'uploader_url': r're:https://nebula\.(tv|app)/tldrnewseu',
+            'duration': 524,
+            'channel_url': r're:https://nebula\.(tv|app)/tldrnewseu',
+            'series': 'TLDR News EU',
+            'thumbnail': r're:https://\w+\.cloudfront\.net/[\w-]+',
+            'creator': 'TLDR News EU',
+            '_old_archive_ids': ['nebula 63f64c74366fcd00017c1513', 'nebulasubscriptions 63f64c74366fcd00017c1513'],
         },
-        {
-            'url': 'https://beta.nebula.tv/videos/money-episode-1-the-draw',
-            'only_matching': True,
-        },
-    ]
+        'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://beta.nebula.tv/videos/money-episode-1-the-draw',
+        'only_matching': True,
+    }]
 
     def _real_extract(self, url):
         slug = self._match_id(url)
@@ -239,24 +233,22 @@ class NebulaIE(NebulaBaseIE):
 
 class NebulaClassIE(NebulaBaseIE):
     _VALID_URL = rf'{_BASE_URL_RE}/(?P<id>[-\w]+)/(?P<ep>\d+)'
-    _TESTS = [
-        {
-            'url': 'https://nebula.tv/copyright-for-fun-and-profit/14',
-            'info_dict': {
-                'id': 'd7432cdc-c608-474d-942c-f74345daed7b',
-                'ext': 'mp4',
-                'display_id': '14',
-                'channel_url': 'https://nebula.tv/copyright-for-fun-and-profit',
-                'episode_number': 14,
-                'thumbnail': 'https://dj423fildxgac.cloudfront.net/d533718d-9307-42d4-8fb0-e283285e99c9',
-                'uploader_url': 'https://nebula.tv/copyright-for-fun-and-profit',
-                'duration': 646,
-                'episode': 'Episode 14',
-                'title': 'Photos, Sculpture, and Video',
-            },
-            'params': {'skip_download': 'm3u8'},
+    _TESTS = [{
+        'url': 'https://nebula.tv/copyright-for-fun-and-profit/14',
+        'info_dict': {
+            'id': 'd7432cdc-c608-474d-942c-f74345daed7b',
+            'ext': 'mp4',
+            'display_id': '14',
+            'channel_url': 'https://nebula.tv/copyright-for-fun-and-profit',
+            'episode_number': 14,
+            'thumbnail': 'https://dj423fildxgac.cloudfront.net/d533718d-9307-42d4-8fb0-e283285e99c9',
+            'uploader_url': 'https://nebula.tv/copyright-for-fun-and-profit',
+            'duration': 646,
+            'episode': 'Episode 14',
+            'title': 'Photos, Sculpture, and Video',
         },
-    ]
+        'params': {'skip_download': 'm3u8'},
+    }]
 
     def _real_extract(self, url):
         slug, episode = self._match_valid_url(url).group('id', 'ep')
@@ -281,15 +273,13 @@ class NebulaClassIE(NebulaBaseIE):
 class NebulaSubscriptionsIE(NebulaBaseIE):
     IE_NAME = 'nebula:subscriptions'
     _VALID_URL = rf'{_BASE_URL_RE}/(?P<id>myshows|library/latest-videos)'
-    _TESTS = [
-        {
-            'url': 'https://nebula.tv/myshows',
-            'playlist_mincount': 1,
-            'info_dict': {
-                'id': 'myshows',
-            },
+    _TESTS = [{
+        'url': 'https://nebula.tv/myshows',
+        'playlist_mincount': 1,
+        'info_dict': {
+            'id': 'myshows',
         },
-    ]
+    }]
 
     def _generate_playlist_entries(self):
         next_url = update_url_query('https://content.api.nebula.app/video_episodes/', {
@@ -316,41 +306,39 @@ class NebulaSubscriptionsIE(NebulaBaseIE):
 class NebulaChannelIE(NebulaBaseIE):
     IE_NAME = 'nebula:channel'
     _VALID_URL = rf'{_BASE_URL_RE}/(?!myshows|library|videos/)(?P<id>[-\w]+)/?(?:$|[?#])'
-    _TESTS = [
-        {
-            'url': 'https://nebula.tv/tom-scott-presents-money',
-            'info_dict': {
-                'id': 'tom-scott-presents-money',
-                'title': 'Tom Scott Presents: Money',
-                'description': 'Tom Scott hosts a series all about trust, negotiation and money.',
-            },
-            'playlist_count': 5,
-        }, {
-            'url': 'https://nebula.tv/lindsayellis',
-            'info_dict': {
-                'id': 'lindsayellis',
-                'title': 'Lindsay Ellis',
-                'description': 'Enjoy these hottest of takes on Disney, Transformers, and Musicals.',
-            },
-            'playlist_mincount': 2,
-        }, {
-            'url': 'https://nebula.tv/johnnyharris',
-            'info_dict': {
-                'id': 'johnnyharris',
-                'title': 'Johnny Harris',
-                'description': 'I make videos about maps and many other things.',
-            },
-            'playlist_mincount': 90,
-        }, {
-            'url': 'https://nebula.tv/copyright-for-fun-and-profit',
-            'info_dict': {
-                'id': 'copyright-for-fun-and-profit',
-                'title': 'Copyright for Fun and Profit',
-                'description': 'md5:6690248223eed044a9f11cd5a24f9742',
-            },
-            'playlist_count': 23,
-        }
-    ]
+    _TESTS = [{
+        'url': 'https://nebula.tv/tom-scott-presents-money',
+        'info_dict': {
+            'id': 'tom-scott-presents-money',
+            'title': 'Tom Scott Presents: Money',
+            'description': 'Tom Scott hosts a series all about trust, negotiation and money.',
+        },
+        'playlist_count': 5,
+    }, {
+        'url': 'https://nebula.tv/lindsayellis',
+        'info_dict': {
+            'id': 'lindsayellis',
+            'title': 'Lindsay Ellis',
+            'description': 'Enjoy these hottest of takes on Disney, Transformers, and Musicals.',
+        },
+        'playlist_mincount': 2,
+    }, {
+        'url': 'https://nebula.tv/johnnyharris',
+        'info_dict': {
+            'id': 'johnnyharris',
+            'title': 'Johnny Harris',
+            'description': 'I make videos about maps and many other things.',
+        },
+        'playlist_mincount': 90,
+    }, {
+        'url': 'https://nebula.tv/copyright-for-fun-and-profit',
+        'info_dict': {
+            'id': 'copyright-for-fun-and-profit',
+            'title': 'Copyright for Fun and Profit',
+            'description': 'md5:6690248223eed044a9f11cd5a24f9742',
+        },
+        'playlist_count': 23,
+    }]
 
     def _generate_playlist_entries(self, collection_id):
         next_url = f'https://content.api.nebula.app/video_channels/{collection_id}/video_episodes/?ordering=-published_at'

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -5,7 +5,9 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     format_field,
+    make_archive_id,
     parse_iso8601,
+    remove_start,
     smuggle_url,
     traverse_obj,
     unsmuggle_url,
@@ -70,8 +72,8 @@ class NebulaBaseIE(InfoExtractor):
     def _extract_video_metadata(self, episode):
         channel_url = format_field(episode, 'channel_slug', 'https://nebula.app/%s')
         return {
+            'id': remove_start(episode['id'], 'video_episode:'),
             **traverse_obj(episode, {
-                'id': 'zype_id',
                 'display_id': 'slug',
                 'title': 'title',
                 'description': 'description',
@@ -83,6 +85,7 @@ class NebulaBaseIE(InfoExtractor):
                 'uploader': 'channel_title',
                 'series': 'channel_title',
                 'creator': 'channel_title',
+                '_old_archive_ids': ('zype_id', {lambda x: [make_archive_id(NebulaIE, x)]}),
             }),
             'channel_url': channel_url,
             'uploader_url': channel_url,
@@ -172,7 +175,8 @@ class NebulaIE(NebulaBaseIE):
         }, {
             'url': 'https://nebula.tv/videos/tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
             'info_dict': {
-                'id': '63f64c74366fcd00017c1513',
+                'id': 'e389af9d-1dab-44f2-8788-ee24deb7ff0d',
+                'ext': 'mp4',
                 'display_id': 'tldrnewseu-did-the-us-really-blow-up-the-nordstream-pipelines',
                 'title': 'Did the US Really Blow Up the NordStream Pipelines?',
                 'description': 'md5:b4e2a14e3ff08f546a3209c75261e789',
@@ -188,7 +192,7 @@ class NebulaIE(NebulaBaseIE):
                 'series': 'TLDR News EU',
                 'thumbnail': r're:https?://.*\.jpeg',
                 'creator': 'TLDR News EU',
-                'ext': 'mp4',
+                '_old_archive_ids': ['nebula 63f64c74366fcd00017c1513'],
             },
             'params': {'skip_download': 'm3u8'},
         },

--- a/yt_dlp/extractor/nebula.py
+++ b/yt_dlp/extractor/nebula.py
@@ -85,7 +85,9 @@ class NebulaBaseIE(InfoExtractor):
                 'uploader': 'channel_title',
                 'series': 'channel_title',
                 'creator': 'channel_title',
-                '_old_archive_ids': ('zype_id', {lambda x: [make_archive_id(NebulaIE, x)]}),
+                # Old code was wrongly setting extractor_key from NebulaSubscriptionsIE
+                '_old_archive_ids': ('zype_id', {lambda x: [
+                    make_archive_id(NebulaIE, x), make_archive_id(NebulaSubscriptionsIE, x)]}),
             }),
             'channel_url': channel_url,
             'uploader_url': channel_url,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Built on top of https://github.com/yt-dlp/yt-dlp/pull/6538 and https://github.com/yt-dlp/yt-dlp/pull/6334.
In addition, adds support for classes, cookies, high quality AVC formats, better reauthorization, and updated API endpoints.

Fixes #7588, Fixes #4300, Fixes #5814


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 079920d</samp>

### Summary
🐛🎓🚀

<!--
1.  🐛 - This emoji represents the bug fix for the archive feature, as it is a common symbol for bugs or errors in software development.
2.  🎓 - This emoji represents the Nebula Class platform, as it is a common symbol for education, learning, or academic achievement.
3.  🚀 - This emoji represents the addition of a new extractor, as it is a common symbol for launching, deploying, or releasing new features or products.
-->
Add support for Nebula Class and fix archive bug. The pull request introduces a new extractor for `NebulaClassIE` and allows the `_old_archive_ids` field to be used in the test helper.

> _`_old_archive_ids`_
> _Fixing a bug in archive_
> _Winter of downloads_

### Walkthrough
*  Add support for Nebula Class platform ([link](https://github.com/yt-dlp/yt-dlp/pull/8566/files?diff=unified&w=0#diff-780b22dc7eb280f5a7b2bbf79aff17826de88ddcbf2fc1116ba19901827aa4e3R1233))
* Fix archive bug for videos with ignored prefixes ([link](https://github.com/yt-dlp/yt-dlp/pull/8566/files?diff=unified&w=0#diff-4dd682d5c858fe7d3f39400e3da7a0ea9e77232bab93c6d51e5cb523844665b2L217-R219))



</details>
