### PR TITLE
[networking] Add support for zstandard content-encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ curl-cffi = [
     "curl-cffi==0.5.10; os_name=='nt' and implementation_name=='cpython'",
     "curl-cffi>=0.5.10,!=0.6.*,<0.8; os_name!='nt' and implementation_name=='cpython'",
 ]
+zstd = [
+    "zstandard>=0.22.0",
+]
 secretstorage = [
     "cffi",
     "secretstorage",

--- a/yt_dlp/dependencies/__init__.py
+++ b/yt_dlp/dependencies/__init__.py
@@ -22,6 +22,10 @@ else:
     if not _path_exists(certifi.where()):
         certifi = None
 
+try:
+    import zstandard
+except ImportError:
+    zstandard = None
 
 try:
     import mutagen

--- a/yt_dlp/networking/_curlcffi.py
+++ b/yt_dlp/networking/_curlcffi.py
@@ -29,7 +29,7 @@ if curl_cffi is None:
     raise ImportError('curl_cffi is not installed')
 
 
-curl_cffi_version = tuple(map(int, re.split(r'[^\d]+', curl_cffi.__version__)[:3]))
+curl_cffi_version = tuple(map(int, re.split(r'\D+', curl_cffi.__version__)[:3]))
 
 if curl_cffi_version != (0, 5, 10) and not ((0, 7, 0) <= curl_cffi_version < (0, 8, 0)):
     curl_cffi._yt_dlp__version = f'{curl_cffi.__version__} (unsupported)'

--- a/yt_dlp/networking/_requests.py
+++ b/yt_dlp/networking/_requests.py
@@ -8,7 +8,7 @@ import re
 import socket
 import warnings
 
-from ..dependencies import brotli, requests, urllib3
+from ..dependencies import requests, urllib3
 from ..utils import bug_reports_message, int_or_none, variadic
 from ..utils.networking import normalize_url
 
@@ -59,12 +59,7 @@ from .exceptions import (
 )
 from ..socks import ProxyError as SocksProxyError
 
-SUPPORTED_ENCODINGS = [
-    'gzip', 'deflate',
-]
-
-if brotli is not None:
-    SUPPORTED_ENCODINGS.append('br')
+SUPPORTED_ENCODINGS = urllib3.util.request.ACCEPT_ENCODING.split(',')
 
 '''
 Override urllib3's behavior to not convert lower-case percent-encoded characters
@@ -259,7 +254,6 @@ class RequestsRH(RequestHandler, InstanceStoreMixin):
     https://github.com/psf/requests
     """
     _SUPPORTED_URL_SCHEMES = ('http', 'https')
-    _SUPPORTED_ENCODINGS = tuple(SUPPORTED_ENCODINGS)
     _SUPPORTED_PROXY_SCHEMES = ('http', 'https', 'socks4', 'socks4a', 'socks5', 'socks5h')
     _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
     RH_NAME = 'requests'


### PR DESCRIPTION
Supported by urllib/requests/curl_cffi

Closes #9525 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [X] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
