### PR TITLE
[build] Bump Pyinstaller to `>=6.7.0` for all builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,8 +267,7 @@ jobs:
             for dylib in lib{ssl,crypto}.3.dylib; do
               cp "${python_libdir}/${dylib}" "curl_cffi/.dylibs/${dylib}"
               for wheel in curl_cffi*macos*x86_64.whl; do
-                touch "curl_cffi/.dylibs/${dylib}"
-                zip -u "${wheel}" "curl_cffi/.dylibs/${dylib}"
+                zip "${wheel}" "curl_cffi/.dylibs/${dylib}"
               done
             done
           )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,8 +274,8 @@ jobs:
           python3 -m delocate.cmd.delocate_fuse curl_cffi_whls/curl_cffi*.whl -w curl_cffi_universal2
           python3 -m delocate.cmd.delocate_fuse curl_cffi_whls/cffi*.whl -w curl_cffi_universal2
           cd curl_cffi_universal2
-          for wheel in *cffi*.whl; do mv -n -- "${wheel}" "${wheel/x86_64/universal2}"; done
-          python3 -m pip install -U --user *cffi*.whl
+          for wheel in ./*cffi*.whl; do mv -n -- "${wheel}" "${wheel/x86_64/universal2}"; done
+          python3 -m pip install -U --user ./*cffi*.whl
 
       - name: Prepare
         run: |
@@ -322,7 +322,7 @@ jobs:
           # Hack to get the latest patch version. Uncomment if needed
           #brew install python@3.10
           #export PYTHON_VERSION=$( $(brew --prefix)/opt/python@3.10/bin/python3 --version | cut -d ' ' -f 2 )
-          curl https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macos11.pkg -o "python.pkg"
+          curl "https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macos11.pkg" -o "python.pkg"
           sudo installer -pkg python.pkg -target /
           python3 --version
       - name: Install Requirements
@@ -486,8 +486,8 @@ jobs:
         run: |
           cd ./artifact/
           # make sure SHA sums are also printed to stdout
-          sha256sum * | tee ../SHA2-256SUMS
-          sha512sum * | tee ../SHA2-512SUMS
+          sha256sum -- * | tee ../SHA2-256SUMS
+          sha512sum -- * | tee ../SHA2-512SUMS
 
       - name: Make Update spec
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,7 +361,7 @@ jobs:
         run: | # Custom pyinstaller built with https://github.com/yt-dlp/pyinstaller-builds
           python devscripts/install_deps.py -o --include build
           python devscripts/install_deps.py --include curl-cffi
-          python -m pip install -U "https://yt-dlp.github.io/Pyinstaller-Builds/x86_64/pyinstaller-5.8.0-py3-none-any.whl"
+          python -m pip install -U "https://yt-dlp.github.io/Pyinstaller-Builds/x86_64/pyinstaller-6.7.0-py3-none-any.whl"
 
       - name: Prepare
         run: |
@@ -421,7 +421,7 @@ jobs:
         run: |
           python devscripts/install_deps.py -o --include build
           python devscripts/install_deps.py
-          python -m pip install -U "https://yt-dlp.github.io/Pyinstaller-Builds/i686/pyinstaller-5.8.0-py3-none-any.whl"
+          python -m pip install -U "https://yt-dlp.github.io/Pyinstaller-Builds/i686/pyinstaller-6.7.0-py3-none-any.whl"
 
       - name: Prepare
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,7 @@ jobs:
               -r requirements.txt
           done
           ( # Overwrite x86_64-only libs with fat/universal2 libs or else Pyinstaller will do the opposite
+            # See https://github.com/yt-dlp/yt-dlp/pull/10069
             cd curl_cffi_whls
             mkdir -p curl_cffi/.dylibs
             python_libdir=$(python3 -c 'import sys; from pathlib import Path; print(Path(sys.path[1]).parent)')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,6 +260,18 @@ jobs:
               --pre -d curl_cffi_whls \
               -r requirements.txt
           done
+          (  # Overwrite x86_64-only libs with fat/universal2 libs or else Pyinstaller will do the opposite
+            cd curl_cffi_whls
+            mkdir -p curl_cffi/.dylibs
+            python_libdir=$(python3 -c 'import sys; from pathlib import Path; print(Path(sys.path[1]).parent)')
+            for dylib in lib{ssl,crypto}.3.dylib; do
+              cp "${python_libdir}/${dylib}" "curl_cffi/.dylibs/${dylib}"
+              for wheel in curl_cffi*macos*x86_64.whl; do
+                touch "curl_cffi/.dylibs/${dylib}"
+                zip -u "${wheel}" "curl_cffi/.dylibs/${dylib}"
+              done
+            done
+          )
           python3 -m delocate.cmd.delocate_fuse curl_cffi_whls/curl_cffi*.whl -w curl_cffi_universal2
           python3 -m delocate.cmd.delocate_fuse curl_cffi_whls/cffi*.whl -w curl_cffi_universal2
           cd curl_cffi_universal2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,7 +260,7 @@ jobs:
               --pre -d curl_cffi_whls \
               -r requirements.txt
           done
-          (  # Overwrite x86_64-only libs with fat/universal2 libs or else Pyinstaller will do the opposite
+          ( # Overwrite x86_64-only libs with fat/universal2 libs or else Pyinstaller will do the opposite
             cd curl_cffi_whls
             mkdir -p curl_cffi/.dylibs
             python_libdir=$(python3 -c 'import sys; from pathlib import Path; print(Path(sys.path[1]).parent)')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ build = [
     "build",
     "hatchling",
     "pip",
-    "setuptools>=66.1.0,<70",
+    "setuptools",
     "wheel",
 ]
 dev = [
@@ -78,8 +78,7 @@ test = [
     "pytest~=8.1",
 ]
 pyinstaller = [
-    "pyinstaller>=6.3; sys_platform!='darwin'",
-    "pyinstaller==5.13.2; sys_platform=='darwin'",  # needed for curl_cffi
+    "pyinstaller>=6.7.0",  # for compat with setuptools>=70
 ]
 py2exe = [
     "py2exe>=0.12",


### PR DESCRIPTION
This PR bumps the minimum required version of Pyinstaller to 6.7.0 for our build jobs (and for our users who wish to bundle yt-dlp themselves).

`setuptools` v70 was released last week and broke yt-dlp builds when using Pyinstaller <6.7:
- https://github.com/pyinstaller/pyinstaller/issues/8554

We had done a quick and dirty fix of pinning setuptools to `>=66.1,<70`, but this is untenable moving forward.

---

For the `macos` (universal2) builds, ever since including `curl-cffi`, we had to pin Pyinstaller to 5.13.2, since Pyinstaller >=6 produced "universal2" builds that did not actually work on arm64 architecture. I knew that this was the problem, but I didn't know exactly why. @seproDev further investigated this issue:

> The curl-cffi x86_64 wheels include `libssl.3.dylib` and `libcrypto.3.dylib` (OpenSSL 3.3.0). These dylibs are absent (among others) from the arm64 wheels.
> On fusing we now only have x86_64 versions of these libs and so can't create a fat lib containing both the arm64 and x86_64 code.
> Meaning our fused universal2 curl-cffi wheel contains some fat libraries, while others (including the OpenSSL ones) are x86_64 only.
> Pyinstaller can seemingly only pick a single version per lib and decides to pick the ones from curl-cffi for OpenSSL instead of the ones provided by python.
> This however means that the python runtime will also have to use the OpenSSL version shipped with curl-cffi, causing the builds to longer execute on arm64 as we are now trying to run x86_64 libs inside a arm64 application.
> Running the "broken" build through the x86 emulation layer it executes fine. 
> Why did this ever work to begin with? In older versions pyinstaller used openssl provided by python instead of the version provided by curl-cffi. 

This PR patches the `macos` build job so that we replace the libssl and libcrypto dylibs in the curl_cffi wheel with the fat libs that we need to work on both architectures.

---

Here's a successful build run:
https://github.com/bashonly/yt-dlp/actions/runs/9308327250/job/25621777998

The new `macos` and `windows` builds were tested on MacOS x64_64, MacOS arm64 and Windows 7.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence): **co-authored by @seproDev**

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
