### PR TITLE
[build] `macos` job requires `setuptools<70`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ build = [
     "build",
     "hatchling",
     "pip",
+    "setuptools>=66.1.0,<70",
     "wheel",
 ]
 dev = [


### PR DESCRIPTION
Fixes [broken macOS builds](https://github.com/bashonly/yt-dlp/actions/runs/9180166463/job/25244391798) due to today's problematic release of setuptools 70.0.0.
Refs:
- https://github.com/pypa/setuptools/issues/4374
- https://github.com/pyinstaller/pyinstaller/issues/8554

We also need to specify `>=66.1.0` or else installing dependencies fails on Python 3.12.
Ref:
- https://github.com/pypa/setuptools/blob/main/NEWS.rst#v6610

> Fix improper usage of deprecated/removed `pkgutil` APIs in Python 3.12+.

[example of broken setuptools <66.1.0](https://github.com/bashonly/yt-dlp/actions/runs/9180939393/job/25246533378)

[successful example with this patch](https://github.com/bashonly/yt-dlp/actions/runs/9181173439)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
