### PR TITLE
Fix GoPro extractor.

### DIFF
--- a/yt_dlp/extractor/gopro.py
+++ b/yt_dlp/extractor/gopro.py
@@ -3,18 +3,10 @@ from ..utils import (
     int_or_none,
     remove_end,
     str_or_none,
-    strip_or_none,
     try_get,
     unified_timestamp,
     url_or_none,
 )
-
-
-# gopro.com returns empty string as author/track for some video. Treat it as
-# if it were null.
-def nonempty_or_none(s):
-    v = strip_or_none(s)
-    return None if v == '' else v
 
 
 class GoProIE(InfoExtractor):
@@ -106,8 +98,8 @@ class GoProIE(InfoExtractor):
                 try_get(metadata, lambda x: x['account']['nickname'])),
             'duration': int_or_none(
                 video_info.get('source_duration')),
-            'artist': nonempty_or_none(
-                video_info.get('music_track_artist')),
-            'track': nonempty_or_none(
-                video_info.get('music_track_name')),
+            'artist': str_or_none(
+                video_info.get('music_track_artist')) or None,
+            'track': str_or_none(
+                video_info.get('music_track_name')) or None,
         }

--- a/yt_dlp/extractor/gopro.py
+++ b/yt_dlp/extractor/gopro.py
@@ -57,8 +57,8 @@ class GoProIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        metadata = self._parse_json(
-            self._html_search_regex(r'window\.__reflectData\s*=\s*([^;]+)', webpage, 'metadata'), video_id)
+        metadata = self._search_json(r'<script>window\.__reflectData\s*=',
+                                     webpage, 'metadata', video_id)
 
         video_info = metadata['collectionMedia'][0]
         media_data = self._download_json(

--- a/yt_dlp/extractor/gopro.py
+++ b/yt_dlp/extractor/gopro.py
@@ -3,10 +3,18 @@ from ..utils import (
     int_or_none,
     remove_end,
     str_or_none,
+    strip_or_none,
     try_get,
     unified_timestamp,
     url_or_none,
 )
+
+
+# gopro.com returns empty string as author/track for some video. Treat it as
+# if it were null.
+def nonempty_or_none(s):
+    v = strip_or_none(s)
+    return None if v == '' else v
 
 
 class GoProIE(InfoExtractor):
@@ -98,8 +106,8 @@ class GoProIE(InfoExtractor):
                 try_get(metadata, lambda x: x['account']['nickname'])),
             'duration': int_or_none(
                 video_info.get('source_duration')),
-            'artist': str_or_none(
+            'artist': nonempty_or_none(
                 video_info.get('music_track_artist')),
-            'track': str_or_none(
+            'track': nonempty_or_none(
                 video_info.get('music_track_name')),
         }

--- a/yt_dlp/extractor/gopro.py
+++ b/yt_dlp/extractor/gopro.py
@@ -58,7 +58,7 @@ class GoProIE(InfoExtractor):
         webpage = self._download_webpage(url, video_id)
 
         metadata = self._search_json(
-            r'<script>window\.__reflectData\s*=', webpage, 'metadata', video_id)
+            r'window\.__reflectData\s*=', webpage, 'metadata', video_id)
 
         video_info = metadata['collectionMedia'][0]
         media_data = self._download_json(

--- a/yt_dlp/extractor/gopro.py
+++ b/yt_dlp/extractor/gopro.py
@@ -57,8 +57,8 @@ class GoProIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        metadata = self._search_json(r'<script>window\.__reflectData\s*=',
-                                     webpage, 'metadata', video_id)
+        metadata = self._search_json(
+            r'<script>window\.__reflectData\s*=', webpage, 'metadata', video_id)
 
         video_info = metadata['collectionMedia'][0]
         media_data = self._download_json(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

The GoPro extractor fails even when used on the URLs recorded in the tests with an error like:

```
[GoPro] Extracting URL: https://gopro.com/v/KRm6Vgp2peg4e [GoPro] KRm6Vgp2peg4e: Downloading webpage
ERROR: [GoPro] KRm6Vgp2peg4e: KRm6Vgp2peg4e: Failed to parse JSON (caused by JSONDecodeError('Expecting \',\' delimiter in \'"shop_url"=>"https:/\': line 1 column 5120 (char 5119)')); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
  File "/storage/avn/git/yt-dlp/yt_dlp/extractor/common.py", line 718, in extract
...
```

- The JSON in the webpage now contains semicolons as part of HTML entities such as `&quot;`. This makes the regexp used for matching truncate the JSON prematurely.
- The same entities are replaced with the respective characters by `clean_html`, resulting in an invalid JSON.
- One of the tests for the extractor fails because of unexpected `author` and `track` fields in the returned dictionary.

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
</details>
