### PR TITLE
Fixed mediastream when hls uses extra arguments

### DIFF
--- a/yt_dlp/extractor/mediastream.py
+++ b/yt_dlp/extractor/mediastream.py
@@ -125,19 +125,19 @@ class MediaStreamIE(MediaStreamBaseIE):
                 src = player_config['src'][video_format]
                 params = {}
 
-                uid = self._search_regex(r'window\.MDSTRMUID\s*=\s*["\']([^"\']+)["\'];', webpage, 'uid', fatal = False, default = None)
+                uid = self._search_regex(r'window\.MDSTRMUID\s*=\s*["\']([^"\']+)["\'];', webpage, 'uid', fatal=False, default=None)
                 if uid:
                     params['uid'] = uid
 
-                sid = self._search_regex(r'window\.MDSTRMSID\s*=\s*["\']([^"\']+)["\'];', webpage, 'sid', fatal = False, default = None)
+                sid = self._search_regex(r'window\.MDSTRMSID\s*=\s*["\']([^"\']+)["\'];', webpage, 'sid', fatal=False, default=None)
                 if sid:
                     params['sid'] = sid
 
-                pid = self._search_regex(r'window\.MDSTRMPID\s*=\s*["\']([^"\']+)["\'];', webpage, 'pid', fatal = False, default = None)
+                pid = self._search_regex(r'window\.MDSTRMPID\s*=\s*["\']([^"\']+)["\'];', webpage, 'pid', fatal=False, default=None)
                 if pid:
                     params['pid'] = pid
 
-                version = self._search_regex(r'window\.VERSION\s*=\s*["\']([^"\']+)["\'];', webpage, 'version', fatal = False, default = None)
+                version = self._search_regex(r'window\.VERSION\s*=\s*["\']([^"\']+)["\'];', webpage, 'version', fatal=False, default=None)
                 if version:
                     params['at'] = 'web-app'
                     params['av'] = version

--- a/yt_dlp/extractor/mediastream.py
+++ b/yt_dlp/extractor/mediastream.py
@@ -149,7 +149,7 @@ class MediaStreamIE(MediaStreamBaseIE):
                         params['access_token'] = qs['access_token'][0]
 
                 if len(params):
-                    src = f"{src}?{urlencode(params)}"
+                    src = f'{src}?{urlencode(params)}'
 
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(src, video_id)
                 formats.extend(fmts)

--- a/yt_dlp/extractor/mediastream.py
+++ b/yt_dlp/extractor/mediastream.py
@@ -6,9 +6,9 @@ from ..utils import (
     remove_end,
     traverse_obj,
     urljoin,
+    parse_qs,
+    update_url_query
 )
-
-from urllib.parse import urlparse, urlencode, parse_qs
 
 
 class MediaStreamBaseIE(InfoExtractor):
@@ -122,36 +122,29 @@ class MediaStreamIE(MediaStreamBaseIE):
         formats, subtitles = [], {}
         for video_format in player_config['src']:
             if video_format == 'hls':
-                src = player_config['src'][video_format]
                 params = {}
 
-                uid = self._search_regex(r'window\.MDSTRMUID\s*=\s*["\']([^"\']+)["\'];', webpage, 'uid', fatal=False, default=None)
+                uid = self._search_regex(r'window\.MDSTRMUID\s*=\s*["\']([^"\']+)["\'];', webpage, 'uid', default=None)
                 if uid:
                     params['uid'] = uid
 
-                sid = self._search_regex(r'window\.MDSTRMSID\s*=\s*["\']([^"\']+)["\'];', webpage, 'sid', fatal=False, default=None)
+                sid = self._search_regex(r'window\.MDSTRMSID\s*=\s*["\']([^"\']+)["\'];', webpage, 'sid', default=None)
                 if sid:
                     params['sid'] = sid
 
-                pid = self._search_regex(r'window\.MDSTRMPID\s*=\s*["\']([^"\']+)["\'];', webpage, 'pid', fatal=False, default=None)
+                pid = self._search_regex(r'window\.MDSTRMPID\s*=\s*["\']([^"\']+)["\'];', webpage, 'pid', default=None)
                 if pid:
                     params['pid'] = pid
 
-                version = self._search_regex(r'window\.VERSION\s*=\s*["\']([^"\']+)["\'];', webpage, 'version', fatal=False, default=None)
+                version = self._search_regex(r'window\.VERSION\s*=\s*["\']([^"\']+)["\'];', webpage, 'version', default=None)
                 if version:
                     params['at'] = 'web-app'
                     params['av'] = version
 
-                parsed = urlparse(url)
-                if len(parsed.query) > 0:
-                    qs = parse_qs(parsed.query)
-                    if 'access_token' in qs and len(qs['access_token']) > 0:
-                        params['access_token'] = qs['access_token'][0]
+                if access_token := parse_qs(url).get('access_token', [None])[0]:
+                    params['access_token'] = access_token
 
-                if len(params):
-                    src = f'{src}?{urlencode(params)}'
-
-                fmts, subs = self._extract_m3u8_formats_and_subtitles(src, video_id)
+                fmts, subs = self._extract_m3u8_formats_and_subtitles(update_url_query(player_config['src'][video_format], params), video_id)
                 formats.extend(fmts)
                 self._merge_subtitles(subs, target=subtitles)
             elif video_format == 'mpd':


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fixes the mediastream extractor for sites that uses `access_token` or extra arguments in the HLS link.

The fix targets particularly to the iframe link of these two sites (the iframe link has to be extracted using the browser, it'll be the url passed to `yt-dlp`):

 - `https://www.tvn.cl/en-vivo`
 - `https://www.mega.cl/senal-en-vivo/`

These streams have a geo restriction and can only be accessed from Chile.

I have not made any new test, what would be the recommended way to test these changes?.

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
