### PR TITLE
[build] Optional dependencies cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,11 +125,12 @@ jobs:
           sudo apt -y install zip pandoc man sed
           cat > ./requirements.txt << EOF
           python=3.10.*
+          pyinstaller
           brotli-python
           EOF
           python devscripts/install_deps.py --print \
             --exclude brotli --exclude brotlicffi \
-            --include secretstorage --include pyinstaller >> ./requirements.txt
+            --include secretstorage >> ./requirements.txt
           mamba create -n build --file ./requirements.txt
 
       - name: Prepare
@@ -247,7 +248,7 @@ jobs:
         run: |
           brew install coreutils
           python3 devscripts/install_deps.py --user -o --include build
-          python3 devscripts/install_deps.py --print --include pyinstaller_macos > requirements.txt
+          python3 devscripts/install_deps.py --print --include pyinstaller > requirements.txt
           # We need to ignore wheels otherwise we break universal2 builds
           python3 -m pip install -U --user --no-binary :all: -r requirements.txt
           # We need to fuse our own universal2 wheels for curl_cffi
@@ -319,7 +320,7 @@ jobs:
         run: |
           brew install coreutils
           python3 devscripts/install_deps.py --user -o --include build
-          python3 devscripts/install_deps.py --user --include pyinstaller_macos --include curl_cffi
+          python3 devscripts/install_deps.py --user --include pyinstaller --include curl_cffi
 
       - name: Prepare
         run: |

--- a/devscripts/install_deps.py
+++ b/devscripts/install_deps.py
@@ -37,24 +37,16 @@ def main():
     optional_groups = project_table['optional-dependencies']
     excludes = args.exclude or []
 
-    deps = []
+    targets = []
     if not args.only_optional:  # `-o` should exclude 'dependencies' and the 'default' group
-        deps.extend(project_table['dependencies'])
+        targets.extend(project_table['dependencies'])
         if 'default' not in excludes:  # `--exclude default` should exclude entire 'default' group
-            deps.extend(optional_groups['default'])
-
-    def name(dependency):
-        return re.match(r'[\w-]+', dependency)[0].lower()
-
-    target_map = {name(dep): dep for dep in deps}
+            targets.extend(optional_groups['default'])
 
     for include in filter(None, map(optional_groups.get, args.include or [])):
-        target_map.update(zip(map(name, include), include))
+        targets.extend(include)
 
-    for exclude in map(name, excludes):
-        target_map.pop(exclude, None)
-
-    targets = list(target_map.values())
+    targets = [t for t in targets if re.match(r'[\w-]+', t).group(0).lower() not in excludes]
 
     if args.print:
         for target in targets:

--- a/devscripts/install_deps.py
+++ b/devscripts/install_deps.py
@@ -10,6 +10,8 @@ import argparse
 import re
 import subprocess
 
+from pathlib import Path
+
 from devscripts.tomlparse import parse_toml
 from devscripts.utils import read_file
 
@@ -17,17 +19,23 @@ from devscripts.utils import read_file
 def parse_args():
     parser = argparse.ArgumentParser(description='Install dependencies for yt-dlp')
     parser.add_argument(
-        'input', nargs='?', metavar='TOMLFILE', default='pyproject.toml', help='Input file (default: %(default)s)')
+        'input', nargs='?', metavar='TOMLFILE', default=Path(__file__).parent.parent / 'pyproject.toml',
+        help='Input file (default: %(default)s)')
     parser.add_argument(
-        '-e', '--exclude', metavar='DEPENDENCY', action='append', help='Exclude a dependency')
+        '-e', '--exclude', metavar='DEPENDENCY', action='append',
+        help='Exclude a dependency')
     parser.add_argument(
-        '-i', '--include', metavar='GROUP', action='append', help='Include an optional dependency group')
+        '-i', '--include', metavar='GROUP', action='append',
+        help='Include an optional dependency group')
     parser.add_argument(
-        '-o', '--only-optional', action='store_true', help='Only install optional dependencies')
+        '-o', '--only-optional', action='store_true',
+        help='Only install optional dependencies')
     parser.add_argument(
-        '-p', '--print', action='store_true', help='Only print a requirements.txt to stdout')
+        '-p', '--print', action='store_true',
+        help='Only print requirements to stdout')
     parser.add_argument(
-        '-u', '--user', action='store_true', help='Install with pip as --user')
+        '-u', '--user', action='store_true',
+        help='Install with pip as --user')
     return parser.parse_args()
 
 

--- a/devscripts/install_deps.py
+++ b/devscripts/install_deps.py
@@ -20,22 +20,22 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Install dependencies for yt-dlp')
     parser.add_argument(
         'input', nargs='?', metavar='TOMLFILE', default=Path(__file__).parent.parent / 'pyproject.toml',
-        help='Input file (default: %(default)s)')
+        help='input file (default: %(default)s)')
     parser.add_argument(
         '-e', '--exclude', metavar='DEPENDENCY', action='append',
-        help='Exclude a dependency')
+        help='exclude a dependency')
     parser.add_argument(
         '-i', '--include', metavar='GROUP', action='append',
-        help='Include an optional dependency group')
+        help='include an optional dependency group')
     parser.add_argument(
         '-o', '--only-optional', action='store_true',
-        help='Only install optional dependencies')
+        help='only install optional dependencies')
     parser.add_argument(
         '-p', '--print', action='store_true',
-        help='Only print requirements to stdout')
+        help='only print requirements to stdout')
     parser.add_argument(
         '-u', '--user', action='store_true',
-        help='Install with pip as --user')
+        help='install with pip as --user')
     return parser.parse_args()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,10 @@ dev = [
     "isort",
     "pytest",
 ]
-pyinstaller = ["pyinstaller>=6.3"]
-pyinstaller_macos = ["pyinstaller==5.13.2"]  # needed for curl_cffi builds
+pyinstaller = [
+    "pyinstaller>=6.3; sys_platform!='darwin'",
+    "pyinstaller==5.13.2; sys_platform=='darwin'",  # needed for curl_cffi
+]
 py2exe = ["py2exe>=0.12"]
 
 [project.urls]


### PR DESCRIPTION
This PR reworks the `unix` job in the build workflow and the `install_deps` devscript so that we can have a single `pyinstaller` optional dependency group.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
