### PR TITLE
[patreon] fix some vimeo embed downloads

### DIFF
--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -252,7 +252,7 @@ class PatreonIE(PatreonBaseIE):
             if v_url:
                 v_url = VimeoIE._smuggle_referrer(v_url, 'https://patreon.com')
                 if self._request_webpage(v_url, video_id, 'Checking Vimeo embed URL', fatal=False, errnote=False):
-                    return self.url_result(v_url, 'Vimeo', url_transparent=True, **info)
+                    return self.url_result(v_url, VimeoIE, url_transparent=True, **info)
 
         embed_url = try_get(attributes, lambda x: x['embed']['url'])
         if embed_url and self._request_webpage(embed_url, video_id, 'Checking embed URL', fatal=False, errnote=False):

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -253,21 +253,12 @@ class PatreonIE(PatreonBaseIE):
                 v_url = VimeoIE._smuggle_referrer(v_url, 'https://patreon.com')
 
                 if self._request_webpage(v_url, video_id, 'Checking Vimeo embed URL', fatal=False, errnote=False):
-                    return {
-                        **info,
-                        '_type': 'url_transparent',
-                        'url': v_url,
-                        'ie_key': 'Vimeo',
-                    }
+                    return self.url_result(v_url, 'Vimeo', **info, url_transparent=True)
 
         embed_url = try_get(attributes, lambda x: x['embed']['url'])
         if embed_url:
             if self._request_webpage(embed_url, video_id, 'Checking embed URL', fatal=False, errnote=False):
-                return {
-                    **info,
-                    '_type': 'url',
-                    'url': embed_url,
-                }
+                return self.url_result(embed_url, **info)
 
         post_file = traverse_obj(attributes, 'post_file')
         if post_file:

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -92,7 +92,7 @@ class PatreonIE(PatreonBaseIE):
             'thumbnail': 're:^https?://.*$',
             'upload_date': '20150211',
             'description': 'md5:8af6425f50bd46fbf29f3db0fc3a8364',
-            'uploader_id': 'TraciJHines',
+            'uploader_id': '@TraciHinesMusic',
             'categories': ['Entertainment'],
             'duration': 282,
             'view_count': int,
@@ -106,8 +106,10 @@ class PatreonIE(PatreonBaseIE):
             'availability': 'public',
             'channel_follower_count': int,
             'playable_in_embed': True,
-            'uploader_url': 'http://www.youtube.com/user/TraciJHines',
+            'uploader_url': 'https://www.youtube.com/@TraciHinesMusic',
             'comment_count': int,
+            'channel_is_verified': True,
+            'chapters': 'count:4',
         },
         'params': {
             'noplaylist': True,
@@ -176,6 +178,27 @@ class PatreonIE(PatreonBaseIE):
             'uploader_url': 'https://www.patreon.com/thenormies',
         },
         'skip': 'Patron-only content',
+    }, {
+        # dead vimeo and embed URLs, need to extract post_file
+        'url': 'https://www.patreon.com/posts/hunter-x-hunter-34007913',
+        'info_dict': {
+            'id': '34007913',
+            'ext': 'mp4',
+            'title': 'Hunter x Hunter | Kurapika DESTROYS Uvogin!!!',
+            'like_count': int,
+            'uploader': 'YaBoyRoshi',
+            'timestamp': 1581636833,
+            'channel_url': 'https://www.patreon.com/yaboyroshi',
+            'thumbnail': r're:^https?://.*$',
+            'tags': ['Hunter x Hunter'],
+            'uploader_id': '14264111',
+            'comment_count': int,
+            'channel_follower_count': int,
+            'description': 'Kurapika is a walking cheat code!',
+            'upload_date': '20200213',
+            'channel_id': '2147162',
+            'uploader_url': 'https://www.patreon.com/yaboyroshi',
+        },
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -250,22 +250,19 @@ class PatreonIE(PatreonBaseIE):
             v_url = url_or_none(compat_urllib_parse_unquote(
                 self._search_regex(r'(https(?:%3A%2F%2F|://)player\.vimeo\.com.+app_id(?:=|%3D)+\d+)', embed_html, 'vimeo url', fatal=False)))
             if v_url:
-                vimeo_embed_url = VimeoIE._smuggle_referrer(v_url, 'https://patreon.com')
-                response = self._request_webpage(vimeo_embed_url, video_id, fatal=False)
+                v_url = VimeoIE._smuggle_referrer(v_url, 'https://patreon.com')
 
-                if response is not False:
+                if self._request_webpage(v_url, video_id, 'Checking Vimeo embed URL', fatal=False, errnote=False):
                     return {
                         **info,
                         '_type': 'url_transparent',
-                        'url': vimeo_embed_url,
+                        'url': v_url,
                         'ie_key': 'Vimeo',
                     }
 
         embed_url = try_get(attributes, lambda x: x['embed']['url'])
         if embed_url:
-            response = self._request_webpage(embed_url, video_id, fatal=False)
-
-            if response is not False:
+            if self._request_webpage(embed_url, video_id, 'Checking embed URL', fatal=False, errnote=False):
                 return {
                     **info,
                     '_type': 'url',

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -4,7 +4,6 @@ from .common import InfoExtractor
 from .vimeo import VimeoIE
 from ..compat import compat_urllib_parse_unquote
 from ..networking.exceptions import HTTPError
-from ..networking import HEADRequest
 from ..utils import (
     KNOWN_EXTENSIONS,
     ExtractorError,
@@ -252,7 +251,7 @@ class PatreonIE(PatreonBaseIE):
                 self._search_regex(r'(https(?:%3A%2F%2F|://)player\.vimeo\.com.+app_id(?:=|%3D)+\d+)', embed_html, 'vimeo url', fatal=False)))
             if v_url:
                 vimeo_embed_url = VimeoIE._smuggle_referrer(v_url, 'https://patreon.com')
-                response = self._request_webpage(HEADRequest(vimeo_embed_url), video_id, fatal=False)
+                response = self._request_webpage(vimeo_embed_url, video_id, fatal=False)
 
                 if response is not False:
                     return {
@@ -264,7 +263,7 @@ class PatreonIE(PatreonBaseIE):
 
         embed_url = try_get(attributes, lambda x: x['embed']['url'])
         if embed_url:
-            response = self._request_webpage(HEADRequest(embed_url), video_id, fatal=False)
+            response = self._request_webpage(embed_url, video_id, fatal=False)
 
             if response is not False:
                 return {

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -251,14 +251,12 @@ class PatreonIE(PatreonBaseIE):
                 self._search_regex(r'(https(?:%3A%2F%2F|://)player\.vimeo\.com.+app_id(?:=|%3D)+\d+)', embed_html, 'vimeo url', fatal=False)))
             if v_url:
                 v_url = VimeoIE._smuggle_referrer(v_url, 'https://patreon.com')
-
                 if self._request_webpage(v_url, video_id, 'Checking Vimeo embed URL', fatal=False, errnote=False):
-                    return self.url_result(v_url, 'Vimeo', **info, url_transparent=True)
+                    return self.url_result(v_url, 'Vimeo', url_transparent=True, **info)
 
         embed_url = try_get(attributes, lambda x: x['embed']['url'])
-        if embed_url:
-            if self._request_webpage(embed_url, video_id, 'Checking embed URL', fatal=False, errnote=False):
-                return self.url_result(embed_url, **info)
+        if embed_url and self._request_webpage(embed_url, video_id, 'Checking embed URL', fatal=False, errnote=False):
+            return self.url_result(embed_url, **info)
 
         post_file = traverse_obj(attributes, 'post_file')
         if post_file:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

~~This change prioritizes downloading from m3u8 instead of vimeo embeds (or embeds in general), which in some cases may no longer exist and only the m3u8 video attachment does.~~

This change adds checks to verify if external embeds of Patreon posts are still valid before trying to download them (since they may have been deleted from vimeo/dropbox/etc. but still be attached to the Patreon post), and if it is invalid then it tries other options

Example, using `python -m yt_dlp https://www.patreon.com/posts/hunter-x-hunter-34007913` (this video is public, so no need for cookies/account to test with)

```sh
# Before change, finds a vimeo embed (that no longer exists) and fails to download it
python -m yt_dlp https://www.patreon.com/posts/hunter-x-hunter-34007913
[Patreon] Extracting URL: https://www.patreon.com/posts/hunter-x-hunter-34007913
[Patreon] 34007913: Downloading API JSON
[vimeo] Extracting URL: https://player.vimeo.com/video/391366663?app_id=122963#__youtubedl_smuggle=%7B%22referer%22%3A+%2...%2Fpatreon.com%22%7D
[vimeo] 391366663: Downloading webpage
ERROR: [vimeo] 391366663: Unable to download webpage: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
```

```sh
# After change: checks for vimeo embed, fails, then tries to download the m3u8 file attachment
python -m yt_dlp https://www.patreon.com/posts/hunter-x-hunter-34007913
[Patreon] Extracting URL: https://www.patreon.com/posts/hunter-x-hunter-34007913
[Patreon] 34007913: Downloading API JSON
[Patreon] 34007913: Downloading webpage
WARNING: [Patreon] Unable to download webpage: HTTP Error 405: Method Not Allowed
[Patreon] 34007913: Downloading webpage
WARNING: [Patreon] Unable to download webpage: HTTP Error 404: Not Found
[Patreon] 34007913: Downloading m3u8 information
[info] 34007913: Downloading 1 format(s): 4712
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 284
[download] Destination: Hunter x Hunter ｜ Kurapika DESTROYS Uvogin!!! [34007913].mp4
[download]  10.2% of ~ 721.42MiB at    2.61MiB/s ETA 03:26 (frag 28/284)
```

**Possibly** fixes https://github.com/yt-dlp/yt-dlp/issues/8702 (don't have access to the post in the example to test but seems pretty similar to my test case)


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
