### PR TITLE
[build] Move optional dependencies to the `default` group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
-dependencies = [
+dependencies = []
+
+[project.optional-dependencies]
+default = [
     "brotli; implementation_name=='cpython'",
     "brotlicffi; implementation_name!='cpython'",
     "certifi",
@@ -51,9 +54,6 @@ dependencies = [
     "urllib3>=1.26.17,<3",
     "websockets>=13.0",
 ]
-
-[project.optional-dependencies]
-default = []
 curl-cffi = [
     "curl-cffi==0.5.10; os_name=='nt' and implementation_name=='cpython'",
     "curl-cffi>=0.5.10,!=0.6.*,<0.7.2; os_name!='nt' and implementation_name=='cpython'",


### PR DESCRIPTION
This makes the Python optional depedencies *actually* optional by moving them into the `default` optional dependency group (i.e. the `default` extra).

yt-dlp's current documentation<sup>[[1]](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#update)</sup><sup>[[2]](https://github.com/yt-dlp/yt-dlp/wiki/Installation#with-pip)</sup> already reflects this change, which means that when installing via pip/pipx, the `default` group/extra will need to be specified in the install/upgrade command, e.g.:

```
python3 -m pip install -U "yt-dlp[default]"
```

The documentation was updated over 7 months ago<sup>[[1]](https://github.com/yt-dlp/yt-dlp/commit/cf91400a1dd6cc99b11a6d163e1af73b64d618c9)</sup><sup>[[2]](https://github.com/yt-dlp/yt-dlp-wiki/commit/e68fe1dcf88e7d7cf27d8b0173a0340a205fd9ac)</sup>, which should have been a sufficient period of advance warning.

**Note:** although this makes all dependencies truly optional, **it is still strongly recommended to install `certifi`, `requests`, & `urllib3`** along with yt-dlp. 

The primary reason for doing this is so that other Python projects which depend on yt-dlp are not burdened with any transitive dependencies, since none of yt-dlp's dependencies are a hard requirement for using `yt_dlp` as a library.

Closes #11221

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
