### PR TITLE
Add option for specifying plugins directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,9 +348,8 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     containing directory ("-" for stdin). Can be
                                     used multiple times and inside other
                                     configuration files
-    --plugin-dirs PATH              Path to a directory for yt-dlp to search for
-                                    plugins (in addition to the default plugin
-                                    directories). Note that this currently only
+    --plugin-dirs PATH              Path to an additional directory to search
+                                    for plugins. Note that this currently only
                                     works for extractor plugins; postprocessor
                                     plugins can only be loaded from the default
                                     plugin directories. This option can be used

--- a/README.md
+++ b/README.md
@@ -349,11 +349,12 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     used multiple times and inside other
                                     configuration files
     --plugin-dirs PATH              Path to an additional directory to search
-                                    for plugins. Note that this currently only
-                                    works for extractor plugins; postprocessor
-                                    plugins can only be loaded from the default
-                                    plugin directories. This option can be used
-                                    multiple times to add multiple directories
+                                    for plugins. This option can be used
+                                    multiple times to add multiple directories.
+                                    Note that this currently only works for
+                                    extractor plugins; postprocessor plugins can
+                                    only be loaded from the default plugin
+                                    directories
     --flat-playlist                 Do not extract the videos of a playlist,
                                     only list them
     --no-flat-playlist              Fully extract the videos of a playlist

--- a/README.md
+++ b/README.md
@@ -348,9 +348,13 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     containing directory ("-" for stdin). Can be
                                     used multiple times and inside other
                                     configuration files
-    --plugin-locations PATH         Location to search for plugin packages. Can
-                                    be used multiple times to add multiple
-                                    directories.
+    --plugin-dirs PATH              Path to a directory for yt-dlp to search for
+                                    plugins (in addition to the default plugin
+                                    directories). Note that this currently only
+                                    works for extractor plugins; postprocessor
+                                    plugins can only be loaded from the default
+                                    plugin directories. This option can be used
+                                    multiple times to add multiple directories
     --flat-playlist                 Do not extract the videos of a playlist,
                                     only list them
     --no-flat-playlist              Fully extract the videos of a playlist

--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     containing directory ("-" for stdin). Can be
                                     used multiple times and inside other
                                     configuration files
+    --plugin-locations PATH         Location to search for plugin packages. Can
+                                    be used multiple times to add multiple
+                                    directories.
     --flat-playlist                 Do not extract the videos of a playlist,
                                     only list them
     --no-flat-playlist              Fully extract the videos of a playlist

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -69,10 +69,10 @@ class TestPlugins(unittest.TestCase):
             importlib.invalidate_caches()  # reset the import caches
 
     def test_plugin_locations(self):
-        # Internal plugin locations hack for CLI --plugin-locations
+        # Internal plugin locations hack for CLI --plugin-dirs
         # To be replaced with proper system later
         custom_plugin_locations_path = TEST_DATA_DIR / 'plugin_packages'
-        Config._plugin_locations = [str(custom_plugin_locations_path)]
+        Config._plugin_dirs = [str(custom_plugin_locations_path)]
         importlib.invalidate_caches()  # reset the import caches
 
         try:
@@ -83,7 +83,7 @@ class TestPlugins(unittest.TestCase):
             self.assertIn('PackagePluginIE', plugins_ie.keys())
 
         finally:
-            Config._plugin_locations = []
+            Config._plugin_dirs = []
             importlib.invalidate_caches()  # reset the import caches
 
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -10,7 +10,8 @@ TEST_DATA_DIR = Path(os.path.dirname(os.path.abspath(__file__)), 'testdata')
 sys.path.append(str(TEST_DATA_DIR))
 importlib.invalidate_caches()
 
-from yt_dlp.plugins import Config, PACKAGE_NAME, directories, load_plugins
+from yt_dlp import Config
+from yt_dlp.plugins import PACKAGE_NAME, directories, load_plugins
 
 
 class TestPlugins(unittest.TestCase):
@@ -68,16 +69,16 @@ class TestPlugins(unittest.TestCase):
             os.remove(zip_path)
             importlib.invalidate_caches()  # reset the import caches
 
-    def test_plugin_locations(self):
-        # Internal plugin locations hack for CLI --plugin-dirs
+    def test_plugin_dirs(self):
+        # Internal plugin dirs hack for CLI --plugin-dirs
         # To be replaced with proper system later
-        custom_plugin_locations_path = TEST_DATA_DIR / 'plugin_packages'
-        Config._plugin_dirs = [str(custom_plugin_locations_path)]
+        custom_plugin_dir = TEST_DATA_DIR / 'plugin_packages'
+        Config._plugin_dirs = [str(custom_plugin_dir)]
         importlib.invalidate_caches()  # reset the import caches
 
         try:
             package = importlib.import_module(f'{PACKAGE_NAME}.extractor')
-            self.assertIn(custom_plugin_locations_path / 'testpackage' / PACKAGE_NAME / 'extractor', map(Path, package.__path__))
+            self.assertIn(custom_plugin_dir / 'testpackage' / PACKAGE_NAME / 'extractor', map(Path, package.__path__))
 
             plugins_ie = load_plugins('extractor', 'IE')
             self.assertIn('PackagePluginIE', plugins_ie.keys())

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -4,14 +4,13 @@ import shutil
 import sys
 import unittest
 from pathlib import Path
-from yt_dlp import Config
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 TEST_DATA_DIR = Path(os.path.dirname(os.path.abspath(__file__)), 'testdata')
 sys.path.append(str(TEST_DATA_DIR))
 importlib.invalidate_caches()
 
-from yt_dlp.plugins import PACKAGE_NAME, directories, load_plugins
+from yt_dlp.plugins import Config, PACKAGE_NAME, directories, load_plugins
 
 
 class TestPlugins(unittest.TestCase):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -10,7 +10,7 @@ TEST_DATA_DIR = Path(os.path.dirname(os.path.abspath(__file__)), 'testdata')
 sys.path.append(str(TEST_DATA_DIR))
 importlib.invalidate_caches()
 
-from yt_dlp import Config
+from yt_dlp.utils import Config
 from yt_dlp.plugins import PACKAGE_NAME, directories, load_plugins
 
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import unittest
 from pathlib import Path
+from yt_dlp import Config
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 TEST_DATA_DIR = Path(os.path.dirname(os.path.abspath(__file__)), 'testdata')
@@ -66,6 +67,24 @@ class TestPlugins(unittest.TestCase):
         finally:
             sys.path.remove(str(zip_path))
             os.remove(zip_path)
+            importlib.invalidate_caches()  # reset the import caches
+
+    def test_plugin_locations(self):
+        # Internal plugin locations hack for CLI --plugin-locations
+        # To be replaced with proper system later
+        custom_plugin_locations_path = TEST_DATA_DIR / 'plugin_packages'
+        Config._plugin_locations = [str(custom_plugin_locations_path)]
+        importlib.invalidate_caches()  # reset the import caches
+
+        try:
+            package = importlib.import_module(f'{PACKAGE_NAME}.extractor')
+            self.assertIn(custom_plugin_locations_path / 'testpackage' / PACKAGE_NAME / 'extractor', map(Path, package.__path__))
+
+            plugins_ie = load_plugins('extractor', 'IE')
+            self.assertIn('PackagePluginIE', plugins_ie.keys())
+
+        finally:
+            Config._plugin_locations = []
             importlib.invalidate_caches()  # reset the import caches
 
 

--- a/test/testdata/plugin_packages/testpackage/yt_dlp_plugins/extractor/package.py
+++ b/test/testdata/plugin_packages/testpackage/yt_dlp_plugins/extractor/package.py
@@ -1,0 +1,5 @@
+from yt_dlp.extractor.common import InfoExtractor
+
+
+class PackagePluginIE(InfoExtractor):
+    pass

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -62,6 +62,7 @@ from .utils import (
     traverse_obj,
     variadic,
     write_string,
+    Config,
 )
 from .utils.networking import std_headers
 from .utils._utils import _UnsafeExtensionError
@@ -945,6 +946,7 @@ def parse_options(argv=None):
         'xattr_set_filesize': opts.xattr_set_filesize,
         'match_filter': opts.match_filter,
         'color': opts.color,
+        'plugins_location': opts.plugins_location,
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
@@ -966,6 +968,9 @@ def _real_main(argv=None):
     setproctitle('yt-dlp')
 
     parser, opts, all_urls, ydl_opts = parse_options(argv)
+
+    # Set the plugins location early on
+    Config._plugins_location = opts.plugins_location
 
     # Dump user agent
     if opts.dump_user_agent:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -968,7 +968,7 @@ def _real_main(argv=None):
 
     parser, opts, all_urls, ydl_opts = parse_options(argv)
 
-    # HACK: Set the plugins location early on
+    # HACK: Set the plugin dirs early on
     # TODO(coletdjnz): remove when plugin globals system is implemented
     Config._plugin_dirs = opts.plugin_dirs
 

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -946,7 +946,7 @@ def parse_options(argv=None):
         'xattr_set_filesize': opts.xattr_set_filesize,
         'match_filter': opts.match_filter,
         'color': opts.color,
-        'plugin_locations': opts.plugin_locations,
+        'plugin_dirs': opts.plugin_dirs,
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
@@ -971,7 +971,7 @@ def _real_main(argv=None):
 
     # HACK: Set the plugins location early on
     # TODO(coletdjnz): remove when plugin globals system is implemented
-    Config._plugin_locations = opts.plugin_locations
+    Config._plugin_locations = opts.plugin_dirs
 
     # Dump user agent
     if opts.dump_user_agent:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -34,6 +34,7 @@ from .postprocessor import (
 )
 from .update import Updater
 from .utils import (
+    Config,
     NO_DEFAULT,
     POSTPROCESS_WHEN,
     DateRange,
@@ -62,7 +63,6 @@ from .utils import (
     traverse_obj,
     variadic,
     write_string,
-    Config,
 )
 from .utils.networking import std_headers
 from .utils._utils import _UnsafeExtensionError
@@ -946,7 +946,6 @@ def parse_options(argv=None):
         'xattr_set_filesize': opts.xattr_set_filesize,
         'match_filter': opts.match_filter,
         'color': opts.color,
-        'plugin_dirs': opts.plugin_dirs,
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -970,7 +970,7 @@ def _real_main(argv=None):
 
     # HACK: Set the plugins location early on
     # TODO(coletdjnz): remove when plugin globals system is implemented
-    Config._plugin_locations = opts.plugin_dirs
+    Config._plugin_dirs = opts.plugin_dirs
 
     # Dump user agent
     if opts.dump_user_agent:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -946,7 +946,7 @@ def parse_options(argv=None):
         'xattr_set_filesize': opts.xattr_set_filesize,
         'match_filter': opts.match_filter,
         'color': opts.color,
-        'plugins_location': opts.plugins_location,
+        'plugin_locations': opts.plugin_locations,
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
@@ -969,8 +969,9 @@ def _real_main(argv=None):
 
     parser, opts, all_urls, ydl_opts = parse_options(argv)
 
-    # Set the plugins location early on
-    Config._plugins_location = opts.plugins_location
+    # HACK: Set the plugins location early on
+    # TODO(coletdjnz): remove when plugin globals system is implemented
+    Config._plugin_locations = opts.plugin_locations
 
     # Dump user agent
     if opts.dump_user_agent:

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -412,8 +412,8 @@ def create_parser():
         '--plugin-dirs',
         dest='plugin_dirs', metavar='PATH', action='append',
         help=(
-            'Path to a directory for yt-dlp to search for plugins (in addition to the default '
-            'plugin directories). Note that this currently only works for extractor plugins; '
+            'Path to append to the default list of directories yt-dlp uses to search for plugins. '
+            'Note that this currently only works for extractor plugins; '
             'postprocessor plugins can only be loaded from the default plugin directories. This '
             'option can be used multiple times to add multiple directories'))
     general.add_option(

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -409,6 +409,10 @@ def create_parser():
             'Location of the main configuration file; either the path to the config or its containing directory '
             '("-" for stdin). Can be used multiple times and inside other configuration files'))
     general.add_option(
+        '--plugins-location',
+        dest='plugins_location', metavar='PATH', action='append',
+        help=('Location of a folder containing plugins'))
+    general.add_option(
         '--flat-playlist',
         action='store_const', dest='extract_flat', const='in_playlist', default=False,
         help='Do not extract the videos of a playlist, only list them')

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -412,10 +412,10 @@ def create_parser():
         '--plugin-dirs',
         dest='plugin_dirs', metavar='PATH', action='append',
         help=(
-            'Path to append to the default list of directories yt-dlp uses to search for plugins. '
+            'Path to an additional directory to search for plugins. '
             'Note that this currently only works for extractor plugins; '
-            'postprocessor plugins can only be loaded from the default plugin directories. This '
-            'option can be used multiple times to add multiple directories'))
+            'postprocessor plugins can only be loaded from the default plugin directories. '
+            'This option can be used multiple times to add multiple directories'))
     general.add_option(
         '--flat-playlist',
         action='store_const', dest='extract_flat', const='in_playlist', default=False,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -413,9 +413,9 @@ def create_parser():
         dest='plugin_dirs', metavar='PATH', action='append',
         help=(
             'Path to an additional directory to search for plugins. '
+            'This option can be used multiple times to add multiple directories. '
             'Note that this currently only works for extractor plugins; '
-            'postprocessor plugins can only be loaded from the default plugin directories. '
-            'This option can be used multiple times to add multiple directories'))
+            'postprocessor plugins can only be loaded from the default plugin directories'))
     general.add_option(
         '--flat-playlist',
         action='store_const', dest='extract_flat', const='in_playlist', default=False,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -409,9 +409,9 @@ def create_parser():
             'Location of the main configuration file; either the path to the config or its containing directory '
             '("-" for stdin). Can be used multiple times and inside other configuration files'))
     general.add_option(
-        '--plugins-location',
-        dest='plugins_location', metavar='PATH', action='append',
-        help=('Location of a folder containing plugins'))
+        '--plugin-locations',
+        dest='plugin_locations', metavar='PATH', action='append',
+        help='Location to search for plugin packages. Can be used multiple times to add multiple directories.')
     general.add_option(
         '--flat-playlist',
         action='store_const', dest='extract_flat', const='in_playlist', default=False,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -409,9 +409,13 @@ def create_parser():
             'Location of the main configuration file; either the path to the config or its containing directory '
             '("-" for stdin). Can be used multiple times and inside other configuration files'))
     general.add_option(
-        '--plugin-locations',
-        dest='plugin_locations', metavar='PATH', action='append',
-        help='Location to search for plugin packages. Can be used multiple times to add multiple directories.')
+        '--plugin-dirs',
+        dest='plugin_dirs', metavar='PATH', action='append',
+        help=(
+            'Path to a directory for yt-dlp to search for plugins (in addition to the default '
+            'plugin directories). Note that this currently only works for extractor plugins; '
+            'postprocessor plugins can only be loaded from the default plugin directories. This '
+            'option can be used multiple times to add multiple directories'))
     general.add_option(
         '--flat-playlist',
         action='store_const', dest='extract_flat', const='in_playlist', default=False,

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -85,9 +85,10 @@ class PluginFinder(importlib.abc.MetaPathFinder):
         with contextlib.suppress(ValueError):  # Added when running __main__.py directly
             candidate_locations.remove(Path(__file__).parent)
 
-        if Config._plugins_location:
+        # TODO(coletdjnz): remove when plugin globals system is implemented
+        if Config._plugin_locations:
             candidate_locations.extend(_get_package_paths(
-                *Config._plugins_location,
+                *Config._plugin_locations,
                 containing_folder=''))
 
         parts = Path(*fullname.split('.'))

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -86,9 +86,9 @@ class PluginFinder(importlib.abc.MetaPathFinder):
             candidate_locations.remove(Path(__file__).parent)
 
         # TODO(coletdjnz): remove when plugin globals system is implemented
-        if Config._plugin_locations:
+        if Config._plugin_dirs:
             candidate_locations.extend(_get_package_paths(
-                *Config._plugin_locations,
+                *Config._plugin_dirs,
                 containing_folder=''))
 
         parts = Path(*fullname.split('.'))

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -20,6 +20,7 @@ from .utils import (
     get_user_config_dirs,
     orderedSet,
     write_string,
+    Config,
 )
 
 PACKAGE_NAME = 'yt_dlp_plugins'
@@ -83,6 +84,11 @@ class PluginFinder(importlib.abc.MetaPathFinder):
         candidate_locations.extend(map(Path, sys.path))  # PYTHONPATH
         with contextlib.suppress(ValueError):  # Added when running __main__.py directly
             candidate_locations.remove(Path(__file__).parent)
+
+        if Config._plugins_location:
+            candidate_locations.extend(_get_package_paths(
+                *Config._plugins_location,
+                containing_folder=''))
 
         parts = Path(*fullname.split('.'))
         for path in orderedSet(candidate_locations, lazy=True):

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -15,12 +15,12 @@ from zipfile import ZipFile
 
 from .compat import functools  # isort: split
 from .utils import (
+    Config,
     get_executable_path,
     get_system_config_dirs,
     get_user_config_dirs,
     orderedSet,
     write_string,
-    Config,
 )
 
 PACKAGE_NAME = 'yt_dlp_plugins'

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4897,7 +4897,9 @@ class Config:
     filename = None
     __initialized = False
 
-    _plugins_location = None
+    # Internal only, do not use! Hack to enable --plugins-location
+    # TODO(coletdjnz): remove when plugin globals system is implemented
+    _plugin_locations = None
 
     def __init__(self, parser, label=None):
         self.parser, self.label = parser, label

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4897,7 +4897,7 @@ class Config:
     filename = None
     __initialized = False
 
-    # Internal only, do not use! Hack to enable --plugin-dir
+    # Internal only, do not use! Hack to enable --plugin-dirs
     # TODO(coletdjnz): remove when plugin globals system is implemented
     _plugin_dirs = None
 

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4897,9 +4897,9 @@ class Config:
     filename = None
     __initialized = False
 
-    # Internal only, do not use! Hack to enable --plugins-location
+    # Internal only, do not use! Hack to enable --plugin-dir
     # TODO(coletdjnz): remove when plugin globals system is implemented
-    _plugin_locations = None
+    _plugin_dirs = None
 
     def __init__(self, parser, label=None):
         self.parser, self.label = parser, label

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4897,6 +4897,8 @@ class Config:
     filename = None
     __initialized = False
 
+    _plugins_location = None
+
     def __init__(self, parser, label=None):
         self.parser, self.label = parser, label
         self._loaded_paths, self.configs = set(), []


### PR DESCRIPTION
Closes #3260

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Lets you specify `--plugin-locations` 1 or more times and then goes to each specified location and looks for `<package name>/yt_dlp_plugins/` as normal. Via CLI or config file.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
