### PR TITLE
[NZOnScreenIE] Fix extractor

### DIFF
--- a/yt_dlp/extractor/nzonscreen.py
+++ b/yt_dlp/extractor/nzonscreen.py
@@ -1,8 +1,8 @@
 from .common import InfoExtractor
 from ..utils import (
+    determine_ext,
     float_or_none,
     int_or_none,
-    remove_end,
     strip_or_none,
     traverse_obj,
     url_or_none,
@@ -15,12 +15,12 @@ class NZOnScreenIE(InfoExtractor):
         'url': 'https://www.nzonscreen.com/title/shoop-shoop-diddy-wop-cumma-cumma-wang-dang-1982',
         'info_dict': {
             'id': '726ed6585c6bfb30',
-            'ext': 'mp4',
-            'format_id': 'hi',
+            'ext': 'm3u8',
+            'format_id': 'hd',
             'display_id': 'shoop-shoop-diddy-wop-cumma-cumma-wang-dang-1982',
             'title': 'Monte Video - "Shoop Shoop, Diddy Wop"',
             'description': 'Monte Video - "Shoop Shoop, Diddy Wop"',
-            'alt_title': 'Shoop Shoop Diddy Wop Cumma Cumma Wang Dang | Music Video',
+            'alt_title': 'Shoop Shoop Diddy Wop Cumma Cumma Wang Dang',
             'thumbnail': r're:https://www\.nzonscreen\.com/content/images/.+\.jpg',
             'duration': 158,
         },
@@ -29,12 +29,12 @@ class NZOnScreenIE(InfoExtractor):
         'url': 'https://www.nzonscreen.com/title/shes-a-mod-1964?collection=best-of-the-60s',
         'info_dict': {
             'id': '3dbe709ff03c36f1',
-            'ext': 'mp4',
-            'format_id': 'hi',
+            'ext': 'm3u8',
+            'format_id': 'hd',
             'display_id': 'shes-a-mod-1964',
             'title': 'Ray Columbus - \'She\'s A Mod\'',
             'description': 'Ray Columbus - \'She\'s A Mod\'',
-            'alt_title': 'She\'s a Mod | Music Video',
+            'alt_title': 'She\'s a Mod',
             'thumbnail': r're:https://www\.nzonscreen\.com/content/images/.+\.jpg',
             'duration': 130,
         },
@@ -43,51 +43,78 @@ class NZOnScreenIE(InfoExtractor):
         'url': 'https://www.nzonscreen.com/title/puha-and-pakeha-1968/overview',
         'info_dict': {
             'id': 'f86342544385ad8a',
-            'ext': 'mp4',
-            'format_id': 'hi',
+            'ext': 'm3u8',
+            'format_id': 'hd',
             'display_id': 'puha-and-pakeha-1968',
             'title': 'Looking At New Zealand - Puha and Pakeha',
-            'alt_title': 'Looking at New Zealand - \'Pūhā and Pākehā\' | Television',
+            'alt_title': 'Looking at New Zealand - \'Pūhā and Pākehā\'',
             'description': 'An excerpt from this television programme.',
             'duration': 212,
             'thumbnail': r're:https://www\.nzonscreen\.com/content/images/.+\.jpg',
         },
         'params': {'skip_download': 'm3u8'},
+    }, {
+        'url': 'https://www.nzonscreen.com/title/flatmates-episode-one-1997',
+        'info_dict': {
+            'id': 'flatmates-episode-one-1997',
+            'title': 'Flatmates - 1, First Episode',
+        },
+        'playlist_count': 5,
     }]
 
     def _extract_formats(self, playlist):
         for quality, (id_, url) in enumerate(traverse_obj(
-                playlist, ('h264', {'lo': 'lo_res', 'hi': 'hi_res'}), expected_type=url_or_none).items()):
+                playlist, ('h264', {'lo': 'lo_res', 'hi': 'hi_res', 'hd': 'hd_res'}), expected_type=url_or_none).items()):
             yield {
                 'url': url,
                 'format_id': id_,
-                'ext': 'mp4',
+                'ext': determine_ext(url),
                 'quality': quality,
-                'height': int_or_none(playlist.get('height')) if id_ == 'hi' else None,
-                'width': int_or_none(playlist.get('width')) if id_ == 'hi' else None,
+                'height': int_or_none(playlist.get('height')) if id_ == 'hd' else None,
+                'width': int_or_none(playlist.get('width')) if id_ == 'hd' else None,
                 'filesize_approx': float_or_none(traverse_obj(playlist, ('h264', f'{id_}_res_mb')), invscale=1024**2),
             }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
+        title = strip_or_none((
+            self._html_extract_title(webpage, default=None)
+            or self._og_search_title(webpage)).rsplit('|', 2)[0])
+        playlist = self._download_json(
+            f'https://www.nzonscreen.com/html5/video_data/{video_id}', video_id, 'media data')
 
-        playlist = self._parse_json(self._html_search_regex(
-            r'data-video-config=\'([^\']+)\'', webpage, 'media data'), video_id)
-
-        return {
-            'id': playlist['uuid'],
-            'display_id': video_id,
-            'title': strip_or_none(playlist.get('label')),
-            'description': strip_or_none(playlist.get('description')),
-            'alt_title': strip_or_none(remove_end(
-                self._html_extract_title(webpage, default=None) or self._og_search_title(webpage),
-                ' | NZ On Screen')),
-            'thumbnail': traverse_obj(playlist, ('thumbnail', 'path')),
-            'duration': float_or_none(playlist.get('duration')),
-            'formats': list(self._extract_formats(playlist)),
-            'http_headers': {
-                'Referer': 'https://www.nzonscreen.com/',
-                'Origin': 'https://www.nzonscreen.com/',
-            },
-        }
+        if len(playlist) == 1:
+            playinfo = playlist[0]
+            return {
+                'alt_title': title,
+                'display_id': video_id,
+                'formats': list(self._extract_formats(playinfo)),
+                'http_headers': {
+                    'Referer': 'https://www.nzonscreen.com/',
+                    'Origin': 'https://www.nzonscreen.com/',
+                },
+                **traverse_obj(playinfo, {
+                    'id': ('uuid'),
+                    'title': ('label', {strip_or_none}),
+                    'description': ('description', {strip_or_none}),
+                    'thumbnail': ('thumbnail', 'path'),
+                    'duration': ('duration', {float_or_none}),
+                }),
+            }
+        else:
+            return self.playlist_result([{
+                'display_id': video_id,
+                'formats': list(self._extract_formats(playinfo)),
+                'http_headers': {
+                    'Referer': 'https://www.nzonscreen.com/',
+                    'Origin': 'https://www.nzonscreen.com/',
+                },
+                **traverse_obj(playinfo, {
+                    'id': ('uuid'),
+                    'title': ('label', {strip_or_none}),
+                    'description': ('description', {strip_or_none}),
+                    'thumbnail': ('thumbnail', 'path'),
+                    'duration': ('duration', {float_or_none}),
+                }),
+            } for playinfo in playlist], video_id, title)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information


[NZOnScreenIE] Fix extractor, use the play info from API instead of the webpage, add format `hd`

Fixes #6878, Closes #10522


<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
