### PR TITLE
[ie/patreon] Fix comments extraction

### DIFF
--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -426,7 +426,7 @@ class PatreonIE(PatreonBaseIE):
                 f'posts/{post_id}/comments', post_id, query=params, note=f'Downloading comments page {page}')
 
             cursor = None
-            for comment in traverse_obj(response, (('data', ('included', lambda _, v: v['type'] == 'comment')), ...)):
+            for comment in traverse_obj(response, (('data', 'included'), lambda _, v: v['type'] == 'comment' and v['id'])):
                 count += 1
                 if (comment_id := try_call(lambda: comment.get('id'))) is None:
                     continue

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -17,6 +17,7 @@ from ..utils import (
     smuggle_url,
     str_or_none,
     traverse_obj,
+    try_call,
     url_or_none,
     urljoin,
 )
@@ -406,10 +407,9 @@ class PatreonIE(PatreonBaseIE):
             cursor = None
             for comment in traverse_obj(response, (('data', ('included', lambda _, v: v['type'] == 'comment')), ...)):
                 count += 1
-                comment_id = comment.get('id')
-                attributes = comment.get('attributes') or {}
-                if comment_id is None:
+                if (comment_id := try_call(lambda: comment.get('id'))) is None:
                     continue
+                attributes = comment.get('attributes') or {}
                 author_id = traverse_obj(comment, ('relationships', 'commenter', 'data', 'id'))
                 author_info = traverse_obj(
                     response, ('included', lambda _, v: v['id'] == author_id and v['type'] == 'user', 'attributes'),

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -17,7 +17,6 @@ from ..utils import (
     smuggle_url,
     str_or_none,
     traverse_obj,
-    try_call,
     url_or_none,
     urljoin,
 )

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -253,6 +253,27 @@ class PatreonIE(PatreonBaseIE):
             'thumbnail': r're:^https?://.+',
         },
         'skip': 'Patron-only content',
+    }, {
+        # Contains a comment reply in the 'included' section
+        'url': 'https://www.patreon.com/posts/114721679',
+        'info_dict': {
+            'id': '114721679',
+            'ext': 'mp4',
+            'upload_date': '20241025',
+            'uploader': 'Japanalysis',
+            'like_count': int,
+            'thumbnail': r're:^https?://.+',
+            'comment_count': int,
+            'title': 'Karasawa Part 2',
+            'description': 'Part 2 of this video https://www.youtube.com/watch?v=Azms2-VTASk',
+            'uploader_url': 'https://www.patreon.com/japanalysis',
+            'uploader_id': '80504268',
+            'channel_url': 'https://www.patreon.com/japanalysis',
+            'channel_follower_count': int,
+            'timestamp': 1729897015,
+            'channel_id': '9346307',
+        },
+        'params': {'getcomments': True},
     }]
     _RETURN_TYPE = 'video'
 

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -428,9 +428,8 @@ class PatreonIE(PatreonBaseIE):
             cursor = None
             for comment in traverse_obj(response, (('data', 'included'), lambda _, v: v['type'] == 'comment' and v['id'])):
                 count += 1
-                if (comment_id := try_call(lambda: comment.get('id'))) is None:
-                    continue
-                attributes = comment.get('attributes') or {}
+                comment_id = comment['id']
+                attributes = traverse_obj(comment, ('attributes', {dict})) or {}
                 author_id = traverse_obj(comment, ('relationships', 'commenter', 'data', 'id'))
                 author_info = traverse_obj(
                     response, ('included', lambda _, v: v['id'] == author_id and v['type'] == 'user', 'attributes'),

--- a/yt_dlp/extractor/patreon.py
+++ b/yt_dlp/extractor/patreon.py
@@ -431,7 +431,7 @@ class PatreonIE(PatreonBaseIE):
 
                 yield {
                     **traverse_obj(comment, {
-                        'id': 'id',
+                        'id': ('id', {str_or_none}),
                         'text': ('attributes', 'body', {str}),
                         'timestamp': ('attributes', 'created', {parse_iso8601}),
                         'parent': ('relationships', 'parent', 'data', ('id', {value('root')}), {str}, any),


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

The issue appeared to have to do with comments that replied to other comments. These comment objects, in the 'included' block, could be picked up by the traverse_obj call, but were not actually parse-able as comments.

In the attached JSON and screenshot, the string `"153434567"` (the inner red box) is the object referenced by the `comment` variable at the time of the crash, which leads to the `AttributeError` and the crashout. Moving `comment.get('id')` into a `try_call`, and moving the `comment_id is not None` check to the very beginning of the loop body resolved the issue.

Fixes #11483 

![11483](https://github.com/user-attachments/assets/283f79a3-e936-4de1-b3be-84033ffd0d93)
[11483.json](https://github.com/user-attachments/files/17737236/11483.json)


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
