### PR TITLE
[ie/youtube] Support excluding `player_client`s in extractor-arg

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3744,6 +3744,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def _get_requested_clients(self, url, smuggled_data):
         requested_clients = []
         broken_clients = []
+        skip_clients = []
         default = ['ios', 'web_creator']
         allowed_clients = sorted(
             (client for client in INNERTUBE_CLIENTS if client[:1] != '_'),
@@ -3753,6 +3754,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 requested_clients.extend(default)
             elif client == 'all':
                 requested_clients.extend(allowed_clients)
+            elif client.startswith('-'):
+                skip_clients.append(client[1:])
             elif client not in allowed_clients:
                 self.report_warning(f'Skipping unsupported client {client}')
             elif client in self._BROKEN_CLIENTS.values():
@@ -3761,6 +3764,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 requested_clients.append(client)
         # Force deprioritization of _BROKEN_CLIENTS for format de-duplication
         requested_clients.extend(broken_clients)
+        for skip_client in skip_clients:
+            if skip_client in requested_clients:
+                requested_clients.remove(skip_client)
         if not requested_clients:
             requested_clients = default
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -1339,6 +1339,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         short_client_name(client): client
         for client in ('android', 'android_creator', 'android_music')
     }
+    _DEFAULT_CLIENTS = ('ios', 'web_creator')
 
     _GEO_BYPASS = False
 
@@ -3745,13 +3746,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         requested_clients = []
         broken_clients = []
         skip_clients = []
-        default = ['ios', 'web_creator']
         allowed_clients = sorted(
             (client for client in INNERTUBE_CLIENTS if client[:1] != '_'),
             key=lambda client: INNERTUBE_CLIENTS[client]['priority'], reverse=True)
         for client in self._configuration_arg('player_client'):
             if client == 'default':
-                requested_clients.extend(default)
+                requested_clients.extend(self._DEFAULT_CLIENTS)
             elif client == 'all':
                 requested_clients.extend(allowed_clients)
             elif client.startswith('-'):
@@ -3768,7 +3768,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             if skip_client in requested_clients:
                 requested_clients.remove(skip_client)
         if not requested_clients:
-            requested_clients = default
+            requested_clients.extend(self._DEFAULT_CLIENTS)
 
         if smuggled_data.get('is_music_url') or self.is_music_url(url):
             for requested_client in requested_clients:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3757,7 +3757,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             elif client.startswith('-'):
                 excluded_clients.append(client[1:])
             elif client not in allowed_clients:
-                self.report_warning(f'Skipping unsupported client {client}')
+                self.report_warning(f'Skipping unsupported client "{client}"')
             elif client in self._BROKEN_CLIENTS.values():
                 broken_clients.append(client)
             else:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3745,7 +3745,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def _get_requested_clients(self, url, smuggled_data):
         requested_clients = []
         broken_clients = []
-        skip_clients = []
+        excluded_clients = []
         allowed_clients = sorted(
             (client for client in INNERTUBE_CLIENTS if client[:1] != '_'),
             key=lambda client: INNERTUBE_CLIENTS[client]['priority'], reverse=True)
@@ -3755,7 +3755,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             elif client == 'all':
                 requested_clients.extend(allowed_clients)
             elif client.startswith('-'):
-                skip_clients.append(client[1:])
+                excluded_clients.append(client[1:])
             elif client not in allowed_clients:
                 self.report_warning(f'Skipping unsupported client {client}')
             elif client in self._BROKEN_CLIENTS.values():
@@ -3764,9 +3764,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 requested_clients.append(client)
         # Force deprioritization of _BROKEN_CLIENTS for format de-duplication
         requested_clients.extend(broken_clients)
-        for skip_client in skip_clients:
-            if skip_client in requested_clients:
-                requested_clients.remove(skip_client)
+        for excluded_client in excluded_clients:
+            if excluded_client in requested_clients:
+                requested_clients.remove(excluded_client)
         if not requested_clients:
             requested_clients.extend(self._DEFAULT_CLIENTS)
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -3764,11 +3764,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 requested_clients.append(client)
         # Force deprioritization of _BROKEN_CLIENTS for format de-duplication
         requested_clients.extend(broken_clients)
+        if not requested_clients:
+            requested_clients.extend(self._DEFAULT_CLIENTS)
         for excluded_client in excluded_clients:
             if excluded_client in requested_clients:
                 requested_clients.remove(excluded_client)
         if not requested_clients:
-            requested_clients.extend(self._DEFAULT_CLIENTS)
+            raise ExtractorError('No player clients have been requested', expected=True)
 
         if smuggled_data.get('is_music_url') or self.is_music_url(url):
             for requested_client in requested_clients:


### PR DESCRIPTION
When passing the `player_client` youtube extractor-arg, this patch allows a client name to be prefixed with `-` so it can be excluded from `all` or `default`, e.g.:
```
--extractor-args "youtube:player_client=all,-web,-web_safari,-android,-android_music"
--extractor-args "youtube:player_client=default,-web_creator"
```

Closes #10699


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
