### PR TITLE
[SubtitleConvertor] Do not attempt to convert unsupported formats

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -972,9 +972,9 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
             if ext == new_ext:
                 self.to_screen(f'Subtitle file for {new_ext} is already in the requested format')
                 continue
-            elif ext == 'json':
+            elif ext not in self.SUPPORTED_EXTS:
                 self.to_screen(
-                    'You have requested to convert json subtitles into another format, '
+                    f'You have requested to convert {ext} subtitles into another format, '
                     'which is currently not possible')
                 continue
             old_file = sub['filepath']


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR fixes an issue where attempting to convert subtitle formats unsupported by ffmpeg (such as `xml`) causes the video download to fail.

Before:
```text
> yt-dlp --write-subs --convert-subs srt --no-download --verbose https://www.bilibili.com/video/av8903802/
[debug] Command-line config: ['--write-subs', '--convert-subs', 'srt', '--no-download', '--verbose', 'https://www.bilibili.com/video/av8903802/']
[debug] Encodings: locale utf-8, fs utf-8, pref utf-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2024.08.06 from yt-dlp/yt-dlp [4d9231208] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: f0bb28504
[debug] Python 3.12.4 (CPython AMD64 64bit) - Windows-10-10.0.19045-SP0 (OpenSSL 3.0.13 30 Jan 2024)
[debug] exe versions: ffmpeg N-115846-gfcf72966a5-20240616 (setts), ffprobe N-115846-gfcf72966a5-20240616, rtmpdump 2.3
[debug] Optional libraries: Cryptodome-3.20.0, brotli-1.1.0, certifi-2024.07.04, curl_cffi-0.5.10, mutagen-1.47.0, requests-2.32.3, secretstorage-3.3.3, sqlite3-3.45.3, urllib3-2.2.2, websockets-12.0
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets, curl_cffi
[debug] Plugin directories: ['C:\\Users\\[REDACTED]\\AppData\\Roaming\\yt-dlp\\plugins\\plug\\yt_dlp_plugins']
[debug] Loaded 1830 extractors
[BiliBili] Extracting URL: https://www.bilibili.com/video/av8903802/
[BiliBili] 8903802: Downloading webpage
[BiliBili] BV13x41117TL: Extracting videos in anthology
[BiliBili] Format(s) 1080P 高清, 720P 高清 are missing; you have to login or become a premium member to download them. Use --cookies-from-browser or --cookies for the authentication. See  https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp  for how to manually pass cookies
[BiliBili] 8903802: Extracting chapters
[BiliBili] BV13x41117TL: Extracting subtitle info 14694589
[info] BV13x41117TL: Downloading subtitles: danmaku
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] BV13x41117TL: Downloading 1 format(s): 30032+30280
Deleting existing file 阿滴英文｜英文歌分享#6 ＂Closer [BV13x41117TL].danmaku.xml
[info] Writing video subtitles to: 阿滴英文｜英文歌分享#6 ＂Closer [BV13x41117TL].danmaku.xml
[debug] Invoking http downloader on "https://comment.bilibili.com/14694589.xml"
[debug] File locking is not supported. Proceeding without locking
[download] Destination: 阿滴英文｜英文歌分享#6 ＂Closer [BV13x41117TL].danmaku.xml
[download] 100% of    2.52KiB in 00:00:00 at 16.42KiB/s
[SubtitlesConvertor] Converting subtitles
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i "file:阿滴英文｜英文歌分享#6 ＂Closer [BV13x41117TL].danmaku.xml" -f srt -movflags +faststart "file:阿滴英文｜英文歌分享#6 ＂Closer [BV13x41117TL].danmaku.srt"
[debug] ffmpeg version N-115846-gfcf72966a5-20240616 Copyright (c) 2000-2024 the FFmpeg developers
  built with gcc 13.2.0 (crosstool-NG 1.26.0.65_ecc5e41)
  configuration: --prefix=/ffbuild/prefix --pkg-config-flags=--static --pkg-config=pkg-config --cross-prefix=x86_64-w64-mingw32- --arch=x86_64 --target-os=mingw32 --enable-gpl --enable-version3 --disable-debug --disable-w32threads --enable-pthreads --enable-iconv --enable-libxml2 --enable-zlib --enable-libfreetype --enable-libfribidi --enable-gmp --enable-fontconfig --enable-libharfbuzz --enable-libvorbis --enable-opencl --disable-libpulse --enable-libvmaf --disable-libxcb --disable-xlib --enable-amf --enable-libaom --enable-libaribb24 --enable-avisynth --enable-chromaprint --enable-libdav1d --enable-libdavs2 --enable-libdvdread --enable-libdvdnav --disable-libfdk-aac --enable-ffnvcodec --enable-cuda-llvm --enable-frei0r --enable-libgme --enable-libkvazaar --enable-libaribcaption --enable-libass --enable-libbluray --enable-libjxl --enable-libmp3lame --enable-libopus --enable-librist --enable-libssh --enable-libtheora --enable-libvpx --enable-libwebp --enable-lv2 --enable-libvpl --enable-openal --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenh264 --enable-libopenjpeg --enable-libopenmpt --enable-librav1e --enable-librubberband --enable-schannel --enable-sdl2 --enable-libsoxr --enable-libsrt --enable-libsvtav1 --enable-libtwolame --enable-libuavs3d --disable-libdrm --enable-vaapi --enable-libvidstab --enable-vulkan --enable-libshaderc --enable-libplacebo --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxvid --enable-libzimg --enable-libzvbi --extra-cflags=-DLIBTWOLAME_STATIC --extra-cxxflags= --extra-libs=-lgomp --extra-ldflags=-pthread --extra-ldexeflags= --cc=x86_64-w64-mingw32-gcc --cxx=x86_64-w64-mingw32-g++ --ar=x86_64-w64-mingw32-gcc-ar --ranlib=x86_64-w64-mingw32-gcc-ranlib --nm=x86_64-w64-mingw32-gcc-nm --extra-version=20240616
  libavutil      59. 22.100 / 59. 22.100
  libavcodec     61.  8.100 / 61.  8.100
  libavformat    61.  3.104 / 61.  3.104
  libavdevice    61.  2.100 / 61.  2.100
  libavfilter    10.  2.102 / 10.  2.102
  libswscale      8.  2.100 /  8.  2.100
  libswresample   5.  2.100 /  5.  2.100
  libpostproc    58.  2.100 / 58.  2.100
[in#0 @ 0000014291dd24c0] Error opening input: Invalid data found when processing input
Error opening input file file:阿滴英文｜英文歌分享#6 ＂Closer [BV13x41117TL].danmaku.xml.
Error opening input files: Invalid data found when processing input

ERROR: Preprocessing: Error opening input files: Invalid data found when processing input
Traceback (most recent call last):
  File "D:\programming\yt-dlp\yt_dlp\YoutubeDL.py", line 3732, in pre_process
    info = self.run_all_pps(key, info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\programming\yt-dlp\yt_dlp\YoutubeDL.py", line 3725, in run_all_pps
    info = self.run_pp(pp, info)
           ^^^^^^^^^^^^^^^^^^^^^
  File "D:\programming\yt-dlp\yt_dlp\YoutubeDL.py", line 3703, in run_pp
    files_to_delete, infodict = pp.run(infodict)
                                ^^^^^^^^^^^^^^^^
  File "D:\programming\yt-dlp\yt_dlp\postprocessor\common.py", line 23, in run
    ret = func(self, info, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\programming\yt-dlp\yt_dlp\postprocessor\ffmpeg.py", line 1010, in run
    self.run_ffmpeg(old_file, new_file, ['-f', new_format])
  File "D:\programming\yt-dlp\yt_dlp\postprocessor\ffmpeg.py", line 375, in run_ffmpeg
    return self.run_ffmpeg_multiple_files([path], out_path, opts, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\programming\yt-dlp\yt_dlp\postprocessor\ffmpeg.py", line 330, in run_ffmpeg_multiple_files
    return self.real_run_ffmpeg(
           ^^^^^^^^^^^^^^^^^^^^^
  File "D:\programming\yt-dlp\yt_dlp\postprocessor\ffmpeg.py", line 368, in real_run_ffmpeg
    raise FFmpegPostProcessorError(stderr.strip().splitlines()[-1])
yt_dlp.postprocessor.ffmpeg.FFmpegPostProcessorError: Error opening input files: Invalid data found when processing input

ERROR: Preprocessing: Error opening input files: Invalid data found when processing input
```

After:
```text
...
[download] 100% of    2.52KiB in 00:00:00 at 18.29KiB/s
[SubtitlesConvertor] Converting subtitles
[SubtitlesConvertor] You have requested to convert xml subtitles into another format, which is currently not possible
```


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
