### PR TITLE
[utils] `traverse_obj`: Support `xml.etree.ElementTree.Element`

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2338,6 +2338,56 @@ Line 1
         self.assertEqual(traverse_obj(mobj, lambda k, _: k in (0, 'group')), ['0123', '3'],
                          msg='function on a `re.Match` should give group name as well')
 
+        # Test xml.etree.ElementTree.Element as input obj
+        etree = xml.etree.ElementTree.fromstring('''<?xml version="1.0"?>
+        <data>
+            <country name="Liechtenstein">
+                <rank>1</rank>
+                <year>2008</year>
+                <gdppc>141100</gdppc>
+                <neighbor name="Austria" direction="E"/>
+                <neighbor name="Switzerland" direction="W"/>
+            </country>
+            <country name="Singapore">
+                <rank>4</rank>
+                <year>2011</year>
+                <gdppc>59900</gdppc>
+                <neighbor name="Malaysia" direction="N"/>
+            </country>
+            <country name="Panama">
+                <rank>68</rank>
+                <year>2011</year>
+                <gdppc>13600</gdppc>
+                <neighbor name="Costa Rica" direction="W"/>
+                <neighbor name="Colombia" direction="E"/>
+            </country>
+        </data>''')
+        self.assertEqual(traverse_obj(etree, 'country'), list(etree),
+                         msg='str key should lead all children with that tag name')
+        self.assertEqual(traverse_obj(etree, ...), list(etree),
+                         msg='`...` as key should return all children')
+        self.assertEqual(traverse_obj(etree, lambda _, x: x[0].text == "4"), [etree[1]],
+                         msg='function as key should get element as value')
+        self.assertEqual(traverse_obj(etree, lambda i, _: i == 1), [etree[1]],
+                         msg='function as key should get index as key')
+        self.assertEqual(traverse_obj(etree, 0), etree[0],
+                         msg='int key should return the nth child')
+        self.assertEqual(traverse_obj(etree, './/neighbor/@name'),
+                         ['Austria', 'Switzerland', 'Malaysia', 'Costa Rica', 'Colombia'],
+                         msg='`@<attribute>` at end of path should give that attribute')
+        self.assertEqual(traverse_obj(etree, '//neighbor/@fail'), [None, None, None, None, None],
+                         msg='`@<nonexistant>` at end of path should give `None`')
+        self.assertEqual(traverse_obj(etree, ('//neighbor/@', 2)), {'name': 'Malaysia', 'direction': 'N'},
+                         msg='`@` should give the full attribute dict')
+        self.assertEqual(traverse_obj(etree, '//year/text()'), ['2008', '2011', '2011'],
+                         msg='`text()` at end of path should give the inner text')
+        self.assertEqual(traverse_obj(etree, '//*[@direction]/@direction'), ['E', 'W', 'N', 'W', 'E'],
+                         msg='full python xpath features should be supported')
+        self.assertEqual(traverse_obj(etree, (0, '@name', 0)), 'Liechtenstein',
+                         msg='special transformations should act on current element')
+        self.assertEqual(traverse_obj(etree, ('country', 0, ..., 'text()', 0, {int_or_none})), [1, 2008, 141100],
+                         msg='special transformations should act on current element')
+
     def test_http_header_dict(self):
         headers = HTTPHeaderDict()
         headers['ytdl-test'] = b'0'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2362,6 +2362,8 @@ Line 1
                 <neighbor name="Colombia" direction="E"/>
             </country>
         </data>''')
+        self.assertEqual(traverse_obj(etree, ''), None,
+                         msg='empty str key should return `None`')
         self.assertEqual(traverse_obj(etree, 'country'), list(etree),
                          msg='str key should lead all children with that tag name')
         self.assertEqual(traverse_obj(etree, ...), list(etree),
@@ -2383,9 +2385,9 @@ Line 1
                          msg='`text()` at end of path should give the inner text')
         self.assertEqual(traverse_obj(etree, '//*[@direction]/@direction'), ['E', 'W', 'N', 'W', 'E'],
                          msg='full python xpath features should be supported')
-        self.assertEqual(traverse_obj(etree, (0, '@name', 0)), 'Liechtenstein',
+        self.assertEqual(traverse_obj(etree, (0, '@name')), 'Liechtenstein',
                          msg='special transformations should act on current element')
-        self.assertEqual(traverse_obj(etree, ('country', 0, ..., 'text()', 0, {int_or_none})), [1, 2008, 141100],
+        self.assertEqual(traverse_obj(etree, ('country', 0, ..., 'text()', {int_or_none})), [1, 2008, 141100],
                          msg='special transformations should act on current element')
 
     def test_http_header_dict(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2362,8 +2362,8 @@ Line 1
                 <neighbor name="Colombia" direction="E"/>
             </country>
         </data>''')
-        self.assertEqual(traverse_obj(etree, ''), None,
-                         msg='empty str key should return `None`')
+        self.assertEqual(traverse_obj(etree, ''), etree,
+                         msg='empty str key should return the element itself')
         self.assertEqual(traverse_obj(etree, 'country'), list(etree),
                          msg='str key should lead all children with that tag name')
         self.assertEqual(traverse_obj(etree, ...), list(etree),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2368,7 +2368,7 @@ Line 1
                          msg='str key should lead all children with that tag name')
         self.assertEqual(traverse_obj(etree, ...), list(etree),
                          msg='`...` as key should return all children')
-        self.assertEqual(traverse_obj(etree, lambda _, x: x[0].text == "4"), [etree[1]],
+        self.assertEqual(traverse_obj(etree, lambda _, x: x[0].text == '4'), [etree[1]],
                          msg='function as key should get element as value')
         self.assertEqual(traverse_obj(etree, lambda i, _: i == 1), [etree[1]],
                          msg='function as key should get index as key')

--- a/yt_dlp/utils/traversal.py
+++ b/yt_dlp/utils/traversal.py
@@ -180,16 +180,13 @@ def traverse_obj(
         elif isinstance(obj, xml.etree.ElementTree.Element) and isinstance(key, str):
             xpath, sep, special = key.rpartition('/')
             has_specials = special.startswith('@') or special == 'text()'
-
             if not has_specials:
                 xpath = f'{xpath}{sep}{special}'
 
             # Allow abbreviations of relative paths, absolute paths error
             if xpath.startswith('/'):
                 xpath = f'.{xpath}'
-            elif not xpath:
-                pass
-            elif not xpath.startswith('./'):
+            elif xpath and not xpath.startswith('./'):
                 xpath = f'./{xpath}'
 
             findings = obj.iterfind(xpath) if xpath else [obj]

--- a/yt_dlp/utils/traversal.py
+++ b/yt_dlp/utils/traversal.py
@@ -201,11 +201,10 @@ def traverse_obj(
             if not xpath:
                 result = apply_specials(obj)
             else:
-                findings = obj.iterfind(xpath)
+                result = obj.iterfind(xpath)
                 if has_specials:
-                    result = list(map(apply_specials, findings))
-                else:
-                    result = list(findings)
+                    result = map(apply_specials, result)
+                result = list(result)
 
         return branching, result if branching else (result,)
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds support for `xml.etree.ElementTree.Element` in general traversal (`...`, `lambda a, b: ...` as well as `int`/`slice`)
It also adds xpath support when using a `str` key, applying manual special transformations that come in handy, like `@attribute` (get value of that attribute), `@` (get attribute dict) and `text()` (get inner text). The xpath returns a list, except when the key is only `@attr` or `text()`, at which case it returns the value directly.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>