### PR TITLE
[ie/youtube] Invalidate nsig cache from < 2024.07.09

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3142,7 +3142,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
     def _extract_n_function_code(self, video_id, player_url):
         player_id = self._extract_player_info(player_url)
-        func_code = self.cache.load('youtube-nsig', player_id, min_ver='2022.09.1')
+        func_code = self.cache.load('youtube-nsig', player_id, min_ver='2024.07.09')
         jscode = func_code or self._load_player(video_id, player_url)
         jsi = JSInterpreter(jscode)
 


### PR DESCRIPTION
The nsig breakage tracked in #10391 was only partially fixed by 6c056ea7aeb03660281653a9668547f2548f194f and 297b0a379282a15c80d82d51f3757c961db2dae1, at which point version 2024.07.08 was released. With only these two fixes applied, yt-dlp would cache improperly extracted JS code to disk.

Shortly after 2024.07.08 was released, 7ead7332af69422cee931aec3faa277288e9e212 was applied, which actually fixed the nsig breakage and fixed the problem with yt-dlp storing incorrect cache data. This patch was included in the 2024.07.09 release.

The problem is that any user who had updated to version 2024.07.08 (or its equivalent nightly or master releases) may have had yt-dlp store bad nsig function data in their cache, and they will continue to experience nsig breakage even after updating to >=2024.07.09 due to yt-dlp loading the nsig function from cache instead of extracting it anew.

We can fix this by invalidating player cache for all versions older than 2024.07.09. Note: there has not (yet) been a nightly release for 2024.07.09, and there has only been 1 master release (so far) on 2024.07.09 which included 7ead7332af69422cee931aec3faa277288e9e212.



<details open><summary>Template</summary> <!-- OPEN is intentional -->



### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
