### PR TITLE
[ie/francetv] Fix DAI livestreams

### DIFF
--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -119,8 +119,7 @@ class FranceTVIE(InfoExtractor):
             video_url = video['url']
             format_id = video.get('format')
 
-            token_url = url_or_none(video.get('token'))
-            if token_url and video.get('workflow') == 'token-akamai':
+            if token_url := url_or_none(video.get('token')):
                 tokenized_url = traverse_obj(self._download_json(
                     token_url, video_id, f'Downloading signed {format_id} manifest URL',
                     fatal=False, query={

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -255,6 +255,26 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
             'duration': 1441,
         },
     }, {
+        # geo-restricted livestream (workflow == 'token-akamai')
+        'url': 'https://www.france.tv/france-4/direct.html',
+        'info_dict': {
+            'id': '9a6a7670-dde9-4264-adbc-55b89558594b',
+            'ext': 'mp4',
+            'title': r're:France 4 en direct .+',
+            'live_status': 'is_live',
+        },
+        'skip': 'geo-restricted livestream',
+    }, {
+        # livestream (workflow == 'dai')
+        'url': 'https://www.france.tv/france-2/direct.html',
+        'info_dict': {
+            'id': '006194ea-117d-4bcf-94a9-153d999c59ae',
+            'ext': 'mp4',
+            'title': r're:France 2 en direct .+',
+            'live_status': 'is_live',
+        },
+        'params': {'skip_download': 'livestream'},
+    }, {
         # france3
         'url': 'https://www.france.tv/france-3/des-chiffres-et-des-lettres/139063-emission-du-mardi-9-mai-2017.html',
         'only_matching': True,
@@ -269,10 +289,6 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
     }, {
         # franceo
         'url': 'https://www.france.tv/france-o/archipels/132249-mon-ancetre-l-esclave.html',
-        'only_matching': True,
-    }, {
-        # france2 live
-        'url': 'https://www.france.tv/france-2/direct.html',
         'only_matching': True,
     }, {
         'url': 'https://www.france.tv/documentaires/histoire/136517-argentine-les-500-bebes-voles-de-la-dictature.html',


### PR DESCRIPTION
Some livestreams have a `workflow` value of `dai` instead of `token-akamai`, which was causing their m3u8 URLs to remain untokenized and return 403 errors. Since tokenizing the URL is non-fatal (and I can't find any examples of URLs that do not need to be tokenized), we might as well try to do it no matter what the workflow value is.

Addresses https://github.com/yt-dlp/yt-dlp/issues/9323#issuecomment-1983097622
Closes #9382

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
