### PR TITLE
[ie/tiktok] Fix API extraction

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -212,7 +212,7 @@ class TikTokBaseIE(InfoExtractor):
                 'multi/aweme/detail', {}, aweme_id, data=urlencode_postdata({
                     'aweme_ids': f'[{aweme_id}]',
                     'request_source': '0',
-                }), note='Downloading video feed', errnote='Unable to download video feed'),
+                }), note='Downloading aweme detail JSON', errnote='Unable to download aweme detail JSON'),
             ('aweme_details', 0, {dict}))
         if not aweme_detail:
             raise ExtractorError('Unable to find video in feed', video_id=aweme_id)

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -121,8 +121,6 @@ class TikTokBaseIE(InfoExtractor):
         webpage_cookies = self._get_cookies(self._WEBPAGE_HOST)
         if webpage_cookies.get('sid_tt'):
             self._set_cookie(self._API_HOSTNAME, 'sid_tt', webpage_cookies['sid_tt'].value)
-        if data is not None:
-            data = urlencode_postdata(data)
         return self._download_json(
             f'https://{self._API_HOSTNAME}/aweme/v1/{ep}/', video_id=video_id,
             fatal=fatal, note=note, errnote=errnote, headers={
@@ -211,10 +209,10 @@ class TikTokBaseIE(InfoExtractor):
     def _extract_aweme_app(self, aweme_id):
         aweme_detail = traverse_obj(
             self._call_api(
-                'multi/aweme/detail', {}, aweme_id, data={
+                'multi/aweme/detail', {}, aweme_id, data=urlencode_postdata({
                     'aweme_ids': f'[{aweme_id}]',
                     'request_source': '0',
-                }, note='Downloading video feed', errnote='Unable to download video feed'),
+                }), note='Downloading video feed', errnote='Unable to download video feed'),
             ('aweme_details', 0, {dict}))
         if not aweme_detail:
             raise ExtractorError('Unable to find video in feed', video_id=aweme_id)


### PR DESCRIPTION
Credit to @valsoray-dev for figuring this out

The API still requires an `iid` (to be provided by the user w/ the `app_info` extractor-arg), but at least now it will work at all.

Closes #10213


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
