### PR TITLE
[ie/orf:on] Improve extraction

### DIFF
--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -14,6 +14,7 @@ from ..utils import (
     make_archive_id,
     mimetype2ext,
     orderedSet,
+    parse_age_limit,
     remove_end,
     smuggle_url,
     strip_jsonp,
@@ -24,7 +25,6 @@ from ..utils import (
     url_or_none,
 )
 from ..utils.traversal import traverse_obj
-from ..utils import parse_age_limit
 
 
 class ORFTVthekIE(InfoExtractor):

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -635,14 +635,11 @@ class ORFONIE(InfoExtractor):
                 ],
             }, target=subtitles)
 
-        age_classification = traverse_obj(api_json, ('age_classification'), {str})
-        age_limit = parse_age_limit(age_classification)
-
         return {
             'id': video_id,
             'formats': formats,
             'subtitles': subtitles,
-            'age_limit': age_limit,
+            'age_limit': traverse_obj(api_json, ('age_classification'), {parse_age_limit}),
             **traverse_obj(api_json, {
                 'duration': ('duration_second', {float_or_none}),
                 'title': (('title', 'headline'), {str}),

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -622,14 +622,10 @@ class ORFONIE(InfoExtractor):
                 formats.extend(fmts)
                 self._merge_subtitles(subs, target=subtitles)
 
-        for sub_url in traverse_obj(api_json, ('_embedded', 'subtitle', lambda k, _: k.endswith('_url'), {url_or_none})):
-            subtitle_type = sub_url.split('.')[-1]
-            self._merge_subtitles({'de': [{'url': sub_url, 'ext': subtitle_type}]}, target=subtitles)
-        if 'de' in subtitles:
-            subtitles['de'].sort(
-                # sort that vtt is default so `--embed-subs` is working out of the box
-                key=lambda sub: 1 if sub['ext'] == 'vtt' else 0
-            )
+        for sub_url in traverse_obj(api_json, (
+                '_embedded', 'subtitle',
+                ('xml_url', 'sami_url', 'stl_url', 'ttml_url', 'srt_url', 'vtt_url'), {url_or_none})):
+            self._merge_subtitles({'de': [{'url': sub_url}]}, target=subtitles)
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -584,6 +584,20 @@ class ORFONIE(InfoExtractor):
             'timestamp': 1706472362,
             'upload_date': '20240128',
         }
+    }, {
+        'url': 'https://on.orf.at/video/3220355',
+        'md5': 'f94d98e667cf9a3851317efb4e136662',
+        'info_dict': {
+            'id': '3220355',
+            'ext': 'mp4',
+            'duration': 445.04,
+            'thumbnail': 'https://api-tvthek.orf.at/assets/segments/0002/60/thumb_159573_segments_highlight_teaser.png',
+            'title': '50 Jahre Burgenland: Der Festumzug',
+            'description': 'md5:1560bf855119544ee8c4fa5376a2a6b0',
+            'media_type': 'episode',
+            'timestamp': 52916400,
+            'upload_date': '19710905',
+        }
     }]
 
     def _extract_video(self, video_id, display_id):

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -24,6 +24,7 @@ from ..utils import (
     url_or_none,
 )
 from ..utils.traversal import traverse_obj
+from ..utils import parse_age_limit
 
 
 class ORFTVthekIE(InfoExtractor):
@@ -620,10 +621,14 @@ class ORFONIE(InfoExtractor):
                 ],
             }, target=subtitles)
 
+        age_classification = traverse_obj(api_json, ('age_classification'), {str})
+        age_limit = parse_age_limit(age_classification)
+
         return {
             'id': video_id,
             'formats': formats,
             'subtitles': subtitles,
+            'age_limit': age_limit,
             **traverse_obj(api_json, {
                 'duration': ('duration_second', {float_or_none}),
                 'title': (('title', 'headline'), {str}),

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -639,8 +639,8 @@ class ORFONIE(InfoExtractor):
             'id': video_id,
             'formats': formats,
             'subtitles': subtitles,
-            'age_limit': traverse_obj(api_json, ('age_classification'), {parse_age_limit}),
             **traverse_obj(api_json, {
+                'age_limit': ('age_classification', {parse_age_limit}),
                 'duration': ('duration_second', {float_or_none}),
                 'title': (('title', 'headline'), {str}),
                 'description': (('description', 'teaser_text'), {str}),

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -590,6 +590,9 @@ class ORFONIE(InfoExtractor):
         api_json = self._download_json(
             f'https://api-tvthek.orf.at/api/v4.3/public/episode/encrypted/{encrypted_id}', display_id)
 
+        if api_json.get('is_drm_protected'):
+            self.report_drm(video_id)
+
         formats, subtitles = [], {}
         for manifest_type in traverse_obj(api_json, ('sources', {dict.keys}, ...)):
             for manifest_url in traverse_obj(api_json, ('sources', manifest_type, ..., 'src', {url_or_none})):

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -641,7 +641,7 @@ class ORFONIE(InfoExtractor):
         }
 
     def _real_extract(self, url):
-        video_id = self._match_valid_url(url).group('id')
+        video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
         return {

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -605,7 +605,7 @@ class ORFONIE(InfoExtractor):
         api_json = self._download_json(
             f'https://api-tvthek.orf.at/api/v4.3/public/episode/encrypted/{encrypted_id}', video_id)
 
-        if api_json.get('is_drm_protected'):
+        if traverse_obj(api_json, 'is_drm_protected'):
             self.report_drm(video_id)
 
         formats, subtitles = [], {}

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -604,6 +604,19 @@ class ORFONIE(InfoExtractor):
                 formats.extend(fmts)
                 self._merge_subtitles(subs, target=subtitles)
 
+        for subtitle_type in ['vtt']:  # not working formats 'xml', 'srt', 'sami', 'ttml', 'stl'
+            subtitle_url = traverse_obj(api_json, ('_embedded', 'subtitle', f'{subtitle_type}_url'), {str})
+            if subtitle_url is None:
+                continue
+            self._merge_subtitles({
+                'de': [
+                    {
+                        'url': subtitle_url,
+                        'ext': f'{subtitle_type}',
+                    }
+                ],
+            }, target=subtitles)
+
         return {
             'id': video_id,
             'formats': formats,

--- a/yt_dlp/extractor/orf.py
+++ b/yt_dlp/extractor/orf.py
@@ -569,7 +569,7 @@ class ORFFM4StoryIE(InfoExtractor):
 
 class ORFONIE(InfoExtractor):
     IE_NAME = 'orf:on'
-    _VALID_URL = r'https?://on\.orf\.at/video/(?P<id>\d{8})/(?P<slug>[\w-]+)'
+    _VALID_URL = r'https?://on\.orf\.at/video/(?P<id>\d+)(/(?P<slug>[\w-]+))?'
     _TESTS = [{
         'url': 'https://on.orf.at/video/14210000/school-of-champions-48',
         'info_dict': {
@@ -631,6 +631,8 @@ class ORFONIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id, display_id = self._match_valid_url(url).group('id', 'slug')
+        if display_id is None:
+            display_id = video_id
         webpage = self._download_webpage(url, display_id)
 
         return {


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

* add better DRM detection: ref:  #9652
* add parsing of the v4.3 api for subtitles
* better url parsing
  example for 7 digits: https://on.orf.at/video/3229173
* better tests
 the new test data has `killdate: None` as attribute, so this should be more stable for the future
 sadly I did't found any video with age restriction and `right: "worldwide"` only with restriction to Austria and/or with a `killdate` < 2025, IMHO not worth to add as will create future problem


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>


Open Questions:

*  I did't get the other subtitles formats working `'xml', 'srt', 'sami', 'ttml', 'stl'` that are available so I comment them out
*  should `display_id` be remove?! as it is not included with all urls from `on.orf.at`



As this is my first PR to `yt-dlp` I hope I didn't oversaw anything from the good written guidelines.
If so feel free to point that out.