### PR TITLE
[rh:niquests] New network handler with HTTP2

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * yt-dlp tries to parse the external downloader outputs into the standard progress output if possible (Currently implemented: [~~aria2c~~](https://github.com/yt-dlp/yt-dlp/issues/5931)). You can use `--compat-options no-external-downloader-progress` to get the downloader output as-is
 * yt-dlp versions between 2021.09.01 and 2023.01.02 applies `--match-filter` to nested playlists. This was an unintentional side-effect of [8f18ac](https://github.com/yt-dlp/yt-dlp/commit/8f18aca8717bb0dd49054555af8d386e5eda3a88) and is fixed in [d7b460](https://github.com/yt-dlp/yt-dlp/commit/d7b460d0e5fc710950582baed2e3fc616ed98a80). Use `--compat-options playlist-match-filter` to revert this
 * yt-dlp versions between 2021.11.10 and 2023.06.21 estimated `filesize_approx` values for fragmented/manifest formats. This was added for convenience in [f2fe69](https://github.com/yt-dlp/yt-dlp/commit/f2fe69c7b0d208bdb1f6292b4ae92bc1e1a7444a), but was reverted in [0dff8e](https://github.com/yt-dlp/yt-dlp/commit/0dff8e4d1e6e9fb938f4256ea9af7d81f42fd54f) due to the potentially extreme inaccuracy of the estimated values. Use `--compat-options manifest-filesize-approx` to keep extracting the estimated values
-* yt-dlp uses modern http client backends such as `requests`. Use `--compat-options prefer-legacy-http-handler` to prefer the legacy http handler (`urllib`) to be used for standard http requests.
+* yt-dlp uses modern http client backends such as `niquests`. Use `--compat-options prefer-legacy-http-handler` to prefer the legacy http handler (`urllib`) to be used for standard http niquests.
 
 For ease of use, a few more compat options are available:
 
@@ -287,7 +287,7 @@ While all the other dependencies are optional, `ffmpeg` and `ffprobe` are highly
 * [**certifi**](https://github.com/certifi/python-certifi)\* - Provides Mozilla's root certificate bundle. Licensed under [MPLv2](https://github.com/certifi/python-certifi/blob/master/LICENSE)
 * [**brotli**](https://github.com/google/brotli)\* or [**brotlicffi**](https://github.com/python-hyper/brotlicffi) - [Brotli](https://en.wikipedia.org/wiki/Brotli) content encoding support. Both licensed under MIT <sup>[1](https://github.com/google/brotli/blob/master/LICENSE) [2](https://github.com/python-hyper/brotlicffi/blob/master/LICENSE) </sup>
 * [**websockets**](https://github.com/aaugustin/websockets)\* - For downloading over websocket. Licensed under [BSD-3-Clause](https://github.com/aaugustin/websockets/blob/main/LICENSE)
-* [**requests**](https://github.com/psf/requests)\* - HTTP library. For HTTPS proxy and persistent connections support. Licensed under [Apache-2.0](https://github.com/psf/requests/blob/main/LICENSE)
+* [**niquests**](https://github.com/jawah/niquests)\* - HTTP library. For HTTPS proxy and persistent connections support. Licensed under [Apache-2.0](https://github.com/jawah/niquests/blob/main/LICENSE)
 
 ### Metadata
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,5 @@ pycryptodomex
 websockets
 brotli; implementation_name=='cpython'
 brotlicffi; implementation_name!='cpython'
-certifi
-requests>=2.31.0,<3
-urllib3>=1.26.17,<3
+niquests>=3.3.0
 websockets>=12.0

--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -857,7 +857,7 @@ class TestRequestsRequestHandler(TestRequestHandlerBase):
         (lambda: urllib3.exceptions.DecodeError(), TransportError, None),
         (lambda: urllib3.exceptions.HTTPError(), TransportError, None),  # catch-all
         (
-            lambda: urllib3.exceptions.ProtocolError('error', http.client.IncompleteRead(partial=b'abc', expected=4)),
+            lambda: urllib3.exceptions.ProtocolError('error', urllib3.exceptions.IncompleteRead(partial="abc", expected=4)),
             IncompleteRead,
             '3 bytes read, 4 more expected'
         ),
@@ -869,8 +869,8 @@ class TestRequestsRequestHandler(TestRequestHandlerBase):
     ])
     @pytest.mark.parametrize('handler', ['Requests'], indirect=True)
     def test_response_error_mapping(self, handler, monkeypatch, raised, expected, match):
-        from requests.models import Response as RequestsResponse
         from urllib3.response import HTTPResponse as Urllib3Response
+        from niquests.models import Response as RequestsResponse
 
         from yt_dlp.networking._requests import RequestsResponseAdapter
         requests_res = RequestsResponse()

--- a/test/test_networking_utils.py
+++ b/test/test_networking_utils.py
@@ -17,7 +17,7 @@ import urllib.error
 import warnings
 
 from yt_dlp.cookies import YoutubeDLCookieJar
-from yt_dlp.dependencies import certifi
+from yt_dlp.dependencies import wassima
 from yt_dlp.networking import Response
 from yt_dlp.networking._helper import (
     InstanceStoreMixin,
@@ -93,10 +93,10 @@ class TestNetworkingUtils:
         with pytest.raises(ValueError, match='Unknown SOCKS proxy version: socks'):
             make_socks_proxy_opts('socks://127.0.0.1')
 
-    @pytest.mark.skipif(not certifi, reason='certifi is not installed')
+    @pytest.mark.skipif(not wassima, reason='wassima is not installed')
     def test_load_certifi(self):
         context_certifi = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        context_certifi.load_verify_locations(cafile=certifi.where())
+        context_certifi.load_verify_locations(cadata=wassima.generate_ca_bundle())
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_load_certs(context, use_certifi=True)
         assert context.get_ca_certs() == context_certifi.get_ca_certs()
@@ -108,7 +108,7 @@ class TestNetworkingUtils:
         assert context.get_ca_certs() == context_default.get_ca_certs()
 
         if context_default.get_ca_certs() == context_certifi.get_ca_certs():
-            pytest.skip('System uses certifi as default. The test is not valid')
+            pytest.skip('System uses wassima as default. The test is not valid')
 
     @pytest.mark.parametrize('method,status,expected', [
         ('GET', 303, 'GET'),

--- a/yt_dlp/__pyinstaller/hook-yt_dlp.py
+++ b/yt_dlp/__pyinstaller/hook-yt_dlp.py
@@ -22,10 +22,10 @@ def get_hidden_imports():
     yield from ('yt_dlp.utils._legacy', 'yt_dlp.utils._deprecated')
     yield pycryptodome_module()
     # Only `websockets` is required, others are collected just in case
-    for module in ('websockets', 'requests', 'urllib3'):
+    for module in ('websockets', 'niquests', 'urllib3'):
         yield from collect_submodules(module)
     # These are auto-detected, but explicitly add them just in case
-    yield from ('mutagen', 'brotli', 'certifi', 'secretstorage')
+    yield from ('mutagen', 'brotli', 'wassima', 'secretstorage')
 
 
 hiddenimports = list(get_hidden_imports())

--- a/yt_dlp/dependencies/__init__.py
+++ b/yt_dlp/dependencies/__init__.py
@@ -12,15 +12,9 @@ except ImportError:
 
 
 try:
-    import certifi
+    import wassima
 except ImportError:
-    certifi = None
-else:
-    from os.path import exists as _path_exists
-
-    # The certificate may not be bundled in executable
-    if not _path_exists(certifi.where()):
-        certifi = None
+    wassima = None
 
 
 try:
@@ -64,7 +58,7 @@ except ImportError:
     urllib3 = None
 
 try:
-    import requests
+    import niquests as requests
 except ImportError:
     requests = None
 

--- a/yt_dlp/networking/_helper.py
+++ b/yt_dlp/networking/_helper.py
@@ -10,7 +10,7 @@ import urllib.parse
 import urllib.request
 
 from .exceptions import RequestError, UnsupportedRequest
-from ..dependencies import certifi
+from ..dependencies import wassima
 from ..socks import ProxyType, sockssocket
 from ..utils import format_field, traverse_obj
 
@@ -21,8 +21,8 @@ if typing.TYPE_CHECKING:
 
 
 def ssl_load_certs(context: ssl.SSLContext, use_certifi=True):
-    if certifi and use_certifi:
-        context.load_verify_locations(cafile=certifi.where())
+    if wassima and use_certifi:
+        context.load_verify_locations(cadata=wassima.generate_ca_bundle())
     else:
         try:
             context.load_default_certs()


### PR DESCRIPTION
Hello fellow maintainers,

This PR is probably going to be unexpected, but bear with me until the end :+1: 

Recently, _yt-dlp_ made the decision to support _Requests_ as one of the supported network adapters via https://github.com/yt-dlp/yt-dlp/pull/3668
For understandable reasons, the participants almost wanted to try _another client_ instead.

Today, I may make you even more satisfied with that choice. :rocket:  Let me introduce you to a replacement candidate. [Niquests](https://github.com/jawah/niquests). It is a drop-in replacement for the former that is no longer under feature freeze.

There's a ton of pros, but amongst them, you'll find:

- Native OS Trust Store, Certifi is gone!
- HTTP/2, and HTTP/3
- No more Python httplib for HTTP/1.1
- Faster ~10 to 20% without multiplexed, still non-negligible
- Can leverage a multiplexed connection to get up to 3X faster throughput
- Resilient to most bot detector
- Better security
- More reliable and compliant to standards

This current PR does not leverage the multiplexed aspect of HTTP/2, and HTTP/3 because it does require a bit more work.
I am willing to give it a shot if, you (_yt-dlp_ team) are open to it. A multiplexed connection is important to leverage the protocol's capabilities.

Now, you can have multiple concurrent requests without ever needing threads, multiple connections, etc... Potentially linked to https://github.com/yt-dlp/yt-dlp/issues/1918

If you are open to thinking about this, I will guarantee the utmost standard and protection against regression with _yt-dlp_. We will be in close contact to make sure everything is fine.

I truly think that we have a unique opportunity to bootstrap something cool.

Regards,

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
