### PR TITLE
[floatplane] feat: share playlist post fields with playlist entries

### DIFF
--- a/yt_dlp/extractor/floatplane.py
+++ b/yt_dlp/extractor/floatplane.py
@@ -112,7 +112,6 @@ class FloatplaneIE(InfoExtractor):
         'url': 'https://www.floatplane.com/post/65B5PNoBtf',
         'info_dict': {
             'id': '65B5PNoBtf',
-            'ext': None,
             'description': 'I recorded the inbuilt demo mode for your 90\'s enjoyment, thanks for being Floaties!',
             'display_id': '65B5PNoBtf',
             'like_count': int,
@@ -124,15 +123,13 @@ class FloatplaneIE(InfoExtractor):
             'channel_url': 'https://www.floatplane.com/channel/TheTrashNetwork/home/thedrumthing',
             'comment_count': int,
             'title': 'The $50 electronic drum kit.',
-            'duration': None,
             'channel_id': '64424fe73cd58cbcf8d8e131',
             'thumbnail': 'https://pbs.floatplane.com/blogPost_thumbnails/65B5PNoBtf/725555379422705_1701247052743.jpeg',
             'dislike_count': int,
             'channel': 'The Drum Thing',
             'release_date': '20231129',
         },
-        'uploader_url': 'https://www.floatplane.com/channel/TheTrashNetwork/home',
-        "playlist_count": 2,
+        'playlist_count': 2,
         'playlist': [{
             'info_dict': {
                 'id': 'ISPJjexylS',
@@ -158,7 +155,6 @@ class FloatplaneIE(InfoExtractor):
                 'release_timestamp': 1701249480,
                 'title': 'Roland TD-7 Demo.m4a',
                 'channel_id': '64424fe73cd58cbcf8d8e131',
-                'thumbnail': None,
                 'availability': 'subscriber_only',
                 'uploader': 'The Trash Network',
                 'duration': 114,
@@ -192,10 +188,10 @@ class FloatplaneIE(InfoExtractor):
 
         common_info = {
             **traverse_obj(post_data, {
-                'uploader': ('creator', 'title'),
-                'uploader_id': ('creator', 'id'),
-                'channel': ('channel', 'title'),
-                'channel_id': ('channel', 'id'),
+                'uploader': ('creator', 'title', {str}),
+                'uploader_id': ('creator', 'id', {str}),
+                'channel': ('channel', 'title', {str}),
+                'channel_id': ('channel', 'id', {str}),
                 'release_timestamp': ('releaseDate', {parse_iso8601}),
             }),
             'uploader_url': uploader_url,

--- a/yt_dlp/extractor/floatplane.py
+++ b/yt_dlp/extractor/floatplane.py
@@ -11,6 +11,7 @@ from ..utils import (
     join_nonempty,
     parse_codecs,
     parse_iso8601,
+    url_or_none,
     urljoin,
 )
 from ..utils.traversal import traverse_obj
@@ -224,11 +225,11 @@ class FloatplaneIE(InfoExtractor):
             formats = []
             for quality in traverse_obj(stream, ('resource', 'data', 'qualityLevels', ...)):
                 url = urljoin(stream['cdn'], format_path(traverse_obj(
-                    stream, ('resource', 'data', 'qualityLevelParams', quality['name']))))
+                    stream, ('resource', 'data', 'qualityLevelParams', quality['name'], {dict}))))
                 formats.append({
                     **traverse_obj(quality, {
-                        'format_id': 'name',
-                        'format_note': 'label',
+                        'format_id': ('name', {str}),
+                        'format_note': ('label', {str}),
                         'width': ('width', {int}),
                         'height': ('height', {int}),
                     }),
@@ -241,9 +242,9 @@ class FloatplaneIE(InfoExtractor):
                 **common_info,
                 'id': media_id,
                 **traverse_obj(metadata, {
-                    'title': 'title',
+                    'title': ('title', {str}),
                     'duration': ('duration', {int_or_none}),
-                    'thumbnail': ('thumbnail', 'path'),
+                    'thumbnail': ('thumbnail', 'path', {url_or_none}),
                 }),
                 'formats': formats,
             })
@@ -253,12 +254,12 @@ class FloatplaneIE(InfoExtractor):
             'id': post_id,
             'display_id': post_id,
             **traverse_obj(post_data, {
-                'title': 'title',
+                'title': ('title', {str}),
                 'description': ('text', {clean_html}),
                 'like_count': ('likes', {int_or_none}),
                 'dislike_count': ('dislikes', {int_or_none}),
                 'comment_count': ('comments', {int_or_none}),
-                'thumbnail': ('thumbnail', 'path'),
+                'thumbnail': ('thumbnail', 'path', {url_or_none}),
             }),
         }
 

--- a/yt_dlp/extractor/floatplane.py
+++ b/yt_dlp/extractor/floatplane.py
@@ -184,9 +184,11 @@ class FloatplaneIE(InfoExtractor):
 
         uploader_url = format_field(
             post_data, [('creator', 'urlname')], 'https://www.floatplane.com/channel/%s/home') or None
-        channel_url = urljoin(f'{uploader_url}/', traverse_obj(post_data, ('channel', 'urlname')))
 
         common_info = {
+            'uploader_url': uploader_url,
+            'channel_url': urljoin(f'{uploader_url}/', traverse_obj(post_data, ('channel', 'urlname'))),
+            'availability': self._availability(needs_subscription=True),
             **traverse_obj(post_data, {
                 'uploader': ('creator', 'title', {str}),
                 'uploader_id': ('creator', 'id', {str}),
@@ -194,9 +196,6 @@ class FloatplaneIE(InfoExtractor):
                 'channel_id': ('channel', 'id', {str}),
                 'release_timestamp': ('releaseDate', {parse_iso8601}),
             }),
-            'uploader_url': uploader_url,
-            'channel_url': channel_url,
-            'availability': self._availability(needs_subscription=True),
         }
 
         items = []


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Floatplane post can contain multiple items of video/audio, not just one. I'll call these playlist posts as opposed to regular posts

The extractor properly picks up all the entries in a playlist post. Downloading works fine. However some of the fields that would be available when downloading a regular post were not available for playlist entries. 

I ran into this myself when I tried to use `%(release_date)s` in an output template. 

This change:
- collects common fields for the post entry and playlist entries ...
- ... and spreads them in 1) the post info, and 2) every playlist entry
- adds a test to verify.

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
