### PR TITLE
[ie/crunchyroll:show] Implement language filter extractor arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1791,6 +1791,9 @@ The following extractors use this feature:
 #### crunchyrollbeta (Crunchyroll)
 * `hardsub`: One or more hardsub versions to extract (in order of preference), or `all` (default: `None` = no hardsubs will be extracted), e.g. `crunchyrollbeta:hardsub=en-US,de-DE`
 
+#### crunchyrollbetashow (Crunchyroll)
+* `language`: The language variants to extract, or `all` (default: `all`)
+
 #### vikichannel
 * `video_types`: Types of videos to download - one or more of `episodes`, `movies`, `clips`, `trailers`
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Speedup for language selection (`--match-filters language=ja-JP` => `--extractor-args crunchyrollbetashow:language=ja-jp`) as per [#9867 (comment)](<https://github.com/yt-dlp/yt-dlp/pull/9867#issuecomment-2108724484>).

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
