### PR TITLE
[cookies] Fix --cookies-from-browser=safari with unusual field order

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -645,14 +645,17 @@ def _parse_safari_cookies_record(data, jar, logger):
     _creation_date = _mac_absolute_time_to_posix(p.read_double())  # noqa: F841
 
     try:
-        p.skip_to(domain_offset)
-        domain = p.read_cstring()
+        temp = DataParser(data, logger)
+        temp.skip_to(domain_offset)
+        domain = temp.read_cstring()
 
-        p.skip_to(name_offset)
-        name = p.read_cstring()
+        temp = DataParser(data, logger)
+        temp.skip_to(name_offset)
+        name = temp.read_cstring()
 
-        p.skip_to(path_offset)
-        path = p.read_cstring()
+        temp = DataParser(data, logger)
+        temp.skip_to(path_offset)
+        path = temp.read_cstring()
 
         p.skip_to(value_offset)
         value = p.read_cstring()


### PR DESCRIPTION
### Description of your *pull request* and other information

These fields can be specified in any order. `DataParser` doesn't support skipping backwards, so I make a temporary copy for each.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
