### PR TITLE
[core] Warn user when FFmpeg is missing

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2183,7 +2183,7 @@ class YoutubeDL:
             formats = self._get_formats(info_dict)
             evaluate_formats = lambda spec: self._select_formats(formats, self.build_format_selector(spec))
             if evaluate_formats('b/bv+ba') != evaluate_formats('bv*+ba/b'):
-                self.report_warning('ffmpeg not found. The downloaded format is not the highest available quality. '
+                self.report_warning('ffmpeg not found. The downloaded format may not be the best available. '
                                     'Installing ffmpeg is strongly recommended: https://github.com/yt-dlp/yt-dlp#dependencies')
 
         compat = (self.params.get('allow_multiple_audio_streams')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2167,7 +2167,7 @@ class YoutubeDL:
             return merger.available and merger.can_merge()
 
         def evaluate_formats(format_spec):
-            formats = info_dict.get('formats') or []
+            formats = self._get_formats(info_dict)
             return list(self.build_format_selector(format_spec)({
                 'formats': formats,
                 'has_merged_format': any('none' not in (f.get('acodec'), f.get('vcodec')) for f in formats),

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2138,6 +2138,7 @@ class YoutubeDL:
         for f in formats:
             if f.get('__working'):
                 yield f
+                continue
             self.to_screen('[info] Testing format %s' % f['format_id'])
             path = self.get_output_path('temp')
             if not self._ensure_dir_exists(f'{path}/'):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2136,8 +2136,10 @@ class YoutubeDL:
 
     def _check_formats(self, formats):
         for f in formats:
-            if f.get('__working'):
-                yield f
+            working = f.get('__working')
+            if working is not None:
+                if working:
+                    yield f
                 continue
             self.to_screen('[info] Testing format %s' % f['format_id'])
             path = self.get_output_path('temp')
@@ -2155,8 +2157,8 @@ class YoutubeDL:
                         os.remove(temp_file.name)
                     except OSError:
                         self.report_warning('Unable to delete temporary file "%s"' % temp_file.name)
+            f['__working'] = success
             if success:
-                f['__working'] = True
                 yield f
             else:
                 self.to_screen('[info] Unable to download format %s. Skipping...' % f['format_id'])

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2177,7 +2177,10 @@ class YoutubeDL:
         def evaluate_formats(format_spec):
             formats = self._get_formats(info_dict)
             return self._select_formats(formats, self.build_format_selector(format_spec))
-        if not can_merge() and evaluate_formats('best/bestvideo+bestaudio') != evaluate_formats('bestvideo*+bestaudio/best'):
+
+        to_stdout = self.params['outtmpl']['default'] == '-'
+
+        if not can_merge() and not to_stdout and evaluate_formats('b/bv+ba') != evaluate_formats('bv*+ba/b'):
             self.report_warning('ffmpeg not found. The downloaded format is not the highest available quality. '
                                 'Installing ffmpeg is strongly recommended: https://github.com/yt-dlp/yt-dlp#dependencies')
 
@@ -2187,7 +2190,7 @@ class YoutubeDL:
             and (
                 not can_merge()
                 or info_dict.get('is_live') and not self.params.get('live_from_start')
-                or self.params['outtmpl']['default'] == '-'))
+                or to_stdout))
         compat = (
             prefer_best
             or self.params.get('allow_multiple_audio_streams', False)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Warns the user when the selected format on the default format selection differs due to FFmpeg missing.

As this is part of the `_default_format_spec` function we don't need to check if the user has passed any custom format selection.
To suppress this warning, the user can pass `-f best/bestvideo+bestaudio`.

Fixes #9843

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
