### PR TITLE
Allow thumbnails with `.jpe` extension

### DIFF
--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -5165,6 +5165,7 @@ class _UnsafeExtensionError(Exception):
         'ico',
         'image',
         'jng',
+        'jpe',
         'jpeg',
         'jxl',
         'svg',


### PR DESCRIPTION
Fix 5ce582448ececb8d9c30c8c31f58330090ced03a

Closes #11407

<details open><summary>Template</summary> <!-- OPEN is intentional -->



### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
