### PR TITLE
Expand paths in `--plugin-dirs`

### DIFF
--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -970,7 +970,8 @@ def _real_main(argv=None):
 
     # HACK: Set the plugin dirs early on
     # TODO(coletdjnz): remove when plugin globals system is implemented
-    Config._plugin_dirs = opts.plugin_dirs
+    if opts.plugin_dirs is not None:
+        Config._plugin_dirs = list(map(expand_path, opts.plugin_dirs))
 
     # Dump user agent
     if opts.dump_user_agent:


### PR DESCRIPTION
Currently, passing `--plugin-dirs ~/path/to/plugins` in a shell works, but the same doesn't work in a config file.

Similarly, passing `--plugin-dirs '~/path/to/plugins'` doesn't work in a shell or in a config file.

We need to call `expand_path` on the path values like we do for all of the other options that accept path values.

Bugfix for 0f593dca9fa995d88eb763170a932da61c8f24dc

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
