### PR TITLE
Update cookies.py to support parsing manual cookies files

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -1327,18 +1327,20 @@ class YoutubeDLCookieJar(http.cookiejar.MozillaCookieJar):
                 raise ValueError(http.cookiejar.MISSING_FILENAME_TEXT)
 
         def prepare_line(line):
+            assert line.endswith('\n')
+            line = line[:-1]
             if line.startswith(self._HTTPONLY_PREFIX):
                 line = line[len(self._HTTPONLY_PREFIX):]
             # comments and empty lines are fine
             if line.startswith('#') or not line.strip():
-                return line
+                return line + '\n'
             cookie_list = line.split('\t')
             if len(cookie_list) != self._ENTRY_LEN:
                 raise http.cookiejar.LoadError(f'invalid length {len(cookie_list)}')
             cookie = self._CookieFileEntry(*cookie_list)
             if cookie.expires_at and not cookie.expires_at.isdigit():
                 raise http.cookiejar.LoadError(f'invalid expires at {cookie.expires_at}')
-            return line
+            return line + '\n'
 
         cf = io.StringIO()
         with self.open(filename) as f:


### PR DESCRIPTION
Fix the "invalid length 8" errors for valid lines.

Previously, on my system at least, it couldn't parse either its own output or the output of cookies.txt files I had because of not removing the trailing '\n' from the line and considering it an extra entry, putting the number at 8 not 7.

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Parsing a manual cookies.txt file not from a browser doesn't work on my system, even to parse yt-dlp's own output.  I don't know if that affects everyone (I didn't see a bug report, but maybe no one uses this feature), but for my system at least, this patch fixes the issue.

It would probably be a good idea for others to confirm that this works before accepting this PR but that's up to yall.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
