### PR TITLE
Manpage: Replace `*` with `\*` in OPTIONS

### DIFF
--- a/devscripts/prepare_manpage.py
+++ b/devscripts/prepare_manpage.py
@@ -65,9 +65,7 @@ def move_sections(readme):
 
 def filter_options(readme):
     section = re.search(r'(?sm)^# USAGE AND OPTIONS\n.+?(?=^# )', readme).group(0)
-
-    # Replace * with \*. See https://github.com/yt-dlp/yt-dlp/issues/5108
-    section_new = section.replace('*', r'\*') if section else ''
+    section_new = section.replace('*', R'\*')
 
     options = '# OPTIONS\n'
     for line in section_new.split('\n')[1:]:

--- a/devscripts/prepare_manpage.py
+++ b/devscripts/prepare_manpage.py
@@ -65,8 +65,12 @@ def move_sections(readme):
 
 def filter_options(readme):
     section = re.search(r'(?sm)^# USAGE AND OPTIONS\n.+?(?=^# )', readme).group(0)
+
+    # Replace * with \*. See https://github.com/yt-dlp/yt-dlp/issues/5108
+    section_new = section.replace('*', r'\*') if section else ''
+
     options = '# OPTIONS\n'
-    for line in section.split('\n')[1:]:
+    for line in section_new.split('\n')[1:]:
         mobj = re.fullmatch(r'''(?x)
                 \s{4}(?P<opt>-(?:,\s|[^\s])+)
                 (?:\s(?P<meta>(?:[^\s]|\s(?!\s))+))?


### PR DESCRIPTION
### Description of your *pull request* and other information

In the section "USAGE AND OPTIONS" in the README there's a few `*`. As this section is converted to Pandoc's definition_lists (no longer code blocks), the `*` are interpreted as emphasis.

This PR adds code to prepare_manpage.py, which replaces all occurrences of `*` with `\*`, so that they are properly escaped and displayed as intended in the manpage.

Fixes #5108

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))