### PR TITLE
[ie/podbayfm] Fix extraction

### DIFF
--- a/yt_dlp/extractor/podbayfm.py
+++ b/yt_dlp/extractor/podbayfm.py
@@ -1,16 +1,25 @@
 from .common import InfoExtractor
-from ..utils import OnDemandPagedList, int_or_none, jwt_decode_hs256, try_call
+from ..utils import (
+    OnDemandPagedList,
+    int_or_none,
+    jwt_decode_hs256,
+    url_or_none,
+)
+from ..utils.traversal import traverse_obj
 
 
-def result_from_props(props, episode_id=None):
+def result_from_props(props):
     return {
-        'id': props.get('podcast_id') or episode_id,
-        'title': props.get('title'),
-        'url': props['mediaURL'],
+        **traverse_obj(props, {
+            'id': ('_id', {str}),
+            'title': ('title', {str}),
+            'url': ('mediaURL', {url_or_none}),
+            'thumbnail': ('image', {jwt_decode_hs256}, 'url', {url_or_none}),
+            'timestamp': ('timestamp', {int_or_none}),
+            'duration': ('duration', {int_or_none}),
+        }),
         'ext': 'mp3',
-        'thumbnail': try_call(lambda: jwt_decode_hs256(props['image'])['url']),
-        'timestamp': props.get('timestamp'),
-        'duration': int_or_none(props.get('duration')),
+        'vcodec': 'none',
     }
 
 
@@ -18,9 +27,9 @@ class PodbayFMIE(InfoExtractor):
     _VALID_URL = r'https?://podbay\.fm/p/[^/]*/e/(?P<id>[^/]*)/?(?:[\?#].*)?$'
     _TESTS = [{
         'url': 'https://podbay.fm/p/behind-the-bastards/e/1647338400',
-        'md5': '98b41285dcf7989d105a4ed0404054cf',
+        'md5': '895ac8505de349515f5ee8a4a3195c93',
         'info_dict': {
-            'id': '1647338400',
+            'id': '62306451f4a48e58d0c4d6a8',
             'title': 'Part One: Kissinger',
             'ext': 'mp3',
             'thumbnail': r're:^https?://.*\.jpg',
@@ -34,7 +43,7 @@ class PodbayFMIE(InfoExtractor):
         episode_id = self._match_id(url)
         webpage = self._download_webpage(url, episode_id)
         data = self._search_nextjs_data(webpage, episode_id)
-        return result_from_props(data['props']['pageProps']['episode'], episode_id)
+        return result_from_props(data['props']['pageProps']['episode'])
 
 
 class PodbayFMChannelIE(InfoExtractor):
@@ -45,13 +54,14 @@ class PodbayFMChannelIE(InfoExtractor):
             'id': 'behind-the-bastards',
             'title': 'Behind the Bastards',
         },
+        'playlist_mincount': 21,
     }]
     _PAGE_SIZE = 10
 
     def _fetch_page(self, channel_id, pagenum):
         return self._download_json(
             f'https://podbay.fm/api/podcast?reverse=true&page={pagenum}&slug={channel_id}',
-            channel_id)['podcast']
+            f'Downloading channel JSON page {pagenum + 1}', channel_id)['podcast']
 
     @staticmethod
     def _results_from_page(channel_id, page):

--- a/yt_dlp/extractor/podbayfm.py
+++ b/yt_dlp/extractor/podbayfm.py
@@ -47,7 +47,7 @@ class PodbayFMIE(InfoExtractor):
 
 
 class PodbayFMChannelIE(InfoExtractor):
-    _VALID_URL = r'https?://podbay\.fm/p/(?P<id>[^/?#]+)'
+    _VALID_URL = r'https?://podbay\.fm/p/(?P<id>[^/?#]+)/?(?:$|[?#])'
     _TESTS = [{
         'url': 'https://podbay.fm/p/behind-the-bastards',
         'info_dict': {

--- a/yt_dlp/extractor/podbayfm.py
+++ b/yt_dlp/extractor/podbayfm.py
@@ -1,6 +1,7 @@
 from .common import InfoExtractor
 from ..utils import (
     OnDemandPagedList,
+    clean_html,
     int_or_none,
     jwt_decode_hs256,
     url_or_none,
@@ -14,6 +15,7 @@ def result_from_props(props):
             'id': ('_id', {str}),
             'title': ('title', {str}),
             'url': ('mediaURL', {url_or_none}),
+            'description': ('description', {clean_html}),
             'thumbnail': ('image', {jwt_decode_hs256}, 'url', {url_or_none}),
             'timestamp': ('timestamp', {int_or_none}),
             'duration': ('duration', {int_or_none}),
@@ -32,6 +34,7 @@ class PodbayFMIE(InfoExtractor):
             'id': '62306451f4a48e58d0c4d6a8',
             'title': 'Part One: Kissinger',
             'ext': 'mp3',
+            'description': r're:^We begin our epic six part series on Henry Kissinger.+',
             'thumbnail': r're:^https?://.*\.jpg',
             'timestamp': 1647338400,
             'duration': 5001,

--- a/yt_dlp/extractor/podbayfm.py
+++ b/yt_dlp/extractor/podbayfm.py
@@ -24,7 +24,7 @@ def result_from_props(props):
 
 
 class PodbayFMIE(InfoExtractor):
-    _VALID_URL = r'https?://podbay\.fm/p/[^/]*/e/(?P<id>[^/]*)/?(?:[\?#].*)?$'
+    _VALID_URL = r'https?://podbay\.fm/p/[^/?#]+/e/(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://podbay.fm/p/behind-the-bastards/e/1647338400',
         'md5': '895ac8505de349515f5ee8a4a3195c93',
@@ -47,7 +47,7 @@ class PodbayFMIE(InfoExtractor):
 
 
 class PodbayFMChannelIE(InfoExtractor):
-    _VALID_URL = r'https?://podbay\.fm/p/(?P<id>[^/]*)/?(?:[\?#].*)?$'
+    _VALID_URL = r'https?://podbay\.fm/p/(?P<id>[^/?#]+)'
     _TESTS = [{
         'url': 'https://podbay.fm/p/behind-the-bastards',
         'info_dict': {


### PR DESCRIPTION
The `id` that was being extracted was not unique, and the `id`s we were extracting with the channel extractor were completely wrong.

These URLs would result in `id` collision with the single podcast extractor:
```
https://podbay.fm/p/the-rest-is-history-667328/e/1704067800
https://podbay.fm/p/leading-682335/e/1704067800
```

And here's what the channel extractor used to do:
```shell
$ yt-dlp -I1-9 --print id "https://podbay.fm/p/behind-the-bastards"
1373812661
1373812661
1373812661
1373812661
1373812661
1373812661
1373812661
1373812661
1373812661
```


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence): co-authored by @seproDev 

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
