### PR TITLE
[cookies] Fix cookie load error handling

### DIFF
--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -15,7 +15,7 @@ import re
 import traceback
 
 from .compat import compat_os_name
-from .cookies import SUPPORTED_BROWSERS, SUPPORTED_KEYRINGS
+from .cookies import SUPPORTED_BROWSERS, SUPPORTED_KEYRINGS, CookieLoadError
 from .downloader.external import get_external_downloader
 from .extractor import list_extractor_classes
 from .extractor.adobepass import MSO_INFO
@@ -1084,7 +1084,7 @@ def main(argv=None):
     _IN_CLI = True
     try:
         _exit(*variadic(_real_main(argv)))
-    except DownloadError:
+    except (CookieLoadError, DownloadError):
         _exit(1)
     except SameFileError as e:
         _exit(f'ERROR: {e}')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Exit early when encountering a cookie load error. See this log:
```console
$ yt-dlp --cookies-from-browser whale test:youtube test:youtube
[TestURL] Extracting URL: test:youtube
[TestURL] Test URL: https://www.youtube.com/watch?v=BaW_jenozKc&t=1s&end=9
Extracting cookies from whale
ERROR: could not find whale cookies database in "/home/grub4k/.config/naver-whale"
[TestURL] Extracting URL: test:youtube
[TestURL] Test URL: https://www.youtube.com/watch?v=BaW_jenozKc&t=1s&end=9
Extracting cookies from whale
ERROR: could not find whale cookies database in "/home/grub4k/.config/naver-whale"
```

Since the cookiejar is created lazily, the error now gets thrown inside the `_handle_extraction_exceptions` function, silencing the error (because of `ignoreerrors` as `'in_playlist'`) and continuing with the next url.

This PR introduces a new error that gets handled explicitly and forces exit

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement
</details>
