### PR TITLE
[ie/youtube] Fix `n` function name extraction for player `20dfca59`

### DIFF
--- a/test/test_youtube_signature.py
+++ b/test/test_youtube_signature.py
@@ -175,6 +175,10 @@ _NSIG_TESTS = [
         'https://www.youtube.com/s/player/3400486c/player_ias.vflset/en_US/base.js',
         'lL46g3XifCKUZn1Xfw', 'z767lhet6V2Skl',
     ),
+    (
+        'https://www.youtube.com/s/player/20dfca59/player_ias.vflset/en_US/base.js',
+        '-fLCxedkAk4LUTK2', 'O8kfRq1y1eyHGw',
+    ),
 ]
 
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3196,7 +3196,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             self.report_warning('Falling back to generic n function search')
             return self._search_regex(
                 r'''(?xs)
-                \b(?P<name>[a-zA-Z0-9_$]+)\s*=\s*function\([a-zA-Z0-9_$]+\)
+                ;\s*(?P<name>[a-zA-Z0-9_$]+)\s*=\s*function\([a-zA-Z0-9_$]+\)
                 \s*\{(?:(?!};).)+?["']enhanced_except_''',
                 jscode, 'Initial JS player n function name', group='name')
         elif not idx:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3197,7 +3197,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             return self._search_regex(
                 r'''(?xs)
                 \b(?P<name>[a-zA-Z0-9_$]+)\s*=\s*function\([a-zA-Z0-9_$]+\)
-                \s*\{(?:(?!\};).)+?["\']enhanced_except_''',
+                \s*\{(?:(?!};).)+?["']enhanced_except_''',
                 jscode, 'Initial JS player n function name', group='name')
         elif not idx:
             return funcname


### PR DESCRIPTION
Also adds a fallback regex search which looks for the function itself

Closes #10608


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
