### PR TITLE
[ie/bilibili] Provide fallback for playinfo extraction

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -164,17 +164,15 @@ class BilibiliBaseIE(InfoExtractor):
         params['w_rid'] = hashlib.md5(f'{query}{self._get_wbi_key(video_id)}'.encode()).hexdigest()
         return params
 
-    def _download_playinfo(self, bvid, cid, headers=None, qn=None, fatal=True):
+    def _download_playinfo(self, bvid, cid, headers=None, qn=None):
         params = {'bvid': bvid, 'cid': cid, 'fnval': 4048}
         if qn:
             params['qn'] = qn
         play_info = self._download_json(
             'https://api.bilibili.com/x/player/wbi/playurl', bvid,
-            query=self._sign_wbi(params, bvid), headers=headers, fatal=fatal,
+            query=self._sign_wbi(params, bvid), headers=headers,
             note=f'Downloading video formats for cid {cid} {qn or ""}')
-        if fatal:
-            return play_info['data']
-        return traverse_obj(play_info, ('data', {dict})) or {}
+        return play_info['data']
 
     def json2srt(self, json_data):
         srt_data = ''
@@ -693,9 +691,7 @@ class BiliBiliIE(BilibiliBaseIE):
                 self._search_json(
                     r'window\.__playinfo__\s*=', webpage, 'play info', video_id, default=None),
                 ('data', {dict}))
-            or self._download_playinfo(video_id, cid, headers=headers, fatal=False))
-        if not play_info:
-            raise ExtractorError('Failed to extract play info')
+            or self._download_playinfo(video_id, cid, headers=headers))
 
         festival_info = {}
         if is_festival:

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -653,7 +653,7 @@ class BiliBiliIE(BilibiliBaseIE):
             video_data = initial_state['videoData']
 
         if video_data.get('is_upower_exclusive'):
-            high_level = traverse_obj(initial_state, ('elecFullInfo', 'show_info', 'high_level'))
+            high_level = traverse_obj(initial_state, ('elecFullInfo', 'show_info', 'high_level', {dict})) or {}
             raise ExtractorError(
                 'This is a supporter-only video: '
                 f'{join_nonempty("title", "sub_title", from_dict=high_level, delim="，")}. '

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -654,10 +654,8 @@ class BiliBiliIE(BilibiliBaseIE):
 
         if video_data.get('is_upower_exclusive'):
             high_level = traverse_obj(initial_state, ('elecFullInfo', 'show_info', 'high_level'))
-            support_title = traverse_obj(high_level, 'title', default='')
-            support_subtitle = traverse_obj(high_level, 'sub_title', default='')
             raise ExtractorError(
-                f'This is a supporter-only video: {support_title}，{support_subtitle}. '
+                f'{join_nonempty("title", "sub_title", from_dict=high_level, delim="，")}. '
                 f'{self._login_hint()}', expected=True)
 
         video_id, title = video_data['bvid'], video_data.get('title')

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -653,7 +653,7 @@ class BiliBiliIE(BilibiliBaseIE):
                     raise ExtractorError(
                         'This video may be deleted or geo-restricted. '
                         'You might want to try a VPN or a proxy server (with --proxy)', expected=True)
-                play_info = self._download_playinfo(traverse_obj(initial_state, ('videoData', 'bvid'), default=video_id),
+                play_info = self._download_playinfo(initial_state['videoData']['bvid'],
                                                     initial_state['cid'], headers=headers)
             else:
                 play_info = traverse_obj(play_info_obj, ('data', {dict}))

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -164,18 +164,17 @@ class BilibiliBaseIE(InfoExtractor):
         params['w_rid'] = hashlib.md5(f'{query}{self._get_wbi_key(video_id)}'.encode()).hexdigest()
         return params
 
-    def _download_playinfo(self, bvid, cid, headers=None, fatal=True, qn=None):
+    def _download_playinfo(self, bvid, cid, headers=None, qn=None, fatal=True):
         params = {'bvid': bvid, 'cid': cid, 'fnval': 4048}
         if qn:
             params['qn'] = qn
-        play_info_obj = self._download_json(
+        play_info = self._download_json(
             'https://api.bilibili.com/x/player/wbi/playurl', bvid,
             query=self._sign_wbi(params, bvid), headers=headers, fatal=fatal,
             note=f'Downloading video formats for cid {cid} {qn or ""}')
         if fatal:
-            return play_info_obj['data']
-        else:
-            return play_info_obj.get('data')
+            return play_info['data']
+        return traverse_obj(play_info, ('data', {dict})) or {}
 
     def json2srt(self, json_data):
         srt_data = ''

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -655,6 +655,7 @@ class BiliBiliIE(BilibiliBaseIE):
         if video_data.get('is_upower_exclusive'):
             high_level = traverse_obj(initial_state, ('elecFullInfo', 'show_info', 'high_level'))
             raise ExtractorError(
+                'This is a supporter-only video: '
                 f'{join_nonempty("title", "sub_title", from_dict=high_level, delim="，")}. '
                 f'{self._login_hint()}', expected=True)
 

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -168,11 +168,10 @@ class BilibiliBaseIE(InfoExtractor):
         params = {'bvid': bvid, 'cid': cid, 'fnval': 4048}
         if qn:
             params['qn'] = qn
-        play_info = self._download_json(
+        return self._download_json(
             'https://api.bilibili.com/x/player/wbi/playurl', bvid,
             query=self._sign_wbi(params, bvid), headers=headers,
-            note=f'Downloading video formats for cid {cid} {qn or ""}')
-        return play_info['data']
+            note=f'Downloading video formats for cid {cid} {qn or ""}')['data']
 
     def json2srt(self, json_data):
         srt_data = ''

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -644,7 +644,8 @@ class BiliBiliIE(BilibiliBaseIE):
             video_data = initial_state['videoInfo']
         else:
             play_info_obj = self._search_json(
-                r'window\.__playinfo__\s*=', webpage, 'play info', video_id, fatal=False)
+                r'window\.__playinfo__\s*=', webpage, 'play info', video_id, default=None)
+            play_info = None
             if not play_info_obj:
                 if traverse_obj(initial_state, ('error', 'trueCode')) == -403:
                     self.raise_login_required()
@@ -652,7 +653,9 @@ class BiliBiliIE(BilibiliBaseIE):
                     raise ExtractorError(
                         'This video may be deleted or geo-restricted. '
                         'You might want to try a VPN or a proxy server (with --proxy)', expected=True)
-            play_info = traverse_obj(play_info_obj, ('data', {dict}))
+                play_info = self._download_playinfo(video_id, initial_state['cid'], headers=headers)
+            else:
+                play_info = traverse_obj(play_info_obj, ('data', {dict}))
             if not play_info:
                 if traverse_obj(play_info_obj, 'code') == 87007:
                     toast = get_element_by_class('tips-toast', webpage) or ''

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -686,8 +686,7 @@ class BiliBiliIE(BilibiliBaseIE):
 
         play_info = (
             traverse_obj(
-                self._search_json(
-                    r'window\.__playinfo__\s*=', webpage, 'play info', video_id, default=None),
+                self._search_json(r'window\.__playinfo__\s*=', webpage, 'play info', video_id, default=None),
                 ('data', {dict}))
             or self._download_playinfo(video_id, cid, headers=headers))
 

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -680,7 +680,6 @@ class BiliBiliIE(BilibiliBaseIE):
         old_video_id = format_field(aid, None, f'%s_part{part_id or 1}')
         cid = traverse_obj(video_data, ('pages', part_id - 1, 'cid')) if part_id else video_data.get('cid')
 
-        festival_info = {}
         play_info = (
             traverse_obj(
                 self._search_json(
@@ -702,6 +701,7 @@ class BiliBiliIE(BilibiliBaseIE):
             raise ExtractorError(
                 f'This is a supporter-only video: {msg}. {self._login_hint()}', expected=True)
 
+        festival_info = {}
         if is_festival:
             festival_info = traverse_obj(initial_state, {
                 'uploader': ('videoInfo', 'upName'),

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -690,16 +690,16 @@ class BiliBiliIE(BilibiliBaseIE):
             raise ExtractorError('Failed to extract play info')
 
         if video_data.get('is_upower_exclusive'):
-            # Supporter only, also indicated by
+            # Supporter-only, also indicated by
             # `not traverse_obj(play_info, ('support_formats', ..., 'codecs'))`
             # Ref: https://github.com/ytdl-org/youtube-dl/issues/32722#issuecomment-1950045012
             high_level = traverse_obj(initial_state, ('elecFullInfo', 'show_info', 'high_level'))
             # Should we inline the title and the subtitle?
             support_title = traverse_obj(high_level, 'title', default='')
-            support_sub_title = traverse_obj(high_level, 'sub_title', default='')
-            msg = f'{support_title}，{support_sub_title}'
+            support_subtitle = traverse_obj(high_level, 'sub_title', default='')
             raise ExtractorError(
-                f'This is a supporter-only video: {msg}. {self._login_hint()}', expected=True)
+                f'This is a supporter-only video: {support_title}，{support_subtitle}. '
+                f'{self._login_hint()}', expected=True)
 
         festival_info = {}
         if is_festival:

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -653,7 +653,8 @@ class BiliBiliIE(BilibiliBaseIE):
                     raise ExtractorError(
                         'This video may be deleted or geo-restricted. '
                         'You might want to try a VPN or a proxy server (with --proxy)', expected=True)
-                play_info = self._download_playinfo(video_id, initial_state['cid'], headers=headers)
+                play_info = self._download_playinfo(traverse_obj(initial_state, ('videoData', 'bvid'), default=video_id),
+                                                    initial_state['cid'], headers=headers)
             else:
                 play_info = traverse_obj(play_info_obj, ('data', {dict}))
             if not play_info:


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

[site-bug]
the site has removed `window.__playinfo__` from the page source. This pr adds a fallback by downloading the playinfo from the API on extraction failure and fixes the error handling for member only videos.

Fixes #11665


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
