### PR TITLE
[ie/soundcloud] Adjust format sorting

### DIFF
--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -217,7 +217,7 @@ class SoundcloudBaseIE(InfoExtractor):
                         'filesize': int_or_none(urlh.headers.get('Content-Length')),
                         'url': format_url,
                         'quality': 10,
-                        'format_note': 'Original format',
+                        'format_note': 'Original',
                     })
 
         def invalid_url(url):

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -217,6 +217,7 @@ class SoundcloudBaseIE(InfoExtractor):
                         'filesize': int_or_none(urlh.headers.get('Content-Length')),
                         'url': format_url,
                         'quality': 10,
+                        'format_note': 'Original format',
                     })
 
         def invalid_url(url):
@@ -233,9 +234,13 @@ class SoundcloudBaseIE(InfoExtractor):
                 format_id_list.append(protocol)
             ext = f.get('ext')
             if ext == 'aac':
-                f['abr'] = '256'
+                f.update({
+                    'abr': 256,
+                    'quality': 5,
+                    'format_note': 'Premium',
+                })
             for k in ('ext', 'abr'):
-                v = f.get(k)
+                v = str_or_none(f.get(k))
                 if v:
                     format_id_list.append(v)
             preview = is_preview or re.search(r'/(?:preview|playlist)/0/30/', f['url'])


### PR DESCRIPTION
Adapts the soundcloud extractor's format sorting to the change in 86a972033e05fea80e5fe7f2aff6723dbe2f3952

Before:
```shell
ID           EXT  RESOLUTION │  FILESIZE  TBR PROTO │ VCODEC     ACODEC   ABR
─────────────────────────────────────────────────────────────────────────────
hls_mp3_128  mp3  audio only │ ~ 5.99MiB 128k m3u8  │ audio only mp3     128k
http_mp3_128 mp3  audio only │ ~ 5.99MiB 128k http  │ audio only mp3     128k
hls_aac_256  aac  audio only │ ~11.99MiB 256k m3u8F │ audio only aac     256k
http_aac_256 aac  audio only │ ~11.99MiB 256k http  │ audio only aac     256k
hls_opus_64  opus audio only │ ~ 3.00MiB  64k m3u8  │ audio only opus     64k
download     wav  audio only │  64.54MiB      https │ audio only unknown
```

After:
```shell
ID           EXT  RESOLUTION │  FILESIZE  TBR PROTO │ VCODEC     ACODEC   ABR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────
hls_mp3_128  mp3  audio only │ ~ 5.99MiB 128k m3u8  │ audio only mp3     128k
http_mp3_128 mp3  audio only │ ~ 5.99MiB 128k http  │ audio only mp3     128k
hls_opus_64  opus audio only │ ~ 3.00MiB  64k m3u8  │ audio only opus     64k
hls_aac_256  aac  audio only │ ~11.99MiB 256k m3u8F │ audio only aac     256k Premium
http_aac_256 aac  audio only │ ~11.99MiB 256k http  │ audio only aac     256k Premium
download     wav  audio only │  64.54MiB      https │ audio only unknown      Original
```


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
