### PR TITLE
[extractor/hidive] Fetch all subtitles

### DIFF
--- a/yt_dlp/extractor/hidive.py
+++ b/yt_dlp/extractor/hidive.py
@@ -70,14 +70,13 @@ class HiDiveIE(InfoExtractor):
 
     def _get_preferred_content_language(self):
         profile_html = self._download_webpage('https://www.hidive.com/profile/edit', None,
-            'Fetching user profile information')
+                                              'Fetching user profile information')
 
         lang_select_html = get_element_by_id('UserProfile_Language', profile_html)
         if not lang_select_html:
             return None
 
-        selected_lang_option = get_element_html_by_attribute('selected', 'selected',
-            lang_select_html, tag='option')
+        selected_lang_option = get_element_html_by_attribute('selected', 'selected', lang_select_html, tag='option')
         if not selected_lang_option:
             return None
 

--- a/yt_dlp/extractor/hidive.py
+++ b/yt_dlp/extractor/hidive.py
@@ -4,6 +4,7 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     int_or_none,
+    traverse_obj,
     try_get,
     url_or_none,
     urlencode_postdata,
@@ -101,7 +102,9 @@ class HiDiveIE(InfoExtractor):
                 cc_lang = try_get(cc_file, (lambda x: x[1].replace(' ', '-').lower(), lambda x: x[0]), str)
                 if cc_url not in parsed_urls and cc_lang:
                     parsed_urls.add(cc_url)
-                    subtitles.setdefault(cc_lang, []).append({'url': cc_url, 'name': cc_file[1]})
+                    subtitles.setdefault(cc_lang, []).append(
+                        {'url': cc_url, 'name': traverse_obj(cc_file, 1, expected_type=str)}
+                    )
 
     def _real_extract(self, url):
         video_id, title, key = self._match_valid_url(url).group('id', 'title', 'key')

--- a/yt_dlp/extractor/hidive.py
+++ b/yt_dlp/extractor/hidive.py
@@ -3,9 +3,6 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
-    extract_attributes,
-    get_element_by_id,
-    get_element_html_by_attribute,
     int_or_none,
     traverse_obj,
     try_get,
@@ -68,27 +65,6 @@ class HiDiveIE(InfoExtractor):
                 'returnUrl': '/dashboard'
             }))
 
-    def _get_preferred_content_language(self):
-        profile_html = self._download_webpage('https://www.hidive.com/profile/edit', None,
-                                              'Fetching user profile information')
-
-        lang_select_html = get_element_by_id('UserProfile_Language', profile_html)
-        if not lang_select_html:
-            return None
-
-        selected_lang_option = get_element_html_by_attribute('selected', 'selected', lang_select_html, tag='option')
-        if not selected_lang_option:
-            return None
-
-        return extract_attributes(selected_lang_option).get('value')
-
-    def _real_initialize(self):
-        self._preferred_content_language = self._get_preferred_content_language()
-        self.write_debug(f'Preferred content language: {self._preferred_content_language}')
-
-        if not self._preferred_content_language:
-            self.report_warning('Failed to determine preferred content language, format sorting might be incorrect')
-
     def _call_api(self, video_id, title, key, data={}, **kwargs):
         data = {
             **data,
@@ -117,7 +93,6 @@ class HiDiveIE(InfoExtractor):
                     m3u8_url, video_id, 'mp4', entry_protocol='m3u8_native', m3u8_id=rendition_id, fatal=False)
                 for f in frmt:
                     f['language'] = audio
-                    f['language_preference'] = 10 if audio == self._preferred_content_language else -1
                     f['format_note'] = f'{version}, {extra}'
                 formats.extend(frmt)
 

--- a/yt_dlp/extractor/hidive.py
+++ b/yt_dlp/extractor/hidive.py
@@ -3,6 +3,9 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    extract_attributes,
+    get_element_by_id,
+    get_element_html_by_attribute,
     int_or_none,
     traverse_obj,
     try_get,
@@ -65,6 +68,28 @@ class HiDiveIE(InfoExtractor):
                 'returnUrl': '/dashboard'
             }))
 
+    def _get_preferred_content_language(self):
+        profile_html = self._download_webpage('https://www.hidive.com/profile/edit', None,
+            'Fetching user profile information')
+
+        lang_select_html = get_element_by_id('UserProfile_Language', profile_html)
+        if not lang_select_html:
+            return None
+
+        selected_lang_option = get_element_html_by_attribute('selected', 'selected',
+            lang_select_html, tag='option')
+        if not selected_lang_option:
+            return None
+
+        return extract_attributes(selected_lang_option).get('value')
+
+    def _real_initialize(self):
+        self._preferred_content_language = self._get_preferred_content_language()
+        self.write_debug(f'Preferred content language: {self._preferred_content_language}')
+
+        if not self._preferred_content_language:
+            self.report_warning('Failed to determine preferred content language, format sorting might be incorrect')
+
     def _call_api(self, video_id, title, key, data={}, **kwargs):
         data = {
             **data,
@@ -93,6 +118,7 @@ class HiDiveIE(InfoExtractor):
                     m3u8_url, video_id, 'mp4', entry_protocol='m3u8_native', m3u8_id=rendition_id, fatal=False)
                 for f in frmt:
                     f['language'] = audio
+                    f['language_preference'] = 10 if audio == self._preferred_content_language else -1
                     f['format_note'] = f'{version}, {extra}'
                 formats.extend(frmt)
 


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR fixes #6724, which manifests in the HIDIVE extractor only seeing a single subtitle language (in my case Spanish):

```
% ./yt-dlp.sh --cookies cookies.txt --list-subs -F https://www.hidive.com/stream/the-eminence-in-shadow/s01e001
[HiDive] Extracting URL: https://www.hidive.com/stream/the-eminence-in-shadow/s01e001
[HiDive] the-eminence-in-shadow/s01e001: Downloading JSON metadata
[HiDive] the-eminence-in-shadow/s01e001: Downloading m3u8 information
[HiDive] the-eminence-in-shadow/s01e001: Downloading m3u8 information
[info] Available subtitles for the-eminence-in-shadow/s01e001:
Language           Formats
spanish-latam-subs vtt
[info] Available formats for the-eminence-in-shadow/s01e001:
ID            EXT RESOLUTION │   TBR PROTO │ VCODEC      ACODEC    MORE INFO
──────────────────────────────────────────────────────────────────────────────
ja_br_or-1490 mp4 640x360    │ 1490k m3u8  │ avc1.4d001e mp4a.40.2 [ja] br, or
en_br_or-1491 mp4 640x360    │ 1491k m3u8  │ avc1.4d001e mp4a.40.2 [en] br, or
en_br_or-2176 mp4 854x480    │ 2176k m3u8  │ avc1.4d001f mp4a.40.2 [en] br, or
ja_br_or-2176 mp4 854x480    │ 2176k m3u8  │ avc1.4d001f mp4a.40.2 [ja] br, or
ja_br_or-3625 mp4 1280x720   │ 3625k m3u8  │ avc1.640029 mp4a.40.2 [ja] br, or
en_br_or-3626 mp4 1280x720   │ 3626k m3u8  │ avc1.640029 mp4a.40.2 [en] br, or
en_br_or-6466 mp4 1920x1080  │ 6466k m3u8  │ avc1.640029 mp4a.40.2 [en] br, or
ja_br_or-6466 mp4 1920x1080  │ 6466k m3u8  │ avc1.640029 mp4a.40.2 [ja] br, or
```

This PR makes the extractor fetch information for all the available subtitles.

With the fix, all subtitles are now extracted:

```
% ./yt-dlp.sh --cookies cookies.txt --list-subs -F https://www.hidive.com/stream/the-eminence-in-shadow/s01e001
[HiDive] Extracting URL: https://www.hidive.com/stream/the-eminence-in-shadow/s01e001
[HiDive] the-eminence-in-shadow/s01e001: Fetching subtitle languages
[HiDive] the-eminence-in-shadow/s01e001: Downloading JSON metadata
[HiDive] the-eminence-in-shadow/s01e001: Downloading JSON metadata
[HiDive] the-eminence-in-shadow/s01e001: Downloading JSON metadata
[HiDive] the-eminence-in-shadow/s01e001: Downloading JSON metadata
[HiDive] the-eminence-in-shadow/s01e001: Downloading m3u8 information
[HiDive] the-eminence-in-shadow/s01e001: Downloading m3u8 information
[info] Available subtitles for the-eminence-in-shadow/s01e001:
Language           Name               Formats
portuguese-subs    Portuguese Subs    vtt
spanish-latam-subs Spanish LatAm Subs vtt
english-subs       English Subs       vtt
english-caps       English Caps       vtt
[info] Available formats for the-eminence-in-shadow/s01e001:
ID            EXT RESOLUTION │   TBR PROTO │ VCODEC      ACODEC    MORE INFO
──────────────────────────────────────────────────────────────────────────────
ja_br_or-1490 mp4 640x360    │ 1490k m3u8  │ avc1.4d001e mp4a.40.2 [ja] br, or
en_br_or-1491 mp4 640x360    │ 1491k m3u8  │ avc1.4d001e mp4a.40.2 [en] br, or
en_br_or-2176 mp4 854x480    │ 2176k m3u8  │ avc1.4d001f mp4a.40.2 [en] br, or
ja_br_or-2176 mp4 854x480    │ 2176k m3u8  │ avc1.4d001f mp4a.40.2 [ja] br, or
ja_br_or-3625 mp4 1280x720   │ 3625k m3u8  │ avc1.640029 mp4a.40.2 [ja] br, or
en_br_or-3626 mp4 1280x720   │ 3626k m3u8  │ avc1.640029 mp4a.40.2 [en] br, or
en_br_or-6466 mp4 1920x1080  │ 6466k m3u8  │ avc1.640029 mp4a.40.2 [en] br, or
ja_br_or-6466 mp4 1920x1080  │ 6466k m3u8  │ avc1.640029 mp4a.40.2 [ja] br, or
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
