### PR TITLE
[build:Makefile] Ensure compatibility with BSD `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ CODE_FOLDERS != find yt_dlp -type f -name '__init__.py' -exec dirname {} \+ | gr
 CODE_FILES != for f in $(CODE_FOLDERS) ; do echo $$f | sed 's,$$,/*.py,' ; done
 yt-dlp: $(CODE_FILES)
 	@echo $(ERROR_MSG)
-	@echo code_folders: '$(CODE_FOLDERS)'
-	@echo code_files: '$(CODE_FILES)'
+	@echo 'code_folders: $(CODE_FOLDERS)'
+	@echo 'code_files: $(CODE_FILES)'
 	mkdir -p zip
 	for d in $(CODE_FOLDERS) ; do \
 	  mkdir -p zip/$$d ;\

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ yt-dlp.tar.gz: all
 		--exclude '__pycache__' \
 		--exclude '.pytest_cache' \
 		--exclude '.git' \
-		--exclude 'test/testdata/sigs/player-*.js' \
 		--exclude '__pyinstaller' \
 		-- \
 		README.md supportedsites.md Changelog.md LICENSE \

--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,11 @@ supportedsites:
 	$(PYTHON) devscripts/make_supportedsites.py supportedsites.md
 
 README.txt: README.md
+	@echo $(ERROR_MSG)
 	pandoc -f $(MARKDOWN) -t plain README.md -o README.txt
 
 yt-dlp.1: README.md devscripts/prepare_manpage.py
+	@echo $(ERROR_MSG)
 	$(PYTHON) devscripts/prepare_manpage.py yt-dlp.1.temp.md
 	pandoc -s -f $(MARKDOWN) -t man yt-dlp.1.temp.md -o yt-dlp.1
 	rm -f yt-dlp.1.temp.md

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PYTHON ?= /usr/bin/env python3
 # $(shell) and $(error) are no-ops in BSD Make and the != variable assignment operator is not supported by GNU Make <4.0
 VERSION_CHECK != echo supported
 VERSION_CHECK ?= $(error GNU Make 4+ or BSD Make is required)
-CHECK_VERSION := $(shell echo $(VERSION_CHECK))
+CHECK_VERSION := $(VERSION_CHECK)
 
 # set markdown input format to "markdown-smart" for pandoc version 2+ and to "markdown" for pandoc prior to version 2
 MARKDOWN != if [ "`pandoc -v | head -n1 | cut -d' ' -f2 | head -c1`" -ge "2" ]; then echo markdown-smart; else echo markdown; fi

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ offlinetest: codetest
 	$(PYTHON) -m pytest -k "not download"
 
 CODE_FOLDERS != find yt_dlp -type f -name '__init__.py' -exec dirname {} \+ | grep -v '/__' | sort
-CODE_FILES != for f in $(CODE_FOLDERS) ; do echo $$f | sed 's,$$,/*.py,' ; done
+CODE_FILES != for f in $(CODE_FOLDERS) ; do echo "$$f" | sed 's,$$,/*.py,' ; done
 yt-dlp: $(CODE_FILES)
 	@echo $(ERROR_MSG)
 	mkdir -p zip

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,10 @@ MANDIR ?= $(PREFIX)/man
 SHAREDIR ?= $(PREFIX)/share
 PYTHON ?= /usr/bin/env python3
 
-# $(shell) is a no-op in BSD Make and the != variable assignment operator is not supported by GNU Make <4.0
-ERROR_MSG := $(shell if [ "`echo $(MAKE_VERSION) | head -c1`" -lt "4" ] ; then echo "GNU Make 4+ or BSD Make is required" ; fi)
+# $(shell) and $(error) are no-ops in BSD Make and the != variable assignment operator is not supported by GNU Make <4.0
+VERSION_CHECK != echo supported
+VERSION_CHECK ?= $(error GNU Make 4+ or BSD Make is required)
+CHECK_VERSION := $(shell echo $(VERSION_CHECK))
 
 # set markdown input format to "markdown-smart" for pandoc version 2+ and to "markdown" for pandoc prior to version 2
 MARKDOWN != if [ "`pandoc -v | head -n1 | cut -d' ' -f2 | head -c1`" -ge "2" ]; then echo markdown-smart; else echo markdown; fi
@@ -76,7 +78,6 @@ offlinetest: codetest
 CODE_FOLDERS != find yt_dlp -type f -name '__init__.py' -exec dirname {} \+ | grep -v '/__' | sort
 CODE_FILES != for f in $(CODE_FOLDERS) ; do echo "$$f" | sed 's,$$,/*.py,' ; done
 yt-dlp: $(CODE_FILES)
-	@echo $(ERROR_MSG)
 	mkdir -p zip
 	for d in $(CODE_FOLDERS) ; do \
 	  mkdir -p zip/$$d ;\
@@ -109,11 +110,9 @@ supportedsites:
 	$(PYTHON) devscripts/make_supportedsites.py supportedsites.md
 
 README.txt: README.md
-	@echo $(ERROR_MSG)
 	pandoc -f $(MARKDOWN) -t plain README.md -o README.txt
 
 yt-dlp.1: README.md devscripts/prepare_manpage.py
-	@echo $(ERROR_MSG)
 	$(PYTHON) devscripts/prepare_manpage.py yt-dlp.1.temp.md
 	pandoc -s -f $(MARKDOWN) -t man yt-dlp.1.temp.md -o yt-dlp.1
 	rm -f yt-dlp.1.temp.md

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,6 @@ CODE_FOLDERS != find yt_dlp -type f -name '__init__.py' -exec dirname {} \+ | gr
 CODE_FILES != for f in $(CODE_FOLDERS) ; do echo $$f | sed 's,$$,/*.py,' ; done
 yt-dlp: $(CODE_FILES)
 	@echo $(ERROR_MSG)
-	@echo 'code_folders: $(CODE_FOLDERS)'
-	@echo 'code_files: $(CODE_FILES)'
 	mkdir -p zip
 	for d in $(CODE_FOLDERS) ; do \
 	  mkdir -p zip/$$d ;\

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,6 @@ MANDIR ?= $(PREFIX)/man
 SHAREDIR ?= $(PREFIX)/share
 PYTHON ?= /usr/bin/env python3
 
-# set SYSCONFDIR to /etc if PREFIX=/usr or PREFIX=/usr/local
-SYSCONFDIR != if [ "$(PREFIX)" = "/usr" -o "$(PREFIX)" = "/usr/local" ]; then echo /etc; else echo $(PREFIX)/etc; fi
-
 # set markdown input format to "markdown-smart" for pandoc version 2 and to "markdown" for pandoc prior to version 2
 MARKDOWN != if [ "`pandoc -v | head -n1 | cut -d' ' -f2 | head -c1`" -ge "2" ]; then echo markdown-smart; else echo markdown; fi
 

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ yt-dlp.tar.gz: all
 		--exclude '__pycache__' \
 		--exclude '.pytest_cache' \
 		--exclude '.git' \
+		--exclude '__pyinstaller' \
 		-- \
 		README.md supportedsites.md Changelog.md LICENSE \
 		CONTRIBUTING.md Collaborators.md CONTRIBUTORS AUTHORS \

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ yt-dlp.tar.gz: all
 		--exclude '__pycache__' \
 		--exclude '.pytest_cache' \
 		--exclude '.git' \
+		--exclude 'test/testdata/sigs/player-*.js' \
 		--exclude '__pyinstaller' \
 		-- \
 		README.md supportedsites.md Changelog.md LICENSE \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PYTHON ?= /usr/bin/env python3
 # $(shell) is a no-op in BSD Make and the != variable assignment operator is not supported by GNU Make <4.0
 ERROR_MSG := $(shell if [ "`echo $(MAKE_VERSION) | head -c1`" -lt "4" ] ; then echo "GNU Make 4+ or BSD Make is required" ; fi)
 
-# set markdown input format to "markdown-smart" for pandoc version 2 and to "markdown" for pandoc prior to version 2
+# set markdown input format to "markdown-smart" for pandoc version 2+ and to "markdown" for pandoc prior to version 2
 MARKDOWN != if [ "`pandoc -v | head -n1 | cut -d' ' -f2 | head -c1`" -ge "2" ]; then echo markdown-smart; else echo markdown; fi
 
 install: lazy-extractors yt-dlp yt-dlp.1 completions

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ MANDIR ?= $(PREFIX)/man
 SHAREDIR ?= $(PREFIX)/share
 PYTHON ?= /usr/bin/env python3
 
+# $(shell) is a no-op in BSD Make and the != variable assignment operator is not supported by GNU Make <4.0
+ERROR_MSG := $(shell if [ "`echo $(MAKE_VERSION) | head -c1`" -lt "4" ] ; then echo "GNU Make 4+ or BSD Make is required" ; fi)
+
 # set markdown input format to "markdown-smart" for pandoc version 2 and to "markdown" for pandoc prior to version 2
 MARKDOWN != if [ "`pandoc -v | head -n1 | cut -d' ' -f2 | head -c1`" -ge "2" ]; then echo markdown-smart; else echo markdown; fi
 
@@ -73,6 +76,7 @@ offlinetest: codetest
 CODE_FOLDERS != find yt_dlp -type f -name '__init__.py' -exec dirname {} \+ | grep -v '/__' | sort
 CODE_FILES != for f in $(CODE_FOLDERS) ; do echo $$f | sed 's,$$,/*.py,' ; done
 yt-dlp: $(CODE_FILES)
+	@echo $(ERROR_MSG)
 	@echo code_folders: '$(CODE_FOLDERS)'
 	@echo code_files: '$(CODE_FILES)'
 	mkdir -p zip


### PR DESCRIPTION
BSD Make can't do `$(shell ...)`. We were already using it in the `MARKDOWN` and `SYSCONFDIR` vars, but by using it in `CODE_FOLDERS` and `CODE_FILES` I broke the `yt-dlp` target for bmake.

Also:
- immediately raise error if GNU Make <4 is being used
- include fixes for the `yt-dlp` target if bmake is run in jobs mode
- remove vestigial `SYSCONFDIR` var assignment
- exclude `__pyinstaller` subdir from tarball

GNU Make versions older than 4.0 don't support `!=`, but considering that gmake 4.0 was released in 2013 IMO we shouldn't need to support it. Apparently Debian was holding onto make 3.8x for a while, but as of Jessie it was bumped to 4.0 (and all Debian versions up-to-and-including Jessie ship EOL Python anyways). CentOS 7 still has make 3.8x, but it is EOL as of the end of June.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
