### PR TITLE
[ie/abematv] support season

### DIFF
--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -421,7 +421,7 @@ class AbemaTVIE(AbemaTVBaseIE):
 
 
 class AbemaTVTitleIE(AbemaTVBaseIE):
-    _VALID_URL = r'https?://abema\.tv/video/title/(?P<id>[^?/]+)(?:\?(?:.*?&)?s=(?P<season>[^&]+))?'
+    _VALID_URL = r'https?://abema\.tv/video/title/(?P<id>[^?/]+)(?:\?(?:[^#]+&)?s=(?P<season>[^&#]+))?'
     _PAGE_SIZE = 25
 
     _TESTS = [{

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -470,8 +470,7 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
             self._PAGE_SIZE)
 
     def _real_extract(self, url):
-        playlist_id = self._match_id(url)
-        season_id = self._match_valid_url(url).group('season')
+        playlist_id, season_id = self._match_valid_url(url).group('id', 'season')
         series_info = self._call_api(f'v1/video/series/{playlist_id}', playlist_id)
 
         return self.playlist_result(

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -455,7 +455,7 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
             'id': '26-2mzbynr-cph',
             'description': 'md5:e67873de1c88f360af1f0a4b84847a52',
         },
-        'playlist_count': 31,
+        'playlist_count': 59,
     }]
 
     def _fetch_page(self, playlist_id, series_version, season_id, page):

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -421,7 +421,7 @@ class AbemaTVIE(AbemaTVBaseIE):
 
 
 class AbemaTVTitleIE(AbemaTVBaseIE):
-    _VALID_URL = r'https?://abema\.tv/video/title/(?P<id>[^?/]+)(?:\?(?:[^#]+&)?s=(?P<season>[^&#]+))?'
+    _VALID_URL = r'https?://abema\.tv/video/title/(?P<id>[^?/#]+)/?(?:\?(?:[^#]+&)?s=(?P<season>[^&#]+))?'
     _PAGE_SIZE = 25
 
     _TESTS = [{

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -448,7 +448,7 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
     }]
 
     def _fetch_page(self, playlist_id, series_version, season_id, page):
-        query={
+        query = {
             'seriesVersion': series_version,
             'offset': str(page * self._PAGE_SIZE),
             'order': 'seq',

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -421,7 +421,7 @@ class AbemaTVIE(AbemaTVBaseIE):
 
 
 class AbemaTVTitleIE(AbemaTVBaseIE):
-    _VALID_URL = r'https?://abema\.tv/video/title/(?P<id>[^?/]+)'
+    _VALID_URL = r'https?://abema\.tv/video/title/(?P<id>[^?/]+)(?:\?(?:.*?&)?s=(?P<season>[^&]+))?'
     _PAGE_SIZE = 25
 
     _TESTS = [{
@@ -447,30 +447,35 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
         'playlist_mincount': 24,
     }]
 
-    def _fetch_page(self, playlist_id, series_version, page):
+    def _fetch_page(self, playlist_id, series_version, season_id, page):
+        query={
+            'seriesVersion': series_version,
+            'offset': str(page * self._PAGE_SIZE),
+            'order': 'seq',
+            'limit': str(self._PAGE_SIZE),
+        }
+        if season_id:
+            query['seasonId'] = season_id
         programs = self._call_api(
             f'v1/video/series/{playlist_id}/programs', playlist_id,
             note=f'Downloading page {page + 1}',
-            query={
-                'seriesVersion': series_version,
-                'offset': str(page * self._PAGE_SIZE),
-                'order': 'seq',
-                'limit': str(self._PAGE_SIZE),
-            })
+            query=query
+        )
         yield from (
             self.url_result(f'https://abema.tv/video/episode/{x}')
             for x in traverse_obj(programs, ('programs', ..., 'id')))
 
-    def _entries(self, playlist_id, series_version):
+    def _entries(self, playlist_id, series_version, season_id):
         return OnDemandPagedList(
-            functools.partial(self._fetch_page, playlist_id, series_version),
+            functools.partial(self._fetch_page, playlist_id, series_version, season_id),
             self._PAGE_SIZE)
 
     def _real_extract(self, url):
         playlist_id = self._match_id(url)
+        season_id = self._match_valid_url(url).group('season')
         series_info = self._call_api(f'v1/video/series/{playlist_id}', playlist_id)
 
         return self.playlist_result(
-            self._entries(playlist_id, series_info['version']), playlist_id=playlist_id,
+            self._entries(playlist_id, series_info['version'], season_id), playlist_id=playlist_id,
             playlist_title=series_info.get('title'),
             playlist_description=series_info.get('content'))

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -455,7 +455,7 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
             'id': '26-2mzbynr-cph',
             'description': 'md5:e67873de1c88f360af1f0a4b84847a52',
         },
-        'playlist_mincount': 31,
+        'playlist_count': 31,
     }]
 
     def _fetch_page(self, playlist_id, series_version, season_id, page):

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -459,8 +459,7 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
         programs = self._call_api(
             f'v1/video/series/{playlist_id}/programs', playlist_id,
             note=f'Downloading page {page + 1}',
-            query=query,
-        )
+            query=query)
         yield from (
             self.url_result(f'https://abema.tv/video/episode/{x}')
             for x in traverse_obj(programs, ('programs', ..., 'id')))

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -425,10 +425,11 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
     _PAGE_SIZE = 25
 
     _TESTS = [{
-        'url': 'https://abema.tv/video/title/90-1597',
+        'url': 'https://abema.tv/video/title/90-1887',
         'info_dict': {
-            'id': '90-1597',
+            'id': '90-1887',
             'title': 'シャッフルアイランド',
+            'description': 'md5:61b2425308f41a5282a926edda66f178',
         },
         'playlist_mincount': 2,
     }, {
@@ -436,15 +437,25 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
         'info_dict': {
             'id': '193-132',
             'title': '真心が届く~僕とスターのオフィス・ラブ!?~',
+            'description': 'md5:9b59493d1f3a792bafbc7319258e7af8',
         },
         'playlist_mincount': 16,
     }, {
-        'url': 'https://abema.tv/video/title/25-102',
+        'url': 'https://abema.tv/video/title/25-1nzan-whrxe',
         'info_dict': {
-            'id': '25-102',
-            'title': 'ソードアート・オンライン アリシゼーション',
+            'id': '25-1nzan-whrxe',
+            'title': 'ソードアート・オンライン',
+            'description': 'md5:c094904052322e6978495532bdbf06e6',
         },
-        'playlist_mincount': 24,
+        'playlist_mincount': 25,
+    }, {
+        'url': 'https://abema.tv/video/title/26-2mzbynr-cph?s=26-2mzbynr-cph_s40',
+        'info_dict': {
+            'title': '〈物語〉シリーズ',
+            'id': '26-2mzbynr-cph',
+            'description': 'md5:e67873de1c88f360af1f0a4b84847a52',
+        },
+        'playlist_mincount': 31,
     }]
 
     def _fetch_page(self, playlist_id, series_version, season_id, page):

--- a/yt_dlp/extractor/abematv.py
+++ b/yt_dlp/extractor/abematv.py
@@ -459,7 +459,7 @@ class AbemaTVTitleIE(AbemaTVBaseIE):
         programs = self._call_api(
             f'v1/video/series/{playlist_id}/programs', playlist_id,
             note=f'Downloading page {page + 1}',
-            query=query
+            query=query,
         )
         yield from (
             self.url_result(f'https://abema.tv/video/episode/{x}')


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

Adds functionality to specify and download a specific season for series with multiple seasons.

ADD DESCRIPTION HERE

- Implemented support for downloading a specific season when explicitly specified in the URL
- Handles season selection through URL parameters (e.g., `?s=420-61_s2`)
- Resolves issue #10602

Example:
- Before: Unable to download season 2 or later
- After: Can download season 2 via URL like https://abema.tv/video/title/420-61?s=420-61_s2

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
