### PR TITLE
[ie/niconico] Directly download live timeshift videos; WebSocket fixes

### DIFF
--- a/yt_dlp/downloader/__init__.py
+++ b/yt_dlp/downloader/__init__.py
@@ -30,7 +30,7 @@ from .hls import HlsFD
 from .http import HttpFD
 from .ism import IsmFD
 from .mhtml import MhtmlFD
-from .niconico import NiconicoDmcFD, NiconicoLiveFD
+from .niconico import NiconicoDmcFD, NiconicoLiveFD, NiconicoLiveTimeshiftFD
 from .rtmp import RtmpFD
 from .rtsp import RtspFD
 from .websocket import WebSocketFragmentFD
@@ -50,7 +50,8 @@ PROTOCOL_MAP = {
     'ism': IsmFD,
     'mhtml': MhtmlFD,
     'niconico_dmc': NiconicoDmcFD,
-    'niconico_live': NiconicoLiveFD,
+    'm3u8_niconico_live': NiconicoLiveFD,
+    'm3u8_niconico_live_timeshift': NiconicoLiveTimeshiftFD,
     'fc2_live': FC2LiveFD,
     'websocket_frag': WebSocketFragmentFD,
     'youtube_live_chat': YoutubeLiveChatFD,

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -919,17 +919,30 @@ class NiconicoLiveIE(InfoExtractor):
         'info_dict': {
             'id': 'lv339533123',
             'title': '激辛ペヤング食べます‪( ;ᯅ; )‬（歌枠オーディション参加中）',
-            'view_count': 1526,
-            'comment_count': 1772,
+            'view_count': int,
+            'comment_count': int,
             'description': '初めましてもかって言います❕\nのんびり自由に適当に暮らしてます',
             'uploader': 'もか',
             'channel': 'ゲストさんのコミュニティ',
             'channel_id': 'co5776900',
             'channel_url': 'https://com.nicovideo.jp/community/co5776900',
             'timestamp': 1670677328,
-            'is_live': True,
+            'ext': None,
+            'live_latency': 'high',
+            'live_status': 'was_live',
+            'thumbnail': r're:^https://[\w.-]+/\w+/\w+',
+            'thumbnails': list,
+            'upload_date': '20221210',
         },
-        'skip': 'livestream',
+        'params': {
+            'skip_download': True,
+            'ignore_no_formats_error': True,
+        },
+        'expected_warnings': [
+            'The live hasn\'t started yet or already ended.',
+            'No video formats found!',
+            'Requested format is not available',
+        ],
     }, {
         'url': 'https://live2.nicovideo.jp/watch/lv339533123',
         'only_matching': True,
@@ -943,36 +956,14 @@ class NiconicoLiveIE(InfoExtractor):
 
     _KNOWN_LATENCY = ('high', 'low')
 
-    def _real_extract(self, url):
-        video_id = self._match_id(url)
-        webpage, urlh = self._download_webpage_handle(f'https://live.nicovideo.jp/watch/{video_id}', video_id)
-
-        embedded_data = self._parse_json(unescapeHTML(self._search_regex(
-            r'<script\s+id="embedded-data"\s*data-props="(.+?)"', webpage, 'embedded data')), video_id)
-
-        ws_url = traverse_obj(embedded_data, ('site', 'relive', 'webSocketUrl'))
-        if not ws_url:
-            raise ExtractorError('The live hasn\'t started yet or already ended.', expected=True)
-        ws_url = update_url_query(ws_url, {
-            'frontend_id': traverse_obj(embedded_data, ('site', 'frontendId')) or '9',
-        })
-
-        hostname = remove_start(urlparse(urlh.url).hostname, 'sp.')
-        latency = try_get(self._configuration_arg('latency'), lambda x: x[0])
-        if latency not in self._KNOWN_LATENCY:
-            latency = 'high'
-
-        ws = self._request_webpage(
-            Request(ws_url, headers={'Origin': f'https://{hostname}'}),
-            video_id=video_id, note='Connecting to WebSocket server')
-
+    def _yield_formats(self, ws, video_id, latency, is_live):
         self.write_debug('[debug] Sending HLS server request')
         ws.send(json.dumps({
             'type': 'startWatching',
             'data': {
                 'stream': {
                     'quality': 'abr',
-                    'protocol': 'hls+fmp4',
+                    'protocol': 'hls',
                     'latency': latency,
                     'chasePlay': False
                 },
@@ -1007,6 +998,35 @@ class NiconicoLiveIE(InfoExtractor):
                     recv = recv[:100] + '...'
                 self.write_debug('Server said: %s' % recv)
 
+        formats = self._extract_m3u8_formats(m3u8_url, video_id, ext='mp4', live=is_live)
+        for fmt, q in zip(formats, reversed(qualities[1:])):
+            fmt.update({
+                'format_id': q,
+                'protocol': 'm3u8_niconico_live' if is_live else 'm3u8_niconico_live_timeshift',
+            })
+            yield fmt
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage, urlh = self._download_webpage_handle(f'https://live.nicovideo.jp/watch/{video_id}', video_id)
+
+        embedded_data = self._parse_json(unescapeHTML(self._search_regex(
+            r'<script\s+id="embedded-data"\s*data-props="(.+?)"', webpage, 'embedded data')), video_id)
+
+        ws = None
+        ws_url = traverse_obj(embedded_data, ('site', 'relive', 'webSocketUrl'))
+        if ws_url:
+            ws_url = update_url_query(ws_url, {
+                'frontend_id': traverse_obj(embedded_data, ('site', 'frontendId')) or '9',
+            })
+            hostname = remove_start(urlparse(urlh.url).hostname, 'sp.')
+
+            ws = self._request_webpage(
+                Request(ws_url, headers={'Origin': f'https://{hostname}'}),
+                video_id=video_id, note='Connecting to WebSocket server')
+        else:
+            self.raise_no_formats('The live hasn\'t started yet or already ended.', expected=True)
+
         title = traverse_obj(embedded_data, ('program', 'title')) or self._html_search_meta(
             ('og:title', 'twitter:title'), webpage, 'live title', fatal=False)
 
@@ -1031,16 +1051,15 @@ class NiconicoLiveIE(InfoExtractor):
                     **res,
                 })
 
-        formats = self._extract_m3u8_formats(m3u8_url, video_id, ext='mp4', live=True)
-        for fmt, q in zip(formats, reversed(qualities[1:])):
-            fmt.update({
-                'format_id': q,
-                'protocol': 'niconico_live',
-                'ws': ws,
-                'video_id': video_id,
-                'live_latency': latency,
-                'origin': hostname,
-            })
+        live_status = {
+            'Before': 'is_live',
+            'Open': 'was_live',
+            'End': 'was_live',
+        }.get(traverse_obj(embedded_data, ('programTimeshift', 'publication', 'status', {str})), 'is_live')
+
+        latency = try_get(self._configuration_arg('latency'), lambda x: x[0])
+        if latency not in self._KNOWN_LATENCY:
+            latency = 'high'
 
         return {
             'id': video_id,
@@ -1055,7 +1074,9 @@ class NiconicoLiveIE(InfoExtractor):
             }),
             'description': clean_html(traverse_obj(embedded_data, ('program', 'description'))),
             'timestamp': int_or_none(traverse_obj(embedded_data, ('program', 'openTime'))),
-            'is_live': True,
+            'live_status': live_status,
             'thumbnails': thumbnails,
-            'formats': formats,
+            'formats': [*self._yield_formats(ws, video_id, latency, live_status == 'is_live')] if ws else None,
+            'live_latency': latency,
+            '__ws': ws,
         }


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR should not block the incoming release (see [Kanban](https://github.com/orgs/yt-dlp/projects/8)).

### Summary

Major changes:

- Make a downloader for live timeshift videos. Time-based download rate limit applies. RetryManager-based error recovery applies.
- Fix the incorrect url for WebSocket reconnection.
- Correctly close the WebSocket connection.
- [!] Apply "FFmpegFixupM3u8PP" for both non-timeshift and timeshift MPEG-TS files by adding "m3u8_*" prefixes and inheriting from "HlsFD".
- [!] Change the protocol from "hls+fmp4" to "hls" in "startWatching" WebSocket requests because I didn't see it in my test.

Minor changes:

- Support metadata extraction when no formats.
- Set "live_status" instead of "is_live".
- Clean up "info_dict": Change WebSocket configs to private to hide them from users; extract common fields and remove unused ones.
- Update a download test.

Related PR:

- #5764
- https://github.com/yt-dlp/yt-dlp/issues/7365#issuecomment-1865211378

### Test

To test this PR:

- Live:
    - Official programs: https://live.nicovideo.jp/focus.
    - Personal programs: https://live.nicovideo.jp/recent.
- Timeshift (VOD): Go to the timetable (https://live.nicovideo.jp/timetable) and find programs without "放送中" (now on air).

### About the new downloader

#### Design

For live and timeshift videos on Niconico Live (ニコニコ生放送), the media playlists are always dynamic. Our FFmpeg downloader works well with them. However, for timeshift ones, the MPEG-TS fragments are actually VOD, so we can download it via HTTP instead of FFmpeg.

Niconico server expects a "`start`" field in the manifest playlist request. The value of that field is the playback position (in seconds) of a video. That is, requesting with different values gives us fragments at different time points. I guess this key *might* be used by the resume mechanism of Niconico player [1].

Downloading many fragments without delay will result in HTTP 403. That's apparently rate limit exceeded. In this PR, the download speed is limited by fragment length and download time.

Downloading fragments without an active WebSocket connection will also cause HTTP 403. That's the authorization way of Niconico. Due to network jitters and other exceptions, the WebSocket connection needs to be re-established. If the server refreshes the manifest playlist url, all subsequent requests with previous urls will be HTTP 403. That's why I protect the playlist with a lock.

[1]: In browser's DevTools, search "beginning_timestamp" in the "stream_sync.json" file.

#### For "FFmpegFixupM3u8PP"

This is totally a hack. I think there could be a better way to do so.

- Derive the class from "HlsFD"

https://github.com/yt-dlp/yt-dlp/blob/263a4b55ac17a796e8991ca8d2d86a3c349f8a60/yt_dlp/YoutubeDL.py#L3498-L3501

- Add the "m3u8_*" prefixes

https://github.com/yt-dlp/yt-dlp/blob/263a4b55ac17a796e8991ca8d2d86a3c349f8a60/yt_dlp/postprocessor/ffmpeg.py#L888-L891

#### Copy-Paste-oriented programming

- RetryManager

https://github.com/yt-dlp/yt-dlp/blob/263a4b55ac17a796e8991ca8d2d86a3c349f8a60/yt_dlp/downloader/ism.py#L259-L260

- Fragment processing

https://github.com/yt-dlp/yt-dlp/blob/263a4b55ac17a796e8991ca8d2d86a3c349f8a60/yt_dlp/downloader/fragment.py#L432-L435

.

<br>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
