### PR TITLE
[ie/NhkRadiru] Extract extended description

### DIFF
--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -539,14 +539,16 @@ class NhkRadiruIE(InfoExtractor):
         },
     }]
 
+    _api_config = None
+
     def _extract_extended_description(self, episode_id, aa_vinfo2, aa_vinfo3):
         service, area = aa_vinfo2.split(",")
 
-        config = self._download_xml('https://www.nhk.or.jp/radio/config/config_web.xml', episode_id,
-                                    'Downloading API information', fatal=False)
-        if not config:
-            return
-        full_meta = self._download_json(f'https:{config.find(".//url_program_detail").text}'.format(
+        if not self._api_config:
+            self._api_config = self._download_xml('https://www.nhk.or.jp/radio/config/config_web.xml',
+                                                  episode_id, 'Downloading API information', fatal=False)
+
+        full_meta = self._download_json(f'https:{self._api_config.find(".//url_program_detail").text}'.format(
                                         service=service, area=area, dateid=aa_vinfo3),
                                         episode_id, note='Downloading extended metadata', fatal=False)
         if not full_meta:

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -507,7 +507,6 @@ class NhkRadiruIE(InfoExtractor):
     }, {
         # one with letters in the id
         'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F300_06_3738470',
-        'skip': 'Test fails due to extended description request failing - falls back to normal in real usage',
         'note': 'Expires on 2024-03-31',
         'info_dict': {
             'id': 'F300_06_3738470',
@@ -522,7 +521,8 @@ class NhkRadiruIE(InfoExtractor):
             'series': 'らじる文庫 by ラジオ深夜便 ',
             'release_timestamp': 1481126700,
             'upload_date': '20211101',
-        }
+        },
+        'expected_warnings': ['Unable to download JSON metadata', 'Couldn\'t get extended description'],
     }, {
         # news
         'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F261_01_3855109',

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -551,8 +551,9 @@ class NhkRadiruIE(InfoExtractor):
             return
 
         if not isinstance(self._api_config, xml.etree.ElementTree.Element):
-            self._api_config = self._download_xml('https://www.nhk.or.jp/radio/config/config_web.xml',
-                                                  episode_id, 'Downloading API information', fatal=False)
+            self._api_config = self._download_xml(
+                'https://www.nhk.or.jp/radio/config/config_web.xml',
+                episode_id, 'Downloading API information', fatal=False)
 
         detail_url = try_call(
             lambda: f'https:{self._api_config.find(".//url_program_detail").text}'.format(
@@ -561,10 +562,9 @@ class NhkRadiruIE(InfoExtractor):
             return
 
         full_meta = self._download_json(detail_url, episode_id, 'Downloading extended metadata', fatal=False)
-        if not full_meta:
-            return
-        return join_nonempty('subtitle', 'content', 'act', 'music', delim='\n\n',
-                             from_dict=traverse_obj(full_meta, ('list', service, 0)))
+        return join_nonempty(
+            'subtitle', 'content', 'act', 'music', delim='\n\n',
+            from_dict=traverse_obj(full_meta, ('list', service, 0, {dict}), default={}))
 
     def _extract_episode_info(self, headline, programme_id, series_meta):
         episode_id = f'{programme_id}_{headline["headline_id"]}'

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -490,7 +490,6 @@ class NhkRadiruIE(InfoExtractor):
             'timestamp': 1708185600,
             'release_timestamp': 1708178400,
             'upload_date': '20240217',
-
         },
     }, {
         # playlist, airs every weekday so it should _hopefully_ be okay forever
@@ -522,7 +521,7 @@ class NhkRadiruIE(InfoExtractor):
             'release_timestamp': 1481126700,
             'upload_date': '20211101',
         },
-        'expected_warnings': ['Unable to download JSON metadata', 'Couldn\'t get extended description'],
+        'expected_warnings': ['Unable to download JSON metadata', 'Failed to get extended description'],
     }, {
         # news
         'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F261_01_3855109',
@@ -570,9 +569,8 @@ class NhkRadiruIE(InfoExtractor):
         episode_id = f'{programme_id}_{headline["headline_id"]}'
         episode = traverse_obj(headline, ('file_list', 0, {dict}))
         description = self._extract_extended_description(episode_id, episode)
-
         if not description:
-            self.report_warning('Couldn\'t get extended description, falling back to summary')
+            self.report_warning('Failed to get extended description, falling back to summary')
             description = traverse_obj(episode, ('file_title_sub', {str}))
 
         return {

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -475,22 +475,22 @@ class NhkRadiruIE(InfoExtractor):
     IE_DESC = 'NHK らじる (Radiru/Rajiru)'
     _VALID_URL = r'https?://www\.nhk\.or\.jp/radio/(?:player/ondemand|ondemand/detail)\.html\?p=(?P<site>[\da-zA-Z]+)_(?P<corner>[\da-zA-Z]+)(?:_(?P<headline>[\da-zA-Z]+))?'
     _TESTS = [{
-        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=0449_01_3853544',
-        'skip': 'Episode expired on 2023-04-16',
+        'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=0449_01_3926210',
+        'skip': 'Episode expired on 2024-02-24',
         'info_dict': {
-            'channel': 'NHK-FM',
-            'uploader': 'NHK-FM',
-            'description': 'md5:94b08bdeadde81a97df4ec882acce3e9',
+            'title': 'ジャズ・トゥナイト　シリーズＪＡＺＺジャイアンツ　５６　ジョニー・ホッジス',
+            'id': '0449_01_3926210',
             'ext': 'm4a',
-            'id': '0449_01_3853544',
             'series': 'ジャズ・トゥナイト',
+            'uploader': 'NHK-FM',
+            'channel': 'NHK-FM',
             'thumbnail': 'https://www.nhk.or.jp/prog/img/449/g449.jpg',
-            'timestamp': 1680969600,
-            'title': 'ジャズ・トゥナイト　ＮＥＷジャズ特集',
-            'upload_date': '20230408',
-            'release_timestamp': 1680962400,
-            'release_date': '20230408',
-            'was_live': True,
+            'release_date': '20240217',
+            'description': 'md5:a456ee8e5e59e6dd2a7d32e62386e811',
+            'timestamp': 1708185600,
+            'release_timestamp': 1708178400,
+            'upload_date': '20240217',
+
         },
     }, {
         # playlist, airs every weekday so it should _hopefully_ be okay forever
@@ -507,6 +507,7 @@ class NhkRadiruIE(InfoExtractor):
     }, {
         # one with letters in the id
         'url': 'https://www.nhk.or.jp/radio/player/ondemand.html?p=F300_06_3738470',
+        'skip': 'Test fails due to extended description request failing - falls back to normal in real usage',
         'note': 'Expires on 2024-03-31',
         'info_dict': {
             'id': 'F300_06_3738470',

--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -561,10 +561,10 @@ class NhkRadiruIE(InfoExtractor):
         if not detail_url:
             return
 
-        full_meta = self._download_json(detail_url, episode_id, 'Downloading extended metadata', fatal=False)
-        return join_nonempty(
-            'subtitle', 'content', 'act', 'music', delim='\n\n',
-            from_dict=traverse_obj(full_meta, ('list', service, 0, {dict}), default={}))
+        full_meta = traverse_obj(
+            self._download_json(detail_url, episode_id, 'Downloading extended metadata', fatal=False),
+            ('list', service, 0, {dict})) or {}
+        return join_nonempty('subtitle', 'content', 'act', 'music', delim='\n\n', from_dict=full_meta)
 
     def _extract_episode_info(self, headline, programme_id, series_meta):
         episode_id = f'{programme_id}_{headline["headline_id"]}'


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Pieces that make up an extended description are available through a
programme info API. They are, in order:
- short summary
- longer description
- the host(s)
- list of songs played

The host(s) field is free text, so it wouldn't be practical to put it in
`cast`. the order of items is copied from the mobile app - other orders
are used on the website's timetable, but I couldn't find the API etc
where they actually come from.

API info is gotten from https://www.nhk.or.jp/radio/config/config_web.xml,
which is the same endpoint used in NhkRadiruLiveIE. I don't think a
BaseIE etc is worth it at this time.

I've made an attempt to only download the API info once when downloading 
a playlist. I'm not sure it's the best/proper way to do it, but it works.

If extracting the extended description fails, it throws a warning and 
falls back to the summary.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
