### PR TITLE
fix download redtube.com

### DIFF
--- a/yt_dlp/extractor/redtube.py
+++ b/yt_dlp/extractor/redtube.py
@@ -79,7 +79,7 @@ class RedTubeIE(InfoExtractor):
                 'media definitions', default='{}'),
             video_id, fatal=False)
         for media in medias if isinstance(medias, list) else []:
-            format_url = url_or_none(media.get('videoUrl'))
+            format_url = url_or_none('https://www.redtube.com' + media.get('videoUrl'))
             if not format_url:
                 continue
             format_id = media.get('format')

--- a/yt_dlp/extractor/redtube.py
+++ b/yt_dlp/extractor/redtube.py
@@ -79,7 +79,7 @@ class RedTubeIE(InfoExtractor):
                 'media definitions', default='{}'),
             video_id, fatal=False)
         for media in medias if isinstance(medias, list) else []:
-            format_url = url_or_none('https://www.redtube.com' + media.get('videoUrl'))
+            format_url = urljoin('https://www.redtube.com', media.get('videoUrl'))
             if not format_url:
                 continue
             format_id = media.get('format')

--- a/yt_dlp/extractor/redtube.py
+++ b/yt_dlp/extractor/redtube.py
@@ -7,6 +7,7 @@ from ..utils import (
     str_to_int,
     unified_strdate,
     url_or_none,
+    urljoin,
 )
 
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Reason: because https://www.redtube.com is not added to the beginning of the URL of the videoURL variable. I added it and it worked fine

```
[debug] Command-line config: ['-Fv', 'https://www.redtube.com/103228341']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.12.30 from yt-dlp/yt-dlp [f10589e34] (linux_exe)
[debug] Python 3.10.12 (CPython x86_64 64bit) - Linux-5.15.0-91-generic-x86_64-with-glibc2.35 (OpenSSL 3.0.2 15 Mar 2022, glibc 2.35)
[debug] exe versions: ffmpeg 4.4.2 (setts), ffprobe 4.4.2
[debug] Optional libraries: Cryptodome-3.20.0, brotli-1.1.0, certifi-2023.11.17, mutagen-1.47.0, requests-2.31.0, secretstorage-3.3.1, sqlite3-3.37.2, urllib3-2.1.0, websockets-12.0
[debug] Request Handlers: urllib, requests, websockets
[debug] Loaded 1819 extractors
[RedTube] Extracting URL: https://www.redtube.com/103228341
[RedTube] 103228341: Downloading webpage
[RedTube] 103228341: Downloading JSON metadata
[RedTube] 103228341: Downloading m3u8 information
[RedTube] 103228341: Downloading m3u8 information
[RedTube] 103228341: Downloading m3u8 information
[RedTube] 103228341: Downloading m3u8 information
[RedTube] 103228341: Downloading m3u8 information
[RedTube] 103228341: Downloading JSON metadata
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] Available formats for 103228341:
ID         EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC      ACODEC
──────────────────────────────────────────────────────────────────────────────
240        mp4 240p           │                  https │ unknown     unknown
hls-377-0  mp4 426x240     30 │ ~ 41.97MiB  378k m3u8  │ avc1.640015 mp4a.40.2
hls-377-1  mp4 426x240     30 │ ~ 41.97MiB  378k m3u8  │ avc1.640015 mp4a.40.2
480        mp4 480p           │                  https │ unknown     unknown
hls-781-0  mp4 854x480     30 │ ~ 86.77MiB  781k m3u8  │ avc1.64001f mp4a.40.2
hls-781-1  mp4 854x480     30 │ ~ 86.77MiB  781k m3u8  │ avc1.64001f mp4a.40.2
720        mp4 720p           │                  https │ unknown     unknown
hls-1411-0 mp4 1280x720    30 │ ~156.82MiB 1412k m3u8  │ avc1.64001f mp4a.40.2
hls-1411-1 mp4 1280x720    30 │ ~156.82MiB 1412k m3u8  │ avc1.64001f mp4a.40.2
1080       mp4 1080p          │                  https │ unknown     unknown
hls-2030-0 mp4 1920x1080   30 │ ~225.61MiB 2031k m3u8  │ avc1.640032 mp4a.40.2
hls-2030-1 mp4 1920x1080   30 │ ~225.61MiB 2031k m3u8  │ avc1.640032 mp4a.40.2
```

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
