### PR TITLE
Adding ssl keys log using SSLKEYLOGFILE env var for SSLContext (yt-dlp/yt-dlp#9531)

### DIFF
--- a/yt_dlp/networking/_helper.py
+++ b/yt_dlp/networking/_helper.py
@@ -8,6 +8,7 @@ import sys
 import typing
 import urllib.parse
 import urllib.request
+import os
 
 from .exceptions import RequestError, UnsupportedRequest
 from ..dependencies import certifi
@@ -119,6 +120,7 @@ def make_ssl_context(
     use_certifi=True,
 ):
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.keylog_filename = os.environ.get('SSLKEYLOGFILE')
     context.check_hostname = verify
     context.verify_mode = ssl.CERT_REQUIRED if verify else ssl.CERT_NONE
 

--- a/yt_dlp/networking/_helper.py
+++ b/yt_dlp/networking/_helper.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import os
 import socket
 import ssl
 import sys
 import typing
 import urllib.parse
 import urllib.request
-import os
 
 from .exceptions import RequestError, UnsupportedRequest
 from ..dependencies import certifi
@@ -120,9 +120,11 @@ def make_ssl_context(
     use_certifi=True,
 ):
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    context.keylog_filename = os.environ.get('SSLKEYLOGFILE')
     context.check_hostname = verify
     context.verify_mode = ssl.CERT_REQUIRED if verify else ssl.CERT_NONE
+    # OpenSSL 1.1.1+ Python 3.8+ keylog file
+    if hasattr(context, 'keylog_filename'):
+        context.keylog_filename = os.environ.get('SSLKEYLOGFILE')
 
     # Some servers may reject requests if ALPN extension is not sent. See:
     # https://github.com/python/cpython/issues/85140


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Added the possibility to log the ssl keys of secure communications by specifying the standard env variable SSLKEYLOGFILE for request handles using the SSLContext. 

Fixes yt-dlp/yt-dlp#9531


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
