### PR TITLE
Handle permission errors during plugin loading

### DIFF
--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -86,7 +86,6 @@ class PluginFinder(importlib.abc.MetaPathFinder):
         parts = Path(*fullname.split('.'))
         for path in orderedSet(candidate_locations, lazy=True):
             candidate = path / parts
-
             try:
                 if candidate.is_dir():
                     yield candidate
@@ -94,7 +93,7 @@ class PluginFinder(importlib.abc.MetaPathFinder):
                     if parts in dirs_in_zip(path):
                         yield candidate
             except PermissionError as e:
-                write_string(f'Permission error while accessing modules in {e.filename}: {e}\n')
+                write_string(f'Permission error while accessing modules in "{e.filename}"\n')
 
     def find_spec(self, fullname, path=None, target=None):
         if fullname not in self.packages:
@@ -142,7 +141,6 @@ def load_plugins(name, suffix):
     for finder, module_name, _ in iter_modules(name):
         if any(x.startswith('_') for x in module_name.split('.')):
             continue
-
         try:
             if sys.version_info < (3, 10) and isinstance(finder, zipimport.zipimporter):
                 # zipimporter.load_module() is deprecated in 3.10 and removed in 3.12
@@ -150,17 +148,13 @@ def load_plugins(name, suffix):
                 # See: https://docs.python.org/3/library/zipimport.html#zipimport.zipimporter.exec_module
                 module = finder.load_module(module_name)
             else:
-                # Use the recommended approach for Python >= 3.10
                 spec = finder.find_spec(module_name)
                 module = importlib.util.module_from_spec(spec)
                 sys.modules[module_name] = module
                 spec.loader.exec_module(module)
         except Exception:
-            # Handle errors specifically related to module loading
             write_string(f'Error while importing module {module_name!r}\n{traceback.format_exc(limit=-1)}')
             continue
-
-        # Update classes based on successfully loaded module
         classes.update(load_module(module, module_name, suffix))
 
     # Compat: old plugin system using __init__.py

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -135,24 +135,28 @@ def load_module(module, module_name, suffix):
 def load_plugins(name, suffix):
     classes = {}
 
-    for finder, module_name, _ in iter_modules(name):
-        if any(x.startswith('_') for x in module_name.split('.')):
-            continue
-        try:
-            if sys.version_info < (3, 10) and isinstance(finder, zipimport.zipimporter):
-                # zipimporter.load_module() is deprecated in 3.10 and removed in 3.12
-                # The exec_module branch below is the replacement for >= 3.10
-                # See: https://docs.python.org/3/library/zipimport.html#zipimport.zipimporter.exec_module
-                module = finder.load_module(module_name)
-            else:
-                spec = finder.find_spec(module_name)
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-                spec.loader.exec_module(module)
-        except Exception:
-            write_string(f'Error while importing module {module_name!r}\n{traceback.format_exc(limit=-1)}')
-            continue
-        classes.update(load_module(module, module_name, suffix))
+    try:
+        for finder, module_name, _ in iter_modules(name):
+            if any(x.startswith('_') for x in module_name.split('.')):
+                continue
+            try:
+                if sys.version_info < (3, 10) and isinstance(finder, zipimport.zipimporter):
+                    # zipimporter.load_module() is deprecated in 3.10 and removed in 3.12
+                    # The exec_module branch below is the replacement for >= 3.10
+                    # See: https://docs.python.org/3/library/zipimport.html#zipimport.zipimporter.exec_module
+                    module = finder.load_module(module_name)
+                else:
+                    spec = finder.find_spec(module_name)
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[module_name] = module
+                    spec.loader.exec_module(module)
+            except Exception:
+                write_string(f'Error while importing module {module_name!r}\n{traceback.format_exc(limit=-1)}')
+                continue
+            classes.update(load_module(module, module_name, suffix))
+    except PermissionError as e:
+        write_string(f'Permission error: {e}\n')
+        return classes
 
     # Compat: old plugin system using __init__.py
     # Note: plugins imported this way do not show up in directories()


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This pull request introduces a modification to the `load_plugins` function within `plugins.py` to gracefully handle `PermissionError` exceptions that occur during the plugin loading process. The modification ensures that `yt-dlp` can continue to run without crashing when it encounters permission issues, specifically when trying to access directories for which it does not have permissions.

This issue has been observed in environments where `yt-dlp` attempts to access restricted directories (e.g., `/root/yt_dlp_plugins`) and throws a `PermissionError`, leading to the program's termination. Such behavior has been reported when running `yt-dlp --version` in a virtual environment and similarly affects other operations, including starting FastAPI applications with Gunicorn where `yt-dlp` is a dependency.

**Example Error:**
```
PermissionError: [Errno 13] Permission denied: '/root/yt_dlp_plugins'
```

The proposed change wraps the plugin loading iteration in a `try-except` block to catch `PermissionError` exceptions, logs the error for debugging purposes, and allows the program to proceed by skipping the problematic plugin loading phase.

**Fixes:** Not applicable as this is a general improvement to error handling.

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
