### PR TITLE
[extractor/twitcasting] Twitcasting Live webpage changed

### DIFF
--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -248,6 +248,7 @@ class TwitCastingLiveIE(InfoExtractor):
             'Pass "https://twitcasting.tv/{0}/show" to download the history'.format(uploader_id))
 
         webpage = self._download_webpage(url, uploader_id)
+        is_live = 'data-is-onlive="true"' in webpage
         current_live = self._search_regex(
             (r'data-type="movie" data-id="(\d+)">',
              r'tw-sound-flag-open-link" data-id="(\d+)" style=',

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -11,6 +11,7 @@ from ..utils import (
     float_or_none,
     get_element_by_class,
     get_element_by_id,
+    int_or_none,
     parse_duration,
     qualities,
     str_to_int,
@@ -252,11 +253,11 @@ class TwitCastingLiveIE(InfoExtractor):
         webpage = self._download_webpage(url, uploader_id)
         is_live = self._search_regex(  #  first pattern is for public live
             (r'(data-is-onlive="true")', _PROTECTED_LIVE_RE), webpage, 'is live?', default=None)
-        current_live = self._search_regex(
-            (r'data-type="movie" data-id="(\d+)">',  # no available?
-             r'tw-sound-flag-open-link" data-id="(\d+)" style=',  # no available?
-             r'data-movie-id="(\d+)"',),  # if uploader didn't have any live, data-movie-id="0"
-            webpage, 'current live ID', default=None)
+        current_live = int_or_none(self._search_regex(
+            (r'data-type="movie" data-id="(\d+)">',  # not available?
+             r'tw-sound-flag-open-link" data-id="(\d+)" style=',  # not available?
+             r'data-movie-id="(\d+)"'),  # if not currently live, value may be 0
+            webpage, 'current live ID', default=None))
         if is_live and not current_live:
             # fetch unfiltered /show to find running livestreams; we can't get ID of the password-protected livestream above
             webpage = self._download_webpage(
@@ -270,7 +271,7 @@ class TwitCastingLiveIE(InfoExtractor):
                     webpage, 'current live ID 2', default=None, group='video_id')
         if not current_live:
             raise UserNotLive(video_id=uploader_id)
-        return self.url_result('https://twitcasting.tv/%s/movie/%s' % (uploader_id, current_live))
+        return self.url_result(f'https://twitcasting.tv/{uploader_id}/movie/{current_live}', TwitCastingIE)
 
 
 class TwitCastingUserIE(InfoExtractor):

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -248,9 +248,6 @@ class TwitCastingLiveIE(InfoExtractor):
             'Pass "https://twitcasting.tv/{0}/show" to download the history'.format(uploader_id))
 
         webpage = self._download_webpage(url, uploader_id)
-        is_live = 'data-is-onlive="true"' in webpage
-        if not is_live:
-            raise UserNotLive(video_id=uploader_id)
         current_live = self._search_regex(
             (r'data-type="movie" data-id="(\d+)">',
              r'tw-sound-flag-open-link" data-id="(\d+)" style=',

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -249,13 +249,13 @@ class TwitCastingLiveIE(InfoExtractor):
 
         webpage = self._download_webpage(url, uploader_id)
         is_live = self._search_regex(
-            (r'(data-is-onlive="true")', # public live
-             r'(?s)(<span\s*class="tw-movie-thumbnail2-badge"\s*data-status="live">\s*LIVE)'), # protected live
+            (r'(data-is-onlive="true")',  # public live
+             r'(?s)(<span\s*class="tw-movie-thumbnail2-badge"\s*data-status="live">\s*LIVE)'),  # protected live
             webpage, 'is live?', default=None)
         current_live = self._search_regex(
-            (r'data-type="movie" data-id="(\d+)">', # no available?
-             r'tw-sound-flag-open-link" data-id="(\d+)" style=', # no available?
-             r'data-movie-id="(\d+)"',),
+            (r'data-type="movie" data-id="(\d+)">',  # no available?
+             r'tw-sound-flag-open-link" data-id="(\d+)" style=',  # no available?
+             r'data-movie-id="(\d+)"',),  # if uploader didn't have any live, data-movie-id="0"
             webpage, 'current live ID', default=None)
         if is_live and not current_live:
             # fetch unfiltered /show to find running livestreams; we can't get ID of the password-protected livestream above
@@ -268,7 +268,7 @@ class TwitCastingLiveIE(InfoExtractor):
                 current_live = self._search_regex(
                     r'(?s)<a\s+class="tw-movie-thumbnail2"\s*href="/[^/]+/movie/(?P<video_id>\d+)"\s*>.+?</a>',
                     webpage, 'current live ID 2', default=None, group='video_id')
-        if not current_live:
+        if not is_live:
             raise UserNotLive(video_id=uploader_id)
         return self.url_result('https://twitcasting.tv/%s/movie/%s' % (uploader_id, current_live))
 

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -251,8 +251,8 @@ class TwitCastingLiveIE(InfoExtractor):
             'Pass "https://twitcasting.tv/{0}/show" to download the history'.format(uploader_id))
 
         webpage = self._download_webpage(url, uploader_id)
-        is_live = self._search_regex(  #  first pattern is for public live
-            (r'(data-is-onlive="true")', _PROTECTED_LIVE_RE), webpage, 'is live?', default=None)
+        is_live = self._search_regex(  # first pattern is for public live
+            (r'(data-is-onlive="true")', self._PROTECTED_LIVE_RE), webpage, 'is live?', default=None)
         current_live = int_or_none(self._search_regex(
             (r'data-type="movie" data-id="(\d+)">',  # not available?
              r'tw-sound-flag-open-link" data-id="(\d+)" style=',  # not available?
@@ -263,7 +263,7 @@ class TwitCastingLiveIE(InfoExtractor):
             webpage = self._download_webpage(
                 f'https://twitcasting.tv/{uploader_id}/show/', uploader_id,
                 note='Downloading live history')
-            is_live = self._search_regex(_PROTECTED_LIVE_RE, webpage, 'is live?', default=None)
+            is_live = self._search_regex(self._PROTECTED_LIVE_RE, webpage, 'is live?', default=None)
             if is_live:
                 # get the first live; running live is always at the first
                 current_live = self._search_regex(

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -241,6 +241,8 @@ class TwitCastingLiveIE(InfoExtractor):
         'expected_exception': 'UserNotLive',
     }]
 
+    _PROTECTED_LIVE_RE = r'(?s)(<span\s*class="tw-movie-thumbnail2-badge"\s*data-status="live">\s*LIVE)'
+
     def _real_extract(self, url):
         uploader_id = self._match_id(url)
         self.to_screen(
@@ -248,10 +250,8 @@ class TwitCastingLiveIE(InfoExtractor):
             'Pass "https://twitcasting.tv/{0}/show" to download the history'.format(uploader_id))
 
         webpage = self._download_webpage(url, uploader_id)
-        is_live = self._search_regex(
-            (r'(data-is-onlive="true")',  # public live
-             r'(?s)(<span\s*class="tw-movie-thumbnail2-badge"\s*data-status="live">\s*LIVE)'),  # protected live
-            webpage, 'is live?', default=None)
+        is_live = self._search_regex(  #  first pattern is for public live
+            (r'(data-is-onlive="true")', _PROTECTED_LIVE_RE), webpage, 'is live?', default=None)
         current_live = self._search_regex(
             (r'data-type="movie" data-id="(\d+)">',  # no available?
              r'tw-sound-flag-open-link" data-id="(\d+)" style=',  # no available?
@@ -262,13 +262,13 @@ class TwitCastingLiveIE(InfoExtractor):
             webpage = self._download_webpage(
                 f'https://twitcasting.tv/{uploader_id}/show/', uploader_id,
                 note='Downloading live history')
-            is_live = self._search_regex(r'(?s)(<span\s*class="tw-movie-thumbnail2-badge"\s*data-status="live">\s*LIVE)', webpage, 'is live?', default=None)
+            is_live = self._search_regex(_PROTECTED_LIVE_RE, webpage, 'is live?', default=None)
             if is_live:
                 # get the first live; running live is always at the first
                 current_live = self._search_regex(
                     r'(?s)<a\s+class="tw-movie-thumbnail2"\s*href="/[^/]+/movie/(?P<video_id>\d+)"\s*>.+?</a>',
                     webpage, 'current live ID 2', default=None, group='video_id')
-        if not is_live:
+        if not current_live:
             raise UserNotLive(video_id=uploader_id)
         return self.url_result('https://twitcasting.tv/%s/movie/%s' % (uploader_id, current_live))
 

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -254,7 +254,7 @@ class TwitCastingLiveIE(InfoExtractor):
              r'tw-sound-flag-open-link" data-id="(\d+)" style=',
              r'data-movie-id="(\d+)"',),
             webpage, 'current live ID', default=None)
-        if not current_live:
+        if is_live and not current_live:
             # fetch unfiltered /show to find running livestreams; we can't get ID of the password-protected livestream above
             webpage = self._download_webpage(
                 f'https://twitcasting.tv/{uploader_id}/show/', uploader_id,

--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -263,7 +263,7 @@ class TwitCastingLiveIE(InfoExtractor):
                 note='Downloading live history')
             is_live = self._search_regex(
                 (r'(?s)(<span\s*class="tw-movie-thumbnail-badge"\s*data-status="live">\s*LIVE)',
-                 r'data-is-onlive="true"',),
+                 r'(data-is-onlive="true")'),
                 webpage, 'is live?', default=None)
             if is_live:
                 # get the first live; running live is always at the first


### PR DESCRIPTION
The old `_search_regex` in `TwitCastingLiveIE` is no longer available.

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

`r'data-type="movie" data-id="(\d+)">'`,
`r'tw-sound-flag-open-link" data-id="(\d+)" style='`,
`r'(?s)(<span\s*class="tw-movie-thumbnail-badge"\s*data-status="live">\s*LIVE)'` and
`r'(?s)<a\s+class="tw-movie-thumbnail"\s*href="/[^/]+/movie/(?P<video_id>\d+)"\s*>.+?</a>'` now no available in webpage.

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06c1eb6</samp>

### Summary
🐛🚨📺

<!--
1.  🐛 - This emoji represents a bug fix, as the previous regexes were not always accurate and could lead to false positives or negatives for live streams and offline users.
2.  🚨 - This emoji represents an improvement in error handling, as the extractor now raises a `ExtractorError` with a clear message when the user is offline or the stream is not found, instead of returning an empty playlist or a generic error.
3.  📺 - This emoji represents a feature related to live streams, as the extractor now uses the `data-is-onlive` and `data-movie-id` attributes to detect and extract live streams more reliably.
-->
Improve live stream extraction and error handling for `twitcasting` extractor. Use HTML attributes instead of regexes to get stream status and id.

> _Sing, O Muse, of the skillful `twitcasting` extractor_
> _That deftly discerns the live streams from the silent ones_
> _And gracefully handles the errors of offline users_
> _With attributes more trustworthy than the old regexes_

### Walkthrough
*  Add a check for the `data-is-onlive` attribute to determine the live status of the user ([link](https://github.com/yt-dlp/yt-dlp/pull/8574/files?diff=unified&w=0#diff-da40a341858d2a623c9ce4832d7be0117985c613125ccc6184b3e078f8251dd0L251-R257), [link](https://github.com/yt-dlp/yt-dlp/pull/8574/files?diff=unified&w=0#diff-da40a341858d2a623c9ce4832d7be0117985c613125ccc6184b3e078f8251dd0L260-R267))
*  Raise a `UserNotLive` exception if the user is not live, instead of returning an empty playlist ([link](https://github.com/yt-dlp/yt-dlp/pull/8574/files?diff=unified&w=0#diff-da40a341858d2a623c9ce4832d7be0117985c613125ccc6184b3e078f8251dd0L251-R257))
*  Add another regex to match the `data-movie-id` attribute as a possible source of the live ID ([link](https://github.com/yt-dlp/yt-dlp/pull/8574/files?diff=unified&w=0#diff-da40a341858d2a623c9ce4832d7be0117985c613125ccc6184b3e078f8251dd0L251-R257))



</details>
