### PR TITLE
[build] Fix pyinstaller hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ yt-dlp.tar.gz: all
 		--exclude '__pycache__' \
 		--exclude '.pytest_cache' \
 		--exclude '.git' \
-		--exclude '__pyinstaller' \
 		-- \
 		README.md supportedsites.md Changelog.md LICENSE \
 		CONTRIBUTING.md Collaborators.md CONTRIBUTORS AUTHORS \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ include = [
     "/setup.cfg",
     "/supportedsites.md",
 ]
-exclude = ["/yt_dlp/__pyinstaller"]
 artifacts = [
     "/yt_dlp/extractor/lazy_extractors.py",
     "/completions",
@@ -105,7 +104,6 @@ artifacts = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["yt_dlp"]
-exclude = ["/yt_dlp/__pyinstaller"]
 artifacts = ["/yt_dlp/extractor/lazy_extractors.py"]
 
 [tool.hatch.build.targets.wheel.shared-data]

--- a/yt_dlp/__pyinstaller/hook-yt_dlp.py
+++ b/yt_dlp/__pyinstaller/hook-yt_dlp.py
@@ -31,4 +31,4 @@ def get_hidden_imports():
 hiddenimports = list(get_hidden_imports())
 print(f'Adding imports: {hiddenimports}')
 
-excludedimports = ['youtube_dl', 'youtube_dlc', 'test', 'ytdlp_plugins', 'devscripts']
+excludedimports = ['youtube_dl', 'youtube_dlc', 'test', 'ytdlp_plugins', 'devscripts', 'bundle']


### PR DESCRIPTION
Bugfix for 775cde82dc5b1dc64ab0539a92dd8c7ba6c0ad33

`__pyinstaller` needs to be included in the sdist and wheel so that pyinstaller works properly when yt-dlp is installed in a venv



### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
