### PR TITLE
Enable use of session cookies in chrome

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -299,7 +299,7 @@ def _extract_chrome_cookies(browser_name, profile, keyring, logger):
             cursor.connection.text_factory = bytes
             column_names = _get_column_names(cursor, 'cookies')
             secure_column = 'is_secure' if 'is_secure' in column_names else 'secure'
-            cursor.execute(f'SELECT host_key, name, value, encrypted_value, path, expires_utc, has_expires, {secure_column} FROM cookies')
+            cursor.execute(f'SELECT host_key, name, value, encrypted_value, path, expires_utc, {secure_column} FROM cookies')
             jar = YoutubeDLCookieJar()
             failed_cookies = 0
             unencrypted_cookies = 0
@@ -335,7 +335,7 @@ def _extract_chrome_cookies(browser_name, profile, keyring, logger):
                 cursor.connection.close()
 
 
-def _process_chrome_cookie(decryptor, host_key, name, value, encrypted_value, path, expires_utc, has_expires, is_secure):
+def _process_chrome_cookie(decryptor, host_key, name, value, encrypted_value, path, expires_utc, is_secure):
     host_key = host_key.decode()
     name = name.decode()
     value = value.decode()

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -347,6 +347,8 @@ def _process_chrome_cookie(decryptor, host_key, name, value, encrypted_value, pa
         if value is None:
             return is_encrypted, None
 
+    # In chrome, session cookies have has_expires and expires_utc set to 0
+    # In Python, cookies that do not expire have expires set to None
     if not has_expires:
         expires_utc = None
 

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -347,9 +347,9 @@ def _process_chrome_cookie(decryptor, host_key, name, value, encrypted_value, pa
         if value is None:
             return is_encrypted, None
 
-    # In chrome, session cookies have has_expires and expires_utc set to 0
-    # In Python, cookies that do not expire have expires set to None
-    if not has_expires:
+    # In chrome, session cookies have expires_utc set to 0
+    # In our cookie-store, cookies that do not expire should have expires set to None
+    if not expires_utc:
         expires_utc = None
 
     return is_encrypted, http.cookiejar.Cookie(

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -347,9 +347,7 @@ def _process_chrome_cookie(decryptor, host_key, name, value, encrypted_value, pa
         if value is None:
             return is_encrypted, None
 
-    if has_expires == 1:
-        expires_utc = expires_utc
-    else:
+    if not has_expires:
         expires_utc = None
 
     return is_encrypted, http.cookiejar.Cookie(


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Partially Fixes #5534

The chrome (and brave, have not checked other chrome based browsers) cookies database has 2 columns related to cookie expiry: expires_utc and has_expires. yt-dlp only checks the expires_utc column:

- For session cookies expires_utc is set to 0 and has_expires to 0. 
- For expiring cookies expires_utc is set to a utc timestamp and has_expires to 1

The current logic in yt-dlp takes expires_utc only and the phyton cookie will consider a value of 0 as expired:
```python
class Cookie:
    # ...
    def is_expired(self, now=None):
        if now is None: now = time.time()
        if (self.expires is not None) and (self.expires <= now):
            return True
        return False
```

To support session_cookies we should therefore set expires to None, since they do not expire.



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
