### PR TITLE
[ie/ARDBetaMediathekIE] Rework extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -134,6 +134,7 @@ from .arcpublishing import ArcPublishingIE
 from .arkena import ArkenaIE
 from .ard import (
     ARDBetaMediathekIE,
+    ARDMediathekCollectionIE,
     ARDIE,
 )
 from .arte import (

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -135,7 +135,6 @@ from .arkena import ArkenaIE
 from .ard import (
     ARDBetaMediathekIE,
     ARDIE,
-    ARDMediathekIE,
 )
 from .arte import (
     ArteTVIE,

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -382,8 +382,7 @@ class ARDBetaMediathekIE(InfoExtractor):
             for media in traverse_obj(stream, ('media', lambda _, v: url_or_none(v['url']))):
                 media_url = media['url']
 
-                audio_kind = traverse_obj(media,
-                    ('audios', 0, 'kind', {str}), default='').replace('standard', '')
+                audio_kind = traverse_obj(media, ('audios', 0, 'kind', {str}), default='').replace('standard', '')
                 lang_code = traverse_obj(media, ('audios', 0, 'languageCode', {str})) or 'deu'
                 lang = join_nonempty(lang_code, audio_kind)
                 language_preference = 10 if lang == 'deu' else -10

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -290,6 +290,24 @@ class ARDBetaMediathekIE(InfoExtractor):
             '_old_archive_ids': ['ardbetamediathekie 10049223'],
         },
     }, {
+        'url': 'https://www.ardmediathek.de/video/7-tage/7-tage-unter-harten-jungs/hr-fernsehen/N2I2YmM5MzgtNWFlOS00ZGFlLTg2NzMtYzNjM2JlNjk4MDg3',
+        'md5': '1e73ded21cb79bac065117e80c81dc88',
+        'info_dict': {
+            'id': 'N2I2YmM5MzgtNWFlOS00ZGFlLTg2NzMtYzNjM2JlNjk4MDg3',
+            'ext': 'mp4',
+            'duration': 2700,
+            'episode': '7 Tage ... unter harten Jungs',
+            'description': 'md5:0f215470dcd2b02f59f4bd10c963f072',
+            'upload_date': '20231005',
+            'timestamp': 1696491171,
+            'display_id': '7-tage/7-tage-unter-harten-jungs/hr-fernsehen',
+            'series': '7 Tage ...',
+            'channel': 'HR',
+            'thumbnail': 'https://api.ardmediathek.de/image-service/images/urn:ard:image:f6e6d5ffac41925c?w=960&ch=fa32ba69bc87989a',
+            'title': '7 Tage ... unter harten Jungs',
+            '_old_archive_ids': ['ardbetamediathekie 94834686'],
+        },
+    }, {
         'url': 'https://beta.ardmediathek.de/ard/video/Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhdG9ydC9mYmM4NGM1NC0xNzU4LTRmZGYtYWFhZS0wYzcyZTIxNGEyMDE',
         'only_matching': True,
     }, {
@@ -440,10 +458,51 @@ class ARDMediathekCollectionIE(InfoExtractor):
         (?P<playlist>sendung|serie|sammlung)/
         (?:(?P<display_id>[^?#]+?)/)?
         (?P<id>[a-zA-Z0-9]+)
-        (?:/(?P<season>\d+)(?:/(?P<ov>OV))?)?/?(?:[?#]|$)'''
+        (?:/(?P<season>\d+)(?:/(?P<version>OV|AD))?)?/?(?:[?#]|$)'''
     _GEO_COUNTRIES = ['DE']
 
     _TESTS = [{
+        'url': 'https://www.ardmediathek.de/serie/quiz/staffel-1-originalversion/Y3JpZDovL3dkci5kZS9vbmUvcXVpeg/1/OV',
+        'info_dict': {
+            'id': 'Y3JpZDovL3dkci5kZS9vbmUvcXVpeg_1_OV',
+            'display_id': 'quiz/staffel-1-originalversion',
+            'title': 'Staffel 1 Originalversion',
+        },
+        'playlist_count': 3,
+    }, {
+        'url': 'https://www.ardmediathek.de/serie/babylon-berlin/staffel-4-mit-audiodeskription/Y3JpZDovL2Rhc2Vyc3RlLmRlL2JhYnlsb24tYmVybGlu/4/AD',
+        'info_dict': {
+            'id': 'Y3JpZDovL2Rhc2Vyc3RlLmRlL2JhYnlsb24tYmVybGlu_4_AD',
+            'display_id': 'babylon-berlin/staffel-4-mit-audiodeskription',
+            'title': 'Staffel 4 mit Audiodeskription',
+        },
+        'playlist_count': 12,
+    }, {
+        'url': 'https://www.ardmediathek.de/serie/babylon-berlin/staffel-1/Y3JpZDovL2Rhc2Vyc3RlLmRlL2JhYnlsb24tYmVybGlu/1/',
+        'info_dict': {
+            'id': 'Y3JpZDovL2Rhc2Vyc3RlLmRlL2JhYnlsb24tYmVybGlu_1',
+            'display_id': 'babylon-berlin/staffel-1',
+            'title': 'Staffel 1',
+        },
+        'playlist_count': 8,
+    }, {
+        'url': 'https://www.ardmediathek.de/sendung/tatort/Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhdG9ydA',
+        'info_dict': {
+            'id': 'Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhdG9ydA',
+            'display_id': 'tatort',
+            'title': 'Tatort',
+        },
+        'playlist_mincount': 500,
+    }, {
+        'url': 'https://www.ardmediathek.de/sammlung/die-kirche-bleibt-im-dorf/5eOHzt8XB2sqeFXbIoJlg2',
+        'info_dict': {
+            'id': '5eOHzt8XB2sqeFXbIoJlg2',
+            'display_id': 'die-kirche-bleibt-im-dorf',
+            'title': 'Die Kirche bleibt im Dorf',
+            'description': 'Die Kirche bleibt im Dorf',
+        },
+        'playlist_count': 4,
+    }, {
         # playlist of type 'sendung'
         'url': 'https://www.ardmediathek.de/ard/sendung/doctor-who/Y3JpZDovL3dkci5kZS9vbmUvZG9jdG9yIHdobw/',
         'only_matching': True,
@@ -460,8 +519,8 @@ class ARDMediathekCollectionIE(InfoExtractor):
     _PAGE_SIZE = 100
 
     def _real_extract(self, url):
-        playlist_id, display_id, playlist_type, season_number, original_version = self._match_valid_url(url).group(
-            'id', 'display_id', 'playlist', 'season', 'ov')
+        playlist_id, display_id, playlist_type, season_number, version = self._match_valid_url(url).group(
+            'id', 'display_id', 'playlist', 'season', 'version')
 
         def call_api(i):
             api_path = 'compilations/ard' if playlist_type == 'sammlung' else 'widgets/ard/asset'
@@ -472,7 +531,8 @@ class ARDMediathekCollectionIE(InfoExtractor):
                     **({
                         'seasoned': 'true',
                         'seasonNumber': season_number,
-                        'withOriginalversion': 'true' if original_version else 'false',
+                        'withOriginalversion': 'true' if version == 'OV' else 'false',
+                        'withAudiodescription': 'true' if version == 'AD' else 'false',
                     } if season_number else {}),
                 })
 
@@ -489,7 +549,8 @@ class ARDMediathekCollectionIE(InfoExtractor):
                     timestamp=parse_iso8601(item.get('broadcastedOn')))
 
         page_data = call_api(0)
+        full_id = join_nonempty(playlist_id, season_number, version, delim='_')
 
         return self.playlist_result(
-            OnDemandPagedList(fetch_page, self._PAGE_SIZE), playlist_id, display_id=display_id,
+            OnDemandPagedList(fetch_page, self._PAGE_SIZE), full_id, display_id=display_id,
             title=page_data.get('title'), description=page_data.get('synopsis'))

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -382,7 +382,8 @@ class ARDBetaMediathekIE(InfoExtractor):
             for media in traverse_obj(stream, ('media', lambda _, v: url_or_none(v['url']))):
                 media_url = media['url']
 
-                audio_kind = traverse_obj(media, ('audios', 0, 'kind', {str}), default='').replace('standard', '')
+                audio_kind = traverse_obj(media, (
+                    'audios', 0, 'kind', {str}), default='').replace('standard', '')
                 lang_code = traverse_obj(media, ('audios', 0, 'languageCode', {str})) or 'deu'
                 lang = join_nonempty(lang_code, audio_kind)
                 language_preference = 10 if lang == 'deu' else -10

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -385,7 +385,7 @@ class ARDBetaMediathekIE(InfoExtractor):
 
         formats = []
         subtitles = {}
-        for stream in media_data.get('streams') or []:
+        for stream in traverse_obj(media_data, ('streams', ..., {dict})):
             kind = stream.get('kind')
             # Prioritize main stream over sign language and others
             preference = 1 if kind == 'main' else None
@@ -420,8 +420,8 @@ class ARDBetaMediathekIE(InfoExtractor):
                         }),
                     })
 
-        for sub in media_data.get('subtitles') or []:
-            for sources in sub.get('sources') or []:
+        for sub in traverse_obj(media_data, ('subtitles', ..., {dict})):
+            for sources in traverse_obj(sub, ('sources', ..., {dict})):
                 subtitles.setdefault(sub.get('languageCode') or 'deu', []).append({
                     'url': sources.get('url'),
                     'ext': {'webvtt': 'vtt', 'ebutt': 'ttml'}.get(sources.get('kind')),
@@ -537,7 +537,7 @@ class ARDMediathekCollectionIE(InfoExtractor):
                 })
 
         def fetch_page(i):
-            for item in call_api(i).get('teasers') or []:
+            for item in traverse_obj(call_api(i), ('teasers', ..., {dict})):
                 item_id = traverse_obj(item, ('links', 'target', ('urlId', 'id')), 'id', get_all=False)
                 if not item_id:
                     continue

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -255,7 +255,7 @@ class ARDBetaMediathekIE(InfoExtractor):
             'series': 'Filme im MDR',
             'age_limit': 0,
             'channel': 'MDR',
-            '_old_archive_ids': ['ardbetamediathekie 12939099'],
+            '_old_archive_ids': ['ardbetamediathek 12939099'],
         },
     }, {
         'url': 'https://www.ardmediathek.de/mdr/video/die-robuste-roswita/Y3JpZDovL21kci5kZS9iZWl0cmFnL2Ntcy84MWMxN2MzZC0wMjkxLTRmMzUtODk4ZS0wYzhlOWQxODE2NGI/',
@@ -288,7 +288,7 @@ class ARDBetaMediathekIE(InfoExtractor):
             'series': 'tagesschau',
             'thumbnail': 'https://api.ardmediathek.de/image-service/images/urn:ard:image:fbb21142783b0a49?w=960&ch=ee69108ae344f678',
             'channel': 'ARD-Aktuell',
-            '_old_archive_ids': ['ardbetamediathekie 10049223'],
+            '_old_archive_ids': ['ardbetamediathek 10049223'],
         },
     }, {
         'url': 'https://www.ardmediathek.de/video/7-tage/7-tage-unter-harten-jungs/hr-fernsehen/N2I2YmM5MzgtNWFlOS00ZGFlLTg2NzMtYzNjM2JlNjk4MDg3',
@@ -306,7 +306,7 @@ class ARDBetaMediathekIE(InfoExtractor):
             'channel': 'HR',
             'thumbnail': 'https://api.ardmediathek.de/image-service/images/urn:ard:image:f6e6d5ffac41925c?w=960&ch=fa32ba69bc87989a',
             'title': '7 Tage ... unter harten Jungs',
-            '_old_archive_ids': ['ardbetamediathekie 94834686'],
+            '_old_archive_ids': ['ardbetamediathek 94834686'],
         },
     }, {
         'url': 'https://beta.ardmediathek.de/ard/video/Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhdG9ydC9mYmM4NGM1NC0xNzU4LTRmZGYtYWFhZS0wYzcyZTIxNGEyMDE',
@@ -435,7 +435,7 @@ class ARDBetaMediathekIE(InfoExtractor):
                 'channel': 'clipSourceName',
             })),
             **self._extract_episode_info(page_data.get('title')),
-            '_old_archive_ids': [make_archive_id('ARDBetaMediathekIE', old_id)],
+            '_old_archive_ids': [make_archive_id(ARDBetaMediathekIE, old_id)],
         }
 
 

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -231,10 +231,10 @@ class ARDBetaMediathekIE(InfoExtractor):
     _VALID_URL = r'''(?x)https://
         (?:(?:beta|www)\.)?ardmediathek\.de/
         (?:[^/]+/)?
-        (?:player|live|video|(?P<playlist>sendung|serie|sammlung))/
-        (?:(?P<display_id>(?(playlist)[^?#]+?|[^?#]+))/)?
+        (?:player|live|video)/
+        (?:(?P<display_id>[^?#]+)/)?
         (?P<id>[a-zA-Z0-9]+)
-        (?(playlist)/(?:(?P<season>\d+)(?:/(?P<ov>OV))?))?/?(?:[?#]|$)'''
+        /?(?:[?#]|$)'''
     _GEO_COUNTRIES = ['DE']
 
     _TESTS = [{
@@ -305,18 +305,6 @@ class ARDBetaMediathekIE(InfoExtractor):
         'url': 'https://www.ardmediathek.de/swr/live/Y3JpZDovL3N3ci5kZS8xMzQ4MTA0Mg',
         'only_matching': True,
     }, {
-        # playlist of type 'sendung'
-        'url': 'https://www.ardmediathek.de/ard/sendung/doctor-who/Y3JpZDovL3dkci5kZS9vbmUvZG9jdG9yIHdobw/',
-        'only_matching': True,
-    }, {
-        # playlist of type 'serie'
-        'url': 'https://www.ardmediathek.de/serie/nachtstreife/staffel-1/Y3JpZDovL3N3ci5kZS9zZGIvc3RJZC8xMjQy/1',
-        'only_matching': True,
-    }, {
-        # playlist of type 'sammlung'
-        'url': 'https://www.ardmediathek.de/ard/sammlung/team-muenster/5JpTzLSbWUAK8184IOvEir/',
-        'only_matching': True,
-    }, {
         'url': 'https://www.ardmediathek.de/video/coronavirus-update-ndr-info/astrazeneca-kurz-lockdown-und-pims-syndrom-81/ndr/Y3JpZDovL25kci5kZS84NzE0M2FjNi0wMWEwLTQ5ODEtOTE5NS1mOGZhNzdhOTFmOTI/',
         'only_matching': True,
     }]
@@ -360,38 +348,8 @@ class ARDBetaMediathekIE(InfoExtractor):
             res['episode'] = title.strip()
         return res
 
-    _PAGE_SIZE = 100
-
-    def _extract_playlist(self, playlist_id, playlist_type, season_number, original_version):
-        def fetch_page(i):
-            api_path = 'compilations/ard' if playlist_type == 'sammlung' else 'widgets/ard/asset'
-            page_data = self._download_json(
-                f'https://api.ardmediathek.de/page-gateway/{api_path}/{playlist_id}', playlist_id, query={
-                    'pageNumber': i,
-                    'pageSize': self._PAGE_SIZE,
-                    **({
-                        'seasoned': 'true',
-                        'seasonNumber': season_number,
-                        'withOriginalversion': 'true' if original_version else 'false',
-                    } if season_number else {}),
-                })
-            for item in page_data.get('teasers') or []:
-                item_id = traverse_obj(item, ('links', 'target', ('urlId', 'id')), 'id', get_all=False)
-                if not item_id:
-                    continue
-                item_mode = 'sammlung' if item.get('type') == 'compilation' else 'video'
-                yield self.url_result(
-                    f'https://www.ardmediathek.de/{item_mode}/{item_id}', ie=ARDBetaMediathekIE,
-                    id=item.get('id'), title=item.get('longTitle'), duration=int_or_none(item.get('duration')),
-                    timestamp=parse_iso8601(item.get('broadcastedOn')))
-        return self.playlist_result(OnDemandPagedList(fetch_page, self._PAGE_SIZE), playlist_id)
-
     def _real_extract(self, url):
-        video_id, display_id, playlist_type, season_number, original_version = self._match_valid_url(url).group(
-            'id', 'display_id', 'playlist', 'season', 'ov')
-
-        if playlist_type:
-            return self._extract_playlist(video_id, playlist_type, season_number, original_version)
+        video_id, display_id = self._match_valid_url(url).group('id', 'display_id')
 
         page_data = self._download_json(
             f'https://api.ardmediathek.de/page-gateway/pages/ard/item/{video_id}', video_id, query={
@@ -473,3 +431,65 @@ class ARDBetaMediathekIE(InfoExtractor):
             **self._extract_episode_info(page_data.get('title')),
             '_old_archive_ids': [make_archive_id('ARDBetaMediathekIE', old_id)],
         }
+
+
+class ARDMediathekCollectionIE(InfoExtractor):
+    _VALID_URL = r'''(?x)https://
+        (?:(?:beta|www)\.)?ardmediathek\.de/
+        (?:[^/]+/)?
+        (?P<playlist>sendung|serie|sammlung)/
+        (?:(?P<display_id>[^?#]+?)/)?
+        (?P<id>[a-zA-Z0-9]+)
+        (?:/(?P<season>\d+)(?:/(?P<ov>OV))?)?/?(?:[?#]|$)'''
+    _GEO_COUNTRIES = ['DE']
+
+    _TESTS = [{
+        # playlist of type 'sendung'
+        'url': 'https://www.ardmediathek.de/ard/sendung/doctor-who/Y3JpZDovL3dkci5kZS9vbmUvZG9jdG9yIHdobw/',
+        'only_matching': True,
+    }, {
+        # playlist of type 'serie'
+        'url': 'https://www.ardmediathek.de/serie/nachtstreife/staffel-1/Y3JpZDovL3N3ci5kZS9zZGIvc3RJZC8xMjQy/1',
+        'only_matching': True,
+    }, {
+        # playlist of type 'sammlung'
+        'url': 'https://www.ardmediathek.de/ard/sammlung/team-muenster/5JpTzLSbWUAK8184IOvEir/',
+        'only_matching': True,
+    }]
+
+    _PAGE_SIZE = 100
+
+    def _real_extract(self, url):
+        playlist_id, display_id, playlist_type, season_number, original_version = self._match_valid_url(url).group(
+            'id', 'display_id', 'playlist', 'season', 'ov')
+
+        def call_api(i):
+            api_path = 'compilations/ard' if playlist_type == 'sammlung' else 'widgets/ard/asset'
+            return self._download_json(
+                f'https://api.ardmediathek.de/page-gateway/{api_path}/{playlist_id}', playlist_id, query={
+                    'pageNumber': i,
+                    'pageSize': self._PAGE_SIZE,
+                    **({
+                        'seasoned': 'true',
+                        'seasonNumber': season_number,
+                        'withOriginalversion': 'true' if original_version else 'false',
+                    } if season_number else {}),
+                })
+
+        def fetch_page(i):
+            for item in call_api(i).get('teasers') or []:
+                item_id = traverse_obj(item, ('links', 'target', ('urlId', 'id')), 'id', get_all=False)
+                if not item_id:
+                    continue
+                item_mode = 'sammlung' if item.get('type') == 'compilation' else 'video'
+                yield self.url_result(
+                    f'https://www.ardmediathek.de/{item_mode}/{item_id}',
+                    ie=(ARDMediathekCollectionIE if item_mode == 'sammlung' else ARDBetaMediathekIE),
+                    id=item.get('id'), title=item.get('longTitle'), duration=int_or_none(item.get('duration')),
+                    timestamp=parse_iso8601(item.get('broadcastedOn')))
+
+        page_data = call_api(0)
+
+        return self.playlist_result(
+            OnDemandPagedList(fetch_page, self._PAGE_SIZE), playlist_id, display_id=display_id,
+            title=page_data.get('title'), description=page_data.get('synopsis'))

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -530,7 +530,7 @@ class ARDMediathekCollectionIE(InfoExtractor):
         def fetch_page(page_num):
             for item in traverse_obj(call_api(page_num), ('teasers', ..., {dict})):
                 item_id = traverse_obj(item, ('links', 'target', ('urlId', 'id')), 'id', get_all=False)
-                if not item_id:
+                if not item_id or item_id == playlist_id:
                     continue
                 item_mode = 'sammlung' if item.get('type') == 'compilation' else 'video'
                 yield self.url_result(

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -291,7 +291,7 @@ class ARDBetaMediathekIE(InfoExtractor):
         },
     }, {
         'url': 'https://www.ardmediathek.de/video/7-tage/7-tage-unter-harten-jungs/hr-fernsehen/N2I2YmM5MzgtNWFlOS00ZGFlLTg2NzMtYzNjM2JlNjk4MDg3',
-        'md5': '1e73ded21cb79bac065117e80c81dc88',
+        'md5': 'c428b9effff18ff624d4f903bda26315',
         'info_dict': {
             'id': 'N2I2YmM5MzgtNWFlOS00ZGFlLTg2NzMtYzNjM2JlNjk4MDg3',
             'ext': 'mp4',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Reworks the ARD extractor. Some notes:
I changed the ID to the actual video ID and not the legacy tracking ID. This does come at the cost of having longer IDs and thus potentially issues with filename length. Open to feedback on if you think this is the right call.

`ARDMediathekBaseIE` can't yet be removed due to still being used by SWR. This can be addressed in a seperate PR.

The API always seems to return that the video is not geo-blocked. The CDN then redirects to a geo-blocking video. On some servers (ARD), this can be circumvented with xff.

To support accounts (watching age restricted videos during the daytime) requires a bit more work, re-implementing parts of their auth flow. This can also be done in a separate PR.


Fixes #8731, Fixes #6784, Fixes #2366, Fixes #2975, Closes #8760


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
