### PR TITLE
Attempting to fix 503 error for ARDMediathek

### DIFF
--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -644,8 +644,7 @@ class ARDBetaMediathekIE(ARDMediathekBaseIE):
                 player_page = self._download_json(
                     f'https://api.ardmediathek.de/page-gateway/pages/ard/item/{video_id}', display_id, headers={
                         'Content-Type': 'application/json'
-                    }, note='Downloading fallback JSON metadata'
-                )
+                    }, note='Downloading fallback JSON metadata')
 
                 raw_player_page = player_page
                 player_page = try_get(player_page.get('widgets'), lambda x: x[0])


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR attempts to fix the 503 error  (described in issue #8731 ) which recently occurred while trying to download a video from ARDMediathek.
In my commit message, there is a typo, 513 was meant to be 503.
As this is my first PR on this project, please tell me if I did something wrong or whether something is missing.

Fixes #8731

The fix consists of two parts:

1. I've changed the API endpoint for JSON from "https://api.ardmediathek.de/public-gateway" to "https://api.ardmediathek.de/page-gateway/pages/ard/item/<video_id>". This is the endpoint which is now used by ARDMediathek's web player.
2. The new endpoint has a new JSON structure:
2.1 The relevant data is not encapsulated anymore and directly reachable from the JSON's root. The unboxing with  ['data']['playerPage'] is obsolete.
2.2 There now is a list of possible playback items in the field "widgets". The list item contains all the necessary metadata for playback, with the same structure as the old endpoint but with new fields like _width and _height for all formats. These new fields may be useful to improve the extractor, but aren't used in this fix.

For my fix I just take the first list item and use it's metadata. This isn't the best solution, but it works for now. As far as I can tell the list actually contains up to two metadata objects. 
The first one with the metadata of the desired video and the second one with the "Hörfassung (audio commentary)"-version for visually impaired people, if available.
This also reflects the changes in ARDMediathek's web player, as the audio commentary version is now switchable in the player, rather than being listed as a separate video entry on the page.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
