### PR TITLE
[rh:requests] Bump minimum version requirement for `requests` to 2.32.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ You can also run `make yt-dlp` instead to compile only the binary without updati
 
 ### Standalone Py2Exe Builds (Windows)
 
-While we provide the option to build with [py2exe](https://www.py2exe.org), it is recommended to build [using PyInstaller](#standalone-pyinstaller-builds) instead since the py2exe builds **cannot contain `pycryptodomex`/`certifi` and need VC++14** on the target computer to run.
+While we provide the option to build with [py2exe](https://www.py2exe.org), it is recommended to build [using PyInstaller](#standalone-pyinstaller-builds) instead since the py2exe builds **cannot contain `pycryptodomex`/`certifi`/`requests` and need VC++14** on the target computer to run.
 
 If you wish to build it anyway, install Python (if it is not already installed) and you can run the following commands:
 

--- a/bundle/py2exe.py
+++ b/bundle/py2exe.py
@@ -42,9 +42,9 @@ def main():
                 # py2exe cannot import Crypto
                 'Crypto',
                 'Cryptodome',
-                # py2exe appears to confuse this with our socks library.
-                # We don't use pysocks and urllib3.contrib.socks would fail to import if tried.
-                'urllib3.contrib.socks'
+                # requests >=2.32.0 breaks py2exe builds due to certifi dependency
+                'requests',
+                'urllib3'
             ],
             'dll_excludes': ['w9xpopen.exe', 'crypt32.dll'],
             # Modules that are only imported dynamically must be added here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "certifi",
     "mutagen",
     "pycryptodomex",
-    "requests>=2.31.0,<3",
+    "requests>=2.32.2,<3",
     "urllib3>=1.26.17,<3",
     "websockets>=12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ pyinstaller = [
 ]
 py2exe = [
     "py2exe>=0.12",
-    "requests==2.31.*",
 ]
 
 [project.urls]

--- a/yt_dlp/networking/_requests.py
+++ b/yt_dlp/networking/_requests.py
@@ -21,8 +21,8 @@ urllib3_version = tuple(int_or_none(x, default=0) for x in urllib3.__version__.s
 if urllib3_version < (1, 26, 17):
     raise ImportError('Only urllib3 >= 1.26.17 is supported')
 
-if requests.__build__ < 0x023100:
-    raise ImportError('Only requests >= 2.31.0 is supported')
+if requests.__build__ < 0x023202:
+    raise ImportError('Only requests >= 2.32.2 is supported')
 
 import requests.adapters
 import requests.utils
@@ -186,7 +186,7 @@ class RequestsHTTPAdapter(requests.adapters.HTTPAdapter):
     def cert_verify(*args, **kwargs):
         pass
 
-    # requests 2.31.0-2.32.1
+    # requests 2.32.0-2.32.1
     def _get_connection(self, request, *_, proxies=None, **__):
         return self.get_connection(request.url, proxies)
 

--- a/yt_dlp/networking/_requests.py
+++ b/yt_dlp/networking/_requests.py
@@ -182,13 +182,8 @@ class RequestsHTTPAdapter(requests.adapters.HTTPAdapter):
         return super().proxy_manager_for(proxy, **proxy_kwargs, **self._pm_args, **extra_kwargs)
 
     # Skip `requests` internal verification; we use our own SSLContext
-    # requests 2.31.0+
     def cert_verify(*args, **kwargs):
         pass
-
-    # requests 2.32.0-2.32.1
-    def _get_connection(self, request, *_, proxies=None, **__):
-        return self.get_connection(request.url, proxies)
 
     # requests 2.32.2+: Reimplementation without `_urllib3_request_context`
     def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):


### PR DESCRIPTION
OpenSUSE's `python-requests` package breaks `requests` support in yt-dlp, and likely won't be the only one to do it. Details: https://github.com/yt-dlp/yt-dlp/issues/10078#issuecomment-2142640582

The only proper solution is to bump the minimum required version of `requests` to 2.32.2 with its new "stable" API.

This PR also removes `requests` from the `py2exe` builds, which are broken by `requests>2.31.0`. Newer versions try to load certifi's `cacert.pem` which throws a `FileNotFoundError`, since `certifi` is not (and cannot be) properly included in the py2exe builds. We never really should have been including `requests` in the py2exe builds anyways, since `requests` has had a hard dependency on `certifi` for as long as yt-dlp as supported `requests`.

A user-made build would also fail like in the linked issue if they are using system python packages and their `requests 2.31.0` is afflicted by a "creative" security backport like OpenSUSE's. 

Closes #10078


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
