### PR TITLE
[ie/afreecatv] Fix login and use `legacy_ssl`

### DIFF
--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -33,7 +33,8 @@ class AfreecaTVBaseIE(InfoExtractor):
 
         response = self._download_json(
             'https://login.afreecatv.com/app/LoginAction.php', None,
-            'Logging in', data=urlencode_postdata(login_form))
+            'Logging in', data=urlencode_postdata(login_form),
+            impersonate=not self.get_param('legacyserverconnect'))
 
         _ERRORS = {
             -4: 'Your account has been suspended due to a violation of our terms and policies.',
@@ -189,7 +190,7 @@ class AfreecaTVIE(AfreecaTVBaseIE):
             headers={'Referer': url}, data=urlencode_postdata({
                 'nTitleNo': video_id,
                 'nApiLevel': 10,
-            }), impersonate=True)['data']
+            }), impersonate=not self.get_param('legacyserverconnect'))['data']
 
         error_code = traverse_obj(data, ('code', {int}))
         if error_code == -6221:
@@ -269,7 +270,8 @@ class AfreecaTVCatchStoryIE(AfreecaTVBaseIE):
         video_id = self._match_id(url)
         data = self._download_json(
             'https://api.m.afreecatv.com/catchstory/a/view', video_id, headers={'Referer': url},
-            query={'aStoryListIdx': '', 'nStoryIdx': video_id}, impersonate=True)
+            query={'aStoryListIdx': '', 'nStoryIdx': video_id},
+            impersonate=not self.get_param('legacyserverconnect'))
 
         return self.playlist_result(self._entries(data), video_id)
 

--- a/yt_dlp/extractor/afreecatv.py
+++ b/yt_dlp/extractor/afreecatv.py
@@ -20,6 +20,10 @@ from ..utils.traversal import traverse_obj
 class AfreecaTVBaseIE(InfoExtractor):
     _NETRC_MACHINE = 'afreecatv'
 
+    @property
+    def is_impersonation_needed(self):
+        return not self.get_param('legacyserverconnect')
+
     def _perform_login(self, username, password):
         login_form = {
             'szWork': 'login',
@@ -34,7 +38,7 @@ class AfreecaTVBaseIE(InfoExtractor):
         response = self._download_json(
             'https://login.afreecatv.com/app/LoginAction.php', None,
             'Logging in', data=urlencode_postdata(login_form),
-            impersonate=not self.get_param('legacyserverconnect'))
+            impersonate=self.is_impersonation_needed)
 
         _ERRORS = {
             -4: 'Your account has been suspended due to a violation of our terms and policies.',
@@ -190,7 +194,7 @@ class AfreecaTVIE(AfreecaTVBaseIE):
             headers={'Referer': url}, data=urlencode_postdata({
                 'nTitleNo': video_id,
                 'nApiLevel': 10,
-            }), impersonate=not self.get_param('legacyserverconnect'))['data']
+            }), impersonate=self.is_impersonation_needed)['data']
 
         error_code = traverse_obj(data, ('code', {int}))
         if error_code == -6221:
@@ -271,7 +275,7 @@ class AfreecaTVCatchStoryIE(AfreecaTVBaseIE):
         data = self._download_json(
             'https://api.m.afreecatv.com/catchstory/a/view', video_id, headers={'Referer': url},
             query={'aStoryListIdx': '', 'nStoryIdx': video_id},
-            impersonate=not self.get_param('legacyserverconnect'))
+            impersonate=self.is_impersonation_needed)
 
         return self.playlist_result(self._entries(data), video_id)
 


### PR DESCRIPTION
**EDIT**: Since 150ecc45d9cacc919550c13b04fd998ac5103a6b has been merged and a `legacy_ssl` request extension has been implemented, we can leverage that instead of impersonation and fix the login regression in a much simpler way.

The old/outdated PR description is below

---

Currently, afreecatv is not actually performing any TLS fingerprinting, they are just using SSL ciphers that are incompatible with any request handler other than curl_cffi. We were using `impersonate=True` with some of these extractors' API requests so that the user doesn't need to manually pass `--legacy-server-connect`. (The only alternative was downgrading these API requests to `http:`, which was not a viable solution since account session cookies are passed with these requests.)

We were not using impersonation/curl_cffi with the login request, though, since the login endpoint wasn't using the incompatible ciphers. But the session cookies being set by the login request (made by urllib/requests) were not being passed with the subsequent impersonate/curl_cffi request to the VOD API endpoint. If we change the login request to use impersonation/curl_cffi, then the session cookies are passed with the subsequent impersonate/curl_cffi request. I'm assuming that there is some discrepancy between how session cookies are stored in the cookiejar with the `urllib` & `requests` request handlers and how the `curl_cffi` RH stores the session cookies.

This PR fixes this issue at the extractor level, since I'm currently unable to figure out the exact problem with core cookie handling.

Closes #10438


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
