### PR TITLE
Add support for CENC, Clear Key, AES-128-CBC in DASH manifests

### DIFF
--- a/test/test_InfoExtractor.py
+++ b/test/test_InfoExtractor.py
@@ -1564,6 +1564,71 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
                     'has_drm': True,
                 }],
                 {},
+            ), (
+                # DASH SEA with AES-128-CBC
+                'dash_sea',
+                'https://unknown/manifest.mpd',  # mpd_url
+                'https://unknown/',  # mpd_base_url
+                [{
+                    'manifest_url': 'https://unknown/manifest.mpd',
+                    'ext': 'm4a',
+                    'format_id': '5_A_aac_eng_2_127999_2_1_1',
+                    'format_note': 'DASH audio',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'mp4a.40.2',
+                    'vcodec': 'none',
+                    'tbr': 127.999,
+                    'hls_aes': {
+                        'uri': 'https://zavideoplatform.keydelivery.eastus.media.azure.net/?kid=9280864f-064e-48c0-97e0-f2bcb1d8d012',
+                        'iv': '0x7BD31E102B0CE9CCD39691782533656C',
+                    },
+                }, {
+                    'manifest_url': 'https://unknown/manifest.mpd',
+                    'ext': 'mp4',
+                    'format_id': '1_V_video_3',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.64001F',
+                    'tbr': 258.591,
+                    'width': 960,
+                    'height': 540,
+                    'hls_aes': {
+                        'uri': 'https://zavideoplatform.keydelivery.eastus.media.azure.net/?kid=9280864f-064e-48c0-97e0-f2bcb1d8d012',
+                        'iv': '0x7BD31E102B0CE9CCD39691782533656C',
+                    },
+                }, {
+                    'manifest_url': 'https://unknown/manifest.mpd',
+                    'ext': 'mp4',
+                    'format_id': '1_V_video_2',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.64001F',
+                    'tbr': 422.519,
+                    'width': 1280,
+                    'height': 720,
+                    'hls_aes': {
+                        'uri': 'https://zavideoplatform.keydelivery.eastus.media.azure.net/?kid=9280864f-064e-48c0-97e0-f2bcb1d8d012',
+                        'iv': '0x7BD31E102B0CE9CCD39691782533656C',
+                    },
+                }, {
+                    'manifest_url': 'https://unknown/manifest.mpd',
+                    'ext': 'mp4',
+                    'format_id': '1_V_video_1',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.640028',
+                    'tbr': 628.102,
+                    'width': 1920,
+                    'height': 1080,
+                    'hls_aes': {
+                        'uri': 'https://zavideoplatform.keydelivery.eastus.media.azure.net/?kid=9280864f-064e-48c0-97e0-f2bcb1d8d012',
+                        'iv': '0x7BD31E102B0CE9CCD39691782533656C',
+                    },
+                }],
+                {},
             ),
         ]
 

--- a/test/test_InfoExtractor.py
+++ b/test/test_InfoExtractor.py
@@ -1460,6 +1460,110 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
                     'fps': 30,
                 }],
                 {},
+            ), (
+                # Clear Key with CENC default_KID
+                'clearkey_cenc',
+                'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd',  # mpd_url
+                'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/',  # mpd_base_url
+                [{
+                    'manifest_url': 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd',
+                    'ext': 'mp4',
+                    'format_id': '1',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.64001f',
+                    'tbr': 389.802,
+                    'width': 512,
+                    'height': 288,
+                    'dash_cenc': {
+                        'laurl': 'https://drm-clearkey-testvectors.axtest.net/AcquireLicense',
+                        'key_ids': ['9eb4050de44b4802932e27d75083e266'],
+                    },
+                }, {
+                    'manifest_url': 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd',
+                    'ext': 'mp4',
+                    'format_id': '2',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.64001f',
+                    'tbr': 764.935,
+                    'width': 640,
+                    'height': 360,
+                    'dash_cenc': {
+                        'laurl': 'https://drm-clearkey-testvectors.axtest.net/AcquireLicense',
+                        'key_ids': ['9eb4050de44b4802932e27d75083e266'],
+                    },
+                }, {
+                    'manifest_url': 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd',
+                    'ext': 'mp4',
+                    'format_id': '3',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.640028',
+                    'tbr': 1120.439,
+                    'width': 852,
+                    'height': 480,
+                    'dash_cenc': {
+                        'laurl': 'https://drm-clearkey-testvectors.axtest.net/AcquireLicense',
+                        'key_ids': ['9eb4050de44b4802932e27d75083e266'],
+                    },
+                }, {
+                    'manifest_url': 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd',
+                    'ext': 'mp4',
+                    'format_id': '4',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.640032',
+                    'tbr': 1945.258,
+                    'width': 1280,
+                    'height': 720,
+                    'dash_cenc': {
+                        'laurl': 'https://drm-clearkey-testvectors.axtest.net/AcquireLicense',
+                        'key_ids': ['9eb4050de44b4802932e27d75083e266'],
+                    },
+                }, {
+                    'manifest_url': 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd',
+                    'ext': 'mp4',
+                    'format_id': '5',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.640033',
+                    'tbr': 2726.377,
+                    'width': 1920,
+                    'height': 1080,
+                    'dash_cenc': {
+                        'laurl': 'https://drm-clearkey-testvectors.axtest.net/AcquireLicense',
+                        'key_ids': ['9eb4050de44b4802932e27d75083e266'],
+                    },
+                }],
+                {},
+            ), (
+                # default CENC KID overridden via W3C PSSH box, no license server in manifest
+                'w3c_pssh',
+                'https://unknown/manifest.mpd',  # mpd_url
+                'https://unknown/',  # mpd_base_url
+                [{
+                    'manifest_url': 'https://unknown/manifest.mpd',
+                    'ext': 'mp4',
+                    'format_id': '1',
+                    'format_note': 'DASH video',
+                    'protocol': 'http_dash_segments',
+                    'acodec': 'none',
+                    'vcodec': 'avc1.64001f',
+                    'tbr': 389.802,
+                    'width': 512,
+                    'height': 288,
+                    'dash_cenc': {
+                        'key_ids': ['43215678123412341234123412341234'],
+                    },
+                    'has_drm': True,
+                }],
+                {},
             ),
         ]
 

--- a/test/testdata/mpd/clearkey_cenc.mpd
+++ b/test/testdata/mpd/clearkey_cenc.mpd
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+Version information:
+Axinom.MediaProcessing v3.0.0 targeting General Purpose Media Format specification v7
+ffmpeg version N-81423-g61fac0e Copyright (c) 2000-2016 the FFmpeg developers
+x265 [info]: HEVC encoder version 2.0+12-49a0d1176aef5bc6
+x264 0.148.2705 3f5ed56
+MP4Box - GPAC version 0.6.2-DEV-rev683-g7b29fbe-master
+MediaInfoLib - v0.7.87
+
+For more info about this video, see https://github.com/Axinom/dash-test-vectors
+-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static" mediaPresentationDuration="PT0H12M14.000S" maxSegmentDuration="PT0H0M4.000S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:clearkey="http://dashif.org/guidelines/clearKey">
+	<Period duration="PT0H12M14.000S">
+		<AdaptationSet segmentAlignment="true" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="und">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="9eb4050d-e44b-4802-932e-27d75083e266" />
+			<ContentProtection value="ClearKey1.0" schemeIdUri="urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e">
+				<clearkey:Laurl Lic_type="EME-1.0">https://drm-clearkey-testvectors.axtest.net/AcquireLicense</clearkey:Laurl>
+			</ContentProtection>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+			<SegmentTemplate timescale="24" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="96" initialization="$RepresentationID$/init.mp4" />
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.64001f" width="512" height="288" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="389802"></Representation>
+			<Representation id="2" mimeType="video/mp4" codecs="avc1.64001f" width="640" height="360" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="764935"></Representation>
+			<Representation id="3" mimeType="video/mp4" codecs="avc1.640028" width="852" height="480" frameRate="24" sar="640:639" startWithSAP="1" bandwidth="1120439"></Representation>
+			<Representation id="4" mimeType="video/mp4" codecs="avc1.640032" width="1280" height="720" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="1945258"></Representation>
+			<Representation id="5" mimeType="video/mp4" codecs="avc1.640033" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2726377"></Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>

--- a/test/testdata/mpd/dash_sea.mpd
+++ b/test/testdata/mpd/dash_sea.mpd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+	xmlns="urn:mpeg:dash:schema:mpd:2011"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static"
+	xmlns:sea="urn:mpeg:dash:schema:sea:2012" mediaPresentationDuration="PT3M32.949S" minBufferTime="PT3S">
+	<Period>
+		<AdaptationSet id="1" group="5" profiles="ccff" bitstreamSwitching="false" segmentAlignment="true" contentType="audio" mimeType="audio/mp4" codecs="mp4a.40.2" lang="en">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:sea:2012">
+				<sea:SegmentEncryption schemeIdUri="urn:mpeg:dash:sea:aes128-cbc:2013"/>
+				<sea:KeySystem keySystemUri="urn:mpeg:dash:sea:keysys:http:2013"/>
+				<sea:CryptoPeriod keyUriTemplate="https://zavideoplatform.keydelivery.eastus.media.azure.net/?kid=9280864f-064e-48c0-97e0-f2bcb1d8d012" IV="0x7BD31E102B0CE9CCD39691782533656C"/>
+			</ContentProtection>
+			<Label>aac_eng_2_127999_2_1</Label>
+			<SegmentTemplate timescale="10000000" media="QualityLevels($Bandwidth$)/Fragments(aac_eng_2_127999_2_1=$Time$,format=mpd-time-csf)" initialization="QualityLevels($Bandwidth$)/Fragments(aac_eng_2_127999_2_1=i,format=mpd-time-csf)">
+				<SegmentTimeline>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333" r="1"/>
+					<S d="20053334"/>
+					<S d="20053333"/>
+					<S d="3840000"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="5_A_aac_eng_2_127999_2_1_1" bandwidth="127999" audioSamplingRate="48000"/>
+		</AdaptationSet>
+		<AdaptationSet id="2" group="1" profiles="ccff" bitstreamSwitching="false" segmentAlignment="true" contentType="video" mimeType="video/mp4" codecs="avc1.640028" maxWidth="1920" maxHeight="1080" startWithSAP="1">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:sea:2012">
+				<sea:SegmentEncryption schemeIdUri="urn:mpeg:dash:sea:aes128-cbc:2013"/>
+				<sea:KeySystem keySystemUri="urn:mpeg:dash:sea:keysys:http:2013"/>
+				<sea:CryptoPeriod keyUriTemplate="https://zavideoplatform.keydelivery.eastus.media.azure.net/?kid=9280864f-064e-48c0-97e0-f2bcb1d8d012" IV="0x7BD31E102B0CE9CCD39691782533656C"/>
+			</ContentProtection>
+			<SegmentTemplate timescale="10000000" media="QualityLevels($Bandwidth$)/Fragments(video=$Time$,format=mpd-time-csf)" initialization="QualityLevels($Bandwidth$)/Fragments(video=i,format=mpd-time-csf)">
+				<SegmentTimeline>
+					<S d="20000000" r="105"/>
+					<S d="8666666"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="1_V_video_1" bandwidth="628102" width="1920" height="1080"/>
+			<Representation id="1_V_video_2" bandwidth="422519" codecs="avc1.64001F" width="1280" height="720"/>
+			<Representation id="1_V_video_3" bandwidth="258591" codecs="avc1.64001F" width="960" height="540"/>
+		</AdaptationSet>
+	</Period>
+</MPD>

--- a/test/testdata/mpd/w3c_pssh.mpd
+++ b/test/testdata/mpd/w3c_pssh.mpd
@@ -1,0 +1,13 @@
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static" mediaPresentationDuration="PT0H12M14.000S" maxSegmentDuration="PT0H0M4.000S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:clearkey="http://dashif.org/guidelines/clearKey">
+	<Period duration="PT0H12M14.000S">
+		<AdaptationSet segmentAlignment="true" group="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9" lang="und">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="9eb4050d-e44b-4802-932e-27d75083e266" />
+            <ContentProtection schemeIdUri="urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b">
+              <cenc:pssh>AAAANHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAFDIVZ4EjQSNBI0EjQSNBI0AAAAAA==</cenc:pssh>
+            </ContentProtection>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+			<SegmentTemplate timescale="24" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="96" initialization="$RepresentationID$/init.mp4" />
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.64001f" width="512" height="288" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="389802"></Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -59,6 +59,7 @@ from .networking.impersonate import ImpersonateRequestHandler, ImpersonateTarget
 from .plugins import directories as plugin_directories, load_all_plugins
 from .postprocessor import (
     EmbedThumbnailPP,
+    FFmpegCENCDecryptPP,
     FFmpegFixupDuplicateMoovPP,
     FFmpegFixupDurationPP,
     FFmpegFixupM3u8PP,
@@ -3474,6 +3475,8 @@ class YoutubeDL:
                         self.report_error(f'{msg}. Aborting')
                         return
 
+                decrypter = FFmpegCENCDecryptPP(self)
+                info_dict.setdefault('__files_to_cenc_decrypt', [])
                 if info_dict.get('requested_formats') is not None:
                     old_ext = info_dict['ext']
                     if self.params.get('merge_output_format') is None:
@@ -3555,8 +3558,12 @@ class YoutubeDL:
                                 downloaded.append(fname)
                             partial_success, real_download = self.dl(fname, new_info)
                             info_dict['__real_download'] = info_dict['__real_download'] or real_download
+                            if new_info.get('dash_cenc', {}).get('key'):
+                                info_dict['__files_to_cenc_decrypt'].append((fname, new_info['dash_cenc']['key']))
                             success = success and partial_success
 
+                    if downloaded and info_dict['__files_to_cenc_decrypt'] and decrypter.available:
+                        info_dict['__postprocessors'].append(decrypter)
                     if downloaded and merger.available and not self.params.get('allow_unplayable_formats'):
                         info_dict['__postprocessors'].append(merger)
                         info_dict['__files_to_merge'] = downloaded
@@ -3573,6 +3580,9 @@ class YoutubeDL:
                         # So we should try to resume the download
                         success, real_download = self.dl(temp_filename, info_dict)
                         info_dict['__real_download'] = real_download
+                        if info_dict.get('dash_cenc', {}).get('key') and decrypter.available:
+                            info_dict['__postprocessors'].append(decrypter)
+                            info_dict['__files_to_cenc_decrypt'] = [(temp_filename, info_dict['dash_cenc']['key'])]
                     else:
                         self.report_file_already_downloaded(dl_filename)
 

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3544,6 +3544,7 @@ class YoutubeDL:
                                 f'You have requested downloading multiple formats to stdout {reason}. '
                                 'The formats will be streamed one after the other')
                             fname = temp_filename
+                        first_cenc = next((f['dash_cenc'] for f in info_dict['requested_formats'] if 'dash_cenc' in f), None)
                         for f in info_dict['requested_formats']:
                             new_info = dict(info_dict)
                             del new_info['requested_formats']
@@ -3560,6 +3561,14 @@ class YoutubeDL:
                             info_dict['__real_download'] = info_dict['__real_download'] or real_download
                             if new_info.get('dash_cenc', {}).get('key'):
                                 info_dict['__files_to_cenc_decrypt'].append((fname, new_info['dash_cenc']['key']))
+                            else:
+                                # If a file is encrypted but not specified as such in the manifest, fallback to another key
+                                # This is the same observed behavior as Chrome
+                                with open(fname, 'rb') as f:
+                                    if re.search(br'schm\x00\x00\x00\x00(cbcs|cenc)', f.read()):
+                                        if not first_cenc:
+                                            raise ExtractorError('Cannot decrypt this format')
+                                        info_dict['__files_to_cenc_decrypt'].append((fname, first_cenc['key']))
                             success = success and partial_success
 
                     if downloaded and info_dict['__files_to_cenc_decrypt'] and decrypter.available:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -3268,14 +3268,19 @@ class InfoExtractor:
         scheme_id = cp_e.get('schemeIdUri')
         cenc_info = info.get('dash_cenc', {})
         if scheme_id == 'urn:mpeg:dash:mp4protection:2011':
-            if cp_e.get('value') == 'cenc':
+            if cp_e.get('value') in ('cenc', 'cbcs'):
                 # ISO/IEC 23009-1 MPEG Common Encryption (CENC)
                 if not cenc_info.get('key_ids'):
                     try:
-                        default_kid = uuid.UUID(cp_e.get('{urn:mpeg:cenc:2013}default_KID')).hex
+                        default_kid = uuid.UUID(cp_e.get(f'{{urn:mpeg:{cp_e.get("value")}:2013}}default_KID')).hex
                         cenc_info['key_ids'] = [default_kid]
                     except (ValueError, TypeError):
-                        pass
+                        # It can still be under the cenc namespace
+                        try:
+                            default_kid = uuid.UUID(cp_e.get('{urn:mpeg:cenc:2013}default_KID')).hex
+                            cenc_info['key_ids'] = [default_kid]
+                        except (ValueError, TypeError):
+                            pass
         elif scheme_id == 'urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e':
             # Clear Key DASH-IF
             for tag, ns in itertools.product(
@@ -3302,6 +3307,10 @@ class InfoExtractor:
                     cenc_info['key_ids'] = kids
                 except (ValueError, TypeError, struct.error):
                     pass
+            elif cp_e.get('value') == 'ClearKey1.0':
+                laurl = cp_e.find(self._xpath_ns('Laurl', 'http://dashif.org/guidelines/clearKey'))
+                assert laurl.attrib['Lic_type'] == 'EME-1.0'
+                cenc_info['laurl'] = laurl.text
         elif scheme_id == 'urn:mpeg:dash:sea:2012':
             # ISO/IEC 23009-4 DASH Segment Encryption and Authentication (AES-128-CBC)
             sea_ns = 'urn:mpeg:dash:schema:sea:2012'

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -253,7 +253,9 @@ class InfoExtractor:
                     * hls_aes    A dictionary of HLS AES-128 decryption information
                                  used by the native HLS downloader to override the
                                  values in the media playlist when an '#EXT-X-KEY' tag
-                                 is present in the playlist:
+                                 is present in the playlist. Used by the native DASH downloader
+                                 when DASH-SEA with AES-128-CBC content protection is present
+                                 in the manifest.:
                                  * uri  The URI from which the key will be downloaded
                                  * key  The key (as hex) used to decrypt fragments.
                                         If `key` is given, any key URI will be ignored
@@ -275,7 +277,8 @@ class InfoExtractor:
                     * is_dash_periods  Whether the format is a result of merging
                                  multiple DASH periods.
                     * dash_cenc  A dictionary of DASH CENC decryption information
-                                 used by the native DASH downloader when set.
+                                 used by the native DASH downloader when MPEG CENC content protection
+                                 is present in the manifest.
                                  * laurl    The Clear Key license server URL from which
                                             CENC keys will be downloaded.
                                  * key_ids  List of key IDs (as hex) to request from the ClearKey
@@ -2863,10 +2866,11 @@ class InfoExtractor:
                 assert 'is_dash_periods' not in f, 'format already processed'
                 f['is_dash_periods'] = True
                 format_key = tuple(v for k, v in f.items() if k not in (
-                    ('format_id', 'fragments', 'manifest_stream_number', 'dash_cenc')))
-                if 'dash_cenc' in f:
-                    format_key = format_key + tuple(
-                        tuple(v) if isinstance(v, list) else v for v in f['dash_cenc'].values())
+                    ('format_id', 'fragments', 'manifest_stream_number', 'dash_cenc', 'hls_aes')))
+                for k in ('dash_cenc', 'hls_aes'):
+                    if k in f:
+                        format_key = format_key + tuple(
+                            tuple(v) if isinstance(v, list) else v for v in f[k].values())
                 if format_key not in formats:
                     formats[format_key] = f
                 elif 'fragments' in f:
@@ -2901,15 +2905,13 @@ class InfoExtractor:
             return self._xpath_ns(path, namespace)
 
         def extract_drm_info(element):
+            info = {}
             has_drm = False
-            cenc_info = {}
             for cp_e in element.findall(_add_ns('ContentProtection')):
                 has_drm = True
-                self._extract_mpd_content_protection_info(cp_e, cenc_info)
-            info = {'dash_cenc': cenc_info} if cenc_info else {}
-            if has_drm and not (
-                cenc_info.get('key') or cenc_info.get('laurl') and cenc_info.get('key_ids')
-            ):
+                self._extract_mpd_content_protection_info(cp_e, info)
+            cenc_info = info.get('dash_cenc', {})
+            if has_drm and not ('hls_aes' in info or cenc_info.get('key') or (cenc_info.get('laurl') and cenc_info.get('key_ids'))):
                 info['has_drm'] = True
             return info
 
@@ -3234,7 +3236,7 @@ class InfoExtractor:
                         period_entry['subtitles'][lang or 'und'].append(f)
             yield period_entry
 
-    def _extract_mpd_content_protection_info(self, cp_e, cenc_info):
+    def _extract_mpd_content_protection_info(self, cp_e, info):
         """
         Extract supported DASH-CENC parameters for an MPD ContentProtection element.
 
@@ -3244,13 +3246,16 @@ class InfoExtractor:
         from the manifest or when an extractor needs to process the optional data section in W3C
         PSSH boxes).
 
-        Note that the `has_drm` flag will be set for any format that does not meet one or more
-        of these conditions:
+        Note that after all ContentProtection elements have been handled, the `has_drm` flag
+        will be set for any format that does not meet one or more of these conditions:
 
-            * Both `laurl` and `key_ids` are set (indicating the native DASH downloader should
-               use the specified Clear Key server URL to retreive the CENC key for this format.
-            * `key_id` is set (indicating the native DASH downloader should use the specified
+            * `dash_cenc` is set and both `laurl` and `key_ids` are set (indicating the native
+               DASH downloader should use the specified Clear Key server URL to retreive the
                CENC key for this format).
+            * `dash_cenc` is set and `key` is set (indicating the native DASH downloader should
+               use the specified CENC key for this format).
+            * `hls_aes` is set (indicating the native DASH downloader should use DASH SEA
+              AES-128-CBC decryption for this format).
 
         References:
          1. DASH-IF Content Protection Identifiers
@@ -3261,6 +3266,7 @@ class InfoExtractor:
             https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html
         """
         scheme_id = cp_e.get('schemeIdUri')
+        cenc_info = info.get('dash_cenc', {})
         if scheme_id == 'urn:mpeg:dash:mp4protection:2011':
             if cp_e.get('value') == 'cenc':
                 # ISO/IEC 23009-1 MPEG Common Encryption (CENC)
@@ -3296,6 +3302,19 @@ class InfoExtractor:
                     cenc_info['key_ids'] = kids
                 except (ValueError, TypeError, struct.error):
                     pass
+        elif scheme_id == 'urn:mpeg:dash:sea:2012':
+            # ISO/IEC 23009-4 DASH Segment Encryption and Authentication (AES-128-CBC)
+            sea_ns = 'urn:mpeg:dash:schema:sea:2012'
+            se_e = cp_e.find(self._xpath_ns('SegmentEncryption', sea_ns))
+            ks_e = cp_e.find(self._xpath_ns('KeySystem', sea_ns))
+            crypto_e = cp_e.find(self._xpath_ns('CryptoPeriod', sea_ns))
+            if (se_e is not None and se_e.get('schemeIdUri') == 'urn:mpeg:dash:sea:aes128-cbc:2013'
+                    and ks_e is not None and ks_e.get('keySystemUri') == 'urn:mpeg:dash:sea:keysys:http:2013'
+                    and crypto_e is not None and crypto_e.get('keyUriTemplate') and crypto_e.get('IV')
+                    ):
+                info['hls_aes'] = {'uri': crypto_e.get('keyUriTemplate'), 'iv': crypto_e.get('IV')}
+        if cenc_info:
+            info['dash_cenc'] = cenc_info
 
     def _extract_ism_formats(self, *args, **kwargs):
         fmts, subs = self._extract_ism_formats_and_subtitles(*args, **kwargs)

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -12,12 +12,14 @@ import netrc
 import os
 import random
 import re
+import struct
 import subprocess
 import sys
 import time
 import types
 import urllib.parse
 import urllib.request
+import uuid
 import xml.etree.ElementTree
 
 from ..compat import (
@@ -272,6 +274,15 @@ class InfoExtractor:
                                  * max_quality     (NiconicoLiveFD only) Max stream quality string
                     * is_dash_periods  Whether the format is a result of merging
                                  multiple DASH periods.
+                    * dash_cenc  A dictionary of DASH CENC decryption information
+                                 used by the native DASH downloader when set.
+                                 * laurl    The Clear Key license server URL from which
+                                            CENC keys will be downloaded.
+                                 * key_ids  List of key IDs (as hex) to request from the ClearKey
+                                            license server.
+                                 * key      The CENC key (as hex) used to decrypt fragments.
+                                            If `key` is given, any license server URL and
+                                            key IDs will be ignored.
                     RTMP formats can also have the additional fields: page_url,
                     app, play_path, tc_url, flash_version, rtmp_live, rtmp_conn,
                     rtmp_protocol, rtmp_real_time
@@ -2852,7 +2863,10 @@ class InfoExtractor:
                 assert 'is_dash_periods' not in f, 'format already processed'
                 f['is_dash_periods'] = True
                 format_key = tuple(v for k, v in f.items() if k not in (
-                    ('format_id', 'fragments', 'manifest_stream_number')))
+                    ('format_id', 'fragments', 'manifest_stream_number', 'dash_cenc')))
+                if 'dash_cenc' in f:
+                    format_key = format_key + tuple(
+                        tuple(v) if isinstance(v, list) else v for v in f['dash_cenc'].values())
                 if format_key not in formats:
                     formats[format_key] = f
                 elif 'fragments' in f:
@@ -2886,8 +2900,18 @@ class InfoExtractor:
         def _add_ns(path):
             return self._xpath_ns(path, namespace)
 
-        def is_drm_protected(element):
-            return element.find(_add_ns('ContentProtection')) is not None
+        def extract_drm_info(element):
+            has_drm = False
+            cenc_info = {}
+            for cp_e in element.findall(_add_ns('ContentProtection')):
+                has_drm = True
+                self._extract_mpd_content_protection_info(cp_e, cenc_info)
+            info = {'dash_cenc': cenc_info} if cenc_info else {}
+            if has_drm and not (
+                cenc_info.get('key') or cenc_info.get('laurl') and cenc_info.get('key_ids')
+            ):
+                info['has_drm'] = True
+            return info
 
         def extract_multisegment_info(element, ms_parent_info):
             ms_info = ms_parent_info.copy()
@@ -2961,6 +2985,7 @@ class InfoExtractor:
                 'timescale': 1,
             })
             for adaptation_set in period.findall(_add_ns('AdaptationSet')):
+                adaptation_set_drm_info = extract_drm_info(adaptation_set)
                 adaption_set_ms_info = extract_multisegment_info(adaptation_set, period_ms_info)
                 for representation in adaptation_set.findall(_add_ns('Representation')):
                     representation_attrib = adaptation_set.attrib.copy()
@@ -3049,8 +3074,8 @@ class InfoExtractor:
                             'acodec': 'none',
                             'vcodec': 'none',
                         }
-                    if is_drm_protected(adaptation_set) or is_drm_protected(representation):
-                        f['has_drm'] = True
+                    f.update(adaptation_set_drm_info)
+                    f.update(extract_drm_info(representation))
                     representation_ms_info = extract_multisegment_info(representation, adaption_set_ms_info)
 
                     def prepare_template(template_name, identifiers):
@@ -3208,6 +3233,69 @@ class InfoExtractor:
                     elif content_type == 'text':
                         period_entry['subtitles'][lang or 'und'].append(f)
             yield period_entry
+
+    def _extract_mpd_content_protection_info(self, cp_e, cenc_info):
+        """
+        Extract supported DASH-CENC parameters for an MPD ContentProtection element.
+
+        Called multiple times per extracted format in an MPD (once per ContentProtection element
+        within AdaptationSet and Representation elements). Subclasses may override this method
+        when necessary (such as when the Clear Key license server URL is provided separately
+        from the manifest or when an extractor needs to process the optional data section in W3C
+        PSSH boxes).
+
+        Note that the `has_drm` flag will be set for any format that does not meet one or more
+        of these conditions:
+
+            * Both `laurl` and `key_ids` are set (indicating the native DASH downloader should
+               use the specified Clear Key server URL to retreive the CENC key for this format.
+            * `key_id` is set (indicating the native DASH downloader should use the specified
+               CENC key for this format).
+
+        References:
+         1. DASH-IF Content Protection Identifiers
+            https://dashif.org/identifiers/content_protection/
+         2. DASH-IF Content Protection Guidelines
+            https://dashif.org/docs/IOP-Guidelines/DASH-IF-IOP-Part6-v5.0.0.pdf
+         3. W3C "cenc" Initialization Data Format
+            https://w3c.github.io/encrypted-media/format-registry/initdata/cenc.html
+        """
+        scheme_id = cp_e.get('schemeIdUri')
+        if scheme_id == 'urn:mpeg:dash:mp4protection:2011':
+            if cp_e.get('value') == 'cenc':
+                # ISO/IEC 23009-1 MPEG Common Encryption (CENC)
+                if not cenc_info.get('key_ids'):
+                    try:
+                        default_kid = uuid.UUID(cp_e.get('{urn:mpeg:cenc:2013}default_KID')).hex
+                        cenc_info['key_ids'] = [default_kid]
+                    except (ValueError, TypeError):
+                        pass
+        elif scheme_id == 'urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e':
+            # Clear Key DASH-IF
+            for tag, ns in itertools.product(
+                ('Laurl', 'laurl'),
+                ('https://dashif.org/CPS', 'http://dashif.org/guidelines/clearKey'),
+            ):
+                url_e = cp_e.find(self._xpath_ns(tag, ns))
+                if url_e is not None:
+                    cenc_info['laurl'] = url_e.text
+                    break
+        elif scheme_id == 'urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b':
+            # W3C Common System ID
+            pssh_e = cp_e.find(self._xpath_ns('pssh', 'urn:mpeg:cenc:2013'))
+            if pssh_e is not None:
+                # W3C PSSH box (may contain Clear Key KIDs but can also be used
+                # to store KIDs for other DRM systems)
+                try:
+                    pssh_box = base64.b64decode(pssh_e.text)
+                    kid_count, = struct.unpack('!L', pssh_box[28:32])
+                    kids = []
+                    for i in range(kid_count):
+                        kid = pssh_box[32 + i * 16:32 + (i + 1) * 16]
+                        kids.append(kid.hex())
+                    cenc_info['key_ids'] = kids
+                except (ValueError, TypeError, struct.error):
+                    pass
 
     def _extract_ism_formats(self, *args, **kwargs):
         fmts, subs = self._extract_ism_formats_and_subtitles(*args, **kwargs)

--- a/yt_dlp/postprocessor/__init__.py
+++ b/yt_dlp/postprocessor/__init__.py
@@ -8,6 +8,7 @@ from .ffmpeg import (
     FFmpegCopyStreamPP,
     FFmpegEmbedSubtitlePP,
     FFmpegExtractAudioPP,
+    FFmpegCENCDecryptPP,
     FFmpegFixupDuplicateMoovPP,
     FFmpegFixupDurationPP,
     FFmpegFixupM3u8PP,

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -323,7 +323,7 @@ class FFmpegPostProcessor(PostProcessor):
             [(path, []) for path in input_paths],
             [(out_path, opts)], **kwargs)
 
-    def real_run_ffmpeg(self, input_path_opts, output_path_opts, *, expected_retcodes=(0,)):
+    def real_run_ffmpeg(self, input_path_opts, output_path_opts, *, prepend_opts=None, expected_retcodes=(0,)):
         self.check_version()
 
         oldest_mtime = min(
@@ -333,6 +333,9 @@ class FFmpegPostProcessor(PostProcessor):
         # avconv does not have repeat option
         if self.basename == 'ffmpeg':
             cmd += [encodeArgument('-loglevel'), encodeArgument('repeat+info')]
+
+        if prepend_opts:
+            cmd += prepend_opts
 
         def make_args(file, args, name, number):
             keys = [f'_{name}{number}', f'_{name}']
@@ -847,12 +850,23 @@ class FFmpegMergerPP(FFmpegPostProcessor):
         return True
 
 
+class FFmpegCENCDecryptPP(FFmpegPostProcessor):
+    @PostProcessor._restrict_to(images=False)
+    def run(self, info):
+        for filename, key in info.get('__files_to_cenc_decrypt', []):
+            temp_filename = prepend_extension(filename, 'temp')
+            self.to_screen(f'Decrypting "{filename}"')
+            self.run_ffmpeg(filename, temp_filename, self.stream_copy_opts(), prepend_opts=['-decryption_key', key])
+            os.replace(temp_filename, filename)
+        return [], info
+
+
 class FFmpegFixupPostProcessor(FFmpegPostProcessor):
-    def _fixup(self, msg, filename, options):
+    def _fixup(self, msg, filename, options, prepend_opts=None):
         temp_filename = prepend_extension(filename, 'temp')
 
         self.to_screen(f'{msg} of "{filename}"')
-        self.run_ffmpeg(filename, temp_filename, options)
+        self.run_ffmpeg(filename, temp_filename, options, prepend_opts=prepend_opts)
 
         os.replace(temp_filename, filename)
 
@@ -924,7 +938,11 @@ class FFmpegCopyStreamPP(FFmpegFixupPostProcessor):
 
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
-        self._fixup(self.MESSAGE, info['filepath'], self.stream_copy_opts())
+        self._fixup(
+            self.MESSAGE,
+            info['filepath'],
+            self.stream_copy_opts(),
+        )
         return [], info
 
 


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

In general this adds support for the standard non-commercial DRM ContentProtection schemes in DASH manifests: MPEG-CENC/AES-128-CTR (via ffmpeg), AES-128-CBC, Clear Key license server handling

Should fix #7098 

Extractor:

* Adds support for parsing the following `ContentProtection` schemes in DASH manifests:
    * ISO/IEC 23009-1 MPEG Common Encryption (CENC): parses default CENC key ID
    * [DASH-IF Clear Key](https://github.com/Dash-Industry-Forum/ClearKey-Content-Protection): parses Clear Key license server URL
    * [W3C Common SystemID PSSH boxes](https://www.w3.org/TR/eme-initdata-cenc/): parses additional CENC key IDs which may override the default when used with Clear Key
    * ISO/IEC 23009-4 DASH Segment Encryption and Authentication (DASH SEA): parses required AES-128-CBC fields (for the DASH equivalent to HLS AES-128-CBC) (#7098)
* Adds `dash_cenc` format field for passing CENC information from extractors (roughly equivalent to `hls_aes`)

Downloader:

* Adds native DASH downloader support for retrieving CENC keys from a Clear Key license server (requires the extractor to return the necessary `dash_cenc` fields)
    * The native DASH downloader does not decrypt CENC streams, but it will pass the required CENC key back to be used by postprocessors (i.e. ffmpeg)
* Adds native DASH downloader support for DASH SEA AES-128-CBC encryption (requires the extractor to return the necessary `hls_aes` fields)
    * Segments are decrypted by the native downloader in the same way as the native HLS downloader (does not require any postprocessor)

Postprocessor:

* Adds `FFmpegCENCDecryptPP` postprocessor for decrypting MPEG Common Encryption (CENC) streams with ffmpeg
    * Run automatically when the extractor or downloader set a CENC decryption key for a given format (prior to any merging of separate audio+video formats)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

### Testing

For testing Clear Key + CENC I tested with the Axinom public DASH [test vectors](https://github.com/Axinom/public-test-vectors/blob/master/TestVectors-v7-v8.md) (note that `--no-check-certificates` is required because their testing Clear Key server has an expired cert):

Clear Key + CENC with multiple requested formats (decrypts audio + video separately before merging)
<details>

```
tmp git:dash-clearkey ✩  py:venv-clean ❯ yt-dlp -vU https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd --no-check-certificates
[debug] Command-line config: ['-vU', 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd', '--no-check-certificates']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2024.09.27 from yt-dlp/yt-dlp [c6387abc1]
[debug] Lazy loading extractors is disabled
[debug] Python 3.12.6 (CPython arm64 64bit) - macOS-14.6.1-arm64-arm-64bit (OpenSSL 3.3.2 3 Sep 2024)
[debug] exe versions: ffmpeg 7.0.2 (setts), ffprobe 7.0.2
[debug] Optional libraries: Cryptodome-3.21.0, brotli-1.1.0, certifi-2024.08.30, mutagen-1.47.0, requests-2.32.3, sqlite3-3.46.1, urllib3-2.2.3, websockets-13.1
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets
[debug] Loaded 1838 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Latest version: stable@2024.09.27 from yt-dlp/yt-dlp
yt-dlp is up to date (stable@2024.09.27 from yt-dlp/yt-dlp)
[generic] Extracting URL: https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd
[generic] Manifest_1080p_ClearKey: Downloading webpage
WARNING: [generic] Falling back on generic information extractor
[generic] Manifest_1080p_ClearKey: Extracting information
[debug] Identified a DASH manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] Manifest_1080p_ClearKey: Downloading 1 format(s): 12+15
[debug] Invoking dashsegments downloader on "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd"
[dashsegments] Total fragments: 185
[download] Destination: Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f12.mp4
[download] 100% of  172.45MiB in 00:01:40 at 1.72MiB/s
[debug] Invoking dashsegments downloader on "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd"
[dashsegments] Total fragments: 186
[download] Destination: Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f15.m4a
[download] 100% of    5.85MiB in 00:00:48 at 122.90KiB/s
[CENCDecrypt] Decrypting "Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f12.mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -decryption_key 166634c675823c235a4a9446fad52e4d -i 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f12.mp4' -map 0 -dn -ignore_unknown -c copy -movflags +faststart 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f12.temp.mp4'
[CENCDecrypt] Decrypting "Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f15.m4a"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -decryption_key 166634c675823c235a4a9446fad52e4d -i 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f15.m4a' -map 0 -dn -ignore_unknown -c copy -movflags +faststart 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f15.temp.m4a'
[Merger] Merging formats into "Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f12.mp4' -i 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f15.m4a' -c copy -map 0:v:0 -map 1:a:0 -movflags +faststart 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].temp.mp4'
Deleting original file Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f12.mp4 (pass -k to keep)
Deleting original file Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].f15.m4a (pass -k to keep)
```

</details>

Clear Key + CENC with single requested format:

<details>

```
tmp git:dash-clearkey ✩ ⇣py:venv-clean ❯ yt-dlp -vU https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd --no-check-certificates --format 12
[debug] Command-line config: ['-vU', 'https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd', '--no-check-certificates', '--format', '12']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2024.09.27 from yt-dlp/yt-dlp [c6387abc1]
[debug] Lazy loading extractors is disabled
[debug] Python 3.12.6 (CPython arm64 64bit) - macOS-14.6.1-arm64-arm-64bit (OpenSSL 3.3.2 3 Sep 2024)
[debug] exe versions: ffmpeg 7.0.2 (setts), ffprobe 7.0.2
[debug] Optional libraries: Cryptodome-3.21.0, brotli-1.1.0, certifi-2024.08.30, mutagen-1.47.0, requests-2.32.3, sqlite3-3.46.1, urllib3-2.2.3, websockets-13.1
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets
[debug] Loaded 1838 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Latest version: stable@2024.09.27 from yt-dlp/yt-dlp
yt-dlp is up to date (stable@2024.09.27 from yt-dlp/yt-dlp)
[generic] Extracting URL: https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd
[generic] Manifest_1080p_ClearKey: Downloading webpage
WARNING: [generic] Falling back on generic information extractor
[generic] Manifest_1080p_ClearKey: Extracting information
[debug] Identified a DASH manifest
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec:vp9.2(10), channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] Manifest_1080p_ClearKey: Downloading 1 format(s): 12
[debug] Invoking dashsegments downloader on "https://media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest_1080p_ClearKey.mpd"
[dashsegments] Total fragments: 185
[download] Destination: Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].mp4
[download] 100% of  172.45MiB in 00:01:55 at 1.50MiB/s
[CENCDecrypt] Decrypting "Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -decryption_key 166634c675823c235a4a9446fad52e4d -i 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].mp4' -map 0 -dn -ignore_unknown -c copy -movflags +faststart 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].temp.mp4'
[FixupDuplicateMoov] Fixing duplicate MOOV atoms of "Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].mp4' -map 0 -dn -ignore_unknown -c copy -movflags +faststart 'file:Manifest_1080p_ClearKey [Manifest_1080p_ClearKey].temp.mp4'
```

</details>

TODO:

- [x] ~~Find current test vector for DASH SEA~~