### PR TITLE
[test] Allow running tests explicitly

### DIFF
--- a/devscripts/run_tests.py
+++ b/devscripts/run_tests.py
@@ -39,10 +39,10 @@ def run_tests(*tests, pattern=None, ci=False):
     elif run_download:
         arguments.extend(['-m', 'download'])
     else:
-        for test in tests:
-            if '/' not in test and '::' not in test:
-                test = f'test/test_download.py::TestDownload::test_{fix_test_name(test)}'
-            arguments.append(test)
+        arguments.extend(
+            test if '/' in test
+            else f'test/test_download.py::TestDownload::test_{fix_test_name(test)}'
+            for test in tests)
 
     print(f'Running {arguments}', flush=True)
     try:

--- a/devscripts/run_tests.py
+++ b/devscripts/run_tests.py
@@ -16,7 +16,7 @@ fix_test_name = functools.partial(re.compile(r'IE(_all|_\d+)?$').sub, r'\1')
 def parse_args():
     parser = argparse.ArgumentParser(description='Run selected yt-dlp tests')
     parser.add_argument(
-        'test', help='a extractor tests, or one of "core" or "download"', nargs='*')
+        'test', help='an extractor test, test path, or one of "core" or "download"', nargs='*')
     parser.add_argument(
         '-k', help='run a test matching EXPRESSION. Same as "pytest -k"', metavar='EXPRESSION')
     parser.add_argument(
@@ -27,7 +27,6 @@ def parse_args():
 def run_tests(*tests, pattern=None, ci=False):
     run_core = 'core' in tests or (not pattern and not tests)
     run_download = 'download' in tests
-    tests = list(map(fix_test_name, tests))
 
     pytest_args = args.pytest_args or os.getenv('HATCH_TEST_ARGS', '')
     arguments = ['pytest', '-Werror', '--tb=short', *shlex.split(pytest_args)]
@@ -40,8 +39,10 @@ def run_tests(*tests, pattern=None, ci=False):
     elif run_download:
         arguments.extend(['-m', 'download'])
     else:
-        arguments.extend(
-            f'test/test_download.py::TestDownload::test_{test}' for test in tests)
+        for test in tests:
+            if '/' not in test and '::' not in test:
+                test = f'test/test_download.py::TestDownload::test_{fix_test_name(test)}'
+            arguments.append(test)
 
     print(f'Running {arguments}', flush=True)
     try:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Allows running `hatch test test/test_utils.py::TestUtil::test_sanitize_path` directly, so that you don't have to wait for gathering (takes long especially on Windows).


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
