### PR TITLE
[build] Pin `curl_cffi` to 0.5.10 for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,7 +468,7 @@ jobs:
       - name: Install Requirements
         run: |
           python devscripts/install_deps.py -o --include build
-          python devscripts/install_deps.py --include curl-cffi
+          python devscripts/install_deps.py
           python -m pip install -U "https://yt-dlp.github.io/Pyinstaller-Builds/i686/pyinstaller-6.7.0-py3-none-any.whl"
 
       - name: Prepare

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following provide support for impersonating browser requests. This may be re
 
 * [**curl_cffi**](https://github.com/yifeikong/curl_cffi) (recommended) - Python binding for [curl-impersonate](https://github.com/lwthiker/curl-impersonate). Provides impersonation targets for Chrome, Edge and Safari. Licensed under [MIT](https://github.com/yifeikong/curl_cffi/blob/main/LICENSE)
   * Can be installed with the `curl-cffi` group, e.g. `pip install "yt-dlp[default,curl-cffi]"`
-  * Currently included in `yt-dlp.exe`, `yt-dlp_x86.exe`, `yt-dlp_linux` and `yt-dlp_macos` builds
+  * Currently included in `yt-dlp.exe`, `yt-dlp_linux` and `yt-dlp_macos` builds
 
 
 ### Metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
 [project.optional-dependencies]
 default = []
 curl-cffi = [
-    "curl-cffi>=0.5.10,!=0.6.*,<0.8; implementation_name=='cpython'",
+    "curl-cffi==0.5.10; os_name=='nt' and implementation_name=='cpython'",
+    "curl-cffi>=0.5.10,!=0.6.*,<0.8; os_name!='nt' and implementation_name=='cpython'",
 ]
 secretstorage = [
     "cffi",


### PR DESCRIPTION
curl_cffi 0.7.0 does not work under Windows 7 and will cause yt-dlp to crash. The crash occurs with both the `win_exe` and Python installations. It appears to be an issue with curl_cffi's forked curl-impersonate library, see: https://github.com/yifeikong/curl-impersonate/issues/72

Until that issue is resolved on curl_cffi's end, or until we [drop support for Windows 7](https://github.com/yt-dlp/yt-dlp/issues/10086) in October/November, we'll need to pin `curl_cffi` to version 0.5.10 for Windows. A side effect of this is the complete removal of curl_cffi from the `yt-dlp_x86.exe` builds, since version 0.5.10 doesn't support 32-bit Windows (while 0.7.X does).

Closes #10426


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
