### PR TITLE
[ie/tiktok] Extract all web formats

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -440,7 +440,7 @@ class TikTokBaseIE(InfoExtractor):
                 'filesize': traverse_obj(bitrate_info, ('PlayAddr', 'DataSize', {int_or_none})),
             })
 
-            if dimension := res and int_or_none(res[:-1]):
+            if dimension := (res and int(res[:-1])):
                 if dimension == 540:  # '540p' is actually 576p
                     dimension = 576
                 if ratio < 1:  # portrait: res/dimension is width
@@ -463,8 +463,8 @@ class TikTokBaseIE(InfoExtractor):
                     'url': self._proto_relative_url(video_url),
                 })
 
-        play_quality = traverse_obj(
-            formats, (lambda _, v: v['width'] == width and v['vcodec'] == 'h264', 'quality', any))
+        # We don't have res string for play formats, but need quality for sorting & de-duplication
+        play_quality = traverse_obj(formats, (lambda _, v: v['width'] == width, 'quality', any))
 
         for play_url in traverse_obj(video_info, ('playAddr', ((..., 'src'), None), {url_or_none})):
             formats.append({

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1,4 +1,3 @@
-import functools
 import itertools
 import json
 import random


### PR DESCRIPTION
Extract all formats during webpage extraction, bringing web formats almost on par with the mobile API formats -- enough to close the linked issue, at least.

Notably, this patch changes the `format_id` of the previously-known sometimes-unwatermarked web format from `0` to `play` -- and `play` is usually removed as a duplicate of one of the `h264_res_bitrate` formats.

Closes #9506


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
