### PR TITLE
[cookies] Support Firefox containers JSON version 5

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -146,7 +146,8 @@ def _extract_firefox_cookies(profile, container, logger):
             identities = json.load(containers).get('identities', [])
         container_id = next((context.get('userContextId') for context in identities if container in (
             context.get('name'),
-            try_call(lambda: re.fullmatch(r'userContext([^\.]+)\.label', context['l10nID']).group())
+            try_call(lambda: re.fullmatch(r'userContext([^\.]+)\.label', context['l10nID']).group()),
+            try_call(lambda: re.fullmatch(r'user-context-(.+)', context['l10nId']).group())
         )), None)
         if not isinstance(container_id, int):
             raise ValueError(f'could not find firefox container "{container}" in containers.json')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Firefox has a new version of the containers.json that needs to be read to extract the correct cookies. E.g. the follow command currently fails even though the default container user-context-personal exists:

```sh
yt-dlp --cookies-from-browser firefox:aaaa9aaa.default::user-context-personal "https://www.youtube.com/playlist?list=UUMOLe_q9axMaeTbjN0hy1Z9xA"
# Extracting cookies from firefox
# ERROR: could not find firefox container "user-context-personal" in containers.json
```

This is because version 5 of the contains.json format has the member `l10nId` (note the small `d`) with the format `user-context-${name}`, where version 4 had `l10nID` with `userContext${name}.label`. Compare the [version 4 from an old issue comment on this repo](https://github.com/yt-dlp/yt-dlp/issues/7520#issuecomment-1623759838) with the following version 5:

```json
{
  "version": 5,
  "lastUserContextId": 31566,
  "identities": [
    {
      "userContextId": 1,
      "public": true,
      "icon": "fingerprint",
      "color": "blue",
      "telemetryId": 1,
      "l10nId": "user-context-personal"
    },
    ⋮
  ]
}
```

This PR fixes this by still supporting version 4, but in addition supporting version 5 by testing one extra regular expression.

I was unable to find any documentation of the different versions of containers.json, I assume Firefox sees this as an internal detail only and not part of any public API.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
