### PR TITLE
[ie/Radiko] Add support for logins and timefree 30

### DIFF
--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -54,7 +54,7 @@ class RadikoBaseIE(InfoExtractor):
                 raise ExtractorError('Invalid username and/or password', expected=True)
             raise
 
-    def _check_account(self):
+    def _check_tf30(self):
         if self._has_tf30 is not None:
             return self._has_tf30
         if self._get_cookies('https://radiko.jp').get('radiko_session') is None:
@@ -145,13 +145,13 @@ class RadikoBaseIE(InfoExtractor):
 
         if broadcast_day_end + datetime.timedelta(days=30) < now:
             self.raise_no_formats('Programme is no longer available.', video_id=video_id, expected=True)
-        elif broadcast_day_end + datetime.timedelta(days=7) < now and not self._check_account():
+        elif broadcast_day_end + datetime.timedelta(days=7) < now and not self._check_tf30():
             self.raise_login_required('Programme is only available with a Timefree 30 subscription',
                                       metadata_available=True)
 
         station_program = self._download_xml(
             f'https://api.radiko.jp/program/v3/date/{broadcast_day_str}/station/{station}.xml', station,
-            note=f'Downloading programme data for {broadcast_day_str}')
+            note=f'Downloading programme information for {broadcast_day_str}')
 
         prog = None
         for p in station_program.findall('.//prog'):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR adds support for programmes older than a week, available with radiko's new premium plan, Timefree 30. It also adds support for logging in with a username and password.

Previously, programme metadata came from an API that just gave info for the whole week at once. That was fine, but it breaks if we want to download something older than a week.
Now we use an API for the specific date/broadcast day, which can go further back in the past.
A broadcast day starts at 5AM and ends at 5AM _the next day_, so I've had to add some code to account for that.

`broadcast_day_end` is the last moment of that broadcast day.
On the free plan, programmes expire 7 days after the end of their broadcast day. On timefree 30, it's 30 days after.
So, if we have the `broadcast_day_end`, we can add 7 or 30 days to it, to work out when the programme expires for each plan, and throw useful errors for each case.

When we login with username/password, the API tells us what plan we have upfront. But we don't get that when logging in with cookies, so I've had to use a different API for that case.

One annoyance is that the cached stream token isn't invalidated - so you could be logged in fine, but not be able to download tf30 programmes because the token was negotiated with a different plan.
but properly fixing that is really annoying

Fixes #11422, #3860


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

I copied the login API url from https://github.com/yyoshiki41/go-radiko/blob/98331dc61de88c734b24c213758e8e649720d053/login.go#L23, as the API currently on the site uses recaptcha. I didn't copy any actual code.

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
