### PR TITLE
[ie/cbc.ca:player] Support new URL format

### DIFF
--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -151,7 +151,7 @@ class CBCIE(InfoExtractor):
 
 class CBCPlayerIE(InfoExtractor):
     IE_NAME = 'cbc.ca:player'
-    _VALID_URL = r'(?:cbcplayer:|https?://(?:www\.)?cbc\.ca/(?:player/play/|i/caffeine/syndicate/\?mediaId=))(?P<id>\d+)'
+    _VALID_URL = r'(?:cbcplayer:|https?://(?:www\.)?cbc\.ca/(?:player/play/|i/caffeine/syndicate/\?mediaId=))(?P<id>(?:\d\.)?\d+)'
     _TESTS = [{
         'url': 'http://www.cbc.ca/player/play/2683190193',
         'md5': '64d25f841ddf4ddb28a235338af32e2c',
@@ -166,8 +166,7 @@ class CBCPlayerIE(InfoExtractor):
         },
         'skip': 'Geo-restricted to Canada and no longer available',
     }, {
-        # Redirected from http://www.cbc.ca/player/AudioMobile/All%20in%20a%20Weekend%20Montreal/ID/2657632011/
-        'url': 'http://www.cbc.ca/player/play/2657631896',
+        'url': 'http://www.cbc.ca/i/caffeine/syndicate/?mediaId=2657631896',
         'md5': 'e5e708c34ae6fca156aafe17c43e8b75',
         'info_dict': {
             'id': '2657631896',
@@ -189,7 +188,7 @@ class CBCPlayerIE(InfoExtractor):
             'media_type': 'Excerpt',
         },
     }, {
-        'url': 'http://www.cbc.ca/player/play/2164402062',
+        'url': 'http://www.cbc.ca/i/caffeine/syndicate/?mediaId=2164402062',
         'md5': '33fcd8f6719b9dd60a5e73adcb83b9f6',
         'info_dict': {
             'id': '2164402062',
@@ -206,31 +205,75 @@ class CBCPlayerIE(InfoExtractor):
             'categories': ['News/Canada/Windsor'],
             'location': 'Windsor',
             'tags': ['cancer'],
-            'creator': 'Allison Johnson',
+            'creators': ['Allison Johnson'],
+            'media_type': 'Excerpt',
+        },
+    }, {
+        # Redirected from http://www.cbc.ca/player/AudioMobile/All%20in%20a%20Weekend%20Montreal/ID/2657632011/
+        'url': 'https://www.cbc.ca/player/play/1.2985700',
+        'md5': 'e5e708c34ae6fca156aafe17c43e8b75',
+        'info_dict': {
+            'id': '2657631896',
+            'ext': 'mp3',
+            'title': 'CBC Montreal is organizing its first ever community hackathon!',
+            'description': 'The modern technology we tend to depend on so heavily, is never without it\'s share of hiccups and headaches. Next weekend - CBC Montreal will be getting members of the public for its first Hackathon.',
+            'timestamp': 1425704400,
+            'upload_date': '20150307',
+            'uploader': 'CBCC-NEW',
+            'thumbnail': 'http://thumbnails.cbc.ca/maven_legacy/thumbnails/sonali-karnick-220.jpg',
+            'chapters': [],
+            'duration': 494.811,
+            'categories': ['AudioMobile/All in a Weekend Montreal'],
+            'tags': 'count:8',
+            'location': 'Quebec',
+            'series': 'All in a Weekend Montreal',
+            'season': 'Season 2015',
+            'season_number': 2015,
+            'media_type': 'Excerpt',
+        },
+    }, {
+        'url': 'https://www.cbc.ca/player/play/1.1711287',
+        'md5': '33fcd8f6719b9dd60a5e73adcb83b9f6',
+        'info_dict': {
+            'id': '2164402062',
+            'ext': 'mp4',
+            'title': 'Cancer survivor four times over',
+            'description': 'Tim Mayer has beaten three different forms of cancer four times in five years.',
+            'timestamp': 1320410746,
+            'upload_date': '20111104',
+            'uploader': 'CBCC-NEW',
+            'thumbnail': 'https://thumbnails.cbc.ca/maven_legacy/thumbnails/277/67/cancer_852x480_2164412612.jpg',
+            'chapters': [],
+            'duration': 186.867,
+            'series': 'CBC News: Windsor at 6:00',
+            'categories': ['News/Canada/Windsor'],
+            'location': 'Windsor',
+            'tags': ['cancer'],
+            'creators': ['Allison Johnson'],
             'media_type': 'Excerpt',
         },
     }, {
         # Has subtitles
         # These broadcasts expire after ~1 month, can find new test URL here:
         # https://www.cbc.ca/player/news/TV%20Shows/The%20National/Latest%20Broadcast
-        'url': 'http://www.cbc.ca/player/play/2284799043667',
-        'md5': '9b49f0839e88b6ec0b01d840cf3d42b5',
+        'url': 'https://www.cbc.ca/player/play/1.7159484',
+        'md5': '6ed6cd0fc2ef568d2297ba68a763d455',
         'info_dict': {
-            'id': '2284799043667',
+            'id': '2324213316001',
             'ext': 'mp4',
-            'title': 'The National | Hockey coach charged, Green grants, Safer drugs',
-            'description': 'md5:84ef46321c94bcf7d0159bb565d26bfa',
-            'timestamp': 1700272800,
-            'duration': 2718.833,
+            'title': 'The National | School boards sue social media giants',
+            'description': 'md5:4b4db69322fa32186c3ce426da07402c',
+            'timestamp': 1711681200,
+            'duration': 2743.400,
             'subtitles': {'eng': [{'ext': 'vtt', 'protocol': 'm3u8_native'}]},
-            'thumbnail': 'https://thumbnails.cbc.ca/maven_legacy/thumbnails/907/171/thumbnail.jpeg',
+            'thumbnail': 'https://thumbnails.cbc.ca/maven_legacy/thumbnails/607/559/thumbnail.jpeg',
             'uploader': 'CBCC-NEW',
             'chapters': 'count:5',
-            'upload_date': '20231118',
+            'upload_date': '20240329',
             'categories': 'count:4',
             'series': 'The National - Full Show',
             'tags': 'count:1',
-            'creator': 'News',
+            'creators': ['News'],
             'location': 'Canada',
             'media_type': 'Full Program',
         },
@@ -238,6 +281,11 @@ class CBCPlayerIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
+        if '.' in video_id:
+            webpage = self._download_webpage(f'https://www.cbc.ca/player/play/{video_id}', video_id)
+            json_content = self._search_json(
+                r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', video_id)
+            video_id = json_content['video']['currentClip']['mediaId']
         return {
             '_type': 'url_transparent',
             'ie_key': 'ThePlatform',

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -277,6 +277,15 @@ class CBCPlayerIE(InfoExtractor):
             'location': 'Canada',
             'media_type': 'Full Program',
         },
+    }, {
+        'url': 'cbcplayer:1.7159484',
+        'only_matching': True,
+    }, {
+        'url': 'cbcplayer:2164402062',
+        'only_matching': True,
+    }, {
+        'url': 'http://www.cbc.ca/player/play/2657631896',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
@@ -286,6 +295,7 @@ class CBCPlayerIE(InfoExtractor):
             json_content = self._search_json(
                 r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', video_id)
             video_id = json_content['video']['currentClip']['mediaId']
+
         return {
             '_type': 'url_transparent',
             'ie_key': 'ThePlatform',

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -172,7 +172,7 @@ class CBCPlayerIE(InfoExtractor):
             'id': '2657631896',
             'ext': 'mp3',
             'title': 'CBC Montreal is organizing its first ever community hackathon!',
-            'description': 'The modern technology we tend to depend on so heavily, is never without it\'s share of hiccups and headaches. Next weekend - CBC Montreal will be getting members of the public for its first Hackathon.',
+            'description': 'md5:dd3b692f0a139b0369943150bd1c46a9',
             'timestamp': 1425704400,
             'upload_date': '20150307',
             'uploader': 'CBCC-NEW',

--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -292,9 +292,9 @@ class CBCPlayerIE(InfoExtractor):
         video_id = self._match_id(url)
         if '.' in video_id:
             webpage = self._download_webpage(f'https://www.cbc.ca/player/play/{video_id}', video_id)
-            json_content = self._search_json(
-                r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', video_id)
-            video_id = json_content['video']['currentClip']['mediaId']
+            video_id = self._search_json(
+                r'window\.__INITIAL_STATE__\s*=', webpage,
+                'initial state', video_id)['video']['currentClip']['mediaId']
 
         return {
             '_type': 'url_transparent',


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This fixes the CBCPlayerIE after a change in the URL structure broke it. The URL no longer holds the video ID from ThePlatform, but an internal ID instead. As a result, the IE needs to extract the "mediaID" from the webpage. After that has finished, everything else can resume as usual. ~As to the question of which ID should be used by yt-dlp internally - I've stuck with the mediaID, but am unsure of whether that's the best decision. Essentially it comes down to:~
~Pros of the current approach:~

- ~This allows one ID to be used across the CBCPlayerIE, CBCCaffeinePlayerIE (see below) and ThePlatformIE~
- ~This doesn't break the archival of previous videos using the `--download-archive` option, and this option would make it recognize links pointing to the same video regardless of if it's a link handled by CBCPlayerIE or CBCCaffeinePlayerIE (again, see below)~

~Cons of the current approach/pros of using the new ID:~

- ~When checking a list of URLs (i.e. extracted from a playlist or similar), the previous archival status of the links could be checked without extracting without downloading anything from the web page.~

~The direct Caffeine Player links still have the mediaID though, so I've split off the CBCCaffeinePlayerIE from the CBCPlayerIE, which basically has the same code as the old CBCPlayerID (extract mediaID from url, pass it on to ThePlatformIE). (Also, I'm unsure if the IE name is ideal - if anyone has any better suggestions, please let me know.)
In addition, I've slightly changed the regex from the CBCIE which was capturing direct links to the CBC Caffeine Player, leading to an extraction failure. I'm not sure if this was a problem previously, but it isn't now (anymore).~
I've also updated the tests, including changing the `creator` field to the `creators` field.
~Finally, I've slightly changed the regexes to match the request in `CONTRIBUTING.md` to not capture groups that aren't used. Only this change is contained in the last commit, if I understood it wrong, please feel free to remove.~
EDIT: changed it back to being only one IE. The IE now looks for a period in the ID and decides accordingly if it should hand that ID to the ThePlatformIE or extract the MediaID from the page as per @bashonly 's suggestion. In case it is needed in the future due to ID changes, I still have the original code on my computer which could then be recommitted.

Fixes #9534


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [X] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
