### PR TITLE
[ie/CHZZK] Raise UserNotLive when the channel is not live.

### DIFF
--- a/yt_dlp/extractor/chzzk.py
+++ b/yt_dlp/extractor/chzzk.py
@@ -2,7 +2,7 @@ import functools
 
 from .common import InfoExtractor
 from ..utils import (
-    ExtractorError,
+    UserNotLive,
     float_or_none,
     int_or_none,
     parse_iso8601,
@@ -40,7 +40,7 @@ class CHZZKLiveIE(InfoExtractor):
             note='Downloading channel info', errnote='Unable to download channel info')['content']
 
         if live_detail.get('status') == 'CLOSE':
-            raise ExtractorError('The channel is not currently live', expected=True)
+            raise UserNotLive()
 
         live_playback = self._parse_json(live_detail['livePlaybackJson'], channel_id)
 

--- a/yt_dlp/extractor/chzzk.py
+++ b/yt_dlp/extractor/chzzk.py
@@ -40,7 +40,7 @@ class CHZZKLiveIE(InfoExtractor):
             note='Downloading channel info', errnote='Unable to download channel info')['content']
 
         if live_detail.get('status') == 'CLOSE':
-            raise UserNotLive()
+            raise UserNotLive(video_id=channel_id)
 
         live_playback = self._parse_json(live_detail['livePlaybackJson'], channel_id)
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Fixes an issue where `--wait-for-video` or `--retries` do not work and yt-dlp exits with an error due to raising `ExtractorError` when the channel is not live.

I've confirmed it works, but I'm not sure if and how I should add tests for this change.

<details><summary>Before Fix</summary>

```
[debug] Command-line config: ['-i', '--wait-for-video', '1', '--progress', '--retries', 'infinite', '-v', '-o', '20240227.mp4', 'https://chzzk.naver.com/live/68f895c59a1043bc5019b5e08c83a5c5']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version nightly@2024.01.28.232706 from yt-dlp/yt-dlp-nightly-builds [41b6cdb41] (zip)
[debug] Python 3.11.6 (CPython x86_64 64bit) - Linux-6.5.0-21-generic-x86_64-with-glibc2.38 (OpenSSL 3.0.10 1 Aug 2023, glibc 2.38)
[debug] exe versions: ffmpeg 6.0 (setts), ffprobe 6.0
[debug] Optional libraries: Cryptodome-3.11.0, certifi-2022.09.24, requests-2.31.0, secretstorage-3.3.3, sqlite3-3.42.0, urllib3-1.26.16
[debug] Proxy map: {}
[debug] Request Handlers: urllib
[debug] Loaded 1824 extractors
[chzzk:live] Extracting URL: https://chzzk.naver.com/live/68f895c59a1043bc5019b5e08c83a5c5
[chzzk:live] 68f895c59a1043bc5019b5e08c83a5c5: Downloading channel info
ERROR: [chzzk:live] 68f895c59a1043bc5019b5e08c83a5c5: The channel is not currently live
  File "/home/hibot/.local/bin/yt-dlp/yt_dlp/extractor/common.py", line 718, in extract
    ie_result = self._real_extract(url)
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hibot/.local/bin/yt-dlp/yt_dlp/extractor/chzzk.py", line 43, in _real_extract
    raise ExtractorError('The channel is not currently live', expected=True)
```

</details>

<details><summary>After Fix</summary>

```
[debug] Command-line config: ['-i', '--wait-for-video', '1', '--progress', '--retries', 'infinite', '-v', '-o', '20240227.mp4', 'https://chzzk.naver.com/live/68f895c59a1043bc5019b5e08c83a5c5']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2023.12.30 from yt-dlp/yt-dlp [f10589e34] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 7220bb169
[debug] Python 3.8.18 (CPython x86_64 64bit) - Linux-6.5.0-21-generic-x86_64-with-glibc2.17 (OpenSSL 3.0.13 30 Jan 2024, glibc 2.38)
[debug] exe versions: ffmpeg 6.0 (setts), ffprobe 6.0, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.15.0, brotli-1.0.9, certifi-2024.02.02, mutagen-1.47.0, requests-2.31.0, sqlite3-3.41.2, urllib3-2.1.0, websockets-12.0
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets
[debug] Loaded 1833 extractors
[chzzk:live] Extracting URL: https://chzzk.naver.com/live/68f895c59a1043bc5019b5e08c83a5c5
[chzzk:live] 68f895c59a1043bc5019b5e08c83a5c5: Downloading channel info
WARNING: [chzzk:live] 68f895c59a1043bc5019b5e08c83a5c5: The channel is not currently live
[wait] Waiting for 00:00:01 - Press Ctrl+C to try now
[wait] Wait period ended; Re-extracting data                 
[chzzk:live] Extracting URL: https://chzzk.naver.com/live/68f895c59a1043bc5019b5e08c83a5c5
[chzzk:live] 68f895c59a1043bc5019b5e08c83a5c5: Downloading channel info
WARNING: [chzzk:live] 68f895c59a1043bc5019b5e08c83a5c5: The channel is not currently live
[wait] Waiting for 00:00:01 - Press Ctrl+C to try now
...
```

</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
