### PR TITLE
[ie/afreecatv:live] Add `cdn` extractor-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1837,6 +1837,9 @@ The following extractors use this feature:
 #### jiosaavn
 * `bitrate`: Audio bitrates to request. One or more of `16`, `32`, `64`, `128`, `320`. Default is `128,320`
 
+#### afreecatvlive
+* `cdn`: One or more CDN IDs to use with the API call for stream URLs, e.g. `gcp_cdn`, `gs_cdn_pc_app`, `gs_cdn_mobile_web`, `gs_cdn_pc_web`
+
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 
 <!-- MANPAGE: MOVE "INSTALLATION" SECTION HERE -->

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -8,9 +8,11 @@ from ..utils import (
     determine_ext,
     filter_dict,
     int_or_none,
+    orderedSet,
     unified_timestamp,
     url_or_none,
     urlencode_postdata,
+    urljoin,
 )
 from ..utils.traversal import traverse_obj
 
@@ -276,6 +278,44 @@ class AfreecaTVLiveIE(AfreecaTVBaseIE):
     }]
 
     _LIVE_API_URL = 'https://live.afreecatv.com/afreeca/player_live_api.php'
+    _WORKING_CDNS = [
+        'gcp_cdn',  # live-global-cdn-v02.afreecatv.com
+        'gs_cdn_pc_app',  # pc-app.stream.afreecatv.com
+        'gs_cdn_mobile_web',  # mobile-web.stream.afreecatv.com
+        'gs_cdn_pc_web',  # pc-web.stream.afreecatv.com
+    ]
+    _BAD_CDNS = [
+        'gs_cdn',  # chromecast.afreeca.gscdn.com (cannot resolve)
+        'azure_cdn',  # live-global-cdn-v01.afreecatv.com (cannot resolve)
+        'aws_cf',  # live-global-cdn-v03.afreecatv.com (cannot resolve)
+    ]
+
+    def _extract_formats(self, channel_info, broadcast_no, aid):
+        stream_base_url = channel_info.get('RMD') or 'https://livestream-manager.afreecatv.com'
+
+        # If user has not passed CDN IDs, try API-provided CDN ID followed by other working CDN IDs
+        default_cdn_ids = orderedSet(filter(
+            lambda x: x and x not in self._BAD_CDNS,
+            [traverse_obj(channel_info, ('CDN', {str})), *self._WORKING_CDNS]))
+        cdn_ids = self._configuration_arg('cdn', default_cdn_ids)
+
+        for attempt, cdn_id in enumerate(cdn_ids, start=1):
+            m3u8_url = traverse_obj(self._download_json(
+                urljoin(stream_base_url, 'broad_stream_assign.html'), broadcast_no,
+                f'Downloading {cdn_id} stream info', f'Unable to download {cdn_id} stream info',
+                fatal=False, query={
+                    'return_type': cdn_id,
+                    'broad_key': f'{broadcast_no}-common-master-hls',
+                }), ('view_url', {url_or_none}))
+            try:
+                return self._extract_m3u8_formats(
+                    m3u8_url, broadcast_no, 'mp4', m3u8_id='hls', query={'aid': aid},
+                    headers={'Referer': 'https://play.afreecatv.com/'})
+            except ExtractorError as e:
+                if attempt == len(cdn_ids):
+                    raise
+                self.report_warning(
+                    f'{e.cause or e.msg}. Retrying... (attempt {attempt} of {len(cdn_ids)})')
 
     def _real_extract(self, url):
         broadcaster_id, broadcast_no = self._match_valid_url(url).group('id', 'bno')
@@ -304,16 +344,7 @@ class AfreecaTVLiveIE(AfreecaTVBaseIE):
                 'pwd': password,
             })))['CHANNEL']['AID']
 
-        stream_base_url = channel_info.get('RMD') or 'https://livestream-manager.afreecatv.com'
-        stream_info = self._download_json(f'{stream_base_url}/broad_stream_assign.html', broadcast_no, query={
-            # works: gs_cdn_pc_app, gs_cdn_mobile_web, gs_cdn_pc_web
-            'return_type': 'gs_cdn_pc_app',
-            'broad_key': f'{broadcast_no}-common-master-hls',
-        }, note='Downloading metadata for stream', errnote='Unable to download metadata for stream')
-
-        formats = self._extract_m3u8_formats(
-            stream_info['view_url'], broadcast_no, 'mp4', m3u8_id='hls',
-            query={'aid': aid}, headers={'Referer': url})
+        formats = self._extract_formats(channel_info, broadcast_no, aid)
 
         station_info = traverse_obj(self._download_json(
             'https://st.afreecatv.com/api/get_station_status.php', broadcast_no,

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -296,9 +296,10 @@ class AfreecaTVLiveIE(AfreecaTVBaseIE):
         stream_base_url = channel_info.get('RMD') or 'https://livestream-manager.afreecatv.com'
 
         # If user has not passed CDN IDs, try API-provided CDN ID followed by other working CDN IDs
-        default_cdn_ids = orderedSet(filter(
-            lambda x: x and x not in self._BAD_CDNS,
-            [traverse_obj(channel_info, ('CDN', {str})), *self._WORKING_CDNS]))
+        default_cdn_ids = orderedSet([
+            *traverse_obj(channel_info, ('CDN', {str}, all, lambda _, v: v not in self._BAD_CDNS)),
+            *self._WORKING_CDNS,
+        ])
         cdn_ids = self._configuration_arg('cdn', default_cdn_ids)
 
         for attempt, cdn_id in enumerate(cdn_ids, start=1):

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -286,8 +286,10 @@ class AfreecaTVLiveIE(AfreecaTVBaseIE):
     ]
     _BAD_CDNS = [
         'gs_cdn',  # chromecast.afreeca.gscdn.com (cannot resolve)
+        'gs_cdn_chromecast',  # chromecast.stream.afreecatv.com (HTTP Error 400)
         'azure_cdn',  # live-global-cdn-v01.afreecatv.com (cannot resolve)
         'aws_cf',  # live-global-cdn-v03.afreecatv.com (cannot resolve)
+        'kt_cdn',  # kt.stream.afreecatv.com (HTTP Error 400)
     ]
 
     def _extract_formats(self, channel_info, broadcast_no, aid):


### PR DESCRIPTION
AfreecaTV's API will serve different m3u8 URLs depending on the value of the `return_type` parameter we send. The `return_type` value is a CDN ID, and each ID is tied to a CDN hostname. 

We are given a CDN ID to use in an earlier API response, but sometimes this is a bad ID that results in an unresolvable hostname (e.g. Korea gets `gs_cdn` which returns an m3u8 URL with the unresolvable hostname `chromecast.afreeca.gscdn.com` -- this is what 9073ae6458f4c6a832aa832c67174c61852869be attempted to fix).

But hardcoding a single working CDN ID is problematic since the best CDN for a given user is dependent upon the user's region; see #6497 and https://github.com/yt-dlp/yt-dlp/issues/9345#issuecomment-2048088892 .

This PR attempts to solve this by doing the following:
- Adding a fallback/retry loop for format extraction that will iterate through a list of known working CDN IDs
- Filtering out known bad/unresolvable CDN IDs from the API response
- Adding the extractor-arg `cdn` by which users can pass one or more CDN IDs (overriding the hardcoded list of working CDN IDs)

Closes #6497
Resolves https://github.com/yt-dlp/yt-dlp/issues/9345#issuecomment-2048088892


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
