### PR TITLE
[ie/tiktok] Fix API extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1805,9 +1805,10 @@ The following extractors use this feature:
 * `max_comments`: Maximum number of comments to extract - default is `120`
 
 #### tiktok
-* `api_hostname`: Hostname to use for mobile API requests, e.g. `api-h2.tiktokv.com`
-* `app_version`: App version to call mobile APIs with - should be set along with `manifest_app_version`, e.g. `20.2.1`
-* `manifest_app_version`: Numeric app version to call mobile APIs with, e.g. `221`
+* `iid`: Install ID of the mobile app required for API requests, e.g. `1234567890123456789`
+* `api_hostname`: Hostname to use for mobile API requests, e.g. `api22-normal-c-alisg.tiktokv.com`
+* `app_version`: App version to call mobile APIs with - should be set along with `manifest_app_version`, e.g. `34.1.2`
+* `manifest_app_version`: Numeric app version to call mobile APIs with, e.g. `2023401020`
 
 #### rokfinchannel
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`

--- a/README.md
+++ b/README.md
@@ -1806,6 +1806,7 @@ The following extractors use this feature:
 
 #### tiktok
 * `iid`: Install ID of the mobile app required for API requests, e.g. `1234567890123456789`
+* `app_name`: Mobile app name to use for API requests, e.g. `trill`
 * `api_hostname`: Hostname to use for mobile API requests, e.g. `api22-normal-c-alisg.tiktokv.com`
 * `app_version`: App version to call mobile APIs with - should be set along with `manifest_app_version`, e.g. `34.1.2`
 * `manifest_app_version`: Numeric app version to call mobile APIs with, e.g. `2023401020`

--- a/README.md
+++ b/README.md
@@ -1805,11 +1805,12 @@ The following extractors use this feature:
 * `max_comments`: Maximum number of comments to extract - default is `120`
 
 #### tiktok
-* `iid`: Install ID of the mobile app required for API requests, e.g. `1234567890123456789`
-* `app_name`: Mobile app name to use for API requests, e.g. `trill`
-* `api_hostname`: Hostname to use for mobile API requests, e.g. `api22-normal-c-alisg.tiktokv.com`
-* `app_version`: App version to call mobile APIs with - should be set along with `manifest_app_version`, e.g. `34.1.2`
-* `manifest_app_version`: Numeric app version to call mobile APIs with, e.g. `2023401020`
+* `api_hostname`: Hostname to use for mobile API calls, e.g. `api22-normal-c-alisg.tiktokv.com`
+* `app_name`: Default app name to use with mobile API calls, e.g. `trill`
+* `app_version`: Default app version to use with mobile API calls - should be set along with `manifest_app_version`, e.g. `34.1.2`
+* `manifest_app_version`: Default numeric app version to use with mobile API calls, e.g. `2023401020`
+* `aid`: Default app ID to use with API calls, e.g. `1180`
+* `app_info`: One or more app info strings in the format of `<iid>/[app_name]/[app_version]/[manifest_app_version]/[aid]`, where `iid` is the unique app install ID. `iid` is the only required value; all other values and their `/` separators can be omitted, e.g. `tiktok:app_info=1234567890123456789` or `tiktok:app_info=123,456/trill///1180,789//34.0.1/340001`
 
 #### rokfinchannel
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -153,15 +153,16 @@ class TikTokBaseIE(InfoExtractor):
             real_query = self._build_api_query(query, self._WORKING_APP_IID)
             return self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
 
-        for count, iid in enumerate(self._APP_INSTALL_IDS, start=1):
+        max_tries = len(self._APP_INSTALL_IDS)
+        for count, iid in enumerate(random.choices(self._APP_INSTALL_IDS, k=max_tries), start=1):
             real_query = self._build_api_query(query, iid)
+            self.write_debug(f'iid={iid}')
             try:
                 res = self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
                 self._WORKING_APP_IID = iid
                 return res
             except ExtractorError as e:
                 if isinstance(e.cause, json.JSONDecodeError) and e.cause.pos == 0:
-                    max_tries = len(self._APP_INSTALL_IDS)
                     message = str(e.cause or e.msg)
                     if count == max_tries:
                         if fatal:

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -153,15 +153,16 @@ class TikTokBaseIE(InfoExtractor):
             real_query = self._build_api_query(query, self._WORKING_APP_IID)
             return self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
 
-        for count, iid in enumerate(self._APP_INSTALL_IDS, start=1):
+        max_tries = len(self._APP_INSTALL_IDS)
+        for count, iid in enumerate(random.sample(self._APP_INSTALL_IDS, max_tries), start=1):
             real_query = self._build_api_query(query, iid)
+            self.write_debug(f'iid={iid}')
             try:
                 res = self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
                 self._WORKING_APP_IID = iid
                 return res
             except ExtractorError as e:
                 if isinstance(e.cause, json.JSONDecodeError) and e.cause.pos == 0:
-                    max_tries = len(self._APP_INSTALL_IDS)
                     message = str(e.cause or e.msg)
                     if count == max_tries:
                         if fatal:

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -153,16 +153,15 @@ class TikTokBaseIE(InfoExtractor):
             real_query = self._build_api_query(query, self._WORKING_APP_IID)
             return self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
 
-        max_tries = len(self._APP_INSTALL_IDS)
-        for count, iid in enumerate(random.choices(self._APP_INSTALL_IDS, k=max_tries), start=1):
+        for count, iid in enumerate(self._APP_INSTALL_IDS, start=1):
             real_query = self._build_api_query(query, iid)
-            self.write_debug(f'iid={iid}')
             try:
                 res = self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
                 self._WORKING_APP_IID = iid
                 return res
             except ExtractorError as e:
                 if isinstance(e.cause, json.JSONDecodeError) and e.cause.pos == 0:
+                    max_tries = len(self._APP_INSTALL_IDS)
                     message = str(e.cause or e.msg)
                     if count == max_tries:
                         if fatal:

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 import json
 import random
@@ -37,12 +38,14 @@ class TikTokBaseIE(InfoExtractor):
         '7351153174894626592',
     ]
     _WORKING_APP_IID = None
-    _APP_UA = 'com.zhiliaoapp.musically'
-    _APP_NAME = 'musical_ly'
-    _AID = 0  # trill = 1180, musical_ly = 1233, universal = 0
+    _AID = 0  # aweme = 1128, trill = 1180, musical_ly = 1233, universal = 0
     _UPLOADER_URL_FORMAT = 'https://www.tiktok.com/@%s'
     _WEBPAGE_HOST = 'https://www.tiktok.com/'
     QUALITIES = ('360p', '540p', '720p', '1080p')
+
+    @property
+    def _APP_NAME(self):
+        return self._configuration_arg('app_name', ['musical_ly'], ie_key=TikTokIE)[0]
 
     @property
     def _APP_VERSION(self):
@@ -51,6 +54,14 @@ class TikTokBaseIE(InfoExtractor):
     @property
     def _MANIFEST_APP_VERSION(self):
         return self._configuration_arg('manifest_app_version', ['2023401020'], ie_key=TikTokIE)[0]
+
+    @functools.cached_property
+    def _APP_USER_AGENT(self):
+        if self._APP_NAME == 'musical_ly':
+            package = 'com.zhiliaoapp.musically'
+        else:  # trill, aweme
+            package = f'com.ss.android.ugc.{self._APP_NAME}'
+        return f'{package}/{self._MANIFEST_APP_VERSION} (Linux; U; Android 13; en_US; Pixel 7; Build/TD1A.220804.031; Cronet/58.0.2991.0)'
 
     @property
     def _API_HOSTNAME(self):
@@ -81,7 +92,7 @@ class TikTokBaseIE(InfoExtractor):
         return self._download_json(
             'https://%s/aweme/v1/%s/' % (self._API_HOSTNAME, ep), video_id=video_id,
             fatal=fatal, note=note, errnote=errnote, headers={
-                'User-Agent': f'{self._APP_UA}/{self._MANIFEST_APP_VERSION} (Linux; U; Android 13; en_US; Pixel 7; Build/TD1A.220804.031; Cronet/58.0.2991.0)',
+                'User-Agent': self._APP_USER_AGENT,
                 'Accept': 'application/json',
             }, query=query)
 


### PR DESCRIPTION
The mobile API feed endpoint that is used to extract high-resolution/no-watermark formats has begun checking/enforcing the `iid` (install id) query param for requests made to it.

A unique install ID is assigned to the mobile app installation by the TT API upon device registration. This PR hardcodes 3 of them that were donated for use in the extractor. The app versions fallback/cache loop has been replaced by an install IDs fallback/cache loop (since having multiple app versions hasn't been useful for quite some time).

~~The PR also adds an `iid` extractor-arg so that users can bring their own install ID if they so wish (or if the hardcoded `iid`s are failing). This also necessitated an `app_name` extractor-arg,~~ 

The PR adds an `app_info` extractor-arg, which allows one or more strings in the format of `<iid>/[app_name]/[app_version]/[manifest_app_version]/[aid]` to be passed, since any given install ID is tethered to the app variant it was assigned to (`trill` for KR/PH/TW/TH/VN or `musical_ly` for rest of world) and each variant has its own versioning and `aid` (app ID).



Closes #9506


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
