### PR TITLE
[ie/tiktok] Add `device_id` extractor-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1815,7 +1815,7 @@ The following extractors use this feature:
 * `manifest_app_version`: Default numeric app version to use with mobile API calls, e.g. `2023401020`
 * `aid`: Default app ID to use with mobile API calls, e.g. `1180`
 * `app_info`: Enable mobile API extraction with one or more app info strings in the format of `<iid>/[app_name]/[app_version]/[manifest_app_version]/[aid]`, where `iid` is the unique app install ID. `iid` is the only required value; all other values and their `/` separators can be omitted, e.g. `tiktok:app_info=1234567890123456789` or `tiktok:app_info=123,456/trill///1180,789//34.0.1/340001`
-* `device_id`: Enable mobile API extraction with an authentic device ID to be used with mobile API calls. Default is a random 19-digit string
+* `device_id`: Enable mobile API extraction with a genuine device ID to be used with mobile API calls. Default is a random 19-digit string
 
 #### rokfinchannel
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`

--- a/README.md
+++ b/README.md
@@ -1815,6 +1815,7 @@ The following extractors use this feature:
 * `manifest_app_version`: Default numeric app version to use with mobile API calls, e.g. `2023401020`
 * `aid`: Default app ID to use with mobile API calls, e.g. `1180`
 * `app_info`: Enable mobile API extraction with one or more app info strings in the format of `<iid>/[app_name]/[app_version]/[manifest_app_version]/[aid]`, where `iid` is the unique app install ID. `iid` is the only required value; all other values and their `/` separators can be omitted, e.g. `tiktok:app_info=1234567890123456789` or `tiktok:app_info=123,456/trill///1180,789//34.0.1/340001`
+* `device_id`: Enable mobile API extraction with an authentic device ID to be used with mobile API calls. Default is a random 19-digit string
 
 #### rokfinchannel
 * `tab`: Which tab to download - one of `new`, `top`, `videos`, `podcasts`, `streams`, `stacks`

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 import json
 import random
@@ -49,21 +50,21 @@ class TikTokBaseIE(InfoExtractor):
     _APP_INFO = None
     _APP_USER_AGENT = None
 
-    @property
+    @functools.cached_property
     def _KNOWN_APP_INFO(self):
         # If we have a genuine device ID, we may not need any IID
         default = [''] if self._KNOWN_DEVICE_ID else []
         return self._configuration_arg('app_info', default, ie_key=TikTokIE)
 
-    @property
+    @functools.cached_property
     def _KNOWN_DEVICE_ID(self):
         return self._configuration_arg('device_id', [None], ie_key=TikTokIE)[0]
 
-    @property
+    @functools.cached_property
     def _DEVICE_ID(self):
         return self._KNOWN_DEVICE_ID or str(random.randint(7250000000000000000, 7351147085025500000))
 
-    @property
+    @functools.cached_property
     def _API_HOSTNAME(self):
         return self._configuration_arg(
             'api_hostname', ['api16-normal-c-useast1a.tiktokv.com'], ie_key=TikTokIE)[0]

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -51,7 +51,7 @@ class TikTokBaseIE(InfoExtractor):
 
     @property
     def _KNOWN_APP_INFO(self):
-        # If we have an genuine device ID, we may not need any IID
+        # If we have a genuine device ID, we may not need any IID
         default = [''] if self._KNOWN_DEVICE_ID else []
         return self._configuration_arg('app_info', default, ie_key=TikTokIE)
 

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -2,7 +2,6 @@ import itertools
 import json
 import random
 import re
-import string
 import time
 import uuid
 

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -183,9 +183,8 @@ class TikTokBaseIE(InfoExtractor):
 
         max_tries = len(self._APP_INFO_POOL) + 1  # _APP_INFO_POOL + _APP_INFO
         for count in itertools.count(1):
+            self.write_debug(str(self._APP_INFO))
             real_query = self._build_api_query(query)
-            device_id = 'PRIVATE' if self._KNOWN_DEVICE_ID else real_query['device_id']
-            self.write_debug(str({**self._APP_INFO, 'device_id': device_id}))
             try:
                 return self._call_api_impl(ep, real_query, video_id, fatal, note, errnote)
             except ExtractorError as e:


### PR DESCRIPTION
Per https://github.com/yt-dlp/yt-dlp/issues/9506#issuecomment-2118378439, some success can be had with mobile API extraction if the user passes a genuine `device_id` instead of relying on the semi-random value the extractor uses. An `iid` may not even be necessary if the device ID is trusted; so this patch also enables API extraction when only a `device_id` is passed (and it then omits `iid` from the API call's query params).

The actual `device_id` can be found in the mobile app's settings screen, making this a much more user-friendly alternative to the `iid`.

Credit to @renandecarlo for discovering this.

Partially addresses #9506

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
