### PR TITLE
[ie/vimeo] Extract "live_status" and "release_timestamp" for live events

### DIFF
--- a/yt_dlp/extractor/vimeo.py
+++ b/yt_dlp/extractor/vimeo.py
@@ -122,12 +122,12 @@ class VimeoBaseInfoExtractor(InfoExtractor):
         video_data = config['video']
         video_title = video_data.get('title')
         live_event = video_data.get('live_event') or {}
-        live_status = traverse_obj(live_event, ('status', {lambda status: {
+        live_status = {
             'pending': 'is_upcoming',
             'active': 'is_live',  # TODO: is live or not?
             'started': 'is_live',
             'ended': 'post_live',
-        }.get(status)}))
+        }.get(live_event.get('status'))
         is_live = live_status == 'is_live'
         request = config.get('request') or {}
 

--- a/yt_dlp/extractor/vimeo.py
+++ b/yt_dlp/extractor/vimeo.py
@@ -21,6 +21,7 @@ from ..utils import (
     parse_qs,
     smuggle_url,
     str_or_none,
+    traverse_obj,
     try_get,
     unified_timestamp,
     unsmuggle_url,
@@ -121,7 +122,13 @@ class VimeoBaseInfoExtractor(InfoExtractor):
         video_data = config['video']
         video_title = video_data.get('title')
         live_event = video_data.get('live_event') or {}
-        is_live = live_event.get('status') == 'started'
+        live_status = traverse_obj(live_event, ('status', {lambda status: {
+            'pending': 'is_upcoming',
+            'active': 'is_live',  # TODO: is live or not?
+            'started': 'is_live',
+            'ended': 'post_live',
+        }.get(status)}))
+        is_live = live_status == 'is_live'
         request = config.get('request') or {}
 
         formats = []
@@ -230,7 +237,8 @@ class VimeoBaseInfoExtractor(InfoExtractor):
             'chapters': chapters or None,
             'formats': formats,
             'subtitles': subtitles,
-            'is_live': is_live,
+            'live_status': live_status,
+            'release_timestamp': traverse_obj(live_event, ('ingest', 'scheduled_start_time', {parse_iso8601})),
             # Note: Bitrates are completely broken. Single m3u8 may contain entries in kbps and bps
             # at the same time without actual units specified.
             '_format_sort_fields': ('quality', 'res', 'fps', 'hdr:12', 'source'),

--- a/yt_dlp/extractor/vimeo.py
+++ b/yt_dlp/extractor/vimeo.py
@@ -124,7 +124,7 @@ class VimeoBaseInfoExtractor(InfoExtractor):
         live_event = video_data.get('live_event') or {}
         live_status = {
             'pending': 'is_upcoming',
-            'active': 'is_live',  # TODO: is live or not?
+            'active': 'is_upcoming',
             'started': 'is_live',
             'ended': 'post_live',
         }.get(live_event.get('status'))


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Note: this is a quick fix. I didn't do thorough testing.

<br>

The `config['video']['live_event']` field is:

```JSON
// is_upcoming

{
  "video": {
    "live_event": {
      "id": "",
      "status": "pending",
      "show_viewer_count": false,
      "settings": {
        "event_schedule": true,
        "hide_live_label": false
      },
      "archive": {
        "status": "",
        "source_url": ""
      },
      "ingest": {
        "scheduled_start_time": "2023-02-29T00:00:00+00:00",
        "width": 0,
        "height": 0,
        "start_time": 0
      },
      "low_latency": false,
      "dvr": false,
      "sessionUrl": null
    }
  }
}

// is_live

{
  "video": {
    "live_event": {
      "id": "00000000-0000-0000-0000-000000000000",
      "status": "started",
      "show_viewer_count": false,
      "settings": {
        "event_schedule": true,
        "hide_live_label": false
      },
      "archive": {
        "status": "started",
        "source_url": ""
      },
      "ingest": {
        "scheduled_start_time": "2023-02-29T00:00:00+00:00",
        "width": 1920,
        "height": 1080,
        "start_time": 1700000000
      },
      "low_latency": false,
      "dvr": false,
      "sessionUrl": "https://live-api.vimeocdn.com/sessions/${video.live_event.id}?~exp=1700000000&~id=player&~sig=..."
    }
  }
}

// was_live

{
  "video": {
    "live_event": null
  }
}

```

For now, our code can't differentiate between "was_live" and "not_live", or say, between "live archives" and "fixed-length videos".

<br>

Those four statuses are from https://f.vimeocdn.com/p/4.28.9/js/player.module.js ([wayback machine backup](https://web.archive.org/web/20240224234253/https://f.vimeocdn.com/p/4.28.9/js/player.module.js)).

```js
{e.pending="pending",e.active="active",e.started="started",e.ended="ended"}

```

<br>

### For future developers

We should get info about live videos by analyzing `https://vimeo.com/live_event/status?clip_id=${video_id}` . This API is still informative after the end of live events.

```json
// is_upcoming

{
  "id": 42,
  "metering": {
    "seconds_remaining": 43200,
    "seconds_max": 43200
  },
  "ingest": {
    "rtmps_url": "rtmps://rtmp-global.cloud.vimeo.com:443/live",
    "height": null,
    "width": null,
    "status": 0,
    "session_id": null,
    "stream_ended_reason": null,
    "start_time": null,
    "scheduled_start_time": "2023-02-29T00:00:00+00:00"
  },
  "archive": {
    "status": 0
  }
}

// is_live

{
  "id": 42,
  "metering": {
    "seconds_remaining": 40000,
    "seconds_max": 43200
  },
  "ingest": {
    "rtmps_url": "rtmps://rtmp-global.cloud.vimeo.com:443/live",
    "height": 1080,
    "width": 1920,
    "status": 4,
    "session_id": "00000000-0000-0000-0000-000000000000",
    "stream_ended_reason": null,
    "start_time": 1700000000,
    "scheduled_start_time": "2023-02-29T00:00:00+00:00"
  },
  "archive": {
    "status": 1
  }
}

// was_live

{
  "id": 42,
  "metering": {
    "seconds_remaining": 43200,
    "seconds_max": 43200
  },
  "ingest": {
    "rtmps_url": "rtmps://rtmp-global.cloud.vimeo.com:443/live",
    "height": 1080,
    "width": 1920,
    "status": 5,
    "session_id": "00000000-0000-0000-0000-000000000000",
    "stream_ended_reason": 6,
    "start_time": 1700000000,
    "scheduled_start_time": "2023-02-29T00:00:00+00:00"
  },
  "archive": {
    "status": 2
  }
}

```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
