### PR TITLE
Refactor download_with_info_file into two separate methods.

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3560,14 +3560,9 @@ class YoutubeDL:
 
         return self._download_retcode
 
-    def download_with_info_file(self, info_filename):
-        with contextlib.closing(fileinput.FileInput(
-                [info_filename], mode='r',
-                openhook=fileinput.hook_encoded('utf-8'))) as f:
-            # FileInput doesn't have a read method, we can't call json.load
-            infos = [self.sanitize_info(info, self.params.get('clean_infojson', True))
-                     for info in variadic(json.loads('\n'.join(f)))]
-        for info in infos:
+    def download_with_info(self, info_list):
+        """Download using already extracted info_dicts."""
+        for info in info_list:
             try:
                 self.__download_wrapper(self.process_ie_result)(info, download=True)
             except (DownloadError, EntryNotInPlaylist, ReExtractInfo) as e:
@@ -3581,6 +3576,16 @@ class YoutubeDL:
             except ExtractorError as e:
                 self.report_error(e)
         return self._download_retcode
+
+    def download_with_info_file(self, info_filename):
+        """Download using an info file."""
+        with contextlib.closing(fileinput.FileInput(
+                [info_filename], mode='r',
+                openhook=fileinput.hook_encoded('utf-8'))) as f:
+            # FileInput doesn't have a read method, we can't call json.load
+            infos = [self.sanitize_info(info, self.params.get('clean_infojson', True))
+                     for info in variadic(json.loads('\n'.join(f)))]
+        return self.download_with_info(infos)
 
     @staticmethod
     def sanitize_info(info_dict, remove_private_keys=False):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This pull request, refactors `YoutubeDL.download_with_info_file` into two separate methods `download_with_info_file` and `download_with_info`.

The purpose of this change is to allow external developers who rely on `yt-dlp` to bypass the tax of having to call `extract_info` twice, if they do any pre-work before sending the item to be downloaded. 

For example, i have a yt-dlp frontend webui called [YTPTube](https://github.com/arabcoders/ytptube) that embeds `yt-dlp`, The tool call `extract_info` for various reasons, before passing the URL to `yt-dlp` which will also call `extract_info` again thus doing multiple network trips. 

I am aware i can call `YoutubeDL.process_ie_result` but calling this method with i assume is not part of the Offical public API will lead to problems down the line. 

The new method does not interduce any new code except for new method definition with the body of the refactored  `download_with_info_file` code. 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence) - `the code is just refactored bit of the original yt-dlp code.`

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
