### PR TITLE
Remove emojis from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1920,12 +1920,12 @@ import yt_dlp
 
 URL = 'https://www.youtube.com/watch?v=BaW_jenozKc'
 
-# ℹ️ See help(yt_dlp.YoutubeDL) for a list of available options and public functions
+# See help(yt_dlp.YoutubeDL) for a list of available options and public functions
 ydl_opts = {}
 with yt_dlp.YoutubeDL(ydl_opts) as ydl:
     info = ydl.extract_info(URL, download=False)
 
-    # ℹ️ ydl.sanitize_info makes the info json-serializable
+    # ydl.sanitize_info makes the info json-serializable
     print(json.dumps(ydl.sanitize_info(info)))
 ```
 #### Download using an info-json
@@ -1951,7 +1951,7 @@ URLS = ['https://www.youtube.com/watch?v=BaW_jenozKc']
 
 ydl_opts = {
     'format': 'm4a/bestaudio/best',
-    # ℹ️ See help(yt_dlp.postprocessor) for a list of available Postprocessors and their arguments
+    # See help(yt_dlp.postprocessor) for a list of available Postprocessors and their arguments
     'postprocessors': [{  # Extract audio using ffmpeg
         'key': 'FFmpegExtractAudio',
         'preferredcodec': 'm4a',
@@ -2009,7 +2009,7 @@ class MyLogger:
         print(msg)
 
 
-# ℹ️ See "progress_hooks" in help(yt_dlp.YoutubeDL)
+# See "progress_hooks" in help(yt_dlp.YoutubeDL)
 def my_hook(d):
     if d['status'] == 'finished':
         print('Done downloading, now post-processing ...')
@@ -2031,7 +2031,7 @@ import yt_dlp
 
 URLS = ['https://www.youtube.com/watch?v=BaW_jenozKc']
 
-# ℹ️ See help(yt_dlp.postprocessor.PostProcessor)
+# See help(yt_dlp.postprocessor.PostProcessor)
 class MyCustomPP(yt_dlp.postprocessor.PostProcessor):
     def run(self, info):
         self.to_screen('Doing stuff')
@@ -2039,7 +2039,7 @@ class MyCustomPP(yt_dlp.postprocessor.PostProcessor):
 
 
 with yt_dlp.YoutubeDL() as ydl:
-    # ℹ️ "when" can take any value in yt_dlp.utils.POSTPROCESS_WHEN
+    # "when" can take any value in yt_dlp.utils.POSTPROCESS_WHEN
     ydl.add_post_processor(MyCustomPP(), when='pre_process')
     ydl.download(URLS)
 ```


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR removes six emojis (that is, all emojis) from the README. I feel like they serve no purpose and look horrible when reading the man page in the terminal.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes)