### PR TITLE
Embed thumbnail using mutagen for audio files, fix lyrics issue #5635

### DIFF
--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -90,12 +90,15 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         success = True
         if info['ext'] == 'mp3':
-            options = [
-                '-c', 'copy', '-map', '0:0', '-map', '1:0', '-write_id3v1', '1', '-id3v2_version', '3',
-                '-metadata:s:v', 'title="Album cover"', '-metadata:s:v', 'comment=Cover (front)']
-
-            self._report_run('ffmpeg', filename)
-            self.run_ffmpeg_multiple_files([filename, thumbnail_filename], temp_filename, options)
+            # Using ffmpeg to embed the thumbnail in mp3 files is messing up lyrics
+            # Using using mutagen instead
+            audio = mutagen.id3.ID3(filename)
+            if 'APIC' in audio:del audio['APIC']
+            with open(thumbnail_filename, 'rb') as thumbfile:
+                audio['APIC'] = mutagen.id3.APIC(
+                    encoding=3, mime='image/%s' % thumbnail_ext, type=3,
+                    desc=u'Cover (front)', data=thumbfile.read())
+            audio.save()
 
         elif info['ext'] in ['mkv', 'mka']:
             options = list(self.stream_copy_opts())
@@ -215,7 +218,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         else:
             raise EmbedThumbnailPPError('Supported filetypes for thumbnail embedding are: mp3, mkv/mka, ogg/opus/flac, m4a/mp4/m4v/mov')
 
-        if success and temp_filename != filename:
+        if info['ext']!='mp3' and success and temp_filename != filename:
             os.replace(temp_filename, filename)
 
         self.try_utime(filename, mtime, mtime)

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -585,7 +585,7 @@ class FFmpegVideoRemuxerPP(FFmpegVideoConvertorPP):
 
 
 class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
-    AUDIO_EXTS = ('mp3','m4a','flac','opus','acc')
+    AUDIO_EXTS = ('mp3','m4a','flac','opus')
     SUPPORTED_EXTS = ('mp4', 'mov', 'm4a', 'webm', 'mkv', 'mka')
 
     def __init__(self, downloader=None, already_have_subtitle=False):
@@ -671,7 +671,7 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
         audio_file = input_files[0]
         subs = input_files[1]
         if not subs.endswith('.lrc'):
-            self.report_error('LRC subtitles required. Use "--convert-subs lrc" to convert')
+            raise PostProcessingError('LRC subtitles required. Use "--convert-subs lrc" to convert')
         else:
             with open(subs, 'r', encoding='utf-8') as f:
                 lyrics=f.read().strip()


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

### Purpose: Fixes [issue #5635](https://github.com/yt-dlp/yt-dlp/issues/5635)
### Examples: 

 - `yt-dlp --audio-format mp3  --extract-audio --embed-subs --convert-subs lrc --embed-thumbnail https://youtu.be/TU2g0bTNTCc?si=TO_NrOr2zlFsZSjJ `
 - `yt-dlp --audio-format m4a  --extract-audio --embed-subs --convert-subs lrc https://youtu.be/TU2g0bTNTCc?si=TO_NrOr2zlFsZSjJ`

### Description:

 - added lyrics support for mp3, m4a, flac and opus
 - for mp3 using ffmpeg to embed thumbnail with lyrics was not working, so used mutagen instead


Fixes [issue #5635](https://github.com/yt-dlp/yt-dlp/issues/5635)



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
