### PR TITLE
[build] Add SHA2-SUMS to GHA logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -467,6 +467,7 @@ jobs:
       - name: Make SHA2-SUMS files
         run: |
           cd ./artifact/
+          # make sure SHA sums are also printed to stdout
           sha256sum * | tee ../SHA2-256SUMS
           sha512sum * | tee ../SHA2-512SUMS
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -467,8 +467,8 @@ jobs:
       - name: Make SHA2-SUMS files
         run: |
           cd ./artifact/
-          sha256sum * > ../SHA2-256SUMS
-          sha512sum * > ../SHA2-512SUMS
+          sha256sum * | tee ../SHA2-256SUMS
+          sha512sum * | tee ../SHA2-512SUMS
 
       - name: Make Update spec
         run: |


### PR DESCRIPTION
In light of what happened with xz's tarballs, I think it would be good to provide a verifiable "chain of custody" from our git repo to our release assets (tarball, binaries).

Our GitHub Actions logs for the build workflow will have a section that looks like this now:

<https://github.com/bashonly/yt-dlp/actions/runs/8497175700/job/23275527118>

```
Make SHA2-SUMS files

Run cd ./artifact/
  cd ./artifact/
  sha256sum * | tee ../SHA2-256SUMS
  sha512sum * | tee ../SHA2-512SUMS
  shell: /usr/bin/bash -e {0}
cd1214ccda412c384c0850443dfab2db81e382ee23e6e5fe638a7f2fbd15ee3a  yt-dlp
5d658358b341a90d6c99f56e404b9e4e42f55181d5ed59b5143b75eb98699b92  yt-dlp.exe
8a303ed7e113b1870591d4fc9ddbf7a5d1c8d602c5370914e753cbe81c825a92  yt-dlp.tar.gz
d7484dcc965c308dfaaaa44e2f659ab001f9d65d55112725d34e21df1bc15e93  yt-dlp_linux
28767a12b06e47a523f57c7520c0bf2ef5dde9d301b5bdccb75049a2d2286b09  yt-dlp_linux.zip
6f34dd1638cbf24e8bafd98f2e2c95556d4548199c4aafc444ebf5e4e4905c28  yt-dlp_linux_aarch64
6c14c77988ce494cea2b9b12d9cdc98bb5e526fb6811600c8ae5917fe259f3dc  yt-dlp_linux_armv7l
1aae9f5f8b85d79d33563fe88096676c81ddba8e8766945f4cb42cdb47572f80  yt-dlp_macos
3f83944bae3306b3ff94b6bb83090c1a146f63160c6998e707c2a3ae0a48133f  yt-dlp_macos.zip
7ecfe36e77f4f19f242f8afb39518bdf441ca386be870088bf1f6a11099444e7  yt-dlp_macos_legacy
727b2cf3b4f426f3a9d5cae357eff18f87c21137475d37e0d74b848f875c547f  yt-dlp_min.exe
7aa0582c24f03bc04bbb11b9f3b7faed21618d5715921c86819a0717fdf4bbb0  yt-dlp_win.zip
b048f7fcd9f6b3987616fca6590067e98e9bfcda7a24de336a835b778f81ed43  yt-dlp_x86.exe
1c438729262c7416b313ffd577bcbf867c227aaf27b869c2f2f07f65f3f819b9b931d023b8627dc9039e79e550a0efa0d53a4eb82253752130b53e7bafbcb387  yt-dlp
258ce97c012f70388b906915549db0c31db98e66e83df56ceff3d31eea498c92a2f299f49afb2de8fca4664d4d072e435fe357a3ca2885f4cea00cb40aae7bda  yt-dlp.exe
f757ec9e7767d5aaddf8dc381a0b05659ded3a27c8164ae35ce509959df72f80da9b4d63fba12b6d4346fff7f74c0ec57cbad34c65362cb257d27af42389b080  yt-dlp.tar.gz
272fca3809d1df1c49168727a6c666716a8eb061ed7e171fb33c4226e87759bfe0557cb1c024b94a89f22c9c23a2e18790ce15d9671e9e5bb4c7e9f3c8916d26  yt-dlp_linux
12e37a4ede23f3ca022c961ab7ae65fbd196ce02da7afc1138fbc808c19ee93208e41a6d9df3fbd8a1077f0233a4c78e7ad752fd7ce78723a321f750ff6d048e  yt-dlp_linux.zip
1643f3e553b76413d07c483c84d48a0f2e311b2785d104f79f5f1533b52663ccbb6ecd44a8e2e7657b232391bc99dc2947ad872482136afb0a0bb97d3d10b716  yt-dlp_linux_aarch64
98a6c8c6397965336b7905ac786a455469f6bb1c9152ece7f191dba96b4f969a96e88a068121e4ec3c6acc9dcc0a5696af15962669ab687c26e0589509089a19  yt-dlp_linux_armv7l
136eec8ce6afb64ab1a7887faee9637a9408336cf3f60676422e4159603fd546b6d4698a56374ba268628504cca89f68045034dbfe498cdc6f65cd4b74a1c068  yt-dlp_macos
39de44e968808eeea07417841a15a7bfe58c53d77bfc7a65574d2658eea607c343d9fb2af0237094a244f6884e8dc5bad1216560efbed9ce7d14158eeff8296a  yt-dlp_macos.zip
a485d2904169274ecf07dcdfec4a0963740721952dc6dbc29c9f1a346f38457f0c2b4b7c6a2ded7b19ecb4dce65c262a81198271c33c2dae2765e96fdb529172  yt-dlp_macos_legacy
080e226839223a4be61f81fd325cb6616e45b3a6337e764a671a906a646dfd0e01cedb3e929004c806ee63e09debca774f91490572f28cd353076af70357b467  yt-dlp_min.exe
4ca017bae87b8a519a2b7fced7a6626411b1835d839afe37d21f21233f1f952e180685f7c7571dc0b3db6787609585db57f41c7b5af1243e4e7de93d9fc433db  yt-dlp_win.zip
0e2b0c1294143af9937cac1e20832e1603bc4452a3d777d401cb137501f013d38c443cf79f1e38b2894f74ad865dd5bb077866d80a2de99dd52c0edfab383be0  yt-dlp_x86.exe
```

Users and downstream packagers can compare the sums in the log with those in the `SHA256SUMS` and `SHA512SUMS` release assets to verify that the release assets are indeed the product of our build workflow and have not been tampered with.



<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
