### PR TITLE
[FFmpegMerger] Fix merger discard input timestamps

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -822,7 +822,7 @@ class FFmpegMergerPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
-        args = ['-c', 'copy']
+        args = ['-c', 'copy', '-copyts']
         audio_streams = 0
         for (i, fmt) in enumerate(info['requested_formats']):
             if fmt.get('acodec') != 'none':


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Some website save video-only and audio-only file with non-zero timestamp(Found on www.bilibili.com). Therefore, when merging the audio and video, ffmpeg should keep the original timestamp or the video and audio will be out of sync.

Example:

yt-dlp -F give:
```
ID    EXT RESOLUTION FPS │   FILESIZE    TBR PROTO │ VCODEC         VBR ACODEC      ABR
───────────────────────────────────────────────────────────────────────────────────────
30216 m4a audio only     │ ≈  2.51MiB    39k https │ audio only         mp4a.40.5   39k
30232 m4a audio only     │ ≈  5.88MiB    92k https │ audio only         mp4a.40.2   92k
30280 m4a audio only     │ ≈  9.87MiB   155k https │ audio only         mp4a.40.2  155k
30016 mp4 640x360     30 │ ≈ 23.35MiB   367k https │ avc1.64001E   367k video only
30032 mp4 852x480     30 │ ≈ 52.44MiB   824k https │ avc1.64001F   824k video only
30064 mp4 1280x720    30 │ ≈116.21MiB  1827k https │ avc1.640028  1827k video only
30080 mp4 1920x1080   30 │ ≈173.36MiB  2725k https │ avc1.640032  2725k video only
30116 mp4 1920x1080   59 │ ≈346.03MiB  5439k https │ avc1.640032  5439k video only
30120 mp4 3840x2160   59 │ ≈  1.16GiB 18644k https │ avc1.640034 18644k video only
```

```
# ffprobe -show_streams f30280.m4a 2>/dev/null |grep start
start_pts=0
start_time=0.000000

# ffprobe -show_streams f30120.mp4 2>/dev/null |grep start
start_pts=19616
start_time=1.226000
```

Fixes #

The fix is very simple, according to ffmpeg doc, copyts is the desired argument.
`-copyts`: Do not process input timestamps, but keep their values without trying to sanitize them. In particular, do not remove the initial start time offset value.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
