### PR TITLE
[ie/PornHub] add attributes, issue #9524

### DIFF
--- a/yt_dlp/extractor/pornhub.py
+++ b/yt_dlp/extractor/pornhub.py
@@ -219,7 +219,7 @@ class PornHubIE(PornHubBaseIE):
             'thumbnail': r're:https?://.+',
             'duration': 8173,
             'timestamp': 1612564932,
-            'age_limit': int,
+            'age_limit': 18,
             'tags': list,
             'like_count': int,
             'view_count': int,

--- a/yt_dlp/extractor/pornhub.py
+++ b/yt_dlp/extractor/pornhub.py
@@ -138,12 +138,13 @@ class PornHubIE(PornHubBaseIE):
     _EMBED_REGEX = [r'<iframe[^>]+?src=["\'](?P<url>(?:https?:)?//(?:www\.)?pornhub(?:premium)?\.(?:com|net|org)/embed/[\da-z]+)']
     _TESTS = [{
         'url': 'http://www.pornhub.com/view_video.php?viewkey=648719015',
-        'md5': 'a6391306d050e4547f62b3f485dd9ba9',
+        'md5': '4d4a4e9178b655776f86cf89ecaf0edf',
         'info_dict': {
             'id': '648719015',
             'ext': 'mp4',
             'title': 'Seductive Indian beauty strips down and fingers her pink pussy',
-            'uploader': 'Babes',
+            'uploader_id': str,
+            'uploader': 'BABES-COM',
             'upload_date': '20130628',
             'timestamp': 1372447216,
             'duration': 361,
@@ -155,6 +156,8 @@ class PornHubIE(PornHubBaseIE):
             'tags': list,
             'categories': list,
             'cast': list,
+            'thumbnail': str,
+            'production': list,
         },
     }, {
         # non-ASCII title
@@ -208,11 +211,23 @@ class PornHubIE(PornHubBaseIE):
         'url': 'http://www.pornhub.com/view_video.php?viewkey=ph601dc30bae19a',
         'info_dict': {
             'id': 'ph601dc30bae19a',
+            'ext': 'mp4',
             'uploader': 'Projekt Melody',
             'uploader_id': 'projekt-melody',
             'upload_date': '20210205',
             'title': '"Welcome to My Pussy Mansion" - CB Stream (02/03/21)',
             'thumbnail': r're:https?://.+',
+            'duration': 8173,
+            'timestamp': 1612564932,
+            'age_limit': int,
+            'tags': list,
+            'like_count': int,
+            'view_count': int,
+            'categories': list,
+            'dislike_count': int,
+            'production': list,
+            'cast': list,
+            'comment_count': int,
         },
     }, {
         'url': 'http://www.pornhub.com/view_video.php?viewkey=ph557bbb6676d2d',
@@ -263,7 +278,33 @@ class PornHubIE(PornHubBaseIE):
     }, {
         'url': 'http://pornhubvybmsymdol4iibwgwtkpwmeyd6luq2gxajgjzfjvotyt5zhyd.onion/view_video.php?viewkey=ph5a9813bfa7156',
         'only_matching': True,
-    }]
+    }, {
+        # language spoken, model attributes, production
+        'url': 'https://www.pornhub.com/view_video.php?viewkey=65a6ca42725f2',
+        'info_dict': {
+            'id': '65a6ca42725f2',
+            'ext': 'mp4',
+            'title': 'Busty blonde sucks the juice out of me',
+            'uploader_id': 'egon-kowalski',
+            'cast': [],
+            'thumbnail': 'https://ei.phncdn.com/videos/202401/16/446618441/thumbs_14/(m=eaAaGwObaaaa)(mh=dIONqa8IT3Sw1RqL)5.jpg',
+            'uploader': 'Egon Kowalski',
+            'upload_date': '20240116',
+            'timestamp': 1705429963,
+            'duration': 358,
+            'view_count': int,
+            'like_count': int,
+            'dislike_count': int,
+            'comment_count': int,
+            'age_limit': 18,
+            'tags': list,
+            'categories': list,
+            'language_spoken': ['german'],
+            'model_attributes': ['tattoos', 'white', 'no piercing'],
+            'production': ['homemade'],
+        }
+    }
+    ]
 
     def _extract_count(self, pattern, webpage, name):
         return str_to_int(self._search_regex(pattern, webpage, '%s count' % name, default=None))
@@ -488,6 +529,15 @@ class PornHubIE(PornHubBaseIE):
             if div:
                 return [clean_html(x).strip() for x in re.findall(r'(?s)<a[^>]+\bhref=[^>]+>.+?</a>', div)]
 
+        def get_model_attributes():
+            model_attributes = re.findall(
+                r'<a[^>]*\bdata-label=["\']model_attributes["\'][^>]*>(.*?)<\/a>',
+                webpage,
+                re.DOTALL)
+
+            if model_attributes:
+                return [x.strip().lower() for x in model_attributes]
+
         info = self._search_json_ld(webpage, video_id, default={})
         # description provided in JSON-LD is irrelevant
         info['description'] = None
@@ -509,6 +559,9 @@ class PornHubIE(PornHubBaseIE):
             'tags': extract_list('tags'),
             'categories': extract_list('categories'),
             'cast': extract_list('pornstars'),
+            'production': extract_list('production'),
+            'language_spoken': extract_list('langSpoken'),
+            'model_attributes': get_model_attributes(),
             'subtitles': subtitles,
         }, info)
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds `model attributes`, `spoken language`, and `production` attributes to the PornHub info extractor. It also fixes some of the broken PornHubIE tests.

Fixes https://github.com/yt-dlp/yt-dlp/issues/9524


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

### PornHubIE Test Logs
```
python3 devscripts/run_tests.py PornHubIE_all
Running ['pytest', '-Werror', '--tb=short', 'test/test_download.py::TestDownload::test_PornHub_all']
Running ['/usr/bin/python3', '-Werror', '-m', 'unittest', 'test.test_download.TestDownload.test_PornHub_all']
[debug] Loaded 1807 extractors
[PornHub] Extracting URL: http://www.pornhub.com/view_video.php?viewkey=648719015
[PornHub] 648719015: Downloading pc webpage
[PornHub] 648719015: Downloading m3u8 information
[PornHub] 648719015: Downloading m3u8 information
[PornHub] 648719015: Downloading m3u8 information
[PornHub] 648719015: Downloading m3u8 information
[PornHub] 648719015: Downloading JSON metadata
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] 648719015: Downloading 1 format(s): hls-1500-1
[info] Writing video metadata as JSON to: test_PornHub_648719015.info.json
[debug] Invoking hlsnative downloader on "https://ev-h.phncdn.com/hls/videos/201306/28/14084201/,200109_2050_720P_4000K,200109_2050_480P_2000K,200109_2050_240P_1000K,_14084201.mp4.urlset/index-f1-v1-a1.m3u8?validfrom=1711319047&validto=1711326247&ipa=72.140.162.251&hdl=-1&hash=misAqEoDasO%2F09xqxlX2SCszsak%3D"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 90
[download] Destination: test_PornHub_648719015.mp4
[download] 100% of    1.02MiB in 00:00:00 at 3.58MiB/s
Skipping PornHub: Video has been flagged for verification in accordance with our trust and safety policy
Skipped test_PornHub_1
Skipping PornHub: This video has been disabled
Skipped test_PornHub_2
[debug] Loaded 1807 extractors
[PornHub] Extracting URL: http://www.pornhub.com/view_video.php?viewkey=ph601dc30bae19a
[PornHub] ph601dc30bae19a: Downloading pc webpage
[PornHub] ph601dc30bae19a: Downloading m3u8 information
[PornHub] ph601dc30bae19a: Downloading m3u8 information
[PornHub] ph601dc30bae19a: Downloading m3u8 information
[PornHub] ph601dc30bae19a: Downloading m3u8 information
[PornHub] ph601dc30bae19a: Downloading m3u8 information
[PornHub] ph601dc30bae19a: Downloading JSON metadata
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] ph601dc30bae19a: Downloading 1 format(s): hls-2835
[info] Writing video metadata as JSON to: test_PornHub_3_ph601dc30bae19a.info.json
[debug] Invoking hlsnative downloader on "https://cv-h.phncdn.com/hls/videos/202102/05/383080302/1080P_8000K_383080302.mp4/index-v1-a1.m3u8?YLun6I8kmbsWj-rMHovpmI-V2Bpldj8Pf139H2Ilg0BFDkSFQXq2i9PcV2hOGwQrXAoBmlOwn5WDbx3_WZHGKpe3ud4FQiXjyAnIjtP1WpRzUa-ttrBhoqdXAhhFBLqKeuWEf9tFbWlLD3D3VUjM0GRNVDd-tCTBvxpmafUxrfFp4aF6tw4CUQUlJ7e5EXQAI9jGuLFcYVk"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 2043
[download] Destination: test_PornHub_3_ph601dc30bae19a.mp4
[download] 100% of  191.30KiB in 00:00:00 at 2.50MiB/s
[debug] Loaded 1807 extractors
[PornHub] Extracting URL: https://www.pornhub.com/view_video.php?viewkey=65a6ca42725f2
[PornHub] 65a6ca42725f2: Downloading pc webpage
[PornHub] 65a6ca42725f2: Downloading m3u8 information
[PornHub] 65a6ca42725f2: Downloading m3u8 information
[PornHub] 65a6ca42725f2: Downloading m3u8 information
[PornHub] 65a6ca42725f2: Downloading m3u8 information
[PornHub] 65a6ca42725f2: Downloading m3u8 information
[PornHub] 65a6ca42725f2: Downloading JSON metadata
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] 65a6ca42725f2: Downloading 1 format(s): hls-3969-1
[info] Writing video metadata as JSON to: test_PornHub_4_65a6ca42725f2.info.json
[debug] Invoking hlsnative downloader on "https://ev-h.phncdn.com/hls/videos/202401/16/446618441/,1080P_4000K,720P_4000K,480P_2000K,240P_1000K,_446618441.mp4.urlset/index-f1-v1-a1.m3u8?validfrom=1711319069&validto=1711326269&ipa=72.140.162.251&hdl=-1&hash=cQh1Jmxnsw5hTsBfmOtGphbB1Yg%3D"
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 89
[download] Destination: test_PornHub_4_65a6ca42725f2.mp4
[download] 100% of  408.68KiB in 00:00:00 at 2.29MiB/s
.
----------------------------------------------------------------------
Ran 1 test in 24.779s

OK
```