### PR TITLE
Bugfix for #10407: Alternative way to access room_id for TikTok lives

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -457,7 +457,7 @@ class TikTokBaseIE(InfoExtractor):
             'thumbnails': thumbnails,
             'duration': (traverse_obj(video_info, (
                 (None, 'download_addr'), 'duration', {functools.partial(int_or_none, scale=1000)}, any))
-                or traverse_obj(music_info, ('duration', {int_or_none}))),
+                         or traverse_obj(music_info, ('duration', {int_or_none}))),
             'availability': self._availability(
                 is_private='Private' in labels,
                 needs_subscription='Friends only' in labels,
@@ -1462,7 +1462,7 @@ class TikTokLiveIE(TikTokBaseIE):
             # first traverse_obj appears to be deprecated, but remains for now to ensure backwards compatability
             room_id = (traverse_obj(data, ('UserModule', 'users', ..., 'roomId', {str_or_none}), get_all=False)
                        or self._search_regex(r'snssdk\d*://live\?room_id=(\d+)', webpage, 'room ID', default=None)
-                       or (traverse_obj(data, ('LiveRoom', "liveRoomUserInfo", "user", "roomId"), get_all=False))
+                       or (traverse_obj(data, ('LiveRoom', 'liveRoomUserInfo', 'user', 'roomId'), get_all=False))
                        or room_id)
             uploader = uploader or traverse_obj(
                 data, ('LiveRoom', 'liveRoomUserInfo', 'user', 'uniqueId'),

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1462,8 +1462,8 @@ class TikTokLiveIE(TikTokBaseIE):
             # first traverse_obj appears to be deprecated, but remains for now to ensure backwards compatability
             room_id = (traverse_obj(data, ('UserModule', 'users', ..., 'roomId', {str_or_none}), get_all=False)
                        or self._search_regex(r'snssdk\d*://live\?room_id=(\d+)', webpage, 'room ID', default=None)
-                       or room_id
-                       or (traverse_obj(data, ('LiveRoom', "liveRoomUserInfo", "user", "roomId"), get_all=False)))
+                       or (traverse_obj(data, ('LiveRoom', "liveRoomUserInfo", "user", "roomId"), get_all=False))
+                       or room_id)
             uploader = uploader or traverse_obj(
                 data, ('LiveRoom', 'liveRoomUserInfo', 'user', 'uniqueId'),
                 ('UserModule', 'users', ..., 'uniqueId'), get_all=False, expected_type=str)

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -457,7 +457,7 @@ class TikTokBaseIE(InfoExtractor):
             'thumbnails': thumbnails,
             'duration': (traverse_obj(video_info, (
                 (None, 'download_addr'), 'duration', {functools.partial(int_or_none, scale=1000)}, any))
-                         or traverse_obj(music_info, ('duration', {int_or_none}))),
+                or traverse_obj(music_info, ('duration', {int_or_none}))),
             'availability': self._availability(
                 is_private='Private' in labels,
                 needs_subscription='Friends only' in labels,
@@ -1458,12 +1458,11 @@ class TikTokLiveIE(TikTokBaseIE):
 
         if webpage:
             data = self._get_sigi_state(webpage, uploader or room_id)
-
-            # first traverse_obj appears to be deprecated, but remains for now to ensure backwards compatability
-            room_id = (traverse_obj(data, ('UserModule', 'users', ..., 'roomId', {str_or_none}), get_all=False)
-                       or self._search_regex(r'snssdk\d*://live\?room_id=(\d+)', webpage, 'room ID', default=None)
-                       or (traverse_obj(data, ('LiveRoom', 'liveRoomUserInfo', 'user', 'roomId'), get_all=False))
-                       or room_id)
+            room_id = (
+                traverse_obj(data, ((
+                    ('LiveRoom', 'liveRoomUserInfo', 'user'),
+                    ('UserModule', 'users', ...)), 'roomId', {str}, any))
+                or self._search_regex(r'snssdk\d*://live\?room_id=(\d+)', webpage, 'room ID', default=room_id))
             uploader = uploader or traverse_obj(
                 data, ('LiveRoom', 'liveRoomUserInfo', 'user', 'uniqueId'),
                 ('UserModule', 'users', ..., 'uniqueId'), get_all=False, expected_type=str)

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1458,9 +1458,12 @@ class TikTokLiveIE(TikTokBaseIE):
 
         if webpage:
             data = self._get_sigi_state(webpage, uploader or room_id)
+
+            # first traverse_obj appears to be deprecated, but remains for now to ensure backwards compatability
             room_id = (traverse_obj(data, ('UserModule', 'users', ..., 'roomId', {str_or_none}), get_all=False)
                        or self._search_regex(r'snssdk\d*://live\?room_id=(\d+)', webpage, 'room ID', default=None)
-                       or room_id)
+                       or room_id
+                       or (traverse_obj(data, ('LiveRoom', "liveRoomUserInfo", "user", "roomId"), get_all=False)))
             uploader = uploader or traverse_obj(
                 data, ('LiveRoom', 'liveRoomUserInfo', 'user', 'uniqueId'),
                 ('UserModule', 'users', ..., 'uniqueId'), get_all=False, expected_type=str)


### PR DESCRIPTION
### Fixes https://github.com/yt-dlp/yt-dlp/issues/10407

Adds the described (backwards compatible) way to access the room_id for TikTok lives.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
