### PR TITLE
Thumbnail selection by ID

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -291,6 +291,7 @@ class YoutubeDL:
                        unless writeinfojson is also given
     writeannotations:  Write the video annotations to a .annotations.xml file
     writethumbnail:    Write the thumbnail image to a file
+    thumbnail_id:      ID of thumbnail to write
     allow_playlist_files: Whether to write playlists' description, infojson etc
                        also to disk when using the 'write*' options
     write_all_thumbnails:  Write all thumbnail formats to files
@@ -2605,6 +2606,7 @@ class YoutubeDL:
 
     def _sort_thumbnails(self, thumbnails):
         thumbnails.sort(key=lambda t: (
+            t.get('id') == self.params.get('thumbnail_id') if t.get('id') is not None else False,
             t.get('preference') if t.get('preference') is not None else -1,
             t.get('width') if t.get('width') is not None else -1,
             t.get('height') if t.get('height') is not None else -1,
@@ -2629,6 +2631,12 @@ class YoutubeDL:
                     self.to_screen(f'[info] Unable to connect to thumbnail {t["id"]} URL {t["url"]!r} - {err}. Skipping...')
                     continue
                 yield t
+
+        thumbnail_id = self.params.get('thumbnail_id')
+        if thumbnail_id and thumbnail_id not in [t.get('id') for t in thumbnails]:
+            self.raise_no_formats(info_dict, msg=(
+                'Invalid thumbnail ID specified. '
+                'Use --list-thumbnails to see available IDs'))
 
         self._sort_thumbnails(thumbnails)
         for i, t in enumerate(thumbnails):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -291,7 +291,7 @@ class YoutubeDL:
                        unless writeinfojson is also given
     writeannotations:  Write the video annotations to a .annotations.xml file
     writethumbnail:    Write the thumbnail image to a file
-    thumbnail_id:      ID of thumbnail to write
+    thumbnail_format:  Format code of thumbnail to write
     allow_playlist_files: Whether to write playlists' description, infojson etc
                        also to disk when using the 'write*' options
     write_all_thumbnails:  Write all thumbnail formats to files
@@ -2606,7 +2606,7 @@ class YoutubeDL:
 
     def _sort_thumbnails(self, thumbnails):
         thumbnails.sort(key=lambda t: (
-            t.get('id') == self.params.get('thumbnail_id') if t.get('id') is not None else False,
+            t.get('id') == self.params.get('thumbnail_format') if t.get('id') is not None else False,
             t.get('preference') if t.get('preference') is not None else -1,
             t.get('width') if t.get('width') is not None else -1,
             t.get('height') if t.get('height') is not None else -1,
@@ -2632,7 +2632,7 @@ class YoutubeDL:
                     continue
                 yield t
 
-        thumbnail_id = self.params.get('thumbnail_id')
+        thumbnail_id = self.params.get('thumbnail_format')
         if thumbnail_id and thumbnail_id not in [t.get('id') for t in thumbnails]:
             self.raise_no_formats(info_dict, msg=(
                 'Invalid thumbnail ID specified. '

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -870,6 +870,7 @@ def parse_options(argv=None):
         'clean_infojson': opts.clean_infojson,
         'getcomments': opts.getcomments,
         'writethumbnail': opts.writethumbnail is True,
+        'thumbnail_id': opts.thumbnail_id,
         'write_all_thumbnails': opts.writethumbnail == 'all',
         'writelink': opts.writelink,
         'writeurllink': opts.writeurllink,

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -870,7 +870,7 @@ def parse_options(argv=None):
         'clean_infojson': opts.clean_infojson,
         'getcomments': opts.getcomments,
         'writethumbnail': opts.writethumbnail is True,
-        'thumbnail_id': opts.thumbnail_id,
+        'thumbnail_format': opts.thumbnail_format,
         'write_all_thumbnails': opts.writethumbnail == 'all',
         'writelink': opts.writelink,
         'writeurllink': opts.writeurllink,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1525,6 +1525,10 @@ def create_parser():
         action='store_false', dest='writethumbnail',
         help='Do not write thumbnail image to disk (default)')
     thumbnail.add_option(
+        '--thumbnail-id',
+        metavar='ID', dest='thumbnail_id',
+        help='ID of thumbnail to write to disk')
+    thumbnail.add_option(
         '--write-all-thumbnails',
         action='store_const', dest='writethumbnail', const='all',
         help='Write all thumbnail image formats to disk')

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1525,9 +1525,9 @@ def create_parser():
         action='store_false', dest='writethumbnail',
         help='Do not write thumbnail image to disk (default)')
     thumbnail.add_option(
-        '--thumbnail-id',
-        metavar='ID', dest='thumbnail_id',
-        help='ID of thumbnail to write to disk')
+        '--thumbnail-format',
+        metavar='format', dest='thumbnail_format',
+        help='Format code of thumbnail to write to disk')
     thumbnail.add_option(
         '--write-all-thumbnails',
         action='store_const', dest='writethumbnail', const='all',

--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -62,7 +62,10 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             self.to_screen('There aren\'t any thumbnails to embed')
             return [], info
 
-        idx = next((-i for i, t in enumerate(info['thumbnails'][::-1], 1) if t.get('filepath')), None)
+        if self._downloader and (fmt := self._downloader.params.get('thumbnail_format')):
+            idx = next((i for i, t in enumerate(info['thumbnails']) if t.get('id') == fmt and t.get('filepath')), None)
+        else:
+            idx = next((-i for i, t in enumerate(info['thumbnails'][::-1], 1) if t.get('filepath')), None)
         if idx is None:
             self.to_screen('There are no thumbnails on disk')
             return [], info


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This allows users to choose what thumbnail to download based on thumbnail ID, with the new option `--thumbnail-id`. Of course, it would be better to implement robust thumbnail format parsing that can handle height/width preferences as well but IMO this feature is useful enough as is (and writing that looks like a pain), though a better solution can be implemented in the future.

I implemented this by altering the thumbnail sorting function, so if this option is used along with `--list-thumbnails` then the ordering will be messed up a little, although I don't think it really makes sense to use both options at the same time. This was just the most convenient solution since there are multiple places where the last thumbnail is chosen to be used, but it can be changed.

I tried to see if there was any code reusable from audio/video format parsing, but it seemed like it was too specific to use for this.

TODO: documentation and tests

Related: #237


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
