### PR TITLE
[ie/Dropbox] supported password,thumbnail

### DIFF
--- a/yt_dlp/extractor/yandexdisk.py
+++ b/yt_dlp/extractor/yandexdisk.py
@@ -1,12 +1,17 @@
 import json
+import urllib.parse
+
+from html import unescape
 
 from .common import InfoExtractor
 from ..utils import (
     determine_ext,
+    ExtractorError,
     float_or_none,
     int_or_none,
     join_nonempty,
     mimetype2ext,
+    traverse_obj,
     try_get,
     urljoin,
 )
@@ -62,6 +67,43 @@ class YandexDiskIE(InfoExtractor):
             webpage, 'store'), video_id)
         resource = store['resources'][store['rootResourceId']]
 
+        if store['rootResourceId'] == 'password-protected':
+            data = {
+                "hash": resource['hash'],
+                "password": self.get_param('videopassword', default=''),
+                "sk": traverse_obj(store, ('environment', 'sk')),
+            }
+            json_string = json.dumps(data, separators=(',', ':'))
+            url_encoded_string = urllib.parse.quote(json_string, safe='')
+            data_bytes = url_encoded_string.encode('utf-8')
+            token = (self._download_json(
+                'https://disk.yandex.ru/public/api/check-password', 
+                video_id, data=data_bytes, fatal=False,
+                headers={
+                    'Accept': '*/*',
+                    'Cache-Control': 'no-cache',
+                    'Connection': 'keep-alive',
+                    'Content-Type': 'text/plain',
+                    'Origin': 'https://disk.yandex.ru',
+                    'Pragma': 'no-cache',
+                    'Referer': url,
+                    'Sec-Fetch-Dest': 'empty',
+                    'Sec-Fetch-Mode': 'cors',
+                    'Sec-Fetch-Site': 'same-origin',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-Retpath-Y': url,
+                }
+            ) or {}).get('token') or {}
+            if not token:
+                raise ExtractorError('Password incorrect!', expected=True)
+            self._set_cookie('disk.yandex.ru', name='passToken', value=token)
+            webpage = self._download_webpage(url, video_id)
+            store = self._parse_json(self._search_regex(
+                r'<script[^>]+id="store-prefetch"[^>]*>\s*({.+?})\s*</script>',
+                webpage, 'store'), video_id)
+            resource = store['resources'][store['rootResourceId']]
+        
+        thumbnail = unescape(self._og_search_property('image', webpage))
         title = resource['name']
         meta = resource.get('meta') or {}
 
@@ -132,6 +174,7 @@ class YandexDiskIE(InfoExtractor):
         return {
             'id': video_id,
             'title': title,
+            'thumbnail': thumbnail,
             'duration': float_or_none(video_streams.get('duration'), 1000),
             'uploader': display_name,
             'uploader_id': uid,


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information
This pull request adds support for Dropbox password and thumbnail extraction. 

**Changes:**
- Added functionality to handle password-protected Dropbox links.
- Implemented thumbnail extraction for Dropbox videos.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
