### PR TITLE
[ie/soundcloud] Add `formats` extractor-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1841,6 +1841,9 @@ The following extractors use this feature:
 #### afreecatvlive
 * `cdn`: One or more CDN IDs to use with the API call for stream URLs, e.g. `gcp_cdn`, `gs_cdn_pc_app`, `gs_cdn_mobile_web`, `gs_cdn_pc_web`
 
+#### soundcloud
+* `formats`: Formats to request from the API. Requested values should be in the format of `{protocol}_{extension}`, e.g. `hls_opus,http_aac`. The `*` character functions as a wildcard, e.g. `*_mp3`, and can passed by itself to request all formats. Known protocols include `http`, `hls`, and `hls-aes`; known extensions include `aac`, `opus` and `mp3`. Original `download` formats are always extracted. Default is `http_aac,hls_aac,http_opus,hls_opus,http_mp3,hls_mp3`
+
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 
 <!-- MANPAGE: MOVE "INSTALLATION" SECTION HERE -->

--- a/README.md
+++ b/README.md
@@ -1842,7 +1842,7 @@ The following extractors use this feature:
 * `cdn`: One or more CDN IDs to use with the API call for stream URLs, e.g. `gcp_cdn`, `gs_cdn_pc_app`, `gs_cdn_mobile_web`, `gs_cdn_pc_web`
 
 #### soundcloud
-* `formats`: Formats to request from the API. Requested values should be in the format of `{protocol}_{extension}`, e.g. `hls_opus,http_aac`. The `*` character functions as a wildcard, e.g. `*_mp3`, and can passed by itself to request all formats. Known protocols include `http`, `hls`, and `hls-aes`; known extensions include `aac`, `opus` and `mp3`. Original `download` formats are always extracted. Default is `http_aac,hls_aac,http_opus,hls_opus,http_mp3,hls_mp3`
+* `formats`: Formats to request from the API. Requested values should be in the format of `{protocol}_{extension}` (omitting the bitrate), e.g. `hls_opus,http_aac`. The `*` character functions as a wildcard, e.g. `*_mp3`, and can passed by itself to request all formats. Known protocols include `http`, `hls` and `hls-aes`; known extensions include `aac`, `opus` and `mp3`. Original `download` formats are always extracted. Default is `http_aac,hls_aac,http_opus,hls_opus,http_mp3,hls_mp3`
 
 **Note**: These options may be changed/removed in the future without concern for backward compatibility
 

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 import json
 import re
@@ -12,6 +13,7 @@ from ..utils import (
     error_to_compat_str,
     float_or_none,
     int_or_none,
+    join_nonempty,
     mimetype2ext,
     parse_qs,
     str_or_none,
@@ -67,6 +69,16 @@ class SoundcloudBaseIE(InfoExtractor):
         't500x500': 500,
         'original': 0,
     }
+
+    _DEFAULT_FORMATS = ['http_aac', 'hls_aac', 'http_opus', 'hls_opus', 'http_mp3', 'hls_mp3']
+
+    @functools.cached_property
+    def _is_requested(self):
+        return re.compile(r'|'.join(set(
+            re.escape(pattern).replace(r'\*', r'.*') if pattern != 'default'
+            else '|'.join(map(re.escape, self._DEFAULT_FORMATS))
+            for pattern in self._configuration_arg('formats', ['default'], ie_key=SoundcloudIE)
+        ))).fullmatch
 
     def _store_client_id(self, client_id):
         self.cache.store('soundcloud', 'client_id', client_id)
@@ -216,7 +228,7 @@ class SoundcloudBaseIE(InfoExtractor):
             redirect_url = (self._download_json(download_url, track_id, fatal=False) or {}).get('redirectUri')
             if redirect_url:
                 urlh = self._request_webpage(
-                    HEADRequest(redirect_url), track_id, fatal=False)
+                    HEADRequest(redirect_url), track_id, 'Checking for original download format', fatal=False)
                 if urlh:
                     format_url = urlh.url
                     format_urls.add(format_url)
@@ -258,7 +270,7 @@ class SoundcloudBaseIE(InfoExtractor):
             abr = f.get('abr')
             if abr:
                 f['abr'] = int(abr)
-            if protocol == 'hls':
+            if protocol in ('hls', 'hls-aes'):
                 protocol = 'm3u8' if ext == 'aac' else 'm3u8_native'
             else:
                 protocol = 'http'
@@ -274,8 +286,27 @@ class SoundcloudBaseIE(InfoExtractor):
             if extract_flat:
                 break
             format_url = t['url']
-            stream = None
 
+            protocol = traverse_obj(t, ('format', 'protocol', {str}))
+            if protocol == 'progressive':
+                protocol = 'http'
+            if protocol != 'hls' and '/hls' in format_url:
+                protocol = 'hls'
+            if protocol == 'encrypted-hls' or '/encrypted-hls' in format_url:
+                protocol = 'hls-aes'
+
+            ext = None
+            if preset := traverse_obj(t, ('preset', {str_or_none})):
+                ext = preset.split('_')[0]
+            if ext not in KNOWN_EXTENSIONS:
+                ext = mimetype2ext(traverse_obj(t, ('format', 'mime_type', {str})))
+
+            identifier = join_nonempty(protocol, ext, delim='_')
+            if not self._is_requested(identifier):
+                self.write_debug(f'"{identifier}" is not a requested format, skipping')
+                continue
+
+            stream = None
             for retry in self.RetryManager(fatal=False):
                 try:
                     stream = self._download_json(format_url, track_id, query=query, headers=self._HEADERS)
@@ -289,27 +320,14 @@ class SoundcloudBaseIE(InfoExtractor):
                     else:
                         self.report_warning(e.msg)
 
-            if not isinstance(stream, dict):
-                continue
-            stream_url = url_or_none(stream.get('url'))
+            stream_url = traverse_obj(stream, ('url', {url_or_none}))
             if invalid_url(stream_url):
                 continue
             format_urls.add(stream_url)
-            stream_format = t.get('format') or {}
-            protocol = stream_format.get('protocol')
-            if protocol != 'hls' and '/hls' in format_url:
-                protocol = 'hls'
-            ext = None
-            preset = str_or_none(t.get('preset'))
-            if preset:
-                ext = preset.split('_')[0]
-            if ext not in KNOWN_EXTENSIONS:
-                ext = mimetype2ext(stream_format.get('mime_type'))
             add_format({
                 'url': stream_url,
                 'ext': ext,
-            }, 'http' if protocol == 'progressive' else protocol,
-                t.get('snipped') or '/preview/' in format_url)
+            }, protocol, t.get('snipped') or '/preview/' in format_url)
 
         for f in formats:
             f['vcodec'] = 'none'

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -309,7 +309,9 @@ class SoundcloudBaseIE(InfoExtractor):
             stream = None
             for retry in self.RetryManager(fatal=False):
                 try:
-                    stream = self._download_json(format_url, track_id, query=query, headers=self._HEADERS)
+                    stream = self._download_json(
+                        format_url, track_id, f'Downloading {identifier} format info JSON',
+                        query=query, headers=self._HEADERS)
                 except ExtractorError as e:
                     if isinstance(e.cause, HTTPError) and e.cause.status == 429:
                         self.report_warning(


### PR DESCRIPTION
The Soundcloud extractor needs to make an API call for every format available in order to extract the actual format URL (and other format metadata such as bitrate).

This is already a problem since this format endpoint has a rate-limit, and users frequently hit the rate-limit when extracting a playlist/batch of songs.

Ideally, [lazy info dict](https://github.com/yt-dlp/yt-dlp/pull/8512) would solve this problem. But now Soundcloud has introduced `encrypted-hls` (AES-128 HLS) formats, which are just dupes of the `hls` formats we already extract, so now every song makes almost double the requests to the rate-limited API endpoint.

Since lazy info dict still has a ways to go before merge, and since the `hls-aes` formats have severely compounded the problem, the best solution is to implement an extractor-arg to allow the user to configure which formats should actually be extracted.

`hls-aes` formats are excluded by default since they are dupes, but now users will be to request them if Soundcloud stops offering the unencrypted `hls` formats in the future.

Note: extracting the original/source quality `download` formats does not count towards the API rate-limit (it doesn't use the problematic endpoint) and therefore is not imapcted by this extractor-arg

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence): **co-authored by @Grub4K**

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
