### PR TITLE
[ie/vimeo] Fix API retries

### DIFF
--- a/yt_dlp/extractor/vimeo.py
+++ b/yt_dlp/extractor/vimeo.py
@@ -869,11 +869,12 @@ class VimeoIE(VimeoBaseInfoExtractor):
         for retry in (False, True):
             try:
                 video = self._call_videos_api(video_id, viewer['jwt'], unlisted_hash)
+                break
             except ExtractorError as e:
                 if (not retry and isinstance(e.cause, HTTPError) and e.cause.status == 400
                     and 'password' in traverse_obj(
-                        e.cause.response.read(),
-                        ({bytes.decode}, {json.loads}, 'invalid_parameters', ..., 'field'),
+                        self._webpage_read_content(e.cause.response, e.cause.response.url, video_id, fatal=False),
+                        ({json.loads}, 'invalid_parameters', ..., 'field'),
                 )):
                     self._verify_video_password(
                         video_id, self._get_video_password(), viewer['xsrft'])


### PR DESCRIPTION
Fix a bug introduced in c1c9bb4adb42d0d93a2fb5d93a7de0a87b6ba884 where the API call for video data could be retried unnecessarily

Also tweak the error handling so that the error response can be captured with `--write-pages` for debug purposes

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
