### PR TITLE
[ie/francetv] Fix m3u8 formats extraction

### DIFF
--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -105,8 +105,8 @@ class FranceTVIE(InfoExtractor):
         # desktop+chrome returns dash; mobile+safari returns hls
         for device_type, browser in [('desktop', 'chrome'), ('mobile', 'safari')]:
             dinfo = self._download_json(
-                'https://player.webservices.francetelevisions.fr/v1/videos/%s' % video_id,
-                video_id, f'Downloading {device_type} {browser} video JSON', query=filter_dict({
+                f'https://k7.ftven.fr/videos/{video_id}', video_id,
+                f'Downloading {device_type} {browser} video JSON', query=filter_dict({
                     'device_type': device_type,
                     'browser': browser,
                     'domain': hostname,

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -218,7 +218,7 @@ class FranceTVIE(InfoExtractor):
                     # a 10×10 grid of thumbnails corresponding to approximately
                     # 2 seconds of the video; the last spritesheet may be shorter
                     'duration': 200,
-                } for sheet in spritesheets]
+                } for sheet in traverse_obj(spritesheets, (..., {url_or_none}))]
             })
 
         return {

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -5,14 +5,12 @@ from .common import InfoExtractor
 from .dailymotion import DailymotionIE
 from ..networking import HEADRequest
 from ..utils import (
-    ExtractorError,
     determine_ext,
     filter_dict,
     format_field,
     int_or_none,
     join_nonempty,
     parse_iso8601,
-    parse_qs,
     smuggle_url,
     unsmuggle_url,
     url_or_none,
@@ -21,53 +19,31 @@ from ..utils.traversal import traverse_obj
 
 
 class FranceTVBaseInfoExtractor(InfoExtractor):
-    def _make_url_result(self, video_or_full_id, catalog=None, url=None):
-        full_id = 'francetv:%s' % video_or_full_id
-        if '@' not in video_or_full_id and catalog:
-            full_id += '@%s' % catalog
+    def _make_url_result(self, video_id, url=None):
+        video_id = video_id.split('@')[0]  # for compat with old @catalog IDs
+        full_id = f'francetv:{video_id}'
         if url:
             full_id = smuggle_url(full_id, {'hostname': urllib.parse.urlparse(url).hostname})
-        return self.url_result(
-            full_id, ie=FranceTVIE.ie_key(),
-            video_id=video_or_full_id.split('@')[0])
+        return self.url_result(full_id, FranceTVIE, video_id)
 
 
 class FranceTVIE(InfoExtractor):
-    _VALID_URL = r'''(?x)
-                    (?:
-                        https?://
-                            sivideo\.webservices\.francetelevisions\.fr/tools/getInfosOeuvre/v2/\?
-                            .*?\bidDiffusion=[^&]+|
-                        (?:
-                            https?://videos\.francetv\.fr/video/|
-                            francetv:
-                        )
-                        (?P<id>[^@]+)(?:@(?P<catalog>.+))?
-                    )
-                    '''
-    _EMBED_REGEX = [r'<iframe[^>]+?src=(["\'])(?P<url>(?:https?://)?embed\.francetv\.fr/\?ue=.+?)\1']
+    _VALID_URL = r'francetv:(?P<id>[^@#]+)'
     _GEO_COUNTRIES = ['FR']
     _GEO_BYPASS = False
 
     _TESTS = [{
-        # without catalog
-        'url': 'https://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion=162311093&callback=_jsonp_loader_callback_request_0',
-        'md5': 'c2248a8de38c4e65ea8fae7b5df2d84f',
+        'url': 'francetv:ec217ecc-0733-48cf-ac06-af1347b849d1',
         'info_dict': {
-            'id': '162311093',
+            'id': 'ec217ecc-0733-48cf-ac06-af1347b849d1',
             'ext': 'mp4',
             'title': '13h15, le dimanche... - Les mystères de Jésus',
-            'description': 'md5:75efe8d4c0a8205e5904498ffe1e1a42',
             'timestamp': 1502623500,
+            'duration': 2580,
+            'thumbnail': r're:^https?://.*\.jpg$',
             'upload_date': '20170813',
         },
-    }, {
-        # with catalog
-        'url': 'https://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion=NI_1004933&catalogue=Zouzous&callback=_jsonp_loader_callback_request_4',
-        'only_matching': True,
-    }, {
-        'url': 'http://videos.francetv.fr/video/NI_657393@Regions',
-        'only_matching': True,
+        'params': {'skip_download': 'm3u8'},
     }, {
         'url': 'francetv:162311093',
         'only_matching': True,
@@ -89,8 +65,7 @@ class FranceTVIE(InfoExtractor):
         'only_matching': True,
     }]
 
-    def _extract_video(self, video_id, catalogue=None, hostname=None):
-        # TODO: Investigate/remove 'catalogue'/'catalog'; it has not been used since 2021
+    def _extract_video(self, video_id, hostname=None):
         is_live = None
         videos = []
         title = None
@@ -239,18 +214,10 @@ class FranceTVIE(InfoExtractor):
 
     def _real_extract(self, url):
         url, smuggled_data = unsmuggle_url(url, {})
-        mobj = self._match_valid_url(url)
-        video_id = mobj.group('id')
-        catalog = mobj.group('catalog')
+        video_id = self._match_id(url)
+        hostname = smuggled_data.get('hostname') or 'www.france.tv'
 
-        if not video_id:
-            qs = parse_qs(url)
-            video_id = qs.get('idDiffusion', [None])[0]
-            catalog = qs.get('catalogue', [None])[0]
-            if not video_id:
-                raise ExtractorError('Invalid URL', expected=True)
-
-        return self._extract_video(video_id, catalog, hostname=smuggled_data.get('hostname'))
+        return self._extract_video(video_id, hostname=hostname)
 
 
 class FranceTVSiteIE(FranceTVBaseInfoExtractor):
@@ -272,6 +239,7 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
         },
         'add_ie': [FranceTVIE.ie_key()],
     }, {
+        # geo-restricted
         'url': 'https://www.france.tv/enfants/six-huit-ans/foot2rue/saison-1/3066387-duel-au-vieux-port.html',
         'info_dict': {
             'id': 'a9050959-eedd-4b4a-9b0d-de6eeaa73e44',
@@ -330,17 +298,16 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
 
         webpage = self._download_webpage(url, display_id)
 
-        catalogue = None
         video_id = self._search_regex(
             r'(?:data-main-video\s*=|videoId["\']?\s*[:=])\s*(["\'])(?P<id>(?:(?!\1).)+)\1',
             webpage, 'video id', default=None, group='id')
 
         if not video_id:
-            video_id, catalogue = self._html_search_regex(
-                r'(?:href=|player\.setVideo\(\s*)"http://videos?\.francetv\.fr/video/([^@]+@[^"]+)"',
-                webpage, 'video ID').split('@')
+            video_id = self._html_search_regex(
+                r'(?:href=|player\.setVideo\(\s*)"http://videos?\.francetv\.fr/video/([^@"]+@[^"]+)"',
+                webpage, 'video ID')
 
-        return self._make_url_result(video_id, catalogue, url=url)
+        return self._make_url_result(video_id, url=url)
 
 
 class FranceTVInfoIE(FranceTVBaseInfoExtractor):
@@ -354,8 +321,9 @@ class FranceTVInfoIE(FranceTVBaseInfoExtractor):
             'ext': 'mp4',
             'title': 'Soir 3',
             'upload_date': '20190822',
-            'timestamp': 1566510900,
-            'description': 'md5:72d167097237701d6e8452ff03b83c00',
+            'timestamp': 1566510730,
+            'thumbnail': r're:^https?://.*\.jpe?g$',
+            'duration': 1637,
             'subtitles': {
                 'fr': 'mincount:2',
             },
@@ -370,8 +338,8 @@ class FranceTVInfoIE(FranceTVBaseInfoExtractor):
         'info_dict': {
             'id': '7d204c9e-a2d3-11eb-9e4c-000d3a23d482',
             'ext': 'mp4',
-            'title': 'Covid-19 : une situation catastrophique à New Dehli',
-            'thumbnail': str,
+            'title': 'Covid-19 : une situation catastrophique à New Dehli - Édition du mercredi 21 avril 2021',
+            'thumbnail': r're:^https?://.*\.jpe?g$',
             'duration': 76,
             'timestamp': 1619028518,
             'upload_date': '20210421',
@@ -397,11 +365,17 @@ class FranceTVInfoIE(FranceTVBaseInfoExtractor):
             'id': 'x4iiko0',
             'ext': 'mp4',
             'title': 'NDDL, référendum, Brexit : Cécile Duflot répond à Patrick Cohen',
-            'description': 'Au lendemain de la victoire du "oui" au référendum sur l\'aéroport de Notre-Dame-des-Landes, l\'ancienne ministre écologiste est l\'invitée de Patrick Cohen. Plus d\'info : https://www.franceinter.fr/emissions/le-7-9/le-7-9-27-juin-2016',
+            'description': 'md5:fdcb582c370756293a65cdfbc6ecd90e',
             'timestamp': 1467011958,
-            'upload_date': '20160627',
             'uploader': 'France Inter',
             'uploader_id': 'x2q2ez',
+            'upload_date': '20160627',
+            'view_count': int,
+            'tags': ['Politique', 'France Inter', '27 juin 2016', 'Linvité de 8h20', 'Cécile Duflot', 'Patrick Cohen'],
+            'age_limit': 0,
+            'duration': 640,
+            'like_count': int,
+            'thumbnail': r're:https://[^/?#]+/v/[^/?#]+/x1080',
         },
         'add_ie': ['Dailymotion'],
     }, {

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -102,10 +102,11 @@ class FranceTVIE(InfoExtractor):
         timestamp = None
         spritesheets = None
 
+        # desktop+chrome returns dash; mobile+safari returns hls
         for device_type, browser in [('desktop', 'chrome'), ('mobile', 'safari')]:
             dinfo = self._download_json(
                 'https://player.webservices.francetelevisions.fr/v1/videos/%s' % video_id,
-                video_id, f'Downloading {device_type} video JSON', query=filter_dict({
+                video_id, f'Downloading {device_type} {browser} video JSON', query=filter_dict({
                     'device_type': device_type,
                     'browser': browser,
                     'domain': hostname,


### PR DESCRIPTION
Per [this comment](https://github.com/yt-dlp/yt-dlp/commit/9749ac7fecbfda391afbadf2870797ce0e382622#commitcomment-139300092) by @boulderob, francetv's HLS formats are generally superior to their DASH formats, and were no longer being extracted after the API changes that were handled by 9749ac7fecbfda391afbadf2870797ce0e382622.

This PR also does some much-needed cleanup: removing dead code paths (`FranceTVIE` hadn't been doing anything with all the `catalog` params being passed to it since 2021) and removing dead subdomains/hostnames (`videos.francetv.fr`, `sivideo.webservices.francetelevisions.fr`) from the URL regex patterns and tests.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
