### PR TITLE
[ie/crunchyroll] Extract `vo_adaptive_hls` formats by default

### DIFF
--- a/yt_dlp/extractor/crunchyroll.py
+++ b/yt_dlp/extractor/crunchyroll.py
@@ -136,7 +136,7 @@ class CrunchyrollBaseIE(InfoExtractor):
         return result
 
     def _extract_formats(self, stream_response, display_id=None):
-        requested_formats = self._configuration_arg('format') or ['adaptive_hls']
+        requested_formats = self._configuration_arg('format') or ['vo_adaptive_hls']
         available_formats = {}
         for stream_type, streams in traverse_obj(
                 stream_response, (('streams', ('data', 0)), {dict.items}, ...)):


### PR DESCRIPTION
Closes #9439


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
