### PR TITLE
[ie/tva] Fix extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2169,10 +2169,7 @@ from .tv5unis import (
     TV5UnisVideoIE,
 )
 from .tv24ua import TV24UAVideoIE
-from .tva import (
-    TVAIE,
-    QubIE,
-)
+from .tva import TVAIE
 from .tvanouvelles import (
     TVANouvellesArticleIE,
     TVANouvellesIE,

--- a/yt_dlp/extractor/tva.py
+++ b/yt_dlp/extractor/tva.py
@@ -49,9 +49,6 @@ class TVAIE(InfoExtractor):
             'series': 'Le Baiser du barbu',
             'channel': 'TVA',
         },
-    }, {
-        'url': 'https://www.qub.ca/tele/video/lcn-ca-vous-regarde-rev-30s-ap369664-1009357943',
-        'only_matching': True,
     }]
     _BC_URL_TMPL = 'https://players.brightcove.net/5481942443001/default_default/index.html?videoId={}'
 

--- a/yt_dlp/extractor/tva.py
+++ b/yt_dlp/extractor/tva.py
@@ -1,60 +1,29 @@
 import functools
 import re
 
+from .brightcove import BrightcoveNewIE
 from .common import InfoExtractor
 from ..utils import float_or_none, int_or_none, smuggle_url, strip_or_none
 from ..utils.traversal import traverse_obj
 
 
 class TVAIE(InfoExtractor):
-    _VALID_URL = r'https?://videos?\.tva\.ca/details/_(?P<id>\d+)'
-    _TESTS = [{
-        'url': 'https://videos.tva.ca/details/_5596811470001',
-        'info_dict': {
-            'id': '5596811470001',
-            'ext': 'mp4',
-            'title': 'Un extrait de l\'épisode du dimanche 8 octobre 2017 !',
-            'uploader_id': '5481942443001',
-            'upload_date': '20171003',
-            'timestamp': 1507064617,
-        },
-        'params': {
-            # m3u8 download
-            'skip_download': True,
-        },
-        'skip': 'HTTP Error 404: Not Found',
-    }, {
-        'url': 'https://video.tva.ca/details/_5596811470001',
-        'only_matching': True,
-    }]
-    BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/5481942443001/default_default/index.html?videoId=%s'
-
-    def _real_extract(self, url):
-        video_id = self._match_id(url)
-
-        return {
-            '_type': 'url_transparent',
-            'id': video_id,
-            'url': smuggle_url(self.BRIGHTCOVE_URL_TEMPLATE % video_id, {'geo_countries': ['CA']}),
-            'ie_key': 'BrightcoveNew',
-        }
-
-
-class QubIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?qub\.ca/(?:[^/]+/)*[0-9a-z-]+-(?P<id>\d+)'
+    IE_NAME = 'tvaplus'
+    IE_DESC = 'TVA+'
+    _VALID_URL = r'https?://(?:www\.)?(?:qub|tvaplus)\.ca/(?:[^/?#]+/)*[\w-]+-(?P<id>\d+)(?:$|[#?])'
     _TESTS = [{
         'url': 'https://www.qub.ca/tvaplus/tva/alerte-amber/saison-1/episode-01-1000036619',
         'md5': '949490fd0e7aee11d0543777611fbd53',
         'info_dict': {
             'id': '6084352463001',
             'ext': 'mp4',
-            'title': 'Ép 01. Mon dernier jour',
+            'title': 'Mon dernier jour',
             'uploader_id': '5481942443001',
             'upload_date': '20190907',
             'timestamp': 1567899756,
             'description': 'md5:9c0d7fbb90939420c651fd977df90145',
             'thumbnail': r're:https://.+\.jpg',
-            'episode': 'Ép 01. Mon dernier jour',
+            'episode': 'Mon dernier jour',
             'episode_number': 1,
             'tags': ['alerte amber', 'alerte amber saison 1', 'surdemande'],
             'duration': 2625.963,
@@ -64,23 +33,39 @@ class QubIE(InfoExtractor):
             'channel': 'TVA',
         },
     }, {
+        'url': 'https://www.tvaplus.ca/tva/le-baiser-du-barbu/le-baiser-du-barbu-886644190',
+        'info_dict': {
+            'id': '6354448043112',
+            'ext': 'mp4',
+            'title': 'Le Baiser du barbu',
+            'uploader_id': '5481942443001',
+            'upload_date': '20240606',
+            'timestamp': 1717694023,
+            'description': 'md5:025b1219086c1cbf4bc27e4e034e8b57',
+            'thumbnail': r're:https://.+\.jpg',
+            'episode': 'Le Baiser du barbu',
+            'tags': ['fullepisode', 'films'],
+            'duration': 6053.504,
+            'series': 'Le Baiser du barbu',
+            'channel': 'TVA',
+        },
+    }, {
         'url': 'https://www.qub.ca/tele/video/lcn-ca-vous-regarde-rev-30s-ap369664-1009357943',
         'only_matching': True,
     }]
-    # reference_id also works with old account_id(5481942443001)
-    # BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/5813221784001/default_default/index.html?videoId=ref:%s'
+    _BC_URL_TMPL = 'https://players.brightcove.net/5481942443001/default_default/index.html?videoId={}'
 
     def _real_extract(self, url):
         entity_id = self._match_id(url)
         webpage = self._download_webpage(url, entity_id)
-        entity = self._search_nextjs_data(webpage, entity_id)['props']['initialProps']['pageProps']['fallbackData']
+        entity = self._search_nextjs_data(webpage, entity_id)['props']['pageProps']['staticEntity']
         video_id = entity['videoId']
         episode = strip_or_none(entity.get('name'))
 
         return {
             '_type': 'url_transparent',
-            'url': f'https://videos.tva.ca/details/_{video_id}',
-            'ie_key': TVAIE.ie_key(),
+            'url': smuggle_url(self._BC_URL_TMPL.format(video_id), {'geo_countries': ['CA']}),
+            'ie_key': BrightcoveNewIE.ie_key(),
             'id': video_id,
             'title': episode,
             'episode': episode,

--- a/yt_dlp/extractor/tva.py
+++ b/yt_dlp/extractor/tva.py
@@ -10,9 +10,9 @@ from ..utils.traversal import traverse_obj
 class TVAIE(InfoExtractor):
     IE_NAME = 'tvaplus'
     IE_DESC = 'TVA+'
-    _VALID_URL = r'https?://(?:www\.)?(?:qub|tvaplus)\.ca/(?:[^/?#]+/)*[\w-]+-(?P<id>\d+)(?:$|[#?])'
+    _VALID_URL = r'https?://(?:www\.)?tvaplus\.ca/(?:[^/?#]+/)*[\w-]+-(?P<id>\d+)(?:$|[#?])'
     _TESTS = [{
-        'url': 'https://www.qub.ca/tvaplus/tva/alerte-amber/saison-1/episode-01-1000036619',
+        'url': 'https://www.tvaplus.ca/tva/alerte-amber/saison-1/episode-01-1000036619',
         'md5': '949490fd0e7aee11d0543777611fbd53',
         'info_dict': {
             'id': '6084352463001',

--- a/yt_dlp/extractor/unsupported.py
+++ b/yt_dlp/extractor/unsupported.py
@@ -49,6 +49,7 @@ class KnownDRMIE(UnsupportedInfoExtractor):
         r'amazon\.(?:\w{2}\.)?\w+/gp/video',
         r'music\.amazon\.(?:\w{2}\.)?\w+',
         r'(?:watch|front)\.njpwworld\.com',
+        r'qub\.ca/vrai'
     )
 
     _TESTS = [{
@@ -148,6 +149,9 @@ class KnownDRMIE(UnsupportedInfoExtractor):
         'only_matching': True,
     }, {
         'url': 'https://front.njpwworld.com/p/s_series_00563_16_bs',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.qub.ca/vrai/l-effet-bocuse-d-or/saison-1/l-effet-bocuse-d-or-saison-1-bande-annonce-1098225063',
         'only_matching': True,
     }]
 

--- a/yt_dlp/extractor/unsupported.py
+++ b/yt_dlp/extractor/unsupported.py
@@ -49,7 +49,7 @@ class KnownDRMIE(UnsupportedInfoExtractor):
         r'amazon\.(?:\w{2}\.)?\w+/gp/video',
         r'music\.amazon\.(?:\w{2}\.)?\w+',
         r'(?:watch|front)\.njpwworld\.com',
-        r'qub\.ca/vrai'
+        r'qub\.ca/vrai',
     )
 
     _TESTS = [{


### PR DESCRIPTION
Everything is `tvaplus.ca` now. Valid (non-DRM) `qub.ca` URLs will redirect to their new `tvaplus.ca` counterparts, and the old `videos.tva.ca` URLs are all dead and redirect to the `tvaplus.ca` homepage. There is also now QUB VRAI, which is completely DRM-protected, and has been added to `yt_dlp.extractor.unsupported` as such.

Closes #10555


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
