### PR TITLE
[RedBull] Fix extractors and add new for shows and events

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1620,6 +1620,8 @@ from .redbulltv import (
     RedBullEmbedIE,
     RedBullTVRrnContentIE,
     RedBullIE,
+    RedBullEventIE,
+    RedBullShowIE,
 )
 from .reddit import RedditIE
 from .redge import RedCDNLivxIE

--- a/yt_dlp/extractor/redbulltv.py
+++ b/yt_dlp/extractor/redbulltv.py
@@ -1,42 +1,71 @@
+import re
+
 from .common import InfoExtractor
-from ..networking.exceptions import HTTPError
 from ..utils import (
-    float_or_none,
+    clean_html,
     ExtractorError,
+    extract_attributes,
+    float_or_none,
+    get_element_by_class,
+    get_element_html_by_class,
+    get_element_text_and_html_by_tag,
+    parse_duration,
+    parse_iso8601,
+    traverse_obj,
+    url_or_none,
 )
+
+
+class RedBullBaseIE(InfoExtractor):
+    _INT_FALLBACK_LIST = ['de', 'en', 'es', 'fr']
+    _LAT_FALLBACK_MAP = ['ar', 'bo', 'car', 'cl', 'co', 'mx', 'pe']
+    _SCHEMAS = {
+        'page_config': 'v1:pageConfig',
+        'structured_data': 'v1:structuredData',
+        'video_hero': 'v1:videoHero',
+    }
+
+    def _get_locale(self, region, lang):
+        regions = [region.upper()]
+        if region != 'int':
+            if region in self._LAT_FALLBACK_MAP:
+                regions.append('LAT')
+            if lang in self._INT_FALLBACK_LIST:
+                regions.append('INT')
+        return '>'.join(['%s-%s' % (lang, reg) for reg in regions])
+
+    def _call_api(self, schema, type, slug, region, lang):
+        locale = self._get_locale(region, lang)
+        res = self._download_json(
+            'https://www.redbull.com/v3/api/graphql/v1/v3/query/' + locale,
+            video_id=slug, note=f'Downloading {type[:-1]} metadata', query={
+                'filter[type]': type,
+                'filter[uriSlug]': slug,
+                'disableUsageRestrictions': 'true',
+                'rb3Schema': schema,
+            })
+        data = res['data']
+        if schema == self._SCHEMAS['structured_data']:
+            if len(data) == 0:
+                raise ExtractorError(f'{type[:-1]} not found', expected=True)
+            return data[0]
+        return data
+
+    def _get_video_resource(self, rrn_id):
+        return self._download_json(
+            'https://api-player.redbull.com/rbcom/videoresource',
+            video_id=rrn_id, note='Downloading video resource metadata', query={
+                'videoId': rrn_id,
+            })
 
 
 class RedBullTVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?redbull(?:\.tv|\.com(?:/[^/]+)?(?:/tv)?)(?:/events/[^/]+)?/(?:videos?|live|(?:film|episode)s)/(?P<id>AP-\w+)'
     _TESTS = [{
-        # film
-        'url': 'https://www.redbull.tv/video/AP-1Q6XCDTAN1W11',
-        'md5': 'fb0445b98aa4394e504b413d98031d1f',
-        'info_dict': {
-            'id': 'AP-1Q6XCDTAN1W11',
-            'ext': 'mp4',
-            'title': 'ABC of... WRC - ABC of... S1E6',
-            'description': 'md5:5c7ed8f4015c8492ecf64b6ab31e7d31',
-            'duration': 1582.04,
-        },
-    }, {
-        # episode
         'url': 'https://www.redbull.tv/video/AP-1PMHKJFCW1W11',
-        'info_dict': {
-            'id': 'AP-1PMHKJFCW1W11',
-            'ext': 'mp4',
-            'title': 'Grime - Hashtags S2E4',
-            'description': 'md5:5546aa612958c08a98faaad4abce484d',
-            'duration': 904,
-        },
-        'params': {
-            'skip_download': True,
-        },
-    }, {
-        'url': 'https://www.redbull.com/int-en/tv/video/AP-1UWHCAR9S1W11/rob-meets-sam-gaze?playlist=playlists::3f81040a-2f31-4832-8e2e-545b1d39d173',
         'only_matching': True,
     }, {
-        'url': 'https://www.redbull.com/us-en/videos/AP-1YM9QCYE52111',
+        'url': 'https://www.redbull.com/int-en/tv/video/AP-1UWHCAR9S1W11/rob-meets-sam-gaze?playlist=playlists::3f81040a-2f31-4832-8e2e-545b1d39d173',
         'only_matching': True,
     }, {
         'url': 'https://www.redbull.com/us-en/events/AP-1XV2K61Q51W11/live/AP-1XUJ86FDH1W11',
@@ -49,95 +78,31 @@ class RedBullTVIE(InfoExtractor):
         'only_matching': True,
     }]
 
-    def extract_info(self, video_id):
-        session = self._download_json(
-            'https://api.redbull.tv/v3/session', video_id,
-            note='Downloading access token', query={
-                'category': 'personal_computer',
-                'os_family': 'http',
-            })
-        if session.get('code') == 'error':
-            raise ExtractorError('%s said: %s' % (
-                self.IE_NAME, session['message']))
-        token = session['token']
-
-        try:
-            video = self._download_json(
-                'https://api.redbull.tv/v3/products/' + video_id,
-                video_id, note='Downloading video information',
-                headers={'Authorization': token}
-            )
-        except ExtractorError as e:
-            if isinstance(e.cause, HTTPError) and e.cause.status == 404:
-                error_message = self._parse_json(
-                    e.cause.response.read().decode(), video_id)['error']
-                raise ExtractorError('%s said: %s' % (
-                    self.IE_NAME, error_message), expected=True)
-            raise
-
-        title = video['title'].strip()
-
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            'https://dms.redbull.tv/v3/%s/%s/playlist.m3u8' % (video_id, token),
-            video_id, 'mp4', entry_protocol='m3u8_native', m3u8_id='hls')
-
-        for resource in video.get('resources', []):
-            if resource.startswith('closed_caption_'):
-                splitted_resource = resource.split('_')
-                if splitted_resource[2]:
-                    subtitles.setdefault('en', []).append({
-                        'url': 'https://resources.redbull.tv/%s/%s' % (video_id, resource),
-                        'ext': splitted_resource[2],
-                    })
-
-        subheading = video.get('subheading')
-        if subheading:
-            title += ' - %s' % subheading
-
-        return {
-            'id': video_id,
-            'title': title,
-            'description': video.get('long_description') or video.get(
-                'short_description'),
-            'duration': float_or_none(video.get('duration'), scale=1000),
-            'formats': formats,
-            'subtitles': subtitles,
-        }
+    _PAGE_URL_REGEX = r'<meta property="og:url"\s*content="(?P<url>[^"]+)"'
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        return self.extract_info(video_id)
+        html = self._download_webpage(url, video_id)
+        return self.url_result(
+            re.findall(self._PAGE_URL_REGEX, html)[0], RedBullIE, video_id)
 
 
-class RedBullEmbedIE(RedBullTVIE):  # XXX: Do not subclass from concrete IE
+class RedBullEmbedIE(RedBullBaseIE):
     _VALID_URL = r'https?://(?:www\.)?redbull\.com/embed/(?P<id>rrn:content:[^:]+:[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}:[a-z]{2}-[A-Z]{2,3})'
     _TESTS = [{
-        # HLS manifest accessible only using assetId
         'url': 'https://www.redbull.com/embed/rrn:content:episode-videos:f3021f4f-3ed4-51ac-915a-11987126e405:en-INT',
         'only_matching': True,
+    }, {
+        'url': 'https://www.redbull.com/embed/rrn:content:videos:0c1d4526-2dfc-4491-bc24-239560dbdfff:en-INT',
+        'only_matching': True,
     }]
-    _VIDEO_ESSENSE_TMPL = '''... on %s {
-      videoEssence {
-        attributes
-      }
-    }'''
 
     def _real_extract(self, url):
         rrn_id = self._match_id(url)
-        asset_id = self._download_json(
-            'https://edge-graphql.crepo-production.redbullaws.com/v1/graphql',
-            rrn_id, headers={
-                'Accept': 'application/json',
-                'API-KEY': 'e90a1ff11335423998b100c929ecc866',
-            }, query={
-                'query': '''{
-  resource(id: "%s", enforceGeoBlocking: false) {
-    %s
-    %s
-  }
-}''' % (rrn_id, self._VIDEO_ESSENSE_TMPL % 'LiveVideo', self._VIDEO_ESSENSE_TMPL % 'VideoResource'),
-            })['data']['resource']['videoEssence']['attributes']['assetId']
-        return self.extract_info(asset_id)
+        video_resource = self._get_video_resource(rrn_id)
+        return self.url_result(
+            video_resource['url'], RedBullIE,
+            video_resource['assetId'], video_resource['title'])
 
 
 class RedBullTVRrnContentIE(InfoExtractor):
@@ -158,67 +123,251 @@ class RedBullTVRrnContentIE(InfoExtractor):
         rrn_id += ':%s-%s' % (lang, region.upper())
         return self.url_result(
             'https://www.redbull.com/embed/' + rrn_id,
-            RedBullEmbedIE.ie_key(), rrn_id)
+            RedBullEmbedIE, rrn_id)
 
 
-class RedBullIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?redbull\.com/(?P<region>[a-z]{2,3})-(?P<lang>[a-z]{2})/(?P<type>(?:episode|film|(?:(?:recap|trailer)-)?video)s|live)/(?!AP-|rrn:content:)(?P<id>[^/?#&]+)'
+class RedBullIE(RedBullBaseIE):
+    _VALID_URL = r'https?:\/\/(?:www\.)?redbull\.com\/(?P<region>[a-z]{2,3})-(?P<lang>[a-z]{2})\/(?P<type>videos|films|episodes|live|recap-videos|trailer-videos)\/(?P<id>[^/#?]+)'
     _TESTS = [{
+        'url': 'https://www.redbull.com/int-en/videos/metal-on-streif-dominik-paris-in-kitzbuhel',
+        'info_dict': {
+            'id': 'AAMU3BN1Z0J04IFZVPJ1',
+            'ext': 'mp4',
+            # 'title': 'Metal on Streif: Dominik Paris in Kitzbühel',
+            # 'description': 'md5:b140b299dca20f5d7b3ca561fe5a5d24',
+            # 'upload_date': '20240209',
+            # 'timestamp': 1707472608,
+            # 'duration': 1977.0,
+            # 'thumbnail': r're:^https?://',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://www.redbull.com/int-en/videos/swatch-nines-2023-best-performers?playlistId=rrn:content:videos:22c7c969-85b9-4d30-9b60-a7eda2432c06:en-INT',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.redbull.com/int-en/films/moto-maverick',
+        'info_dict': {
+            'id': 'AA-21YW2JS5S1W12',
+            'ext': 'mp4',
+            'title': 'Moto Maverick',
+            'description': 'Ryan Sipes examines the current state of motocross racing through a stylised and cinematic lens.',
+            'upload_date': '20211224',
+            'timestamp': 1640332802,
+            'duration': 1425,
+            'thumbnail': r're:^https?://',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://www.redbull.com/int-en/films/in-the-wings?autoplay=true',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.redbull.com/int-en/episodes/more-than-a-dive-s1-e6',
+        'only_matching': True,
+    }, {
         'url': 'https://www.redbull.com/int-en/episodes/grime-hashtags-s02-e04',
-        'md5': 'db8271a7200d40053a1809ed0dd574ff',
         'info_dict': {
             'id': 'AA-1MT8DQWA91W14',
             'ext': 'mp4',
-            'title': 'Grime - Hashtags S2E4',
-            'description': 'md5:5546aa612958c08a98faaad4abce484d',
+            'title': 'Grime',
+            'description': 'Evolving from hip-hop, electronic, and dancehall, grime is a murky musical movement full of passion.',
+            'upload_date': '20170221',
+            'timestamp': 1487660400,
+            'duration': 904.0,
+            'thumbnail': r're:^https?://',
+        },
+        'params': {
+            'skip_download': True,
         },
     }, {
-        'url': 'https://www.redbull.com/int-en/films/kilimanjaro-mountain-of-greatness',
+        'url': 'https://www.redbull.com/int-en/live/mondo-classic-2024',
+        'md5': 'ca8ed1669b71907c68b00cce216cb506',
+        'info_dict': {
+            'id': 'AA3YMCCKHF7JGGUY8HY7',
+            'ext': 'mp4',
+            'title': 'Livestream',
+            'description': 'md5:deff294a59c0e692acfa51e2d02d4b5c',
+            'upload_date': '20240125',
+            'timestamp': 1706191087,
+            'thumbnail': r're:^https?://',
+        },
+    }, {
+        # as a part of a playlist
+        'url': 'https://www.redbull.com/int-en/live/laax-open-2024-freeski-slopestyle',
         'only_matching': True,
     }, {
-        'url': 'https://www.redbull.com/int-en/recap-videos/uci-mountain-bike-world-cup-2017-mens-xco-finals-from-vallnord',
-        'only_matching': True,
-    }, {
-        'url': 'https://www.redbull.com/int-en/trailer-videos/kings-of-content',
-        'only_matching': True,
-    }, {
-        'url': 'https://www.redbull.com/int-en/videos/tnts-style-red-bull-dance-your-style-s1-e12',
-        'only_matching': True,
-    }, {
-        'url': 'https://www.redbull.com/int-en/live/mens-dh-finals-fort-william',
+        'url': 'https://www.redbull.com/int-en/live/laax-open-2024-snowboard-slopestyle?playlistId=rrn:content:live-videos:c4c1b1c8-445a-4bcb-9fb8-d8c510ed69bc:en-INT',
         'only_matching': True,
     }, {
         # only available on the int-en website so a fallback is need for the API
-        # https://www.redbull.com/v3/api/graphql/v1/v3/query/en-GB>en-INT?filter[uriSlug]=fia-wrc-saturday-recap-estonia&rb3Schema=v1:hero
+        # https://www.redbull.com/v3/api/graphql/v1/v3/query/en-GB>en-INT?filter[uriSlug]=fia-wrc-saturday-recap-estonia&rb3Schema=v1:videoHero
         'url': 'https://www.redbull.com/gb-en/live/fia-wrc-saturday-recap-estonia',
         'only_matching': True,
+    }, {
+        'url': 'https://www.redbull.com/int-en/recap-videos/uci-mountain-bike-world-cup-2017-mens-xco-finals-from-vallnord',
+        'info_dict': {
+            'id': 'AA-1UM6YNYX92112',
+            'ext': 'mp4',
+            'title': 'Men\'s XCO finals from Vallnord',
+            'description': 'The world’s best men take on the gruelling cross-country course in Vallnord, Andorra.',
+            'upload_date': '20180201',
+            'timestamp': 1517468400,
+            'duration': 6761.0,
+            'thumbnail': r're:^https?://',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://www.redbull.com/int-en/trailer-videos/kings-of-content',
+        'info_dict': {
+            'id': 'AA-1PRQ4VRAW1W12',
+            'ext': 'mp4',
+            'title': 'Kings of Content',
+            'description': 'md5:4af0f7d9938aef4db22115d3b56f02dd',
+            'upload_date': '20170411',
+            'timestamp': 1491901200,
+            'duration': 45.0,
+            'thumbnail': r're:^https?://',
+        },
+        'params': {
+            'skip_download': True,
+        },
     }]
-    _INT_FALLBACK_LIST = ['de', 'en', 'es', 'fr']
-    _LAT_FALLBACK_MAP = ['ar', 'bo', 'car', 'cl', 'co', 'mx', 'pe']
 
     def _real_extract(self, url):
-        region, lang, filter_type, display_id = self._match_valid_url(url).groups()
-        if filter_type == 'episodes':
-            filter_type = 'episode-videos'
-        elif filter_type == 'live':
-            filter_type = 'live-videos'
+        region, lang, type, slug = self._match_valid_url(url).groups()
+        if type == 'episodes':
+            type = 'episode-videos'
+        if type == 'live':
+            type = 'live-videos'
 
-        regions = [region.upper()]
-        if region != 'int':
-            if region in self._LAT_FALLBACK_MAP:
-                regions.append('LAT')
-            if lang in self._INT_FALLBACK_LIST:
-                regions.append('INT')
-        locale = '>'.join(['%s-%s' % (lang, reg) for reg in regions])
+        video_object = self._call_api(
+            self._SCHEMAS['structured_data'], type, slug, region, lang)
+        if type == 'films' or type == 'episode-videos':
+            video_object = video_object['associatedMedia']
 
-        rrn_id = self._download_json(
-            'https://www.redbull.com/v3/api/graphql/v1/v3/query/' + locale,
-            display_id, query={
-                'filter[type]': filter_type,
-                'filter[uriSlug]': display_id,
-                'rb3Schema': 'v1:hero',
-            })['data']['id']
+        rrn_id = video_object['embedUrl'].replace('https://www.redbull.com/embed/', '')
+        video_resource = self._get_video_resource(rrn_id)
 
-        return self.url_result(
-            'https://www.redbull.com/embed/' + rrn_id,
-            RedBullEmbedIE.ie_key(), rrn_id)
+        playability_errors = traverse_obj(video_resource, ('playabilityErrors'))
+        if 'GEO_BLOCKED' in playability_errors:
+            raise ExtractorError('Geo-restricted', expected=True)
+        if playability_errors:
+            raise ExtractorError('Playability error', expected=True)
+
+        video_id = traverse_obj(video_resource, ('assetId', {str}))
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            video_resource['videoUrl'], video_id, 'mp4')
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            **traverse_obj(video_object, {
+                'title': ('name', {str}),
+                'description': ('description', {str}),
+                'duration': ('duration', {parse_duration}),
+                'timestamp': ('uploadDate', {parse_iso8601}),
+                'thumbnail': ('thumbnailUrl', {url_or_none}),
+            }),
+            'aspect_ratio': traverse_obj(video_resource, ('aspectRatio', {float_or_none})),
+        }
+
+
+class RedBullEventIE(RedBullBaseIE):
+    _VALID_URL = r'https?:\/\/(?:www\.)?redbull\.com\/(?P<region>[a-z]{2,3})-(?P<lang>[a-z]{2})\/events\/(?P<id>[^/#?]+)'
+    _TESTS = [{
+        # one replay
+        'url': 'https://www.redbull.com/int-en/events/mondo-classic',
+        'md5': 'ca8ed1669b71907c68b00cce216cb506',
+        'info_dict': {
+            'id': 'AA3YMCCKHF7JGGUY8HY7',
+            'ext': 'mp4',
+            'title': 'Livestream',
+            'description': 'md5:deff294a59c0e692acfa51e2d02d4b5c',
+            'upload_date': '20240125',
+            'timestamp': 1706191087,
+            'thumbnail': r're:^https?://',
+        },
+    }, {
+        # multiple replays
+        'url': 'https://www.redbull.com/int-en/events/laax-open',
+        'info_dict': {
+            'id': 'laax-open',
+            'title': 'Laax Open',
+        },
+        'playlist_mincount': 5,
+    }, {
+        # no replays
+        'url': 'https://www.redbull.com/int-en/events/hahnenkamm-rennen',
+        'only_matching': True,
+    }]
+
+    def _get_livestream_slug(self, html):
+        livestream_div = get_element_html_by_class('playable-livestream__media', html)
+        if not livestream_div:
+            raise ExtractorError('Livestream not found', expected=True)
+        _, livestream_a = get_element_text_and_html_by_tag('a', livestream_div)
+        return extract_attributes(livestream_a)['href'].split('/')[3]
+
+    def _real_extract(self, url):
+        region, lang, slug = self._match_valid_url(url).groups()
+        html = self._download_webpage(url, slug)
+
+        livestream_slug = self._get_livestream_slug(html)
+        video_hero = self._call_api(
+            self._SCHEMAS['video_hero'], 'live-videos', livestream_slug, region, lang)
+
+        sidebar_items = traverse_obj(video_hero, ('sidebar', 'tabs', 0, 'items'))
+        if not sidebar_items:
+            return self.url_result(
+                'https://www.redbull.com/embed/' + video_hero['id'],
+                RedBullEmbedIE, livestream_slug)
+
+        title = clean_html(get_element_by_class('event-hero-view__title', html))
+
+        def entries():
+            for video in sidebar_items:
+                url = 'https://www.redbull.com/embed/' + video['id']
+                yield self.url_result(url, RedBullEmbedIE, video['id'])
+
+        return self.playlist_result(entries(), slug, title)
+
+
+class RedBullShowIE(RedBullBaseIE):
+    _VALID_URL = r'https?:\/\/(?:www\.)?redbull\.com\/(?P<region>[a-z]{2,3})-(?P<lang>[a-z]{2})\/shows\/(?P<id>[^/#?]+)'
+    _TESTS = [{
+        # one season
+        'url': 'https://www.redbull.com/int-en/shows/in-the-dust',
+        'info_dict': {
+            'id': 'in-the-dust',
+            'title': 'Dakar: In the Dust',
+        },
+        'playlist_mincount': 8,
+    }, {
+        # multiple seasons
+        'url': 'https://www.redbull.com/int-en/shows/fia-world-rally-raid-championship',
+        'info_dict': {
+            'id': 'fia-world-rally-raid-championship',
+            'title': 'FIA World Rally-Raid Championship',
+        },
+        'playlist_mincount': 9,
+    }]
+
+    def _real_extract(self, url):
+        region, lang, slug = self._match_valid_url(url).groups()
+        tv_series = self._call_api(
+            self._SCHEMAS['structured_data'], 'shows', slug, region, lang)
+
+        def entries():
+            for season in tv_series['containsSeason']:
+                for episode in season['episode']:
+                    url = episode['associatedMedia']['url']
+                    episode_id = url.split('/')[5]
+                    yield self.url_result(url, RedBullIE, episode_id)
+
+        return self.playlist_result(entries(), slug, tv_series['name'])


### PR DESCRIPTION
### Description of your *pull request* and other information

`RedBullTVIE` extractor doesn't work for some videos.

This endpoint returns 404
`https://api.redbull.tv/v3/products`

https://www.redbull.com/int-en/films/AP-1ZSMAW8FH2111
https://www.redbull.com/embed/rrn:content:trailer-videos:bd09f486-fbb1-5f6a-95a8-872bf100ff6d:en-INT
https://www.redbull.com/int-en/tv/video/rrn:content:videos:a36a0f36-ff1b-5db8-a69d-ee11a14bf48b/tn-ts-style?playlist=rrn:content:event-profiles:83f05926-5de8-5389-b5e4-9bb312d715e8:extras
https://www.redbull.com/int-en/trailer-videos/kings-of-content
https://www.redbull.com/int-en/videos/tnts-style-red-bull-dance-your-style-s1-e12


All links from tests now redirects to:
`https://www.redbull.com/int-en/%type%/%slug%`

For videos that still works and have a response from `/products`, a link to a playlist doesn't work:

```py
'https://dms.redbull.tv/v3/%s/%s/playlist.m3u8' % (video_id, token)
```

https://www.redbull.tv/video/AP-1PMHKJFCW1W11
https://www.redbull.com/int-en/tv/video/AP-1UWHCAR9S1W11/rob-meets-sam-gaze?playlist=playlists::3f81040a-2f31-4832-8e2e-545b1d39d173
https://www.redbull.com/int-en/episodes/AP-1TQWK7XE11W11

So it's impossible to download any video from tests.

I fixed broken extractors using new API endpoints.

I also added two extractors.

`RedBullEventIE` - download one or multiple event replays (if available)
`RedBullShowIE` - a playlist of all seasons and episodes of a show

All endpoints and responses (can be tested with [this](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) VS Code extension):

<details>
<summary>redbull.rest</summary>

```http
### pageConfig

GET https://www.redbull.com/v3/api/graphql/v1/v3/query/en-INT%3Een-INT
    ?filter[type]=live-videos
    &page[limit]=1
    &filter[uriSlug]=mondo-classic-2024
    &disableUsageRestrictions=true
    &rb3Schema=v1:pageConfig

### videoHero

GET https://www.redbull.com/v3/api/graphql/v1/v3/query/en-INT%3Een-INT
    ?filter[type]=live-videos
    &filter[uriSlug]=laax-open-2024-freeski-slopestyle
    &disableUsageRestrictions=true
    &rb3Locale=int-en
    &rb3Schema=v1:videoHero

### video resource

GET https://api-player.redbull.com/rbcom/videoresource
    ?videoId=rrn:content:videos:22c7c969-85b9-4d30-9b60-a7eda2432c06:en-INT

### video resource livestream (no duration)

GET https://api-player.redbull.com/rbcom/videoresource
    ?videoId=rrn:content:live-videos:43714b72-6dd2-4de6-8623-ce4bc3206bd0:en-INT

### video resource GEO_BLOCKED

GET https://api-player.redbull.com/rbcom/videoresource
    ?videoId=rrn:content:live-videos:43714b72-6dd2-4de6-8623-ce4bc3206bd0:en-INT
    &localeMixing=en-INT

### structuredData shows

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=shows
    &filter[uriSlug]=more-than-a-dive
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData

### structuredData videos

GET https://www.redbull.com/v3/api/graphql/v1/v3/query/en-INT%3Een-INT
    ?filter[type]=videos
    &filter[uriSlug]=swatch-nines-2023-best-performers
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData

### structuredData live-videos

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=live-videos
    &filter[uriSlug]=laax-open-2024-snowboard-halfpipe-japanese-livestream
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData

### structuredData recap-videos

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=recap-videos
    &filter[uriSlug]=uci-mountain-bike-world-cup-2017-mens-xco-finals-from-vallnord
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData

### structuredData trailer-videos

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=trailer-videos
    &filter[uriSlug]=kings-of-content
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData

### structuredData films

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=films
    &filter[uriSlug]=moto-maverick
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData

### structuredData episode-videos

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=episode-videos
    &filter[uriSlug]=more-than-a-dive-s1-e6
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData


### duration is 0

GET https://www.redbull.com/v3/api/graphql/v1/v3/feed/en-INT%3Een-INT
    ?filter[type]=live-videos
    &filter[uriSlug]=mondo-classic-2024
    &disableUsageRestrictions=true
    &rb3Schema=v1:structuredData
```

</details>

Fixes https://github.com/yt-dlp/yt-dlp/issues/9170 https://github.com/yt-dlp/yt-dlp/issues/6670


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
