### PR TITLE
[build] Enable attestations for trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -504,7 +504,8 @@ jobs:
       - windows32
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
           path: artifact
           pattern: build-bin-*

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -28,3 +28,24 @@ jobs:
       actions: write  # For cleaning up cache
       id-token: write  # mandatory for trusted publishing
     secrets: inherit
+
+  publish_pypi:
+    needs: [release]
+    if: vars.MASTER_PYPI_PROJECT != ''
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # mandatory for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          name: build-pypi
+      - name: Verify SHA2-256SUMS
+        run: |
+          cd ./dist/
+          sha256sum -c SHA2-256SUMS
+          rm SHA2-256SUMS
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -36,7 +36,8 @@ jobs:
     permissions:
       id-token: write  # mandatory for trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
           path: dist
           name: build-pypi

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           path: dist
           name: build-pypi
-      - name: Verify SHA2-256SUMS
-        run: |
-          cd ./dist/
-          sha256sum -c SHA2-256SUMS
-          rm SHA2-256SUMS
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -41,3 +41,24 @@ jobs:
       actions: write  # For cleaning up cache
       id-token: write  # mandatory for trusted publishing
     secrets: inherit
+
+  publish_pypi:
+    needs: [release]
+    if: vars.NIGHTLY_PYPI_PROJECT != ''
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # mandatory for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          name: build-pypi
+      - name: Verify SHA2-256SUMS
+        run: |
+          cd ./dist/
+          sha256sum -c SHA2-256SUMS
+          rm SHA2-256SUMS
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -54,11 +54,6 @@ jobs:
         with:
           path: dist
           name: build-pypi
-      - name: Verify SHA2-256SUMS
-        run: |
-          cd ./dist/
-          sha256sum -c SHA2-256SUMS
-          rm SHA2-256SUMS
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -49,7 +49,8 @@ jobs:
     permissions:
       id-token: write  # mandatory for trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
           path: dist
           name: build-pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-          attestations: false  # Currently doesn't work w/ reusable workflows (breaks nightly)
 
   publish:
     needs: [prepare, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: Release
 on:
   workflow_call:
     inputs:
-      prerelease:
-        required: false
-        default: true
-        type: boolean
       source:
         required: false
         default: ''
@@ -18,6 +14,14 @@ on:
         required: false
         default: ''
         type: string
+      prerelease:
+        required: false
+        default: true
+        type: boolean
+      manual_dispatch:
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       source:
@@ -46,6 +50,10 @@ on:
       prerelease:
         description: Pre-release
         default: false
+        type: boolean
+      manual_dispatch:
+        description: Manual dispatch (do not toggle)
+        default: true
         type: boolean
 
 permissions:
@@ -278,7 +286,28 @@ jobs:
           make clean-cache
           python -m build --no-isolation .
 
+      - name: Make SHA2-SUMS files
+        if: ${{ !inputs.manual_dispatch }}
+        run: |
+          cd ./dist/
+          # make sure SHA sums are also printed to stdout
+          sha256sum -- * | tee SHA2-256SUMS
+          # also print as permanent annotations to the summary page
+          while read -r shasum; do
+            echo "::notice title=${shasum##* }::sha256: ${shasum% *}"
+          done < SHA2-256SUMS
+
+      - name: Upload PyPI artifacts
+        if: ${{ !inputs.manual_dispatch }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-pypi
+          path: |
+            dist/*
+          compression-level: 0
+
       - name: Publish to PyPI
+        if: inputs.manual_dispatch
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,8 +267,6 @@ jobs:
           sed -i -E '0,/(name = ")[^"]+(")/s//\1${{ env.pypi_project }}\2/' pyproject.toml
 
       - name: Build
-        env:
-          event_name: ${{ github.event_name }}
         run: |
           rm -rf dist/*
           make pypi-files
@@ -279,17 +277,6 @@ jobs:
           python devscripts/set-variant.py pip -M "You installed yt-dlp with pip or using the wheel from PyPi; Use that to update"
           make clean-cache
           python -m build --no-isolation .
-          cd ./dist/
-          # print SHA sums to stdout
-          sha256sum -- * | tee SHA2-256SUMS
-          # also print as permanent annotations to the summary page
-          while read -r shasum; do
-            echo "::notice title=${shasum##* }::sha256: ${shasum% *}"
-          done < SHA2-256SUMS
-          # if we're publishing from this workflow, we need to remove SHA2-256SUMS from ./dist/ now
-          if [[ "${event_name}" == "workflow_dispatch" ]]; then
-            rm SHA2-256SUMS
-          fi
 
       - name: Upload artifacts
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,6 @@ on:
         required: false
         default: true
         type: boolean
-      manual_dispatch:
-        required: false
-        default: false
-        type: boolean
   workflow_dispatch:
     inputs:
       source:
@@ -50,10 +46,6 @@ on:
       prerelease:
         description: Pre-release
         default: false
-        type: boolean
-      manual_dispatch:
-        description: Manual dispatch (do not toggle)
-        default: true
         type: boolean
 
 permissions:
@@ -275,6 +267,8 @@ jobs:
           sed -i -E '0,/(name = ")[^"]+(")/s//\1${{ env.pypi_project }}\2/' pyproject.toml
 
       - name: Build
+        env:
+          event_name: ${{ github.event_name }}
         run: |
           rm -rf dist/*
           make pypi-files
@@ -285,20 +279,20 @@ jobs:
           python devscripts/set-variant.py pip -M "You installed yt-dlp with pip or using the wheel from PyPi; Use that to update"
           make clean-cache
           python -m build --no-isolation .
-
-      - name: Make SHA2-SUMS files
-        if: ${{ !inputs.manual_dispatch }}
-        run: |
           cd ./dist/
-          # make sure SHA sums are also printed to stdout
+          # print SHA sums to stdout
           sha256sum -- * | tee SHA2-256SUMS
           # also print as permanent annotations to the summary page
           while read -r shasum; do
             echo "::notice title=${shasum##* }::sha256: ${shasum% *}"
           done < SHA2-256SUMS
+          # if we're publishing from this workflow, we need to remove SHA2-256SUMS from ./dist/ now
+          if [[ "${event_name}" == "workflow_dispatch" ]]; then
+            rm SHA2-256SUMS
+          fi
 
-      - name: Upload PyPI artifacts
-        if: ${{ !inputs.manual_dispatch }}
+      - name: Upload artifacts
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: build-pypi
@@ -307,7 +301,7 @@ jobs:
           compression-level: 0
 
       - name: Publish to PyPI
-        if: inputs.manual_dispatch
+        if: github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true


### PR DESCRIPTION
428ffb75aa3534b275cf54de42693a4d261519da disabled digital attestations for trusted publishing to PyPI. This was due to reusable workflows not being supported by the attestation system.

I did some further reading into this issue, and per https://github.com/pypi/warehouse/issues/11096#issuecomment-2260686299, reusable workflows have *never* actually been supported by trusted publishing (with or without attestation); it's only a happy accident that the particular reusable workflow strategy we use happens to work (without attestation). This means our nightly release workflow could break again at any time.

428ffb75aa3534b275cf54de42693a4d261519da will only continue to work as a band-aid until 1 of these 3 things happen:
1. trusted publishing adds proper support for reusable workflows (probably causing `#2`)
2. trusted publishing's "accidental" support for reusable workflows is broken (possibly caused by `#1`)
3. attestation becomes a hard requirement / no longer optional

This PR reverts 428ffb75aa3534b275cf54de42693a4d261519da and refactors our workflows so that the trusted publishing step is always in the parent workflow (and never in a reusable workflow). This allows us to enable attestation and to no longer rely on the "accidental" support of reusable workflows.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
