### PR TITLE
[ie/nfl] Fix extractors

### DIFF
--- a/yt_dlp/extractor/nfl.py
+++ b/yt_dlp/extractor/nfl.py
@@ -11,9 +11,12 @@ from ..utils import (
     clean_html,
     determine_ext,
     get_element_by_class,
-    traverse_obj,
+    int_or_none,
+    make_archive_id,
+    url_or_none,
     urlencode_postdata,
 )
+from ..utils.traversal import traverse_obj
 
 
 class NFLBaseIE(InfoExtractor):
@@ -75,22 +78,15 @@ class NFLBaseIE(InfoExtractor):
             'osVersion': '10.0',
         }, separators=(',', ':')).encode()).decode(),
         'networkType': 'other',
-        'nflClaimGroupsToAdd': [],
-        'nflClaimGroupsToRemove': [],
+        'peacockUUID': 'undefined',
     }
     _ACCOUNT_INFO = {}
-    _API_KEY = None
+    _API_KEY = '3_Qa8TkWpIB8ESCBT8tY2TukbVKgO5F6BJVc7N1oComdwFzI7H2L9NOWdm11i_BY9f'
 
     _TOKEN = None
     _TOKEN_EXPIRY = 0
 
-    def _get_account_info(self, url, slug):
-        if not self._API_KEY:
-            webpage = self._download_webpage(url, slug, fatal=False) or ''
-            self._API_KEY = self._search_regex(
-                r'window\.gigyaApiKey\s*=\s*["\'](\w+)["\'];', webpage, 'API key',
-                fatal=False) or '3_Qa8TkWpIB8ESCBT8tY2TukbVKgO5F6BJVc7N1oComdwFzI7H2L9NOWdm11i_BY9f'
-
+    def _get_account_info(self):
         cookies = self._get_cookies('https://auth-id.nfl.com/')
         login_token = traverse_obj(cookies, (
             (f'glt_{self._API_KEY}', lambda k, _: k.startswith('glt_')), {lambda x: x.value}), get_all=False)
@@ -103,7 +99,7 @@ class NFLBaseIE(InfoExtractor):
                 'or else try using --cookies-from-browser instead', expected=True)
 
         account = self._download_json(
-            'https://auth-id.nfl.com/accounts.getAccountInfo', slug,
+            'https://auth-id.nfl.com/accounts.getAccountInfo', None,
             note='Downloading account info', data=urlencode_postdata({
                 'include': 'profile,data',
                 'lang': 'en',
@@ -111,7 +107,7 @@ class NFLBaseIE(InfoExtractor):
                 'sdk': 'js_latest',
                 'login_token': login_token,
                 'authMode': 'cookie',
-                'pageURL': url,
+                'pageURL': 'https://www.nfl.com/',
                 'sdkBuild': traverse_obj(cookies, (
                     'gig_canary_ver', {lambda x: x.value.partition('-')[0]}), default='15170'),
                 'format': 'json',
@@ -126,55 +122,75 @@ class NFLBaseIE(InfoExtractor):
         if len(self._ACCOUNT_INFO) != 3:
             raise ExtractorError('Failed to retrieve account info with provided cookies', expected=True)
 
-    def _get_auth_token(self, url, slug):
+    def _get_auth_token(self):
         if self._TOKEN and self._TOKEN_EXPIRY > int(time.time() + 30):
             return
-
-        if not self._ACCOUNT_INFO:
-            self._get_account_info(url, slug)
 
         token = self._download_json(
             'https://api.nfl.com/identity/v3/token%s' % (
                 '/refresh' if self._ACCOUNT_INFO.get('refreshToken') else ''),
-            slug, headers={'Content-Type': 'application/json'}, note='Downloading access token',
+            None, headers={'Content-Type': 'application/json'}, note='Downloading access token',
             data=json.dumps({**self._CLIENT_DATA, **self._ACCOUNT_INFO}, separators=(',', ':')).encode())
 
         self._TOKEN = token['accessToken']
         self._TOKEN_EXPIRY = token['expiresIn']
         self._ACCOUNT_INFO['refreshToken'] = token['refreshToken']
 
+    def _extract_video(self, mcp_id):
+        self._get_auth_token()
+        data = self._download_json(
+            f'https://api.nfl.com/play/v1/asset/{mcp_id}', mcp_id, headers={
+                'Authorization': f'Bearer {self._TOKEN}',
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            }, data=json.dumps({'init': True}, separators=(',', ':')).encode())
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            data['accessUrl'], mcp_id, 'mp4', m3u8_id='hls')
+
+        return {
+            'id': mcp_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            '_old_archive_ids': [make_archive_id(AnvatoIE, mcp_id)],
+            **traverse_obj(data, ('metadata', {
+                'title': ('event', ('def_title', 'friendlyName'), {str}, any),
+                'description': ('event', 'def_description', {str}),
+                'duration': ('event', 'duration', {int_or_none}),
+                'thumbnails': ('thumbnails', ..., 'url', {'url': {url_or_none}}),
+            })),
+        }
+
     def _parse_video_config(self, video_config, display_id):
         video_config = self._parse_json(video_config, display_id)
         item = video_config['playlist'][0]
-        mcp_id = item.get('mcpID')
-        if mcp_id:
-            info = self.url_result(f'{self._ANVATO_PREFIX}{mcp_id}', AnvatoIE, mcp_id)
+        if mcp_id := item.get('mcpID'):
+            return self._extract_video(mcp_id)
+
+        media_id = item.get('id') or item['entityId']
+        title = item.get('title')
+        item_url = item['url']
+        info = {'id': media_id}
+        ext = determine_ext(item_url)
+        if ext == 'm3u8':
+            info['formats'] = self._extract_m3u8_formats(item_url, media_id, 'mp4')
         else:
-            media_id = item.get('id') or item['entityId']
-            title = item.get('title')
-            item_url = item['url']
-            info = {'id': media_id}
-            ext = determine_ext(item_url)
-            if ext == 'm3u8':
-                info['formats'] = self._extract_m3u8_formats(item_url, media_id, 'mp4')
-            else:
-                info['url'] = item_url
-                if item.get('audio') is True:
-                    info['vcodec'] = 'none'
-            is_live = video_config.get('live') is True
-            thumbnails = None
-            image_url = item.get(item.get('imageSrc')) or item.get(item.get('posterImage'))
-            if image_url:
-                thumbnails = [{
-                    'url': image_url,
-                    'ext': determine_ext(image_url, 'jpg'),
-                }]
-            info.update({
-                'title': title,
-                'is_live': is_live,
-                'description': clean_html(item.get('description')),
-                'thumbnails': thumbnails,
-            })
+            info['url'] = item_url
+            if item.get('audio') is True:
+                info['vcodec'] = 'none'
+        is_live = video_config.get('live') is True
+        thumbnails = None
+        image_url = item.get(item.get('imageSrc')) or item.get(item.get('posterImage'))
+        if image_url:
+            thumbnails = [{
+                'url': image_url,
+                'ext': determine_ext(image_url, 'jpg'),
+            }]
+        info.update({
+            'title': title,
+            'is_live': is_live,
+            'description': clean_html(item.get('description')),
+            'thumbnails': thumbnails,
+        })
         return info
 
 
@@ -188,24 +204,19 @@ class NFLIE(NFLBaseIE):
             'ext': 'mp4',
             'title': "Baker Mayfield's game-changing plays from 3-TD game Week 14",
             'description': 'md5:85e05a3cc163f8c344340f220521136d',
-            'upload_date': '20201215',
-            'timestamp': 1608009755,
-            'thumbnail': r're:^https?://.*\.jpg$',
-            'uploader': 'NFL',
-            'tags': 'count:6',
+            'thumbnail': r're:https?://.+\.jpg',
             'duration': 157,
-            'categories': 'count:3',
+            '_old_archive_ids': ['anvato 899441'],
         },
     }, {
         'url': 'https://www.chiefs.com/listen/patrick-mahomes-travis-kelce-react-to-win-over-dolphins-the-breakdown',
-        'md5': '6886b32c24b463038c760ceb55a34566',
+        'md5': '92a517f05bd3eb50fe50244bc621aec8',
         'info_dict': {
-            'id': 'd87e8790-3e14-11eb-8ceb-ff05c2867f99',
+            'id': '8b7c3625-a461-4751-8db4-85f536f2bbd0',
             'ext': 'mp3',
             'title': 'Patrick Mahomes, Travis Kelce React to Win Over Dolphins | The Breakdown',
             'description': 'md5:12ada8ee70e6762658c30e223e095075',
         },
-        'skip': 'HTTP Error 404: Not Found',
     }, {
         'url': 'https://www.buffalobills.com/video/buffalo-bills-military-recognition-week-14',
         'only_matching': True,
@@ -236,13 +247,16 @@ class NFLArticleIE(NFLBaseIE):
     def _real_extract(self, url):
         display_id = self._match_id(url)
         webpage = self._download_webpage(url, display_id)
-        entries = []
-        for video_config in re.findall(self._VIDEO_CONFIG_REGEX, webpage):
-            entries.append(self._parse_video_config(video_config, display_id))
+
+        def entries():
+            for video_config in re.findall(self._VIDEO_CONFIG_REGEX, webpage):
+                yield self._parse_video_config(video_config, display_id)
+
         title = clean_html(get_element_by_class(
             'nfl-c-article__title', webpage)) or self._html_search_meta(
             ['og:title', 'twitter:title'], webpage)
-        return self.playlist_result(entries, display_id, title)
+
+        return self.playlist_result(entries(), display_id, title)
 
 
 class NFLPlusReplayIE(NFLBaseIE):
@@ -307,6 +321,9 @@ class NFLPlusReplayIE(NFLBaseIE):
         'all_22': 'All-22',
     }
 
+    def _real_initialize(self):
+        self._get_account_info()
+
     def _real_extract(self, url):
         slug, video_id = self._match_valid_url(url).group('slug', 'id')
         requested_types = self._configuration_arg('type', ['all'])
@@ -315,7 +332,7 @@ class NFLPlusReplayIE(NFLBaseIE):
         requested_types = traverse_obj(self._REPLAY_TYPES, (None, requested_types))
 
         if not video_id:
-            self._get_auth_token(url, slug)
+            self._get_auth_token()
             headers = {'Authorization': f'Bearer {self._TOKEN}'}
             game_id = self._download_json(
                 f'https://api.nfl.com/football/v2/games/externalId/slug/{slug}', slug,
@@ -328,14 +345,13 @@ class NFLPlusReplayIE(NFLBaseIE):
                     'items', lambda _, v: v['subType'] == requested_types[0], 'mcpPlaybackId'), get_all=False)
 
         if video_id:
-            return self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
+            return self._extract_video(video_id)
 
         def entries():
             for replay in traverse_obj(
                 replays, ('items', lambda _, v: v['mcpPlaybackId'] and v['subType'] in requested_types),
             ):
-                video_id = replay['mcpPlaybackId']
-                yield self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
+                yield self._extract_video(replay['mcpPlaybackId'])
 
         return self.playlist_result(entries(), slug)
 
@@ -362,12 +378,15 @@ class NFLPlusEpisodeIE(NFLBaseIE):
         'params': {'skip_download': 'm3u8'},
     }]
 
+    def _real_initialize(self):
+        self._get_account_info()
+
     def _real_extract(self, url):
         slug = self._match_id(url)
-        self._get_auth_token(url, slug)
+        self._get_auth_token()
         video_id = self._download_json(
             f'https://api.nfl.com/content/v1/videos/episodes/{slug}', slug, headers={
                 'Authorization': f'Bearer {self._TOKEN}',
             })['mcpPlaybackId']
 
-        return self.url_result(f'{self._ANVATO_PREFIX}{video_id}', AnvatoIE, video_id)
+        return self._extract_video(video_id)


### PR DESCRIPTION
The site's API changed somewhat, and it now directly serves the m3u8 URLs instead of routing through the Anvato API. The token generator endpoint is now gone (404), so removed the dead code in `AnvatoIE`.

Haven't been able to test with a premium account, but know that the NFLPlus extractors were definitely broken due to the dead token endpoint.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
