### PR TITLE
FFmpegMetadataPP: Don't attempt to copy cover art for .opus and .wav files

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -677,7 +677,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
 
     @staticmethod
     def _options(target_ext):
-        audio_only = target_ext == 'm4a'
+        audio_only = target_ext in ('opus', 'wav')
         yield from FFmpegPostProcessor.stream_copy_opts(not audio_only)
         if audio_only:
             yield from ('-vn', '-acodec', 'copy')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This fixes https://github.com/yt-dlp/yt-dlp/issues/11487 with a workaround. I removed `m4a` from being considered audio-only, because FFmpeg is now capable of embedding cover art in `m4a` files (I tested this by running the following command twice: `yt-dlp http://benprunty.bandcamp.com/track/lanius-battle -f aac-hi --embed-metadata --embed-thumbnail`), also see https://trac.ffmpeg.org/ticket/2798. Since FFmpeg does not support embedding cover art into `opus` files (see https://trac.ffmpeg.org/ticket/4448) I added `opus` to be considered audio-only. I also added `wav` because FFmpeg does not support embedding cover art in `wav` files when `-write_id3v1 1` is set (since ID3v1 doesn't have a cover art tag).

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
