### PR TITLE
[ie/wrestleuniverse] Avoid partial stream formats

### DIFF
--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -12,6 +12,7 @@ from ..utils import (
     jwt_decode_hs256,
     traverse_obj,
     try_call,
+    url_basename,
     url_or_none,
     urlencode_postdata,
     variadic,
@@ -194,8 +195,7 @@ class WrestleUniverseVODIE(WrestleUniverseBaseIE):
 
         return {
             'id': video_id,
-            'formats': self._get_formats(video_data, (
-                (('protocolHls', 'url'), ('chromecastUrls', ...)), {url_or_none}), video_id),
+            'formats': self._get_formats(video_data, ('protocolHls', 'url', {url_or_none}), video_id),
             **traverse_obj(metadata, {
                 'title': ('displayName', {str}),
                 'description': ('description', {str}),
@@ -285,12 +285,16 @@ class WrestleUniversePPVIE(WrestleUniverseBaseIE):
 
         video_data, decrypt = self._call_encrypted_api(
             video_id, ':watchArchive', 'watch archive', data={'method': 1})
-        info['formats'] = self._get_formats(video_data, (
-            ('hls', None), ('urls', 'chromecastUrls'), ..., {url_or_none}), video_id)
+        # 'chromecastUrls' can be only partial videos, avoid
+        info['formats'] = self._get_formats(video_data, ('hls', (('urls', ...), 'url'), {url_or_none}), video_id)
         for f in info['formats']:
             # bitrates are exaggerated in PPV playlists, so avoid wrong/huge filesize_approx values
             if f.get('tbr'):
                 f['tbr'] = int(f['tbr'] / 2.5)
+            # prefer variants with the same basename as the master playlist to avoid partial streams
+            f['format_id'] = url_basename(f['url']).partition('.')[0]
+            if not f['format_id'].startswith(url_basename(f['manifest_url']).partition('.')[0]):
+                f['preference'] = -10
 
         hls_aes_key = traverse_obj(video_data, ('hls', 'key', {decrypt}))
         if hls_aes_key:

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -259,6 +259,10 @@ class WrestleUniversePPVIE(WrestleUniverseBaseIE):
         'params': {
             'skip_download': 'm3u8',
         },
+    }, {
+        'note': 'manifest provides live-a (partial) and live-b (full) streams',
+        'url': 'https://www.wrestle-universe.com/en/lives/umc99R9XsexXrxr9VjTo9g',
+        'only_matching': True,
     }]
 
     _API_PATH = 'events'


### PR DESCRIPTION
Some master m3u8s for PPV/livestreams actually provide variants for two separate streams, e.g. `https://vod.asset.wrestle-universe.com/2e6gptHzDNQS47VDSvUPGQ/live-b.m3u8` has a `live-a` stream and a `live-b` stream:

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-INDEPENDENT-SEGMENTS
#EXT-X-STREAM-INF:BANDWIDTH=23383278,AVERAGE-BANDWIDTH=20222400,CODECS="avc1.640029,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=29.970
live-b_1080p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=23383278,AVERAGE-BANDWIDTH=20222400,CODECS="avc1.640029,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=29.970
live-a_1080p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=10416034,AVERAGE-BANDWIDTH=9011200,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=29.970
live-b_720p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=10416034,AVERAGE-BANDWIDTH=9011200,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=29.970
live-a_720p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=5243216,AVERAGE-BANDWIDTH=4540800,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=960x540,FRAME-RATE=29.970
live-b_540p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=5243216,AVERAGE-BANDWIDTH=4540800,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=960x540,FRAME-RATE=29.970
live-a_540p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=2692008,AVERAGE-BANDWIDTH=2340800,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=640x360,FRAME-RATE=29.970
live-b_360p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=2692008,AVERAGE-BANDWIDTH=2340800,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=640x360,FRAME-RATE=29.970
live-a_360p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1416404,AVERAGE-BANDWIDTH=1240800,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=426x240,FRAME-RATE=29.970
live-b_240p_2997fps.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1416404,AVERAGE-BANDWIDTH=1240800,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=426x240,FRAME-RATE=29.970
live-a_240p_2997fps.m3u8
```

If we look at `https://vod.asset.wrestle-universe.com/2e6gptHzDNQS47VDSvUPGQ/live-a_1080p_2997fps.m3u8`, we can see it is only the first ~30 minutes of `https://vod.asset.wrestle-universe.com/2e6gptHzDNQS47VDSvUPGQ/live-b_1080p_2997fps.m3u8`.

This patch prefers the variant playlists that have the same basename as the master manifest to avoid such partial streams.



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
