### PR TITLE
[ie] Do not test truth value of `xml.etree.ElementTree.Element`

### DIFF
--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -1,8 +1,9 @@
-import re
-import json
 import base64
+import json
+import re
 import time
 import urllib.parse
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
 from ..compat import (
@@ -387,7 +388,7 @@ class CBCGemIE(InfoExtractor):
         url = re.sub(r'(Manifest\(.*?),format=[\w-]+(.*?\))', r'\1\2', base_url)
 
         secret_xml = self._download_xml(url, video_id, note='Downloading secret XML', fatal=False)
-        if not secret_xml:
+        if not isinstance(secret_xml, xml.etree.ElementTree.Element):
             return
 
         for child in secret_xml:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2225,7 +2225,9 @@ class InfoExtractor:
             mpd_url, video_id,
             note='Downloading MPD VOD manifest' if note is None else note,
             errnote='Failed to download VOD manifest' if errnote is None else errnote,
-            fatal=False, data=data, headers=headers, query=query) or {}
+            fatal=False, data=data, headers=headers, query=query)
+        if not isinstance(mpd_doc, xml.etree.ElementTree.Element):
+            return None
         return int_or_none(parse_duration(mpd_doc.get('mediaPresentationDuration')))
 
     @staticmethod

--- a/yt_dlp/extractor/mtv.py
+++ b/yt_dlp/extractor/mtv.py
@@ -1,4 +1,5 @@
 import re
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
 from ..compat import compat_str
@@ -137,7 +138,7 @@ class MTVServicesInfoExtractor(InfoExtractor):
         mediagen_doc = self._download_xml(
             mediagen_url, video_id, 'Downloading video urls', fatal=False)
 
-        if mediagen_doc is False:
+        if not isinstance(mediagen_doc, xml.etree.ElementTree.Element):
             return None
 
         item = mediagen_doc.find('./video/item')

--- a/yt_dlp/extractor/nbc.py
+++ b/yt_dlp/extractor/nbc.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import re
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
 from .theplatform import ThePlatformIE, default_ns
@@ -803,8 +804,10 @@ class NBCStationsIE(InfoExtractor):
             smil = self._download_xml(
                 f'https://link.theplatform.com/s/{pdk_acct}/{player_id}', video_id,
                 note='Downloading SMIL data', query=query, fatal=is_live)
-        subtitles = self._parse_smil_subtitles(smil, default_ns) if smil else {}
-        for video in smil.findall(self._xpath_ns('.//video', default_ns)) if smil else []:
+            if not isinstance(smil, xml.etree.ElementTree.Element):
+                smil = None
+        subtitles = self._parse_smil_subtitles(smil, default_ns) if smil is not None else {}
+        for video in smil.findall(self._xpath_ns('.//video', default_ns)) if smil is not None else []:
             info['duration'] = float_or_none(remove_end(video.get('dur'), 'ms'), 1000)
             video_src_url = video.get('src')
             ext = mimetype2ext(video.get('type'), default=determine_ext(video_src_url))

--- a/yt_dlp/extractor/slideslive.py
+++ b/yt_dlp/extractor/slideslive.py
@@ -1,5 +1,6 @@
 import re
 import urllib.parse
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
 from ..utils import (
@@ -469,11 +470,12 @@ class SlidesLiveIE(InfoExtractor):
             slides = self._download_xml(
                 player_info['slides_xml_url'], video_id, fatal=False,
                 note='Downloading slides XML', errnote='Failed to download slides info')
-            slide_url_template = 'https://cdn.slideslive.com/data/presentations/%s/slides/big/%s%s'
-            for slide_id, slide in enumerate(slides.findall('./slide') if slides else [], 1):
-                slides_info.append((
-                    slide_id, xpath_text(slide, './slideName', 'name'), '.jpg',
-                    int_or_none(xpath_text(slide, './timeSec', 'time'))))
+            if isinstance(slides, xml.etree.ElementTree.Element):
+                slide_url_template = 'https://cdn.slideslive.com/data/presentations/%s/slides/big/%s%s'
+                for slide_id, slide in enumerate(slides.findall('./slide')):
+                    slides_info.append((
+                        slide_id, xpath_text(slide, './slideName', 'name'), '.jpg',
+                        int_or_none(xpath_text(slide, './timeSec', 'time'))))
 
         chapters, thumbnails = [], []
         if url_or_none(player_info.get('thumbnail')):


### PR DESCRIPTION
Testing the truthiness of an `xml.etree.ElementTree.Element` instance is deprecated in py3.12

Refs:
- https://docs.python.org/3/library/xml.etree.elementtree.html#element-objects
- https://docs.python.org/3/whatsnew/3.12.html#pending-removal-in-python-3-14


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))


<!-- Do NOT edit/remove anything below this! -->
</details><details><summary>Copilot Summary</summary>  

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b8d5508</samp>

### Summary
🐛🧹🌐

<!--
1.  🐛 - This emoji represents a bug fix, which is what the first change does by preventing errors when the MPD download fails or returns an invalid response.
2.  🧹 - This emoji represents a cleanup or refactoring, which is what the second change does by sorting imports and handling XML errors in a more consistent way.
3.  🌐 - This emoji represents a web or network-related feature or improvement, which is what the third, fourth, and fifth changes do by adding XML parsing support and error handling for various online video platforms.
-->
Added XML parsing and error handling for various extractors that deal with XML-based formats or endpoints. Modified `common.py` to check for valid MPD responses before using them. Sorted imports in `cbc.py` for readability.

> _We parse the XML, we handle the errors_
> _We extract the formats from the web of terrors_
> _We defy the failures, we resist the invalid_
> _We are the InfoExtractors, we are the metal avid_

### Walkthrough
*  Add `xml.etree.ElementTree` module to parse XML responses from some CBC, MTV, NBC and SlidesLive endpoints ([link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-f0840207126abfbed9de8bbd0799354c8163c9d8924b24c8eb0bed3378fe6ceeL1-R6), [link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-170b237e5ae15340b8b6aae302f30b85bd4b59e85c365aab7290ea524ba0ce3bR2), [link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-db8d06cca3b41f67d5615e9bcf4c7f22a052e1d5a408d90a53c6579c7972ff9bR4), [link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-a020355958ec01ccfb8f2e16139d1245afdc10a8a660a893b2ad92bf217648e4R3))
  - `_find_secret_formats` in `CBCGemIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-f0840207126abfbed9de8bbd0799354c8163c9d8924b24c8eb0bed3378fe6ceeL390-R391))
  - `_extract_mpd_vod_duration` in `InfoExtractor` ([link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-b7f6633815316063666fc3ecebb970e68fdcb5ee01beba03d04c01830e55e8a6L2228-R2230))
  - `_get_video_info` in `MTVServicesInfoExtractor` ([link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-170b237e5ae15340b8b6aae302f30b85bd4b59e85c365aab7290ea524ba0ce3bL140-R141))
  - `_real_extract` in `NBCStationsIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-db8d06cca3b41f67d5615e9bcf4c7f22a052e1d5a408d90a53c6579c7972ff9bL806-R810))
  - `_real_extract` in `SlidesLiveIE` ([link](https://github.com/yt-dlp/yt-dlp/pull/8582/files?diff=unified&w=0#diff-a020355958ec01ccfb8f2e16139d1245afdc10a8a660a893b2ad92bf217648e4L472-R478))



</details>
