### PR TITLE
Fixed a bug when using YT-DLP in Kodi .. Temporarily disabled all plu…

### DIFF
--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -136,6 +136,11 @@ def load_module(module, module_name, suffix):
 
 
 def load_plugins(name, suffix):
+    
+    
+    return {}
+    
+    
     classes = {}
 
     for finder, module_name, _ in iter_modules(name):


### PR DESCRIPTION
YT-DLP is failing with the below error message for all versions of YT-DLP starting from 2023.01.02.

I temporarily fixed it by adding "return {}" as the first line in function "load_plugins()" in file "plugins.py".

That allowed your YT-DLP to bypass the error message and work properly.

====================================

This is the error message:

[WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\\Portable Programs\\\KODI_v19_64bit\\\plugin:\\\plugin.video.arabicvideos\\\yt_dlp_plugins'

====================================

Please note that the path above includes this string "plugin:\\\plugin.video.arabicvideos" which is the Kodi internal path representation (virtual path) not the actual physical path.

====================================

The actual physical full path is:
C:\Portable Programs\KODI_v19_64bit\portable_data\addons\plugin.video.arabicvideos

====================================

If you need a quick fix .. you can just replace the string "\\\plugin:\\\\" with the string "\\\portable_data\\\addons\\\\" .. this solution is always correct in Kodi.

====================================

.