### PR TITLE
[build] Disable attestations for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
+          attestations: false  # Currently doesn't work w/ reusable workflows (breaks nightly)
 
   publish:
     needs: [prepare, build]


### PR DESCRIPTION
Digital attestation for PyPI trusted publishing currently does not work with reusable workflows, e.g. `release-nightly.yml` calling `release.yml`. [This breaks our nightly PyPI releases.](https://github.com/yt-dlp/yt-dlp/actions/runs/11603267731)

It was turned "on by default" in v1.11.0 of `pypa/gh-action-pypi-publish` (yesterday). We need to temporarily disable it until reusable workflows are supported.

- https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0
- https://github.com/pypa/gh-action-pypi-publish/discussions/255
- https://github.com/pypi/warehouse/issues/11096


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
