### PR TITLE
[ie/soundcloud] Enable retries for rate-limiting

### DIFF
--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -273,6 +273,10 @@ class SoundcloudBaseIE(InfoExtractor):
                     stream = self._download_json(format_url, track_id, query=query, headers=self._HEADERS)
                 except ExtractorError as e:
                     if isinstance(e.cause, HTTPError) and e.cause.status == 429:
+                        self.report_warning(
+                            'You have reached the API rate limit, which is ~600 requests per '
+                            '10 minutes. Use the --extractor-retries and --retry-sleep options '
+                            'to configure an appropriate retry count and wait time', only_once=True)
                         retry.error = e.cause
                     else:
                         self.report_warning(e.msg)

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -267,7 +267,7 @@ class SoundcloudBaseIE(InfoExtractor):
             format_url = t['url']
             stream = None
 
-            # Handle rate-limit
+            # Handle rate-limit of ~600 requests per 10 minutes
             for retry in self.RetryManager(fatal=False):
                 try:
                     stream = self._download_json(format_url, track_id, query=query, headers=self._HEADERS)

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -263,7 +263,7 @@ class SoundcloudBaseIE(InfoExtractor):
         # New API
         for t in traverse_obj(info, ('media', 'transcodings', lambda _, v: url_or_none(v['url']))):
             if extract_flat:
-                continue
+                break
             format_url = t['url']
             stream = None
 

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -19,12 +19,12 @@ from ..utils import (
     mimetype2ext,
     parse_qs,
     str_or_none,
-    try_get,
     unified_timestamp,
     update_url_query,
     url_or_none,
     urlhandle_detect_ext,
 )
+from ..utils.traversal import traverse_obj
 
 
 class SoundcloudEmbedIE(InfoExtractor):
@@ -261,16 +261,22 @@ class SoundcloudBaseIE(InfoExtractor):
             formats.append(f)
 
         # New API
-        transcodings = try_get(
-            info, lambda x: x['media']['transcodings'], list) or []
-        for t in transcodings:
-            if not isinstance(t, dict):
+        for t in traverse_obj(info, ('media', 'transcodings', lambda _, v: url_or_none(v['url']))):
+            if extract_flat:
                 continue
-            format_url = url_or_none(t.get('url'))
-            if not format_url:
-                continue
-            stream = None if extract_flat else self._download_json(
-                format_url, track_id, query=query, fatal=False, headers=self._HEADERS)
+            format_url = t['url']
+            stream = None
+
+            # Handle rate-limit
+            for retry in self.RetryManager(fatal=False):
+                try:
+                    stream = self._download_json(format_url, track_id, query=query, headers=self._HEADERS)
+                except ExtractorError as e:
+                    if isinstance(e.cause, HTTPError) and e.cause.status == 429:
+                        retry.error = e.cause
+                    else:
+                        self.report_warning(e.msg)
+
             if not isinstance(stream, dict):
                 continue
             stream_url = url_or_none(stream.get('url'))

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -267,7 +267,6 @@ class SoundcloudBaseIE(InfoExtractor):
             format_url = t['url']
             stream = None
 
-            # Handle rate-limit of ~600 requests per 10 minutes
             for retry in self.RetryManager(fatal=False):
                 try:
                     stream = self._download_json(format_url, track_id, query=query, headers=self._HEADERS)


### PR DESCRIPTION
The Soundcloud extractor has to make an API request to get each format URL, and Soundcloud enforces a rate-limit of approx 600 requests per 10 minutes. Previously, the `_download_json` call in the extractor was only non-fatal, so if the rate-limit was reached, it would warn and continue, pointlessly burning through the rest of the format requests/playlist for the next 10 minutes.

This PR adds a `RetryManager` so the user can configure the rate-limited behavior with `--extractor-retries` and `--retry-sleep`.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
