### PR TITLE
Make calculated filesize available everywhere

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1779,6 +1779,11 @@ class YoutubeDL:
                 'extractor': ie.IE_NAME,
                 'extractor_key': ie.ie_key(),
             })
+        for f in traverse_obj(ie_result, 'formats', default=[]):
+            self.add_extra_info(f, {
+                'filesize_approx': traverse_obj(f, 'filesize_approx', 'filesize',
+                                                default=try_call(lambda: int(ie_result['duration'] * f['tbr'] * (1024 / 8))))
+            })
 
     def process_ie_result(self, ie_result, download=True, extra_info=None):
         """
@@ -3874,9 +3879,7 @@ class YoutubeDL:
                 format_field(f, 'audio_channels', '\t%s'),
                 delim, (
                     format_field(f, 'filesize', ' \t%s', func=format_bytes)
-                    or format_field(f, 'filesize_approx', '≈\t%s', func=format_bytes)
-                    or format_field(try_call(lambda: format_bytes(int(info_dict['duration'] * f['tbr'] * (1024 / 8)))),
-                                    None, self._format_out('~\t%s', self.Styles.SUPPRESS))),
+                    or format_field(f, 'filesize_approx', '~\t%s', func=format_bytes)),
                 format_field(f, 'tbr', '\t%dk', func=round),
                 shorten_protocol_name(f.get('protocol', '')),
                 delim,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I was a bit confused why the command yt-dlp --list-formats prints options that are not available from the formats array in yt-dlp -J. So when embedding yt-dlp in applications and using the recommended way to get the data via the json there is a mismatch.

This removes the custom implementation to calculate the filesize on the fly when printing the table and moves this calculation to a default value instead. That way it can be used in other parts of yt-dlp and when embedding it in other applications.

Fixes # (no issue created)


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

I moved the existing code, so I am not the full author of it, but the existing code was already licensed via unlicense in the past

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
