### PR TITLE
[post-processing] Refactor MoveFilesPP to respect non-video files

### DIFF
--- a/yt_dlp/postprocessor/movefilesafterdownload.py
+++ b/yt_dlp/postprocessor/movefilesafterdownload.py
@@ -4,13 +4,11 @@ from .common import PostProcessor
 from ..compat import shutil
 from ..utils import (
     PostProcessingError,
-    decodeFilename,
-    encodeFilename,
     make_dir,
 )
 
-
 class MoveFilesAfterDownloadPP(PostProcessor):
+    FILETYPE_KEYS = ['media', 'thumbnails', 'requested_subtitles']
 
     def __init__(self, downloader=None, downloaded=True):
         PostProcessor.__init__(self, downloader)
@@ -20,34 +18,77 @@ class MoveFilesAfterDownloadPP(PostProcessor):
     def pp_key(cls):
         return 'MoveFiles'
 
+    def expand_relative_paths(self, files_to_move, finaldir):
+        for filetype in self.FILETYPE_KEYS:
+            if filetype not in files_to_move:
+                continue
+            for file_attrs in files_to_move[filetype]:
+                if not os.path.isabs(file_attrs['final_filepath']):
+                    file_attrs['final_filepath'] = os.path.join(finaldir, file_attrs['final_filepath'])
+                if not os.path.isabs(file_attrs['current_filepath']):
+                    file_attrs['current_filepath'] = os.path.abspath(file_attrs['current_filepath'])
+
+        return files_to_move
+
+    def write_filepath_into_info(self, info, filetype, file_attrs):
+        if filetype == 'media':
+            info['filepath'] = file_attrs['final_filepath']
+            return
+
+        elif filetype == 'thumbnails':
+            for filetype_dict in info[filetype]:
+                if filetype_dict['id'] == file_attrs['id']:
+                    filetype_dict['filepath'] = file_attrs['final_filepath']
+
+        elif filetype == 'requested_subtitles':
+            lang = file_attrs['lang']
+            if lang in info[filetype]:
+                info[filetype][lang]['filepath'] = file_attrs['final_filepath']
+
     def run(self, info):
-        dl_path, dl_name = os.path.split(encodeFilename(info['filepath']))
+        dl_path, dl_name = os.path.split(info['filepath'])
         finaldir = info.get('__finaldir', dl_path)
-        finalpath = os.path.join(finaldir, dl_name)
+        info['__files_to_move']['media'] = []
+
         if self._downloaded:
-            info['__files_to_move'][info['filepath']] = decodeFilename(finalpath)
+            info['__files_to_move']['media'] = [{ 'current_filepath': info['filepath'], 'final_filepath': dl_name }]
 
-        make_newfilename = lambda old: decodeFilename(os.path.join(finaldir, os.path.basename(encodeFilename(old))))
-        for oldfile, newfile in info['__files_to_move'].items():
-            if not newfile:
-                newfile = make_newfilename(oldfile)
-            if os.path.abspath(encodeFilename(oldfile)) == os.path.abspath(encodeFilename(newfile)):
+        files_to_move = self.expand_relative_paths(info['__files_to_move'], finaldir)
+
+        for filetype in self.FILETYPE_KEYS:
+            if filetype not in files_to_move:
                 continue
-            if not os.path.exists(encodeFilename(oldfile)):
-                self.report_warning('File "%s" cannot be found' % oldfile)
-                continue
-            if os.path.exists(encodeFilename(newfile)):
-                if self.get_param('overwrites', True):
-                    self.report_warning('Replacing existing file "%s"' % newfile)
-                    os.remove(encodeFilename(newfile))
-                else:
-                    self.report_warning(
-                        'Cannot move file "%s" out of temporary directory since "%s" already exists. '
-                        % (oldfile, newfile))
+
+            for file_attrs in files_to_move[filetype]:
+                current_filepath = file_attrs['current_filepath']
+                final_filepath = file_attrs['final_filepath']
+
+                if not current_filepath or not final_filepath:
                     continue
-            make_dir(newfile, PostProcessingError)
-            self.to_screen(f'Moving file "{oldfile}" to "{newfile}"')
-            shutil.move(oldfile, newfile)  # os.rename cannot move between volumes
 
-        info['filepath'] = finalpath
+                if current_filepath == final_filepath:
+                    # This ensures the infojson contains the full filepath even
+                    # when --no-overwrites is used
+                    self.write_filepath_into_info(info, filetype, file_attrs)
+                    continue
+
+                if not os.path.exists(current_filepath):
+                    self.report_warning('File "%s" cannot be found' % current_filepath)
+                    continue
+
+                if os.path.exists(final_filepath):
+                    if self.get_param('overwrites', True):
+                        self.report_warning('Replacing existing file "%s"' % final_filepath)
+                        os.remove(final_filepath)
+                    else:
+                        self.report_warning(
+                            'Cannot move file "%s" out of temporary directory since "%s" already exists. '
+                            % (current_filepath, final_filepath))
+                        continue
+
+                make_dir(final_filepath, PostProcessingError)
+                self.to_screen(f'Moving file "{current_filepath}" to "{final_filepath}"')
+                shutil.move(current_filepath, final_filepath)  # os.rename cannot move between volumes
+                self.write_filepath_into_info(info, filetype, file_attrs)
+
         return [], info

--- a/yt_dlp/postprocessor/movefilesafterdownload.py
+++ b/yt_dlp/postprocessor/movefilesafterdownload.py
@@ -7,6 +7,7 @@ from ..utils import (
     make_dir,
 )
 
+
 class MoveFilesAfterDownloadPP(PostProcessor):
     FILETYPE_KEYS = ['media', 'thumbnails', 'requested_subtitles']
 
@@ -51,7 +52,7 @@ class MoveFilesAfterDownloadPP(PostProcessor):
         info['__files_to_move']['media'] = []
 
         if self._downloaded:
-            info['__files_to_move']['media'] = [{ 'current_filepath': info['filepath'], 'final_filepath': dl_name }]
+            info['__files_to_move']['media'] = [{'current_filepath': info['filepath'], 'final_filepath': dl_name}]
 
         files_to_move = self.expand_relative_paths(info['__files_to_move'], finaldir)
 


### PR DESCRIPTION
### Description of your *pull request* and other information

Related to #9445, although it doesn't solve this comment https://github.com/yt-dlp/yt-dlp/issues/9445#issuecomment-2018724344 which I'll address in another PR.

### Issue:

The `MoveFilesAfterDownloadPP` pre-processor  moves all files as expected, but it only updates the filepath for the main media file in the `info` dict. This means that file moves related to thumbnails and subtitles do take place, but the filepath for these entries in the info map isn't updated.

**Example**:
```bash
yt-dlp https://www.youtube.com/watch?v=UfmkgQRmmeE \
  --write-thumbnail \
  --output "%(title)s.%(ext)s" \
  --output "thumbnail:%(title)s-thumb.%(ext)s" \
  --print-to-file "after_move:%()j" output.json
  ```

After running the above command, you'll see that the thumbnail is correctly appended with `-thumb` on the filesystem, but the `thumbnails` section in `output.json` references the original non-`thumb` path.

### Fix:

My approach roughly looks like this:

- Modify `_write_thumbnails` and `_write_subtitles` to return a list of dicts where each dict contains some identifying data about the file that's not related to its filepath
  - For thumbnails it uses `id` and for subtitles it uses a combination of `ext` and the thumbnail's lang
  - This allows us to later update the filepath for any arbitrary number of subtitles and thumbnails (ie: works with `--write-all-thumbnails` or `--sub-langs all`
- Refactor `__files_to_move` to be a dict with 3 keys: `thumbnails`, `requested_subtitles`, and `media`. Each key's value will be a list of dicts where each dict has the keys `current_filepath` and `final_filepath`, along with any required identifying data
  - eg:
  ```
  {
    thumbnails: [
      {
        current_filepath: '...',
        final_filepath: '...',
        id: '21'
      },
      # ...
    ],
    requested_subtitles: [ ... ],
    media: [ ... ]
  }
  ```
- Refactor `MoveFilesAfterDownloadPP` to iterate over each of the above keys in `__files_to_move` and for each file:
  - Ensure it's `current_filepath` and `final_filepath` are absolute paths by expanding relative paths, if needed
  - Running some basic checks to ensure the file exists, should be moved, etc
  - Moving the file
  - Updating the relevant file's`filepath` in the `info` dict
    - This is where the non-filepath identifying data from before is used. For example, this logic lets us determine that the thumbnail we just moved had ID `41` and then we can look for that thumbnail in the info dict to update its `filepath` key
- There are also some refactors around ways that `__files_to_move` was used and set. Most of these are refactors, but there have been some straight-up removals that appeared irrelevant or unused. Please let me know if those should be kept and I'll try to refactor them!

I'll be the first to say that I'm NOT a Python guy, so please let me know if there are better ways to accomplish things. I also have not updated tests yet but can do so if the general approach is approved

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
