### PR TITLE
[Bigo] Fix json extraction

### DIFF
--- a/yt_dlp/extractor/bigo.py
+++ b/yt_dlp/extractor/bigo.py
@@ -29,7 +29,8 @@ class BigoIE(InfoExtractor):
 
         info_raw = self._download_json(
             'https://ta.bigo.tv/official_website/studio/getInternalStudioInfo',
-            user_id, data=urlencode_postdata({'siteId': user_id}))
+            user_id, data=urlencode_postdata({'siteId': user_id}),
+            headers={'Accept': 'application/json'})
 
         if not isinstance(info_raw, dict):
             raise ExtractorError('Received invalid JSON data')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Fixes Bigo extractor.

For some reason `getInternalStudioInfo` endpoint now returns xml in python by default

<details>
<summary>Response</summary>

```xml
<OfficialCommonResult>
	<code>0</code>
	<data>
		<sid>2622124741</sid>
		<siteId>805516745</siteId>
		<uid>582287518</uid>
		<avatar>http://esx.bigo.sg/na_live/3a3/1dB9jT.jpg</avatar>
		<nick_name>Chaise</nick_name>
		<country_code>US</country_code>
		<gameTitle></gameTitle>
		<gameId>0</gameId>
		<roomTopic> Back in the hospital </roomTopic>
		<snapshot>http://esx.bigo.sg/na_live/3a3/1DljJQ.jpg</snapshot>
		<alive>1</alive>
		<roomId>7049898423382340293</roomId>
		<roomStatus>0</roomStatus>
		<covers/>
		<client_ip>152.32.180.207</client_ip>
		<hls_src>https://86488B67.cubetecn.com:1444/list_3453011328_2622124741_0.m3u8</hls_src>
		<cdn_src/>
		<passRoom>false</passRoom>
		<reserver>4108</reserver>
		<clientBigoId>805516745</clientBigoId>
		<roomType>0</roomType>
	</data>
	<msg>success</msg>
	<flag/>
</OfficialCommonResult>
```

</details>

I added `'Accept': 'application/json'` header and now it works fine.

```bash
$ ./yt-dlp.cmd https://www.bigo.tv/805516745 -F
[Bigo] Extracting URL: https://www.bigo.tv/805516745 
[Bigo] 805516745: Downloading JSON metadata 
[Bigo] 805516745: Downloading m3u8 information 
[info] Available formats for 7049898423382340293: 
ID EXT RESOLUTION │ PROTO │ VCODEC  ACODEC 
───────────────────────────────────────────
0  mp4 unknown    │ m3u8F │ unknown unknown
```

Fixes https://github.com/yt-dlp/yt-dlp/issues/8852


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
