### PR TITLE
vp9.2 vcodec format sort bug fix

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -236,6 +236,35 @@ class TestFormatSelection(unittest.TestCase):
         downloaded = ydl.downloaded_info_dicts[0]
         self.assertEqual(downloaded['format_id'], 'vid-vcodec-dot')
 
+    def test_format_selection_by_vcodec_sort(self):
+        formats = [
+            {'format_id': 'av1-format', 'ext': 'mp4', 'vcodec': 'av1', 'acodec': 'none', 'url': TEST_URL},
+            {'format_id': 'vp9-hdr-format', 'ext': 'mp4', 'vcodec': 'vp09.02.50.10.01.09.18.09.00', 'acodec': 'none', 'url': TEST_URL},
+            {'format_id': 'vp9-sdr-format', 'ext': 'mp4', 'vcodec': 'vp09.00.50.08', 'acodec': 'none', 'url': TEST_URL},
+            {'format_id': 'h265-format', 'ext': 'mp4', 'vcodec': 'h265', 'acodec': 'none', 'url': TEST_URL},
+        ]
+        info_dict = _make_result(formats)
+
+        ydl = YDL({'format': 'bestvideo', 'format_sort': ['vcodec:vp9.2']})
+        ydl.process_ie_result(info_dict.copy())
+        downloaded = ydl.downloaded_info_dicts[0]
+        self.assertEqual(downloaded['format_id'], 'vp9-hdr-format')
+
+        ydl = YDL({'format': 'bestvideo', 'format_sort': ['vcodec:vp9']})
+        ydl.process_ie_result(info_dict.copy())
+        downloaded = ydl.downloaded_info_dicts[0]
+        self.assertEqual(downloaded['format_id'], 'vp9-sdr-format')
+
+        ydl = YDL({'format': 'bestvideo', 'format_sort': ['+vcodec:vp9.2']})
+        ydl.process_ie_result(info_dict.copy())
+        downloaded = ydl.downloaded_info_dicts[0]
+        self.assertEqual(downloaded['format_id'], 'vp9-hdr-format')
+
+        ydl = YDL({'format': 'bestvideo', 'format_sort': ['+vcodec:vp9']})
+        ydl.process_ie_result(info_dict.copy())
+        downloaded = ydl.downloaded_info_dicts[0]
+        self.assertEqual(downloaded['format_id'], 'vp9-sdr-format')
+
     def test_format_selection_string_ops(self):
         formats = [
             {'format_id': 'abc-cba', 'ext': 'mp4', 'url': TEST_URL},

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -921,6 +921,11 @@ class TestUtil(unittest.TestCase):
             'acodec': 'none',
             'dynamic_range': 'HDR10',
         })
+        self.assertEqual(parse_codecs('vp09.02.50.10.01.09.18.09.00'), {
+            'vcodec': 'vp09.02.50.10.01.09.18.09.00',
+            'acodec': 'none',
+            'dynamic_range': 'HDR10',
+        })
         self.assertEqual(parse_codecs('av01.0.12M.10.0.110.09.16.09.0'), {
             'vcodec': 'av01.0.12M.10.0.110.09.16.09.0',
             'acodec': 'none',

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -5280,7 +5280,7 @@ class FormatSorter:
 
     settings = {
         'vcodec': {'type': 'ordered', 'regex': True,
-                   'order': ['av0?1', 'vp0?9.2', 'vp0?9', '[hx]265|he?vc?', '[hx]264|avc', 'vp0?8', 'mp4v|h263', 'theora', '', None, 'none']},
+                   'order': ['av0?1', 'vp0?9.0?2', 'vp0?9', '[hx]265|he?vc?', '[hx]264|avc', 'vp0?8', 'mp4v|h263', 'theora', '', None, 'none']},
         'acodec': {'type': 'ordered', 'regex': True,
                    'order': ['[af]lac', 'wav|aiff', 'opus', 'vorbis|ogg', 'aac', 'mp?4a?', 'mp3', 'ac-?4', 'e-?a?c-?3', 'ac-?3', 'dts', '', None, 'none']},
         'hdr': {'type': 'ordered', 'regex': True, 'field': 'dynamic_range',


### PR DESCRIPTION
### Description of your *pull request* and other information

The actual `vcodec` values for vp9 are like 
- `vp09.00.10.08`
- `vp09.02.11.10.01.09.18.09.00`

The existing situation:

`FormatSorter` handles `vcodec` as an `ordered`, with separate entries for vp9.2 and general vp9.

In practice vp9.2 is probably used because it has hdr support but sometimes vp9 with hdr is not supported for hardware decode when basic sdr vp9 is, for instance in nvdec with some nvidia cards (https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new) so they are distinguished as different categories of vcodec value for sorting. Great.

However the regex `FormatSorter` uses for vp9.2 does not match the actual `vcodec` values seen for it -- it does not match the leading `0` of the `02` -- so it is treated as just another regular vp9.

This is separate from the `utils` `parse_codecs()` code which assigns `vp9.2` a higher `dynamic_range`, and already parses the actual `vcodec` value for vp9.2 correctly.

This PR includes:

- fix for vp9.2 codec matching in `FormatSorter`
- test for sorting formats with vp9.2 vcodec falues by vcodec with limit
- test that just non-sorting-related parsing of a real vp9.2 vcodec value in `parse_codecs()` works ok

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
