### PR TITLE
[KukuluLive] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -899,6 +899,7 @@ from .koo import KooIE
 from .kth import KTHIE
 from .krasview import KrasViewIE
 from .ku6 import Ku6IE
+from .kukululive import KukuluLiveIE
 from .kusi import KUSIIE
 from .kuwo import (
     KuwoIE,

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -48,8 +48,7 @@ class KukuluLiveIE(InfoExtractor):
     }]
 
     def _get_quality_meta(self, video_id, desc, code, force_h264=None):
-        if force_h264:
-            desc += ' (force_h264)'
+        desc += ' (force_h264)' if force_h264 else ''
         qs = self._download_webpage(
             'https://live.erinn.biz/live.player.fplayer.php', video_id,
             f'Downloading {desc} quality metadata', f'Unable to download {desc} quality metadata',

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -1,0 +1,103 @@
+from .common import InfoExtractor
+from ..utils import ExtractorError
+from ..compat import compat_parse_qs
+
+
+class KukuluLiveIE(InfoExtractor):
+    _VALID_URL = r'https?://live\.erinn\.biz/live\.php\?h(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://live.erinn.biz/live.php?h675134569',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        html = self._download_webpage(
+            url, video_id,
+            note='Downloading html',
+            errnote='Unable to download html'
+        )
+
+        # https://regex101.com/r/SNbBwa/1
+        title = self._search_regex(r'<SPAN id=\"livetitle\">([^<]+)</SPAN>', html, 'title', fatal=False)
+        description = self._html_search_meta('Description', html)
+        thumbnail_url = self._html_search_meta(['og:image', 'twitter:image'], html)
+        thumbnails = [{'url': thumbnail_url}]
+
+        is_live_stream = 'var timeshift = false;' in html
+        is_vod = 'var timeshift = true;' in html
+
+        if is_live_stream:
+            qualities = [
+                ('hevc', 'getForceLowliveByAjax'),
+                ('h264', 'getZliveByAjax'),
+            ]
+            formats = []
+            for (codec, action) in qualities:
+                qs = self._download_webpage(
+                    'https://live.erinn.biz/live.player.fplayer.php', video_id,
+                    query={'hash': video_id, 'action': action},
+                    note=f'Downloading {codec} metadata',
+                    errnote=f'Unable to download {codec} metadata'
+                )
+                quality_meta = compat_parse_qs(qs)
+                vcodec = quality_meta.get('vcodec')[0]
+                quality = quality_meta.get('now_quality')[0]
+                formats.append({
+                    'format_id': quality,
+                    'url': quality_meta.get('hlsaddr')[0],
+                    'ext': 'mp4',
+                    'vcodec': vcodec,
+                })
+                formats.append({
+                    'format_id': f'{quality}-audioonly',
+                    'url': quality_meta.get('hlsaddr_audioonly')[0],
+                    'ext': 'aac',
+                    'vcodec': 'none',
+                })
+                formats.append({
+                    'format_id': f'{quality}-rtmp',
+                    'url': quality_meta.get('streamaddr')[0],
+                    'ext': 'mp4',
+                    'vcodec': 'vcodec',
+                })
+
+            return {
+                'id': str(video_id),
+                'title': title,
+                'description': description,
+                'thumbnails': thumbnails,
+                'is_live': True,
+                'formats': formats,
+            }
+
+        if is_vod:
+            player_html = self._download_webpage(
+                'https://live.erinn.biz/live.timeshift.fplayer.php', video_id,
+                query={'hash': video_id},
+                note='Downloading player html',
+                errnote='Unable to download player html'
+            )
+
+            # https://regex101.com/r/3AXpSA/3
+            sources = self._search_regex(r'var fplayer_source = ([^;]+)', player_html, 'sources')
+            sources_json = self._parse_json(sources.replace('.mp4",', '.mp4"'), video_id)
+
+            formats = []
+            for source in sources_json:
+                formats.append({
+                    'url': f'https://live.erinn.biz{source.get('file')}',
+                    'ext': 'mp4',
+                    'protocol': 'm3u8_native',
+                })
+
+            return {
+                'id': str(video_id),
+                'title': title,
+                'description': description,
+                'timestamp': sources_json[0].get('time_start'),
+                'thumbnails': thumbnails,
+                'formats': formats,
+            }
+
+        raise ExtractorError('Cannot parse live stream or VOD', expected=True)

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -10,6 +10,52 @@ class KukuluLiveIE(InfoExtractor):
         'only_matching': True,
     }]
 
+    def _get_quality_meta(self, video_id, desc, code, force_h264=''):
+        description = desc if force_h264 == '' else f'{desc} (force_h264)'
+        qs = self._download_webpage(
+            'https://live.erinn.biz/live.player.fplayer.php', video_id,
+            query={
+                'hash': video_id,
+                'action': f'get{code}liveByAjax',
+                'force_h264': force_h264,
+            },
+            note=f'Downloading {description} quality metadata',
+            errnote=f'Unable to download {description} quality metadata'
+        )
+        return compat_parse_qs(qs)
+
+    def _add_quality_formats(self, formats, quality_meta):
+        vcodec = quality_meta.get('vcodec')[0]
+        quality = quality_meta.get('now_quality')[0]
+        quality_priority = {
+            'high': 3,
+            'h264': 2,
+            'low': 1,
+        }
+        formats.extend([
+            {
+                'format_id': quality,
+                'url': quality_meta.get('hlsaddr')[0],
+                'ext': 'mp4',
+                'vcodec': vcodec,
+                'quality': quality_priority[quality],
+            },
+            {
+                'format_id': f'{quality}-rtmp',
+                'url': quality_meta.get('streamaddr')[0],
+                'ext': 'mp4',
+                'vcodec': vcodec,
+                'quality': quality_priority[quality] - 5,
+            },
+            {
+                'format_id': f'{quality}-audioonly',
+                'url': quality_meta.get('hlsaddr_audioonly')[0],
+                'ext': 'aac',
+                'vcodec': 'none',
+                'quality': quality_priority[quality] - 10,
+            },
+        ])
+
     def _real_extract(self, url):
         video_id = self._match_id(url)
         html = self._download_webpage(
@@ -29,38 +75,16 @@ class KukuluLiveIE(InfoExtractor):
 
         if is_live_stream:
             qualities = [
-                ('hevc', 'getForceLowliveByAjax'),
-                ('h264', 'getZliveByAjax'),
+                ('high', 'Z'),
+                ('low', 'ForceLow'),
             ]
             formats = []
-            for (codec, action) in qualities:
-                qs = self._download_webpage(
-                    'https://live.erinn.biz/live.player.fplayer.php', video_id,
-                    query={'hash': video_id, 'action': action},
-                    note=f'Downloading {codec} metadata',
-                    errnote=f'Unable to download {codec} metadata'
-                )
-                quality_meta = compat_parse_qs(qs)
-                vcodec = quality_meta.get('vcodec')[0]
-                quality = quality_meta.get('now_quality')[0]
-                formats.append({
-                    'format_id': quality,
-                    'url': quality_meta.get('hlsaddr')[0],
-                    'ext': 'mp4',
-                    'vcodec': vcodec,
-                })
-                formats.append({
-                    'format_id': f'{quality}-audioonly',
-                    'url': quality_meta.get('hlsaddr_audioonly')[0],
-                    'ext': 'aac',
-                    'vcodec': 'none',
-                })
-                formats.append({
-                    'format_id': f'{quality}-rtmp',
-                    'url': quality_meta.get('streamaddr')[0],
-                    'ext': 'mp4',
-                    'vcodec': 'vcodec',
-                })
+            for (desc, code) in qualities:
+                quality_meta = self._get_quality_meta(video_id, desc, code)
+                self._add_quality_formats(formats, quality_meta)
+                if desc == 'high' and quality_meta.get('vcodec')[0] == 'HEVC':
+                    h264_meta = self._get_quality_meta(video_id, desc, code, force_h264='1')
+                    self._add_quality_formats(formats, h264_meta)
 
             return {
                 'id': str(video_id),

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -88,7 +88,7 @@ class KukuluLiveIE(InfoExtractor):
         description = self._html_search_meta('Description', html)
         thumbnail = self._html_search_meta(['og:image', 'twitter:image'], html)
 
-        if self._search_regex(r'var\s+timeshift\s*=\s*false', html, 'is livestream', default=False):
+        if self._search_regex(r'(var\s+timeshift\s*=\s*false)', html, 'is livestream', default=False):
             streams = [
                 ('high', 'Z'),
                 ('low', 'ForceLow'),

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -16,6 +16,30 @@ class KukuluLiveIE(InfoExtractor):
     _VALID_URL = r'https?://live\.erinn\.biz/live\.php\?h(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://live.erinn.biz/live.php?h675134569',
+        'md5': 'e380fa6a47fc703d91cea913ab44ec2e',
+        'info_dict': {
+            'id': '675134569',
+            'ext': 'mp4',
+            'title': 'プロセカ',
+            'description': 'テストも兼ねたプロセカ配信。',
+            'timestamp': 1702689148,
+            'upload_date': '20231216',
+            'thumbnail': r're:^https?://.*',
+        },
+    }, {
+        'url': 'https://live.erinn.biz/live.php?h102338092',
+        'md5': 'dcf5167a934b1c60333461e13a81a6e2',
+        'info_dict': {
+            'id': '102338092',
+            'ext': 'mp4',
+            'title': 'Among Usで遊びます！！',
+            'description': 'VTuberになりましたねんねこ㌨ですよろしくお願いします',
+            'timestamp': 1704603118,
+            'upload_date': '20240107',
+            'thumbnail': r're:^https?://.*',
+        },
+    }, {
+        'url': 'https://live.erinn.biz/live.php?h878049531',
         'only_matching': True,
     }]
 

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -89,12 +89,8 @@ class KukuluLiveIE(InfoExtractor):
         thumbnail = self._html_search_meta(['og:image', 'twitter:image'], html)
 
         if self._search_regex(r'(var\s+timeshift\s*=\s*false)', html, 'is livestream', default=False):
-            streams = [
-                ('high', 'Z'),
-                ('low', 'ForceLow'),
-            ]
             formats = []
-            for (desc, code) in streams:
+            for (desc, code) in [('high', 'Z'), ('low', 'ForceLow')]:
                 quality_meta = self._get_quality_meta(video_id, desc, code)
                 self._add_quality_formats(formats, quality_meta)
                 if desc == 'high' and quality_meta.get('vcodec')[0] == 'HEVC':

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qs
+import urllib.parse
 
 from .common import InfoExtractor
 from ..utils import (
@@ -55,7 +55,7 @@ class KukuluLiveIE(InfoExtractor):
             },
             note=f'Downloading {description} quality metadata',
             errnote=f'Unable to download {description} quality metadata')
-        return parse_qs(qs)
+        return urllib.parse.parse_qs(qs)
 
     def _add_quality_formats(self, formats, quality_meta):
         vcodec = traverse_obj(quality_meta, ('vcodec', 0))

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -84,7 +84,7 @@ class KukuluLiveIE(InfoExtractor):
         video_id = self._match_id(url)
         html = self._download_webpage(url, video_id)
 
-        if 'タイムシフトが見つかりませんでした。' in html:
+        if '>タイムシフトが見つかりませんでした。<' in html:
             raise ExtractorError('This stream has expired', expected=True)
 
         title = clean_html(

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -4,6 +4,7 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     clean_html,
+    filter_dict,
     get_element_by_id,
     int_or_none,
     join_nonempty,
@@ -46,17 +47,17 @@ class KukuluLiveIE(InfoExtractor):
         'only_matching': True,
     }]
 
-    def _get_quality_meta(self, video_id, desc, code, force_h264=''):
-        description = desc if force_h264 == '' else f'{desc} (force_h264)'
+    def _get_quality_meta(self, video_id, desc, code, force_h264=None):
+        if force_h264:
+            desc += ' (force_h264)'
         qs = self._download_webpage(
             'https://live.erinn.biz/live.player.fplayer.php', video_id,
-            query={
+            f'Downloading {desc} quality metadata', f'Unable to download {desc} quality metadata',
+            query=filter_dict({
                 'hash': video_id,
                 'action': f'get{code}liveByAjax',
                 'force_h264': force_h264,
-            },
-            note=f'Downloading {description} quality metadata',
-            errnote=f'Unable to download {description} quality metadata')
+            }))
         return urllib.parse.parse_qs(qs)
 
     def _add_quality_formats(self, formats, quality_meta):

--- a/yt_dlp/extractor/kukululive.py
+++ b/yt_dlp/extractor/kukululive.py
@@ -85,8 +85,9 @@ class KukuluLiveIE(InfoExtractor):
 
             formats = []
             for source in sources_json:
+                path = source.get('file')
                 formats.append({
-                    'url': f'https://live.erinn.biz{source.get('file')}',
+                    'url': f'https://live.erinn.biz{path}',
                     'ext': 'mp4',
                     'protocol': 'm3u8_native',
                 })


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Extractor for KukuluLive

#### Live stream or VOD

The URL is the same for live streams and for saved videos (VODs).

Here is the difference between generated HTML for live stream and for VODs:
https://gist.github.com/DmitryScaletta/b62a032a10eb0f632b702f4cf4ba110d/revisions

First we need to determine is it live strean or VOD.
The best solution that I came up with is to check this lines:

```js
var _url = "live.player.fplayer.php";    // live stream
var _url = "live.timeshift.fplayer.php"; // VOD

// or

var timeshift = false; // live stream
var timeshift = true;  // VOD
```

#### Live stream

I noticed HD/SD buttons in the player.
They use H264 and HEVC codecs and an `action` query param determines what to use: `getZliveByAjax` for H264 and `getForceLowliveByAjax` for HEVC.

```bash
GET https://live.erinn.biz/live.player.fplayer.php?hash=808987371&action=getZliveByAjax
GET https://live.erinn.biz/live.player.fplayer.php?hash=808987371&action=getForceLowliveByAjax
```

It returns `application/x-www-form-urlencoded`.

```
vcodec=H264&vcodec_trans=&streamaddr=rtmp%3A%2F%2Fzlive-edge-zlive-ydc102.erinn.biz%3A11935%2Flive&streamname=h808987371&hlsaddr=https%3A%2F%2Fzlive-ydc102.erinn.biz%3A12021%2Fhls.server%2F808987371.m3u8&hlsaddr_audioonly=https%3A%2F%2Fzlive-ydc102.erinn.biz%3A12021%2Fhls.server%2F808987371_audio.m3u8&flvaddr=wss%3A%2F%2Fzlive-ydc102.erinn.biz%3A12022%2Flive%2Fh808987371.flv&connecttest=https%3A%2F%2Fzlive-ydc102.erinn.biz%3A12021%2Fenduser_check.php%3Fh808987371&now_quality=high&
```

```
vcodec=HEVC&vcodec_trans=1&streamaddr=rtmp%3A%2F%2Flowlive-edge-lowlive-ydc3.erinn.biz%3A11935%2Flive&streamname=h808987371&hlsaddr=https%3A%2F%2Flowlive-ydc3.erinn.biz%3A11021%2Fhls.server%2F808987371.m3u8&hlsaddr_audioonly=https%3A%2F%2Flowlive-ydc3.erinn.biz%3A11021%2Fhls.server%2F808987371_audio.m3u8&flvaddr=wss%3A%2F%2Flowlive-ydc3.erinn.biz%3A11022%2Flive%2Fh808987371.flv&connecttest=&now_quality=low&
```

Here is how it looks like after decoding 

```js
Object.fromEntries([...new URLSearchParams('...')])
````

```json
{
    "vcodec": "H264",
    "vcodec_trans": "",
    "streamaddr": "rtmp://zlive-edge-zlive-ydc102.erinn.biz:11935/live",
    "streamname": "h808987371",
    "hlsaddr": "https://zlive-ydc102.erinn.biz:12021/hls.server/808987371.m3u8",
    "hlsaddr_audioonly": "https://zlive-ydc102.erinn.biz:12021/hls.server/808987371_audio.m3u8",
    "flvaddr": "wss://zlive-ydc102.erinn.biz:12022/live/h808987371.flv",
    "connecttest": "https://zlive-ydc102.erinn.biz:12021/enduser_check.php?h808987371",
    "now_quality": "high"
}
```

```json
{
    "vcodec": "HEVC",
    "vcodec_trans": "1",
    "streamaddr": "rtmp://lowlive-edge-lowlive-ydc3.erinn.biz:11935/live",
    "streamname": "h808987371",
    "hlsaddr": "https://lowlive-ydc3.erinn.biz:11021/hls.server/808987371.m3u8",
    "hlsaddr_audioonly": "https://lowlive-ydc3.erinn.biz:11021/hls.server/808987371_audio.m3u8",
    "flvaddr": "wss://lowlive-ydc3.erinn.biz:11022/live/h808987371.flv",
    "connecttest": "",
    "now_quality": "low"
}
```

I think they call HEVC low quality because it has slightly lower bitrate.
I also noticed that for H264 the m3u8 url can be different each time you make request.

```
https://zlive-ydc106.erinn.biz:12061/hls.server/619470268.m3u8
https://zlive-ydc101.erinn.biz:12011/hls.server/619470268.m3u8
https://zlive-edge-160-251-72-130.erinn.biz:443/hls.server/619470268.m3u8
```

Looks like for HEVC the link is always the same. 

Formats:

```bash
ID             EXT RESOLUTION │ PROTO │ VCODEC     ACODEC 
──────────────────────────────────────────────────────────
low-audioonly  aac audio only │ m3u8  │ audio only unknown
high-audioonly aac audio only │ m3u8  │ audio only unknown
low-rtmp       mp4 unknown    │ rtmp  │ HEVC       unknown
high-rtmp      mp4 unknown    │ rtmp  │ H264       unknown
low            mp4 unknown    │ m3u8  │ HEVC       unknown
high           mp4 unknown    │ m3u8  │ H264       unknown
```

```bash
ID             EXT RESOLUTION │ PROTO │ VCODEC     ACODEC 
──────────────────────────────────────────────────────────
low-audioonly  aac audio only │ m3u8  │ audio only unknown
h264-audioonly aac audio only │ m3u8  │ audio only unknown
high-audioonly aac audio only │ m3u8  │ audio only unknown
low-rtmp       mp4 unknown    │ rtmp  │ HEVC       unknown
h264-rtmp      mp4 unknown    │ rtmp  │ H264       unknown
high-rtmp      mp4 unknown    │ rtmp  │ HEVC       unknown
low            mp4 unknown    │ m3u8  │ HEVC       unknown
h264           mp4 unknown    │ m3u8  │ H264       unknown
high           mp4 unknown    │ m3u8  │ HEVC       unknown
```

#### VOD

For VODs first we need to make this request:

```
GET https://live.erinn.biz/live.timeshift.fplayer.php?hash=675134569
```

It returns html that contains a link to m3u8 playlist (`file` property).

```js
  var fplayer_source = [
            {
          "time_start": 1702689148, 
          "time_end": 1702689178, 
          "file": "/live.timeshift.fplayer.php?action=genM3U8&hash=675134569&url_m3u8=https%3A%2F%2Frecsv1-hls.erinn.biz%3A20443%2Fliverec_html5v3_107%2F675134569%2F20231216101228726.mp4%2Findex.m3u8",
          "file_rescue": "/live.timeshift.fplayer.php?action=genM3U8&rescue=1&hash=675134569&url_m3u8=https%3A%2F%2Frecsv1-hls.erinn.biz%3A20443%2Fliverec_html5v3_107%2F675134569%2F20231216101228726.mp4%2Findex.m3u8",
          "file_mp4": "https://recsv1-hls.erinn.biz:20443/liverec_mp4_107/675134569/20231216101228726.mp4",
        }
          ];
```

`file_rescue` link adds `rescue=1` to query params and doesn't work, this link returns empty m3u8 with only comments.
`file_mp4` link is also doesn't work, it returns 404.

Sometimes there are multiple entries.
Example url: https://live.erinn.biz/live.php?h878049531

```js
  var fplayer_source = [
            {
          "time_start": 1703727945, 
          "time_end": 1703744724, 
          "file": "/live.timeshift.fplayer.php?action=genM3U8&hash=878049531&url_m3u8=https%3A%2F%2Frecsv3-hls.erinn.biz%3A30443%2Fliverec_html5v3_206%2F878049531%2F20231228104545685.mp4%2Findex.m3u8",
          "file_rescue": "/live.timeshift.fplayer.php?action=genM3U8&rescue=1&hash=878049531&url_m3u8=https%3A%2F%2Frecsv3-hls.erinn.biz%3A30443%2Fliverec_html5v3_206%2F878049531%2F20231228104545685.mp4%2Findex.m3u8",
          "file_mp4": "https://recsv3-hls.erinn.biz:30443/liverec_mp4_206/878049531/20231228104545685.mp4",
        }
        ,       {
          "time_start": 1703744752, 
          "time_end": 1703744975, 
          "file": "/live.timeshift.fplayer.php?action=genM3U8&hash=878049531&url_m3u8=https%3A%2F%2Frecsv3-hls.erinn.biz%3A30443%2Fliverec_html5v3_206%2F878049531%2F20231228152552619.mp4%2Findex.m3u8",
          "file_rescue": "/live.timeshift.fplayer.php?action=genM3U8&rescue=1&hash=878049531&url_m3u8=https%3A%2F%2Frecsv3-hls.erinn.biz%3A30443%2Fliverec_html5v3_206%2F878049531%2F20231228152552619.mp4%2Findex.m3u8",
          "file_mp4": "https://recsv3-hls.erinn.biz:30443/liverec_mp4_206/878049531/20231228152552619.mp4",
        }
          ];
```

In this example the first m3u8 playlist is 231 lines long and the second one is 16787.
Maybe it's chapters I don't know.

Here is my regex for getting this data as a JSON: https://regex101.com/r/3AXpSA/3
There is also a comma after last property `file_mp4`, so it's not a valid JSON.

Formats:

```bash
ID EXT RESOLUTION │ PROTO │ VCODEC  ACODEC 
───────────────────────────────────────────
0  mp4 unknown    │ m3u8  │ unknown unknown
```

```bash
ID EXT RESOLUTION │ PROTO │ VCODEC  ACODEC 
───────────────────────────────────────────
0  mp4 unknown    │ m3u8  │ unknown unknown
1  mp4 unknown    │ m3u8  │ unknown unknown
```

Closes https://github.com/yt-dlp/yt-dlp/issues/8865


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
