### PR TITLE
[ie/naver] Fix video info extraction for now.naver.com/watch URLs

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1145,6 +1145,7 @@ from .naver import (
     NaverIE,
     NaverLiveIE,
     NaverNowIE,
+    NaverNowWatchIE
 )
 from .nba import (
     NBAWatchEmbedIE,

--- a/yt_dlp/extractor/naver.py
+++ b/yt_dlp/extractor/naver.py
@@ -15,6 +15,7 @@ from ..utils import (
     try_get,
     unified_timestamp,
     update_url_query,
+    unified_strdate,
 )
 
 
@@ -395,3 +396,117 @@ class NaverNowIE(NaverBaseIE):
         return self.playlist_result(
             itertools.chain(self._extract_show_replays(show_id), self._extract_show_highlights(show_id)),
             show_id, show_info.get('title'))
+
+
+class NaverNowWatchIE(NaverBaseIE):
+    IE_NAME = 'navernowwatch'
+    # Video ids seem to be exactly 12 characters for now but this hasn't been thoroughly tested
+    # so a wider id length is allowed here
+    _VALID_URL = r'https?://now\.naver\.com/watch/(?P<id>[0-9A-Za-z_-]{10,14})'
+    _API_URL = 'https://apis.naver.com/now_web2/now_web_api/v1/content'
+    _TESTS = [{
+        'url': 'https://now.naver.com/watch/ELt-oy2EfLHs',
+        'md5': 'f6dc239cc08d7ac0d4a3da0794442559',
+        'info_dict': {
+            'id': 'ELt-oy2EfLHs',
+            'title': '[NPOP EP.14] VIXX 외의 다른 건 Forget🌟 l 2023.11.29',
+            'ext': 'mp4',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'timestamp': 1701159669,
+            'upload_date': '20231128',
+            'uploader_id': 'npop',
+            'view_count': int,
+            # The channelUrl from the API is https://m.tv.naver.com/npop but this redirects to https://now.naver.com/s/npop
+            'uploader_url': 'https://m.tv.naver.com/npop',
+            'uploader': 'NPOP (엔팝)',
+            'duration': 1268,
+            'like_count': 186,
+            'description': '[NPOP EP.14] VIXX 외의 다른 건 Forget🌟 l 2023.11.29\r\n\r\nEP.14의 주인공 VIXX(빅스)!💙\r\n컴백한 VIXX의 우당탕탕 STAY N부터 무대장인 STAGE N까지!\r\n내 아티스트의 다양한 모습을 NPOP에서 함께하세요!\r\n\r\n_\r\n💿\"두 개의 공간, 하나로 연결된 우리\"\r\n아티스트와 팬이 함께 만들어가는 월간 K-POP 차트쇼✨\r\n\r\n온라인 팬들과 소통하며 진행되는 관찰형 리얼리티 STAY N과\r\n오프라인 팬들과 함께 만들어가는 무대 STAGE N\r\n두 개의 공간에서 이루어지는 K-POP 월간차트쇼 NAVER <NPOP>\r\n\r\nNPOP 스케줄\r\n📺 11/20(월) 8PM NPOP EP.12 (생방송)\r\n📺 11/22(수) 8PM NPOP EP.13\r\n📺 11/29(수) 8PM NPOP EP.14\r\n\r\n💙 NPOP 공식 채널 💙\r\nNaver: https://tv.naver.com/npop\r\nYouTube : https://www.youtube.com/@NPOP_OFFICIAL\r\nInstagram : https://www.instagram.com/npop_official/\r\nTwitter : https://twitter.com/NPOP_OFFICIAL'
+        },
+        'params': {
+            'noplaylist': True,
+        }
+    }, {
+        # https://now.naver.com/s/now.4759?shareReplayId=26331132#replay= now redirects to this url
+        'url': 'https://now.naver.com/watch/MLrCxZEjX8zE',
+        'md5': 'e05854162c21c221481de16b2944a0bc',
+        'info_dict': {
+            'id': 'MLrCxZEjX8zE',
+            'title': '아이키X노제💖꽁냥꽁냥💖(1)',
+            'ext': 'mp4',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'timestamp': 1650369600,
+            'upload_date': '20220419',
+            'uploader_id': 'now.4759',
+            'view_count': int,
+            'uploader_url': 'https://now.naver.com/s/now.4759',
+            'uploader': '아이키의 떰즈업',
+            'duration': 3173,
+            'like_count': 312,
+            "description": '본: 화요일 밤 9시\r\n재: 본방 직후, 수-일 오전 11시, 오후 7시\r\n\r\n📺 다시보기 📺\r\n본방이 끝난 후 최신 에피소드는 \"NOW.앱 > 쇼 홈 > 에피소드 탭\" 에서 감상하세요!\r\nhttps://bit.ly/3Nw0PNQ\r\n\r\n아이키X노제\r\n우리 그냥 사랑하게 해주세요\r\n\r\n노제여보단 소리 질러~~!\r\n드디어 떰즈업에 강림한\r\n노제여보!\r\n\r\n아이키X노제\r\n투샷존버단 모두 다 모여라!\r\n\r\n✔️ 아이키X노제\r\n꽁냥꽁냥 연애의 밤?\r\n✔️ 강혜인X노지혜\r\n케미라는 것이 폭발한다🔥\r\n\r\n노제의 생애 첫 댄스는 과연 무엇?\r\n당신이 알던 노제,\r\n상상 그 이상의 매력을 보게 될 것!\r\n\r\n오늘도 꿀잼 보장\r\n엄지 손가락 들고\r\n함께해주실 거죠?👍\r\n\r\n구독과 알림 설정.\r\n떰즈로👍 업~~~ 해놓는 거다?'
+        },
+        'params': {
+            'noplaylist': True,
+        }
+    }
+    ]
+
+    def _get_video_info_api_call_qs(self, api_url):
+        import time
+        import base64
+        import hashlib
+        import hmac
+
+        # key from https://now.naver.com/_next/static/chunks/pages/_app-c8bbb02b32a20c3d.js (search for 'md=')
+        key = b'nbxvs5nwNG9QKEWK0ADjYA4JZoujF4gHcIwvoCxFTPAeamq5eemvt5IWAYXxrbYM'
+
+        msgpad = int(time.time() * 1000)
+        # algorithm same as in yt_dlp/extractor/weverse.py::WeverseBaseIE._call_api
+        md = base64.b64encode(hmac.HMAC(
+            key, f'{api_url[:255]}{msgpad}'.encode(), digestmod=hashlib.sha1).digest()).decode()
+        qs = parse_qs(f'msgpad={msgpad}&md={md}')
+        return qs
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        qs = self._get_video_info_api_call_qs(api_url=f"{self._API_URL}/{video_id}")
+
+        video_info_response = self._download_json(
+            f'{self._API_URL}/{video_id}', video_id, query=qs,
+            note=f'Downloading JSON video info for video id {video_id}')
+
+        if not video_info_response:
+            raise ExtractorError('Got unexpected or empty video info JSON response.', expected=True)
+
+        video_info = traverse_obj(video_info_response, ('result', 'result'))
+        if not video_info:
+            raise ExtractorError('Got unexpected video info JSON data.', expected=True)
+
+        video_clip_info = traverse_obj(video_info, 'clip')
+        if not video_clip_info:
+            raise ExtractorError('Could not find video clip info with Naver CDN video id in video info JSON.', expected=True)
+
+        key = traverse_obj(video_info, ('play', 'inKey'))
+        if not key:
+            raise ExtractorError('Could not find API key in video info JSON.', expected=True)
+
+        vid = traverse_obj(video_clip_info, 'videoId')
+        if not vid:
+            raise ExtractorError('Could not find Naver CDN video id in video clip info.', expected=True)
+
+        info = self._extract_video_info(video_id, vid, key)
+
+        info.update({
+            'title': video_clip_info.get('title'),
+            # episodeStartDateTime seems to be the start time for a live stream and registerDateTime the end time
+            # registerDateTime seems to be the upload time for vods
+            'upload_date': unified_strdate(dict_get(video_clip_info, ('episodeStartDateTime', 'registerDateTime'))),
+            'timestamp': unified_timestamp(dict_get(video_clip_info, ('episodeStartDateTime', 'registerDateTime'))),
+            # channelId and channelUrl in the video_clip_info are not always accurate
+            'uploader_id': traverse_obj(video_info, ('channel', 'channelId')),
+            'uploader_url': traverse_obj(video_info, ('channel', 'channelUrl')),
+            'description': video_clip_info.get('description'),
+            'duration': traverse_obj(video_clip_info, 'playTime'),
+            'like_count': traverse_obj(video_clip_info, 'likeItCount')
+        })
+        return info

--- a/yt_dlp/extractor/naver.py
+++ b/yt_dlp/extractor/naver.py
@@ -420,8 +420,8 @@ class NaverNowWatchIE(NaverBaseIE):
             'uploader_url': 'https://m.tv.naver.com/npop',
             'uploader': 'NPOP (엔팝)',
             'duration': 1268,
-            'like_count': 186,
-            'description': '[NPOP EP.14] VIXX 외의 다른 건 Forget🌟 l 2023.11.29\r\n\r\nEP.14의 주인공 VIXX(빅스)!💙\r\n컴백한 VIXX의 우당탕탕 STAY N부터 무대장인 STAGE N까지!\r\n내 아티스트의 다양한 모습을 NPOP에서 함께하세요!\r\n\r\n_\r\n💿\"두 개의 공간, 하나로 연결된 우리\"\r\n아티스트와 팬이 함께 만들어가는 월간 K-POP 차트쇼✨\r\n\r\n온라인 팬들과 소통하며 진행되는 관찰형 리얼리티 STAY N과\r\n오프라인 팬들과 함께 만들어가는 무대 STAGE N\r\n두 개의 공간에서 이루어지는 K-POP 월간차트쇼 NAVER <NPOP>\r\n\r\nNPOP 스케줄\r\n📺 11/20(월) 8PM NPOP EP.12 (생방송)\r\n📺 11/22(수) 8PM NPOP EP.13\r\n📺 11/29(수) 8PM NPOP EP.14\r\n\r\n💙 NPOP 공식 채널 💙\r\nNaver: https://tv.naver.com/npop\r\nYouTube : https://www.youtube.com/@NPOP_OFFICIAL\r\nInstagram : https://www.instagram.com/npop_official/\r\nTwitter : https://twitter.com/NPOP_OFFICIAL'
+            'like_count': int,
+            'description': 'md5:f8b7df218f83ad0e9e941f0be949e832'
         },
         'params': {
             'noplaylist': True,
@@ -442,8 +442,8 @@ class NaverNowWatchIE(NaverBaseIE):
             'uploader_url': 'https://now.naver.com/s/now.4759',
             'uploader': '아이키의 떰즈업',
             'duration': 3173,
-            'like_count': 312,
-            "description": '본: 화요일 밤 9시\r\n재: 본방 직후, 수-일 오전 11시, 오후 7시\r\n\r\n📺 다시보기 📺\r\n본방이 끝난 후 최신 에피소드는 \"NOW.앱 > 쇼 홈 > 에피소드 탭\" 에서 감상하세요!\r\nhttps://bit.ly/3Nw0PNQ\r\n\r\n아이키X노제\r\n우리 그냥 사랑하게 해주세요\r\n\r\n노제여보단 소리 질러~~!\r\n드디어 떰즈업에 강림한\r\n노제여보!\r\n\r\n아이키X노제\r\n투샷존버단 모두 다 모여라!\r\n\r\n✔️ 아이키X노제\r\n꽁냥꽁냥 연애의 밤?\r\n✔️ 강혜인X노지혜\r\n케미라는 것이 폭발한다🔥\r\n\r\n노제의 생애 첫 댄스는 과연 무엇?\r\n당신이 알던 노제,\r\n상상 그 이상의 매력을 보게 될 것!\r\n\r\n오늘도 꿀잼 보장\r\n엄지 손가락 들고\r\n함께해주실 거죠?👍\r\n\r\n구독과 알림 설정.\r\n떰즈로👍 업~~~ 해놓는 거다?'
+            'like_count': int,
+            "description": 'md5:c508c32ae670c583e3ae5bb4f1824dbc'
         },
         'params': {
             'noplaylist': True,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Fixes #8224

Fix Naver Now downloads on their new `watch` pages, e.g. from tests: <https://now.naver.com/watch/ELt-oy2EfLHs> or <https://now.naver.com/watch/MLrCxZEjX8zE>.

The old extractor for `now.naver.com` platform in class `NaverNowIE`  does not seem to work for at least some URLs.

URLs like <https://now.naver.com/s/now.4759?shareReplayId=26331132#replay=> now redirect to <https://now.naver.com/watch/MLrCxZEjX8zE> so it may be possible to replace the old class. However, I did not invest too much in exploring the old URLs and APIs and this PR does not add support for downloading entire playlists or channels as was supported by the old extractor.

A new class `NaverNowWatchIE` was introduced to avoid complicating the regex and logic of  `NaverNowIE` which may still work in some scenarios that I haven't tested.

Some new metadata is now also available including `duration`, `like_count`, and `description`. Additionally, `channel_id` extraction is now more accurate.

Locally running the tests for `NaverNowWatchIE` seem to throw 401 errors sometimes when trying to fetch video info and I'm not sure of the cause. Perhaps a retry mechanism can be implemented. If so, I'd appreciate pointers on this code base's patterns for implementing retry for API calls.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
