### PR TITLE
[roosterteeth] Download ad-free streams

### DIFF
--- a/yt_dlp/extractor/roosterteeth.py
+++ b/yt_dlp/extractor/roosterteeth.py
@@ -91,6 +91,15 @@ class RoosterTeethIE(RoosterTeethBaseIE):
             'thumbnail': r're:^https?://.*\.png$',
             'series': 'Million Dollars, But...',
             'episode': 'Million Dollars, But... The Game Announcement',
+            'tags': ['Game Show', 'Sketch'],
+            'season_number': 2,
+            'availability': 'public',
+            'episode_number': 10,
+            'episode_id': '00374575-464e-11e7-a302-065410f210c4',
+            'season': 'Season 2',
+            'season_id': 'ffa27d48-464d-11e7-a302-065410f210c4',
+            'channel_id': '92b6bb21-91d2-4b1b-bf95-3268fa0d9939',
+            'duration': 145,
         },
         'params': {'skip_download': True},
     }, {
@@ -104,6 +113,15 @@ class RoosterTeethIE(RoosterTeethBaseIE):
             'channel_id': '92f780eb-ebfe-4bf5-a3b5-c6ad5460a5f1',
             'thumbnail': r're:^https?://.*\.(png|jpe?g)$',
             'ext': 'mp4',
+            'availability': 'public',
+            'episode_id': 'f8117b13-f068-499e-803e-eec9ea2dec8c',
+            'episode_number': 3,
+            'tags': ['Animation'],
+            'season_id': '4b8f0a9e-12c4-41ed-8caa-fed15a85bab8',
+            'season': 'Season 1',
+            'series': 'RWBY: World of Remnant',
+            'season_number': 1,
+            'duration': 216,
         },
         'params': {'skip_download': True},
     }, {
@@ -133,10 +151,9 @@ class RoosterTeethIE(RoosterTeethBaseIE):
 
         try:
             video_data = self._download_json(
-                api_episode_url + '/videos', display_id,
-                'Downloading video JSON metadata')['data'][0]
-            m3u8_url = video_data['attributes']['url']
-            # XXX: additional URL at video_data['links']['download']
+                api_episode_url + '/videos', display_id, 'Downloading video JSON metadata',
+                headers={'Client-Type': 'web'})['data'][0]
+            m3u8_url = traverse_obj(video_data, ('links', 'download')) or traverse_obj(video_data, ('attributes', 'url'))
         except ExtractorError as e:
             if isinstance(e.cause, HTTPError) and e.cause.status == 403:
                 if self._parse_json(e.cause.response.read().decode(), display_id).get('access') is False:

--- a/yt_dlp/extractor/roosterteeth.py
+++ b/yt_dlp/extractor/roosterteeth.py
@@ -152,8 +152,9 @@ class RoosterTeethIE(RoosterTeethBaseIE):
         try:
             video_data = self._download_json(
                 api_episode_url + '/videos', display_id, 'Downloading video JSON metadata',
-                headers={'Client-Type': 'web'})['data'][0]
-            m3u8_url = traverse_obj(video_data, ('links', 'download')) or traverse_obj(video_data, ('attributes', 'url'))
+                headers={'Client-Type': 'web'})['data'][0]  # web client-type yields ad-free streams
+            m3u8_url = video_data['attributes']['url']
+            # XXX: additional ad-free URL at video_data['links']['download'] but often gives 403 errors
         except ExtractorError as e:
             if isinstance(e.cause, HTTPError) and e.cause.status == 403:
                 if self._parse_json(e.cause.response.read().decode(), display_id).get('access') is False:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR makes the Rooster Teeth extractor grab ad-free streams instead of streams with embedded ads.

Based on the videos I've looked at, by default `video_data['attributes']['url']` contains ads and `video_data['links']['download']` does not. Preferring the latter over the former is enough to download ad-free streams.

Additionally, passing in a `Client-Type: web` header forces both URLs to be the same ad-free stream. This PR includes that header as well for some slight future-proofing.

The RoosterTeeth tests were failing due to incomplete attribute data in test cases so this PR fixes that too.

Fixes #7647 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
