### PR TITLE
[ie] Add extractor impersonate API

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -937,10 +937,10 @@ class InfoExtractor:
             Note that this argument does not affect success status codes (2xx)
             which are always accepted.
         impersonate -- the impersonate target. Can be any of the following entities:
-                - a boolean value; `True` means any impersonate target is sufficient
+                - a boolean value; True means any impersonate target is sufficient
                 - a string in the format of CLIENT[:OS]
                 - a list or a tuple of strings in the format of CLIENT[:OS]
-                - an instance of yt_dlp.impersonate.ImpersonateTarget
+                - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
         require_impersonation -- flag to toggle whether the request should raise an error
             if impersonation is not possible (bool, default: False)
         """

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -938,10 +938,10 @@ class InfoExtractor:
             Note that this argument does not affect success status codes (2xx)
             which are always accepted.
         impersonate -- the impersonate target. Can be any of the following entities:
-                - a boolean value; True means any impersonate target is sufficient
-                - a string in the format of CLIENT[:OS]
-                - a list or a tuple of strings in the format of CLIENT[:OS]
                 - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
+                - a string in the format of CLIENT[:OS]
+                - a list or a tuple of CLIENT[:OS] strings or ImpersonateTarget instances
+                - a boolean value; True means any impersonate target is sufficient
         require_impersonation -- flag to toggle whether the request should raise an error
             if impersonation is not possible (bool, default: False)
         """

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -862,13 +862,14 @@ class InfoExtractor:
             headers = (headers or {}).copy()
             headers.setdefault('X-Forwarded-For', self._x_forwarded_for_ip)
 
-        extensions, requested_targets = {}, []
-        if impersonate is True:
-            requested_targets.append(ImpersonateTarget())
-        elif isinstance(impersonate, ImpersonateTarget):
-            requested_targets.append(impersonate)
-        elif isinstance(impersonate, (str, list, tuple)):
-            requested_targets = tuple(map(ImpersonateTarget.from_str, variadic(impersonate)))
+        extensions = {}
+
+        if impersonate in (True, ''):
+            impersonate = ImpersonateTarget()
+        requested_targets = [
+            t if isinstance(t, ImpersonateTarget) else ImpersonateTarget.from_str(t)
+            for t in variadic(impersonate)
+        ] if impersonate else []
 
         available_target = next(filter(self._downloader._impersonate_target_available, requested_targets), None)
         if available_target:
@@ -876,8 +877,8 @@ class InfoExtractor:
         elif requested_targets:
             message = 'The extractor is attempting impersonation, but '
             message += (
-                'no impersonate target is available' if impersonate in (True, '', ':')
-                else f'these impersonate targets are not available: "{", ".join(map(str, requested_targets))}"')
+                'no impersonate target is available' if str(impersonate) in ('', ':')
+                else f'none of these impersonate targets are available: "{", ".join(map(str, requested_targets))}"')
             info_msg = ('see  https://github.com/yt-dlp/yt-dlp#impersonation  '
                         'for information on installing the required dependencies')
             if require_impersonation:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -542,6 +542,15 @@ class InfoExtractor:
     will be used by geo restriction bypass mechanism similarly
     to _GEO_COUNTRIES.
 
+    The _IMPERSONATE attribute may contain a target or targets that all of this
+    extractor's requests will attempt to impersonate by default. This value
+    can be overridden by the impersonate parameter of the request helper methods.
+    It can be any of the following entities:
+        - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
+        - a string in the format of CLIENT[:OS]
+        - a list or a tuple of CLIENT[:OS] strings or ImpersonateTarget instances
+        - a boolean value; True means any impersonate target is sufficient
+
     The _ENABLED attribute should be set to False for IEs that
     are disabled by default and must be explicitly enabled.
 
@@ -555,6 +564,7 @@ class InfoExtractor:
     _GEO_BYPASS = True
     _GEO_COUNTRIES = None
     _GEO_IP_BLOCKS = None
+    _IMPERSONATE = None
     _WORKING = True
     _ENABLED = True
     _NETRC_MACHINE = None
@@ -864,6 +874,8 @@ class InfoExtractor:
 
         extensions = {}
 
+        if impersonate is None:
+            impersonate = self._IMPERSONATE
         if impersonate in (True, ''):
             impersonate = ImpersonateTarget()
         requested_targets = [
@@ -941,7 +953,8 @@ class InfoExtractor:
                 - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
                 - a string in the format of CLIENT[:OS]
                 - a list or a tuple of CLIENT[:OS] strings or ImpersonateTarget instances
-                - a boolean value; True means any impersonate target is sufficient
+                - a boolean value; True means any impersonate target is sufficient, and
+                  False can be used to override the extractor's _IMPERSONATE attribute
         require_impersonation -- flag to toggle whether the request should raise an error
             if impersonation is not possible (bool, default: False)
         """

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -542,15 +542,6 @@ class InfoExtractor:
     will be used by geo restriction bypass mechanism similarly
     to _GEO_COUNTRIES.
 
-    The _IMPERSONATE attribute may contain a target or targets that all of this
-    extractor's requests will attempt to impersonate by default. This value
-    can be overridden by the impersonate parameter of the request helper methods.
-    It can be any of the following entities:
-        - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
-        - a string in the format of CLIENT[:OS]
-        - a list or a tuple of CLIENT[:OS] strings or ImpersonateTarget instances
-        - a boolean value; True means any impersonate target is sufficient
-
     The _ENABLED attribute should be set to False for IEs that
     are disabled by default and must be explicitly enabled.
 
@@ -564,7 +555,6 @@ class InfoExtractor:
     _GEO_BYPASS = True
     _GEO_COUNTRIES = None
     _GEO_IP_BLOCKS = None
-    _IMPERSONATE = None
     _WORKING = True
     _ENABLED = True
     _NETRC_MACHINE = None
@@ -874,8 +864,6 @@ class InfoExtractor:
 
         extensions = {}
 
-        if impersonate is None:
-            impersonate = self._IMPERSONATE
         if impersonate in (True, ''):
             impersonate = ImpersonateTarget()
         requested_targets = [
@@ -953,8 +941,7 @@ class InfoExtractor:
                 - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
                 - a string in the format of CLIENT[:OS]
                 - a list or a tuple of CLIENT[:OS] strings or ImpersonateTarget instances
-                - a boolean value; True means any impersonate target is sufficient, and
-                  False can be used to override the extractor's _IMPERSONATE attribute
+                - a boolean value; True means any impersonate target is sufficient
         require_impersonation -- flag to toggle whether the request should raise an error
             if impersonation is not possible (bool, default: False)
         """

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -831,7 +831,7 @@ class InfoExtractor:
         return url_or_request
 
     def _request_webpage(self, url_or_request, video_id, note=None, errnote=None, fatal=True, data=None,
-                         headers=None, query=None, expected_status=None, impersonate=None, force_impersonate=False):
+                         headers=None, query=None, expected_status=None, impersonate=None, require_impersonation=False):
         """
         Return the response handle.
 
@@ -865,7 +865,7 @@ class InfoExtractor:
         extensions = None
         if impersonate is not None:
             target = ImpersonateTarget.from_str(':' if impersonate is True else impersonate)
-            if force_impersonate or self._downloader._impersonate_target_available(target):
+            if require_impersonation or self._downloader._impersonate_target_available(target):
                 extensions = {'impersonate': target}
 
         try:
@@ -889,7 +889,7 @@ class InfoExtractor:
 
     def _download_webpage_handle(self, url_or_request, video_id, note=None, errnote=None, fatal=True,
                                  encoding=None, data=None, headers={}, query={}, expected_status=None,
-                                 impersonate=None, force_impersonate=False):
+                                 impersonate=None, require_impersonation=False):
         """
         Return a tuple (page content as string, URL handle).
 
@@ -922,7 +922,7 @@ class InfoExtractor:
             which are always accepted.
         impersonate -- the impersonate target: can be either a string in the format of
             CLIENT[:OS] or True (bool) if any target is sufficient
-        force_impersonate -- flag to toggle whether the request should raise an error
+        require_impersonation -- flag to toggle whether the request should raise an error
             if impersonation is not possible (bool, default: False)
         """
 
@@ -932,7 +932,7 @@ class InfoExtractor:
 
         urlh = self._request_webpage(url_or_request, video_id, note, errnote, fatal, data=data,
                                      headers=headers, query=query, expected_status=expected_status,
-                                     impersonate=impersonate, force_impersonate=force_impersonate)
+                                     impersonate=impersonate, require_impersonation=require_impersonation)
         if urlh is False:
             assert not fatal
             return False
@@ -1062,11 +1062,11 @@ class InfoExtractor:
 
         def download_handle(self, url_or_request, video_id, note=note, errnote=errnote, transform_source=None,
                             fatal=True, encoding=None, data=None, headers={}, query={}, expected_status=None,
-                            impersonate=None, force_impersonate=False):
+                            impersonate=None, require_impersonation=False):
             res = self._download_webpage_handle(
                 url_or_request, video_id, note=note, errnote=errnote, fatal=fatal, encoding=encoding,
                 data=data, headers=headers, query=query, expected_status=expected_status,
-                impersonate=impersonate, force_impersonate=force_impersonate)
+                impersonate=impersonate, require_impersonation=require_impersonation)
             if res is False:
                 return res
             content, urlh = res
@@ -1074,7 +1074,7 @@ class InfoExtractor:
 
         def download_content(self, url_or_request, video_id, note=note, errnote=errnote, transform_source=None,
                              fatal=True, encoding=None, data=None, headers={}, query={}, expected_status=None,
-                             impersonate=None, force_impersonate=False):
+                             impersonate=None, require_impersonation=False):
             if self.get_param('load_pages'):
                 url_or_request = self._create_request(url_or_request, data, headers, query)
                 filename = self._request_dump_filename(url_or_request.url, video_id)
@@ -1098,7 +1098,7 @@ class InfoExtractor:
                 'query': query,
                 'expected_status': expected_status,
                 'impersonate': impersonate,
-                'force_impersonate': force_impersonate,
+                'require_impersonation': require_impersonation,
             }
             if parser is None:
                 kwargs.pop('transform_source')

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -877,7 +877,7 @@ class InfoExtractor:
         elif requested_targets:
             message = 'The extractor is attempting impersonation, but '
             message += (
-                'no impersonate target is available' if str(impersonate) in ('', ':')
+                'no impersonate target is available' if not str(impersonate)
                 else f'none of these impersonate targets are available: "{", ".join(map(str, requested_targets))}"')
             info_msg = ('see  https://github.com/yt-dlp/yt-dlp#impersonation  '
                         'for information on installing the required dependencies')

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -463,9 +463,10 @@ class Request:
         else:
             raise TypeError('headers must be a mapping')
 
-    def update(self, url=None, data=None, headers=None, query=None):
+    def update(self, url=None, data=None, headers=None, query=None, extensions=None):
         self.data = data if data is not None else self.data
         self.headers.update(headers or {})
+        self.extensions.update(extensions or {})
         self.url = update_url_query(url or self.url, query or {})
 
     def copy(self):


### PR DESCRIPTION
Add an impersonate API for the extractors.

Proposed implementation:

Add `impersonate` and `require_impersonation` params to the following extractor helper methods:

- `_request_webpage()`
- `_download_webage()` and `_download_webpage_handle()`
- `_download_json()` and `_download_json_handle()`
- `_download_xml()` and `_download_xml_handle()`
- `_download_socket_json()` and `_download_socket_json_handle()`

```
        impersonate -- the impersonate target. Can be any of the following entities:
                - an instance of yt_dlp.networking.impersonate.ImpersonateTarget
                - a string in the format of CLIENT[:OS]
                - a list or a tuple of CLIENT[:OS] strings or ImpersonateTarget instances
                - a boolean value; True means any impersonate target is sufficient

        require_impersonation -- flag to toggle whether the request should raise an error
            if impersonation is not possible (bool, default: False)
```

IMO we shouldn't always force impersonation for a request, since a manual bypass of cloudflare fingerprinting is possible with the fresh cookies/UA combo, and since some IPs/users may not experience any blockage at all. 

~~Though maybe we should add a warning if an impersonate target is specified (but not forced) by the extractor and the target is not available.~~ (done)

~~Something else we could consider is allowing a preferred order of multiple impersonate targets for a particular request, though I don't know of any sites where that would be necessary.~~ (done)


Example usage: https://github.com/bashonly/yt-dlp/commit/0691d1c9fc344b915d011df94378c7a256550c3f


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
