### PR TITLE
Assume M3U8/HLS streams with audio rendition group to be video only

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2420,10 +2420,10 @@ class InfoExtractor:
                     # contains EXT-X-STREAM-INF tag which references AUDIO
                     # rendition group but does not have CODECS and despite
                     # referencing an audio group it represents a complete
-                    # (with audio and video) format. So, for such cases we will
-                    # ignore references to rendition groups and treat them
-                    # as complete formats.
-                    if audio_group_id and codecs and f.get('vcodec') != 'none':
+                    # (with audio and video) format. But we can't know that
+                    # at this point so assume it's video only.
+                    # It can be resolved at later stage.
+                    if audio_group_id and f.get('vcodec') != 'none':
                         # Save this to determine quality of audio formats that only have a GROUP-ID
                         f['_audio_group_id'] = audio_group_id
                         audio_group = groups.get(audio_group_id)


### PR DESCRIPTION

### Description of your *pull request* and other information

There can be streams that contain reference to separate audio stream and they don't contain audio itself.
For example I have this `playlist.m3u8` that contains

```
#EXTM3U
#EXT-X-VERSION:4
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="grp0",LANGUAGE="eng",NAME="English",DEFAULT=YES,AUTOSELECT=YES,URI="chunklist_ao.m3u8"
#EXT-X-STREAM-INF:BANDWIDTH=1300000,NAME="1080p",RESOLUTION=1920x1080,AUDIO="grp0"
chunklist_b1300000_vo.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=700000,NAME="720p",RESOLUTION=1280x720,AUDIO="grp0"
chunklist_b700000_vo.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=500000,NAME="576p",RESOLUTION=1024x576,AUDIO="grp0"
chunklist_b500000_vo.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=258719,NAME="360p",RESOLUTION=640x360,AUDIO="grp0"
chunklist_b258719_vo.m3u8
```

Audio is only in `chunklist_ao.m3u8` and those `chunklist_b1300000_vo.m3u8` are video only so when I download it I get video file without audio.

Without this PR it's shown like this
```
ID           EXT RESOLUTION │  FILESIZE   TBR PROTO │ VCODEC     ACODEC  MORE INFO
──────────────────────────────────────────────────────────────────────────────────────
grp0-English mp4 audio only │                 m3u8  │ audio only unknown [eng] English
360p         mp4 640x360    │ ~ 4.74MiB  259k m3u8  │ unknown    unknown
576p         mp4 1024x576   │ ~ 9.16MiB  500k m3u8  │ unknown    unknown
720p         mp4 1280x720   │ ~12.82MiB  700k m3u8  │ unknown    unknown
1080p        mp4 1920x1080  │ ~23.80MiB 1300k m3u8  │ unknown    unknown
```

With this PR it will look like
```
ID           EXT RESOLUTION │  FILESIZE   TBR PROTO │ VCODEC       VBR ACODEC     MORE INFO
───────────────────────────────────────────────────────────────────────────────────────────────
grp0-English mp4 audio only │                 m3u8  │ audio only       unknown    [eng] English
360p         mp4 640x360    │ ~ 4.74MiB  259k m3u8  │ unknown     259k video only
576p         mp4 1024x576   │ ~ 9.16MiB  500k m3u8  │ unknown     500k video only
720p         mp4 1280x720   │ ~12.82MiB  700k m3u8  │ unknown     700k video only
1080p        mp4 1920x1080  │ ~23.80MiB 1300k m3u8  │ unknown    1300k video only
```

This issue seems to be same as ytdl-org/youtube-dl/issues/32750

I know that there can be streams where they do actually contain both while still using audio rendition group. But I think that can be resolved at merge step. That is download both and then when merging decide which one to keep. Maybe embedded audio in that stream is low quality and hence use of such audio group. At this point we have no way of knowing without downloading it.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
