### PR TITLE
[ie/beatbump] Add new domain and update tests

### DIFF
--- a/yt_dlp/extractor/beatbump.py
+++ b/yt_dlp/extractor/beatbump.py
@@ -3,14 +3,13 @@ from .youtube import YoutubeIE, YoutubeTabIE
 
 
 class BeatBumpVideoIE(InfoExtractor):
-    _VALID_URL = r'https://beatbump\.ml/listen\?id=(?P<id>[\w-]+)'
+    _VALID_URL = r'https://beatbump\.(?:ml|io)/listen\?id=(?P<id>[\w-]+)'
     _TESTS = [{
         'url': 'https://beatbump.ml/listen?id=MgNrAu2pzNs',
         'md5': '5ff3fff41d3935b9810a9731e485fe66',
         'info_dict': {
             'id': 'MgNrAu2pzNs',
             'ext': 'mp4',
-            'uploader_url': 'http://www.youtube.com/channel/UC-pWHpBjdGG69N9mM2auIAA',
             'artist': 'Stephen',
             'thumbnail': 'https://i.ytimg.com/vi_webp/MgNrAu2pzNs/maxresdefault.webp',
             'channel_url': 'https://www.youtube.com/channel/UC-pWHpBjdGG69N9mM2auIAA',
@@ -22,10 +21,9 @@ class BeatBumpVideoIE(InfoExtractor):
             'alt_title': 'Voyeur Girl',
             'view_count': int,
             'track': 'Voyeur Girl',
-            'uploader': 'Stephen - Topic',
+            'uploader': 'Stephen',
             'title': 'Voyeur Girl',
             'channel_follower_count': int,
-            'uploader_id': 'UC-pWHpBjdGG69N9mM2auIAA',
             'age_limit': 0,
             'availability': 'public',
             'live_status': 'not_live',
@@ -36,7 +34,12 @@ class BeatBumpVideoIE(InfoExtractor):
             'tags': 'count:11',
             'creator': 'Stephen',
             'channel_id': 'UC-pWHpBjdGG69N9mM2auIAA',
-        }
+            'channel_is_verified': True,
+            'heatmap': 'count:100',
+        },
+    }, {
+        'url': 'https://beatbump.io/listen?id=LDGZAprNGWo',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
@@ -45,7 +48,7 @@ class BeatBumpVideoIE(InfoExtractor):
 
 
 class BeatBumpPlaylistIE(InfoExtractor):
-    _VALID_URL = r'https://beatbump\.ml/(?:release\?id=|artist/|playlist/)(?P<id>[\w-]+)'
+    _VALID_URL = r'https://beatbump\.(?:ml|io)/(?:release\?id=|artist/|playlist/)(?P<id>[\w-]+)'
     _TESTS = [{
         'url': 'https://beatbump.ml/release?id=MPREb_gTAcphH99wE',
         'playlist_count': 50,
@@ -56,25 +59,28 @@ class BeatBumpPlaylistIE(InfoExtractor):
             'title': 'Album - Royalty Free Music Library V2 (50 Songs)',
             'description': '',
             'tags': [],
-            'modified_date': '20221223',
-        }
+            'modified_date': '20231110',
+        },
+        'expected_warnings': ['YouTube Music is not directly supported'],
     }, {
         'url': 'https://beatbump.ml/artist/UC_aEa8K-EOJ3D6gOs7HcyNg',
         'playlist_mincount': 1,
         'params': {'flatplaylist': True},
         'info_dict': {
             'id': 'UC_aEa8K-EOJ3D6gOs7HcyNg',
-            'uploader_url': 'https://www.youtube.com/channel/UC_aEa8K-EOJ3D6gOs7HcyNg',
+            'uploader_url': 'https://www.youtube.com/@NoCopyrightSounds',
             'channel_url': 'https://www.youtube.com/channel/UC_aEa8K-EOJ3D6gOs7HcyNg',
-            'uploader_id': 'UC_aEa8K-EOJ3D6gOs7HcyNg',
+            'uploader_id': '@NoCopyrightSounds',
             'channel_follower_count': int,
-            'title': 'NoCopyrightSounds - Videos',
+            'title': 'NoCopyrightSounds',
             'uploader': 'NoCopyrightSounds',
             'description': 'md5:cd4fd53d81d363d05eee6c1b478b491a',
             'channel': 'NoCopyrightSounds',
-            'tags': 'count:12',
+            'tags': 'count:65',
             'channel_id': 'UC_aEa8K-EOJ3D6gOs7HcyNg',
+            'channel_is_verified': True,
         },
+        'expected_warnings': ['YouTube Music is not directly supported'],
     }, {
         'url': 'https://beatbump.ml/playlist/VLPLRBp0Fe2GpgmgoscNFLxNyBVSFVdYmFkq',
         'playlist_mincount': 1,
@@ -84,16 +90,20 @@ class BeatBumpPlaylistIE(InfoExtractor):
             'uploader_url': 'https://www.youtube.com/@NoCopyrightSounds',
             'description': 'Providing you with copyright free / safe music for gaming, live streaming, studying and more!',
             'view_count': int,
-            'channel_url': 'https://www.youtube.com/@NoCopyrightSounds',
-            'uploader_id': 'UC_aEa8K-EOJ3D6gOs7HcyNg',
+            'channel_url': 'https://www.youtube.com/channel/UC_aEa8K-EOJ3D6gOs7HcyNg',
+            'uploader_id': '@NoCopyrightSounds',
             'title': 'NCS : All Releases 💿',
             'uploader': 'NoCopyrightSounds',
             'availability': 'public',
             'channel': 'NoCopyrightSounds',
             'tags': [],
-            'modified_date': '20221225',
+            'modified_date': '20231112',
             'channel_id': 'UC_aEa8K-EOJ3D6gOs7HcyNg',
-        }
+        },
+        'expected_warnings': ['YouTube Music is not directly supported'],
+    }, {
+        'url': 'https://beatbump.io/playlist/VLPLFCHGavqRG-q_2ZhmgU2XB2--ZY6irT1c',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Site changed from beatbump.ml to beatbump.io, probably due to .ml returning to mali from Freenom.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 73643b0</samp>

### Summary
🌐🎵🛠️

<!--
1.  🌐 - This emoji represents the support for multiple domains and the use of the BeatBump API to extract metadata.
2.  🎵 - This emoji represents the music and video content that the BeatBump website provides and that the extractor classes handle.
3.  🛠️ - This emoji represents the improvements and fixes that the updated classes offer, such as better error handling, playlist extraction, and thumbnail extraction.
-->
Improved BeatBump extractor to handle multiple domains and provide better metadata. Updated `beatbump.py` with new classes, tests, and warnings.



### Walkthrough
*  Update the `_VALID_URL` regexes for both `BeatBumpVideoIE` and `BeatBumpPlaylistIE` classes to support the `.ml` and `.io` domains and the different playlist types ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L6-R6), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L48-R51))
*  Remove the `uploader_url` field from the test case for `BeatBumpVideoIE`, as it is not relevant for the extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L13))
*  Add the `channel_is_verified` and `heatmap` fields to the test case for `BeatBumpVideoIE`, as they are new features of the yt-dlp extractor ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L39-R42))
*  Add a new test case for the `.io` domain for `BeatBumpVideoIE`, with the `only_matching` flag set to True ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L39-R42))
*  Update the `track`, `uploader`, `uploader_id`, `modified_date`, `uploader_url`, `title`, `tags`, `channel_url`, and `channel_is_verified` fields for the test cases for `BeatBumpPlaylistIE`, as they may differ from the YouTube values ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L25-R26), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L59-R64), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L67-R83), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L87-R94), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L94-R106))
*  Add the `expected_warnings` field to the test cases for `BeatBumpPlaylistIE`, as the extractor may emit a warning message that YouTube Music is not directly supported ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L59-R64), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L67-R83), [link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L94-R106))
*  Add a new test case for the `.io` domain for `BeatBumpPlaylistIE`, with the `only_matching` flag set to True ([link](https://github.com/yt-dlp/yt-dlp/pull/8576/files?diff=unified&w=0#diff-c3458a0dd42f4a8e4806d7107494d06deca6ac15ae5f17e268fef263c9d528d2L94-R106))



</details>
