### PR TITLE
[ie/TVer] Add support for downloading Paris Olympic (2024) VOD

### DIFF
--- a/yt_dlp/extractor/tver.py
+++ b/yt_dlp/extractor/tver.py
@@ -54,25 +54,11 @@ class TVerIE(InfoExtractor):
                 webpage, 'url regex'))
 
         if video_type == 'olympic/paris2024/video':
-            olympic_api_info = self._download_json(
-                'https://tver.jp/olympic/paris2024/req/api/hook?q=https%3A%2F%2Folympic-assets.tver.jp%2Fweb-static%2Fjson%2Fconfig.json&d=',
-                video_id,
-                fatal=False,
-            )
-            p_id = traverse_obj(
-                olympic_api_info,
-                ('content', 'brightcove', 'E200', 'pro', 'pc', 'account_id'),
-                get_all=False,
-            )
-            r_id = video_id
-            return {
-                '_type': 'url_transparent',
-                'url': smuggle_url(
-                    self.BRIGHTCOVE_URL_TEMPLATE % (p_id, r_id),
-                    {'geo_countries': ['JP']},
-                ),
-                'ie_key': 'BrightcoveNew',
-            }
+            # Player ID is taken from .content.brightcove.E200.pro.pc.account_id:
+            # https://tver.jp/olympic/paris2024/req/api/hook?q=https%3A%2F%2Folympic-assets.tver.jp%2Fweb-static%2Fjson%2Fconfig.json&d=
+            return self.url_result(smuggle_url(
+                self.BRIGHTCOVE_URL_TEMPLATE % ('4774017240001', video_id),
+                {'geo_countries': ['JP']}), 'BrightcoveNew')
 
         episode_info = self._download_json(
             f'https://platform-api.tver.jp/service/api/v1/callEpisode/{video_id}?require_data=mylist,later[epefy106ur],good[epefy106ur],resume[epefy106ur]',

--- a/yt_dlp/extractor/tver.py
+++ b/yt_dlp/extractor/tver.py
@@ -24,13 +24,24 @@ class TVerIE(InfoExtractor):
         },
         'add_ie': ['BrightcoveNew'],
     }, {
+        'url': 'https://tver.jp/olympic/paris2024/video/6359578055112/',
+        'info_dict': {
+            'id': '6359578055112',
+            'ext': 'mp4',
+            'title': '堀米雄斗 金メダルで五輪連覇！「みんなの応援が最後に乗れたカギ」',
+            'timestamp': 1722279928,
+            'upload_date': '20240729',
+            'tags': ['20240729', 'japanese', 'japanmedal', 'paris'],
+            'uploader_id': '4774017240001',
+            'thumbnail': r're:https?://[^/?#]+boltdns\.net/[^?#]+/1920x1080/match/image\.jpg',
+            'duration': 670.571,
+        },
+        'params': {'skip_download': 'm3u8'},
+    }, {
         'url': 'https://tver.jp/corner/f0103888',
         'only_matching': True,
     }, {
         'url': 'https://tver.jp/lp/f0033031',
-        'only_matching': True,
-    }, {
-        'url': 'https://tver.jp/olympic/paris2024/video/6359578055112/',
         'only_matching': True,
     }]
     BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/%s/default_default/index.html?videoId=%s'
@@ -50,11 +61,6 @@ class TVerIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id, video_type = self._match_valid_url(url).group('id', 'type')
-        if video_type not in {'series', 'episodes'}:
-            webpage = self._download_webpage(url, video_id, note='Resolving to new URL')
-            video_id = self._match_id(self._search_regex(
-                (r'canonical"\s*href="(https?://tver\.jp/[^"]+)"', r'&link=(https?://tver\.jp/[^?&]+)[?&]'),
-                webpage, 'url regex'))
 
         if video_type == 'olympic/paris2024/video':
             # Player ID is taken from .content.brightcove.E200.pro.pc.account_id:
@@ -62,6 +68,12 @@ class TVerIE(InfoExtractor):
             return self.url_result(smuggle_url(
                 self.BRIGHTCOVE_URL_TEMPLATE % ('4774017240001', video_id),
                 {'geo_countries': ['JP']}), 'BrightcoveNew')
+
+        elif video_type not in {'series', 'episodes'}:
+            webpage = self._download_webpage(url, video_id, note='Resolving to new URL')
+            video_id = self._match_id(self._search_regex(
+                (r'canonical"\s*href="(https?://tver\.jp/[^"]+)"', r'&link=(https?://tver\.jp/[^?&]+)[?&]'),
+                webpage, 'url regex'))
 
         episode_info = self._download_json(
             f'https://platform-api.tver.jp/service/api/v1/callEpisode/{video_id}?require_data=mylist,later[epefy106ur],good[epefy106ur],resume[epefy106ur]',

--- a/yt_dlp/extractor/tver.py
+++ b/yt_dlp/extractor/tver.py
@@ -29,6 +29,9 @@ class TVerIE(InfoExtractor):
     }, {
         'url': 'https://tver.jp/lp/f0033031',
         'only_matching': True,
+    }, {
+        'url': 'https://tver.jp/olympic/paris2024/video/6359578055112/',
+        'only_matching': True,
     }]
     BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/%s/default_default/index.html?videoId=%s'
     _PLATFORM_UID = None


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

I have added support for videos of the Paris Olympics on TVer (excluding LIVE). Since these videos are expected to be unavailable after the Olympic period ends, I have set _TESTS to `only_matching`.
Fixes #10583

Sample URLs:
- https://tver.jp/olympic/paris2024/video/6359575021112/
- https://tver.jp/olympic/paris2024/video/6359590242112/
- And more...
  - 207 videos available at: https://tver.jp/olympic/paris2024/video/?type=latest

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
