### PR TITLE
[tnaflix] Fix 2 url detection issues

### DIFF
--- a/yt_dlp/extractor/tnaflix.py
+++ b/yt_dlp/extractor/tnaflix.py
@@ -221,7 +221,7 @@ class TNAEMPFlixBaseIE(TNAFlixNetworkBaseIE):
 
 
 class TNAFlixIE(TNAEMPFlixBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?(?P<host>tnaflix)\.com/[^/]+/(?P<display_id>[^/]+)/video(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:(morigin|m|www)\.)?(?P<host>tnaflix)\.com/(?:[^/]+/){1,2}(?P<display_id>[^/]+)/video(?P<id>\d+)'
 
     _TITLE_REGEX = r'<title>(.+?) - (?:TNAFlix Porn Videos|TNAFlix\.com)</title>'
 
@@ -234,6 +234,7 @@ class TNAFlixIE(TNAEMPFlixBaseIE):
             'display_id': 'Carmella-Decesare-striptease',
             'ext': 'mp4',
             'title': 'Carmella Decesare - striptease',
+            'description': 'No description provided',
             'thumbnail': r're:https?://.*\.jpg$',
             'duration': 91,
             'age_limit': 18,
@@ -252,7 +253,20 @@ class TNAFlixIE(TNAEMPFlixBaseIE):
             'thumbnail': r're:https?://.*\.jpg$',
             'duration': 164,
             'age_limit': 18,
-            'uploader': 'bobwhite39',
+            'categories': list,
+        },
+    }, {
+        'url': 'https://morigin.tnaflix.com/he/amateur-porn/Dirty-minded-girl-is-very-hot/video11310952',
+        'md5': 'b5a5da17899a3ab929586be5450f7adc',
+        'info_dict': {
+            'id': '11310952',
+            'display_id': 'Dirty-minded-girl-is-very-hot',
+            'ext': 'mp4',
+            'thumbnail': r're:https?://.*\.jpg$',
+            'age_limit': 18,
+            'title': 'Dirty minded girl is very hot',
+            'description': 'md5:69631ce458c36cd631be55121a9630f1',
+            'duration': 322,
             'categories': list,
         },
     }, {


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

URLs under tnaflix.com were not being detected by the extractor if they had a subdomain (`m` and `morigin` are both working, and are offered in different contexts. Similarly, localized URLs (2-letter localization as a path part before the category) also were not detected. I updated the regex to pick these up, added a test case, and tweaked the other test-cases to deal with site drift.

Fixes #9769 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
