### PR TITLE
[FlexTV] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -617,6 +617,7 @@ from .filmon import (
 from .filmweb import FilmwebIE
 from .firsttv import FirstTVIE
 from .fivetv import FiveTVIE
+from .flextv import FlexTVIE
 from .flickr import FlickrIE
 from .floatplane import (
     FloatplaneIE,

--- a/yt_dlp/extractor/flextv.py
+++ b/yt_dlp/extractor/flextv.py
@@ -1,0 +1,50 @@
+from .common import InfoExtractor
+from ..networking.exceptions import HTTPError
+from ..utils import (
+    ExtractorError,
+    int_or_none,
+    parse_iso8601,
+    str_or_none,
+    traverse_obj,
+    url_or_none,
+    UserNotLive,
+)
+
+
+class FlexTVIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?flextv\.co\.kr/channels/(?P<id>\d+)/live'
+    _TESTS = [{
+        'url': 'https://www.flextv.co.kr/channels/570421/live',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.flextv.co.kr/channels/746/live',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        channel_id = self._match_id(url)
+
+        try:
+            stream_data = self._download_json(
+                f'https://api.flextv.co.kr/api/channels/{channel_id}/stream?option=all', channel_id)
+        except ExtractorError as e:
+            if isinstance(e.cause, HTTPError) and e.cause.status == 400:
+                raise UserNotLive(video_id=channel_id)
+
+        playlist_url = traverse_obj(stream_data, ('sources', 0, 'url'))
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            playlist_url, channel_id, 'mp4')
+
+        return {
+            'id': channel_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            'is_live': True,
+            **traverse_obj(stream_data, {
+                'title': ('stream', 'title', {str_or_none}),
+                'timestamp': ('stream', 'createdAt', {parse_iso8601}),
+                'thumbnail': ('thumbUrl', {url_or_none}),
+                'channel': ('owner', 'name', {str_or_none}),
+                'channel_id': ('owner', 'id', {int_or_none}),
+            }),
+        }

--- a/yt_dlp/extractor/flextv.py
+++ b/yt_dlp/extractor/flextv.py
@@ -36,7 +36,8 @@ class FlexTVIE(InfoExtractor):
 
         try:
             stream_data = self._download_json(
-                f'https://api.flextv.co.kr/api/channels/{channel_id}/stream?option=all', channel_id)
+                f'https://api.flextv.co.kr/api/channels/{channel_id}/stream',
+                channel_id, query={'option': 'all'})
         except ExtractorError as e:
             if isinstance(e.cause, HTTPError) and e.cause.status == 400:
                 raise UserNotLive(video_id=channel_id)

--- a/yt_dlp/extractor/flextv.py
+++ b/yt_dlp/extractor/flextv.py
@@ -2,10 +2,10 @@ from .common import InfoExtractor
 from ..networking.exceptions import HTTPError
 from ..utils import (
     ExtractorError,
+    UserNotLive,
     parse_iso8601,
     str_or_none,
     traverse_obj,
-    UserNotLive,
     url_or_none,
 )
 


### PR DESCRIPTION
### Description of your *pull request* and other information

Extractor for another Korean twitch alternative.

<details>
<summary>API Response</summary>

```json
{
  "id": 570421,
  "title": "고라니율님의 방송국",
  "description": null,
  "thumbUrl": "https://ivs.flextv.co.kr/ivs/v1/585677956555/eGQ2LbyfNcxr/2024/2/10/9/1/sI5dno2WETsd/media/latest_thumbnail/thumb.jpg",
  "fanIcons": [],
  "subBadge": [
    {
      "id": 63,
      "status": 1,
      "channelId": 570421,
      "imgUrl": "https://rlbmnicudtfv5809615.cdn.ntruss.com/sub-badge/1x821qelrugjx8h.png",
      "month": 1,
      "createdAt": "2024-01-26T09:45:58.000Z",
      "updatedAt": null
    },
    {
      "id": 64,
      "status": 1,
      "channelId": 570421,
      "imgUrl": "https://rlbmnicudtfv5809615.cdn.ntruss.com/sub-badge/1x821qelrugk2wv.png",
      "month": 2,
      "createdAt": "2024-01-26T09:46:05.000Z",
      "updatedAt": null
    },
    {
      "id": 65,
      "status": 1,
      "channelId": 570421,
      "imgUrl": "https://rlbmnicudtfv5809615.cdn.ntruss.com/sub-badge/1x821qelrugk853.png",
      "month": 3,
      "createdAt": "2024-01-26T09:46:11.000Z",
      "updatedAt": null
    },
    {
      "id": 66,
      "status": 1,
      "channelId": 570421,
      "imgUrl": "https://rlbmnicudtfv5809615.cdn.ntruss.com/sub-badge/1x821qelrugkdhs.png",
      "month": 6,
      "createdAt": "2024-01-26T09:46:18.000Z",
      "updatedAt": null
    },
    {
      "id": 67,
      "status": 1,
      "channelId": 570421,
      "imgUrl": "https://rlbmnicudtfv5809615.cdn.ntruss.com/sub-badge/1x821qelrugkiw5.png",
      "month": 9,
      "createdAt": "2024-01-26T09:46:25.000Z",
      "updatedAt": null
    }
  ],
  "altThumbUrl": null,
  "sources": [
    {
      "resolution": 0,
      "url": "https://66368cdf63a9.ap-northeast-2.playback.live-video.net/api/video/v1/ap-northeast-2.585677956555.channel.eGQ2LbyfNcxr.m3u8?token=eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhd3M6Y2hhbm5lbC1hcm4iOiJhcm46YXdzOml2czphcC1ub3J0aGVhc3QtMjo1ODU2Nzc5NTY1NTU6Y2hhbm5lbC9lR1EyTGJ5Zk5jeHIiLCJleHAiOjE3MDc2MDYxMzU1NDgsImlhdCI6MTcwNzU2MjkzNX0.rBGdqQA8vxK5KtzCenMekzIX4CIhA2fUwfoA9tmhW65WFgW5p7zhmd7Opiut1iRjxqZN3Aj8dR_STuQ5gTEK23DAF_u35lZcXGcul67UVBXZZ9BJc9d_PmaNz_UTE_bo",
      "format": "ivs"
    }
  ],
  "sourceType": "aws",
  "owner": {
    "loginId": "golaniyule0",
    "nickname": "고라니율",
    "name": "고라니율",
    "thumbUrl": "https://jcmkeuseuzeq6748407.cdn.ntruss.com/members/832195/19g61ls2t3ipc.jpg?type=w&w=180&quality=90",
    "oauth": null,
    "fan": {
      "rating": 0
    },
    "luv": 0,
    "role": "V",
    "sms": 1,
    "id": 832195,
    "condition": 60,
    "phone": "",
    "status": 1,
    "isAdult": true,
    "PI": {
      "isAdult": true
    },
    "ranker": false,
    "memberDiv": 3,
    "appPush": 1,
    "msgCount": 0,
    "signature": false,
    "billboardIs": {
      "billboardIsView": 1,
      "billboardIsVibes": 1,
      "billboardIsSponser": 1
    },
    "isBigFan": 1,
    "isAdultCheck": 1,
    "setting": {},
    "channelStop": null,
    "anniversary": {
      "memberBirthday": null,
      "isBirthday": false,
      "birthDday": null,
      "streamStartDateAt": null,
      "streamStartDday": null,
      "isAnniversary": false,
      "anniversaryDays": []
    },
    "oauthRegPath": null,
    "passwordCheck": null
  },
  "stream": {
    "id": 268947,
    "channelId": 570421,
    "themeId": 5,
    "title": "쿠라야 미안해",
    "resolution": 720,
    "contentHeight": 1080,
    "contentWidth": 1920,
    "streamAgent": "PC",
    "suspended": 0,
    "blind": 0,
    "isRecording": 1,
    "isForAdult": 0,
    "password": "",
    "minRatingLevel": 0,
    "maxViewerCount": 50000,
    "useAltThumbUrl": 0,
    "userAgentType": "M_APP_V1_IVS",
    "disconnectedAt": null,
    "endedAt": null,
    "createdAt": "2024-02-10T09:01:22.000Z",
    "orderNo": 0,
    "resetdateAt": "2024-02-10T09:01:22.000Z",
    "visitAllow": 0,
    "useGame": 0,
    "stopMember": null,
    "isFrozen": false
  },
  "isMobile": false,
  "streamStats": {
    "topFanId": "851696"
  },
  "role": {
    "app": "V",
    "channel": "V"
  },
  "openUrl": {
    "chat": "/redirects/signin?token=undefined&redirectTo=/popup/chat/570421",
    "chatMobile": "/redirects/signin?token=undefined&redirectTo=/popup/m/chat/570421"
  },
  "status": {
    "stat": {
      "numberOfViews": 1456,
      "numberOfSponsor": 0,
      "numberOfRecommendations": 0,
      "numberOfSubs": 3241,
      "totalGrade": 0
    },
    "barrier": {
      "blind": 0,
      "suspended": false,
      "isLocked": false,
      "minRatingLevel": 0,
      "isForAdult": 0
    },
    "title": "쿠라야 미안해",
    "themeId": 5,
    "startedAt": "2024-02-10T09:01:22.000Z",
    "resolution": 720,
    "password": "",
    "visitAllow": 0,
    "useHigh": 0,
    "tag": []
  },
  "broadcastNotice": null,
  "broadcastRule": null,
  "channelExternalLink": {
    "instagram": "https://www.instagram.com/golaniyule_0/",
    "youtube": "https://www.youtube.com/channel/UC4H0Ig_-z5EkDDk3MEHFDbg",
    "tiktok": "https://www.tiktok.com/@golaniyule0",
    "title1": "🔞Likey🔞",
    "link1": "https://likey.me/yule003"
  }
}
```

</details>

There are also endpoints for viewers count, but I don't think it's necessary.

```http
GET https://api.flextv.co.kr/api/channels/570421/stream/player-count
GET https://api.flextv.co.kr/api/channels/570421/stream/player-count-accumulate
```

Closes https://github.com/yt-dlp/yt-dlp/issues/9175


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
