### PR TITLE
[ie/abematv]: fix extraction when using cache

### DIFF
--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -139,7 +139,7 @@ class AbemaTVBaseIE(InfoExtractor):
         add_opener(self._downloader, AbemaLicenseHandler(self))
 
         username, _ = self._get_login_info()
-        auth_cache = username and self.cache.load(self._NETRC_MACHINE, username, min_ver='2024.01.01')
+        auth_cache = username and self.cache.load(self._NETRC_MACHINE, username, min_ver='2024.01.19')
         AbemaTVBaseIE._USERTOKEN = auth_cache and auth_cache.get('usertoken')
         if AbemaTVBaseIE._USERTOKEN:
             # try authentication with locally stored token
@@ -258,7 +258,7 @@ class AbemaTVIE(AbemaTVBaseIE):
 
     def _perform_login(self, username, password):
         self._get_device_token()
-        if self.cache.load(self._NETRC_MACHINE, username, min_ver="2024.01.01") and self._get_media_token():
+        if self.cache.load(self._NETRC_MACHINE, username, min_ver='2024.01.19') and self._get_media_token():
             self.write_debug('Skipping logging in')
             return
 

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -136,6 +136,9 @@ class AbemaTVBaseIE(InfoExtractor):
         if self._USERTOKEN:
             return self._USERTOKEN
 
+        AbemaTVBaseIE._DEVICE_ID = str(uuid.uuid4())
+        add_opener(self._downloader, AbemaLicenseHandler(self))
+
         username, _ = self._get_login_info()
         AbemaTVBaseIE._USERTOKEN = username and self.cache.load(self._NETRC_MACHINE, username)
         if AbemaTVBaseIE._USERTOKEN:
@@ -146,7 +149,6 @@ class AbemaTVBaseIE(InfoExtractor):
             except ExtractorError as e:
                 self.report_warning(f'Failed to login with cached user token; obtaining a fresh one ({e})')
 
-        AbemaTVBaseIE._DEVICE_ID = str(uuid.uuid4())
         aks = self._generate_aks(self._DEVICE_ID)
         user_data = self._download_json(
             'https://api.abema.io/v1/users', None, note='Authorizing',
@@ -159,7 +161,6 @@ class AbemaTVBaseIE(InfoExtractor):
             })
         AbemaTVBaseIE._USERTOKEN = user_data['token']
 
-        add_opener(self._downloader, AbemaLicenseHandler(self))
         return self._USERTOKEN
 
     def _get_media_token(self, invalidate=False, to_show=True):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The extractor fails with
```
yt_dlp.networking.exceptions.NoSupportingHandlers: Unable to handle request: Unsupported url scheme: "abematv-license" (requests, urllib)
```
and
```
  File "/home/sefidel/projects/contrib/yt-dlp-fork/yt_dlp/extractor/abematv.py", line 79, in _get_videokey_from_ticket
    (license_response['cid'] + self.ie._DEVICE_ID).encode('utf-8'),
     ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```

because when `yt-dlp` fetches the token from cache, it triggers an early return.
Which resulted in `add_opener` not being called, and `_DEVICE_ID` being unset.

This commit fixes the issue by also calling the `add_opener` function when fetching the token from cache, and setting the `_DEVICE_ID` variable earlier.

p.s. I was unable to test it without using the cache (i.e. via username and password auth) since the request kept failing with `409 Conflict`, but I think that's out of the scope of this PR.

Fixes #6532

Note: test is failing, but also fails on latest release.
```
_______________________________________________________________ TestDownload.test_AbemaTV _______________________________________________________________
test/test_download.py:113: in test_template
    raise Exception(f'Test {tname} definition incorrect - "ext" key must be present to define the output file')
E   Exception: Test test_AbemaTV definition incorrect - "ext" key must be present to define the output file
================================================================ short test summary info ================================================================
FAILED test/test_download.py::TestDownload::test_AbemaTV - Exception: Test test_AbemaTV definition incorrect - "ext" key must be present to define the output file
```
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
