### PR TITLE
[ie/adn] require subscriptions in German

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ cookies
 *.png
 *.sbv
 *.srt
+*.ssa
 *.swf
 *.swp
 *.tt

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ cookies
 *.png
 *.sbv
 *.srt
-*.ssa
 *.swf
 *.swp
 *.tt

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -187,6 +187,11 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
             'Downloading player config JSON metadata',
             headers=self._HEADERS)['player']
         options = player['options']
+        video = options['video']
+        startDate = video.get('startDate')
+        currentDate = video.get('currentDate')
+        if startDate and currentDate and startDate > currentDate:
+            raise ExtractorError(f'This video is not available yet. Release date: {startDate}', expected=True)
 
         subscription_msg = 'This video requires a subscription'
         # Ad supported videos are not yet available in German

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -190,7 +190,7 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
 
         user = options['user']
         if not user.get('hasAccess'):
-            self.raise_login_required(msg='This video requires a subscription', method='password')
+            self.raise_login_required('This video requires a subscription', method='password')
 
         token = self._download_json(
             user.get('refreshTokenUrl') or (self._PLAYER_BASE_URL + 'refresh/token'),
@@ -273,7 +273,7 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
                 formats.extend(m3u8_formats)
 
         if not formats:
-            self.raise_login_required(msg='This video requires a subscription', method='password')
+            self.raise_login_required('This video requires a subscription', method='password')
 
         video = (self._download_json(
             self._API_BASE_URL + 'video/%s' % video_id, video_id,

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -176,6 +176,11 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
 
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
+        username, password = self._get_login_info()
+        # ADN requires login for German site (at least for now)
+        if lang == 'de' and (not username or not password):
+            self.raise_login_required(method='password')
+
         video_base_url = self._PLAYER_BASE_URL + 'video/%s/' % video_id
         player = self._download_json(
             video_base_url + 'configuration', video_id,
@@ -183,9 +188,17 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
             headers=self._HEADERS)['player']
         options = player['options']
 
+        subscription_msg = 'This video requires a subscription'
+        # Ad supported videos are not yet available in German
+        if lang == 'de' and 'ads' in options:
+            raise ExtractorError(subscription_msg, expected=True)
+
         user = options['user']
         if not user.get('hasAccess'):
-            self.raise_login_required()
+            if username and password:
+                raise ExtractorError(subscription_msg, expected=True)
+
+            self.raise_login_required(method='password')
 
         token = self._download_json(
             user.get('refreshTokenUrl') or (self._PLAYER_BASE_URL + 'refresh/token'),

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -190,7 +190,7 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
             start_date = traverse_obj(options, ('video', 'startDate', {str}))
             if (parse_iso8601(start_date) or 0) > time.time():
                 raise ExtractorError(f'This video is not available yet. Release date: {start_date}', expected=True)
-            self.raise_login_required(msg='This video requires a subscription', method='password')
+            self.raise_login_required('This video requires a subscription', method='password')
 
         token = self._download_json(
             user.get('refreshTokenUrl') or (self._PLAYER_BASE_URL + 'refresh/token'),


### PR DESCRIPTION
ADN DE requires an account and subscription for all videos
add error message for missing subscription case if logged in

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

ADN only supports login using username/password. Adjust `raise_login_required` call accordingly.
Also the German site is still somewhat restricted as it doesn't provide free ad supported content (yet). Added checks for this and raise Exceptions if the user isn't logged in or doesn't have a subcription.

Fixes #9067


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
