### PR TITLE
[test:download] Raise on network errors

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -20,7 +20,6 @@ from test.helper import (
     gettestcases,
     getwebpagetestcases,
     is_download_test,
-    report_warning,
     try_rm,
 )
 
@@ -178,8 +177,7 @@ def generator(test_case, tname):
                         raise
 
                     if try_num == RETRIES:
-                        report_warning(f'{tname} failed due to network errors, skipping...')
-                        return
+                        raise
 
                     print(f'Retrying: {try_num} failed tries\n\n##########\n\n')
 


### PR DESCRIPTION
It was recently brought to my attention that download test network errors (e.g. cert errors raised during extractor requests) are being silently ignored by pytest: https://github.com/yt-dlp/yt-dlp/pull/10268#discussion_r1657872204 

@seproDev dug into this and found dd508b7c4f0dd8881de07a4e8593d4fcdef9bae7, which clarifies that this retry+warn+pass behavior was intended for the ytdl CI and not for extractor development. 

Since this warn+pass behavior is actually detrimental to extractor dev, this PR partially reverts that commit so that network errors will again raise when the retries are exhausted.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence): co-authored by @seproDev 

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
