### PR TITLE
[ie/facebook] preserve thumbnail provided in video info

### DIFF
--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -515,7 +515,7 @@ class FacebookIE(InfoExtractor):
                 'uploader': uploader,
                 'uploader_id': uploader_data.get('id'),
                 'timestamp': timestamp,
-                'thumbnails': [{'url': thumbnail}],
+                'thumbnails': [{'url': thumbnail}] if url_or_none(thumbnail) else None,
                 'view_count': parse_count(self._search_regex(
                     (r'\bviewCount\s*:\s*["\']([\d,.]+)', r'video_view_count["\']\s*:\s*(\d+)',),
                     webpage, 'view count', default=None)),
@@ -680,8 +680,8 @@ class FacebookIE(InfoExtractor):
                     webpage_info['duration'] = video_info['duration']
                 # preserve preferred_thumbnail in video info
                 if video_info.get('thumbnail'):
-                    if not [x for x in webpage_info['thumbnails'] if video_info['thumbnail'].split('?')[0] in x['url']]:
-                        webpage_info['thumbnails'].append({
+                    if not webpage_info.get('thumbnails') or not [x for x in webpage_info['thumbnails'] if video_info['thumbnail'].split('?')[0] in x['url']]:
+                        webpage_info.setdefault('thumbnails', []).append({
                             'url': video_info['thumbnail'],
                             'preference': 1
                         })

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -515,7 +515,7 @@ class FacebookIE(InfoExtractor):
                 'uploader': uploader,
                 'uploader_id': uploader_data.get('id'),
                 'timestamp': timestamp,
-                'thumbnail': thumbnail,
+                'thumbnails': [{'url': thumbnail}],
                 'view_count': parse_count(self._search_regex(
                     (r'\bviewCount\s*:\s*["\']([\d,.]+)', r'video_view_count["\']\s*:\s*(\d+)',),
                     webpage, 'view count', default=None)),
@@ -678,6 +678,13 @@ class FacebookIE(InfoExtractor):
                 # honor precise duration in video info
                 if video_info.get('duration'):
                     webpage_info['duration'] = video_info['duration']
+                # preserve preferred_thumbnail in video info
+                if video_info.get('thumbnail'):
+                    if not [x for x in webpage_info['thumbnails'] if video_info['thumbnail'].split('?')[0] in x['url']]:
+                        webpage_info['thumbnails'].append({
+                            'url': video_info['thumbnail'],
+                            'preference': 1
+                        })
                 return merge_dicts(webpage_info, video_info)
 
         if not video_data:

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -515,7 +515,7 @@ class FacebookIE(InfoExtractor):
                 'uploader': uploader,
                 'uploader_id': uploader_data.get('id'),
                 'timestamp': timestamp,
-                'thumbnails': [{'url': thumbnail}] if url_or_none(thumbnail) else None,
+                'thumbnails': [{'url': thumbnail}] if url_or_none(thumbnail) else [],
                 'view_count': parse_count(self._search_regex(
                     (r'\bviewCount\s*:\s*["\']([\d,.]+)', r'video_view_count["\']\s*:\s*(\d+)',),
                     webpage, 'view count', default=None)),
@@ -680,8 +680,8 @@ class FacebookIE(InfoExtractor):
                     webpage_info['duration'] = video_info['duration']
                 # preserve preferred_thumbnail in video info
                 if video_info.get('thumbnail'):
-                    if not webpage_info.get('thumbnails') or not [x for x in webpage_info['thumbnails'] if video_info['thumbnail'].split('?')[0] in x['url']]:
-                        webpage_info.setdefault('thumbnails', []).append({
+                    if not [x for x in webpage_info['thumbnails'] if video_info['thumbnail'].split('?')[0] in x['url']]:
+                        webpage_info['thumbnails'].append({
                             'url': video_info['thumbnail'],
                             'preference': 1
                         })

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -515,7 +515,7 @@ class FacebookIE(InfoExtractor):
                 'uploader': uploader,
                 'uploader_id': uploader_data.get('id'),
                 'timestamp': timestamp,
-                'thumbnails': [{'url': thumbnail}] if url_or_none(thumbnail) else [],
+                'thumbnail': thumbnail,
                 'view_count': parse_count(self._search_regex(
                     (r'\bviewCount\s*:\s*["\']([\d,.]+)', r'video_view_count["\']\s*:\s*(\d+)',),
                     webpage, 'view count', default=None)),

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -680,11 +680,7 @@ class FacebookIE(InfoExtractor):
                     webpage_info['duration'] = video_info['duration']
                 # preserve preferred_thumbnail in video info
                 if video_info.get('thumbnail'):
-                    if not [x for x in webpage_info['thumbnails'] if video_info['thumbnail'].split('?')[0] in x['url']]:
-                        webpage_info['thumbnails'].append({
-                            'url': video_info['thumbnail'],
-                            'preference': 1
-                        })
+                    webpage_info['thumbnail'] = video_info['thumbnail']
                 return merge_dicts(webpage_info, video_info)
 
         if not video_data:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Changes to preserve preferred_thumbnail url obtained from video info
because video_info['thumbnail'] is lost during merge_dicts

example:  https://www.facebook.com/events/1509582499515440
Two different thumbnails are provided:
1st one:  from "og:image" meta tag
2nd one:  preferred_thumbnail in ScheduledServerJS json

They will be put into webpage_info['thumbnail'] and video_info['thumbnail'] respectively.
Due to the use of merge_dicts, "merge_dicts(webpage_info, video_info)", webpage_info['thumbnail'] will be put into the merged dict but video_info['thumbnail'] will be ignored. The changes is made in order to keep both.



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
