### PR TITLE
[core] Calculate date by `strftime_or_none`; fix seconds in `datetime_round`

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -98,11 +98,13 @@ from yt_dlp.utils import (
     remove_start,
     render_table,
     replace_extension,
+    datetime_round,
     rot47,
     sanitize_filename,
     sanitize_path,
     sanitize_url,
     shell_quote,
+    strftime_or_none,
     smuggle_url,
     str_to_int,
     strip_jsonp,
@@ -391,6 +393,23 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(datetime_from_str('20210131+59day', precision='day'), datetime_from_str('20210131+2month', precision='auto'))
         self.assertEqual(datetime_from_str('now+1day', precision='hour'), datetime_from_str('now+24hours', precision='auto'))
         self.assertEqual(datetime_from_str('now+23hours', precision='hour'), datetime_from_str('now+23hours', precision='auto'))
+
+    def test_datetime_round(self):
+        self.assertEqual(datetime_round(dt.datetime.strptime('1820-05-12T01:23:45Z', '%Y-%m-%dT%H:%M:%SZ')),
+                         dt.datetime(1820, 5, 12, tzinfo=dt.timezone.utc))
+        self.assertEqual(datetime_round(dt.datetime.strptime('1969-12-31T23:34:45Z', '%Y-%m-%dT%H:%M:%SZ'), 'hour'),
+                         dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc))
+        self.assertEqual(datetime_round(dt.datetime.strptime('2024-12-25T01:23:45Z', '%Y-%m-%dT%H:%M:%SZ'), 'minute'),
+                         dt.datetime(2024, 12, 25, 1, 24, tzinfo=dt.timezone.utc))
+        self.assertEqual(datetime_round(dt.datetime.strptime('2024-12-25T01:23:45.123Z', '%Y-%m-%dT%H:%M:%S.%fZ'), 'second'),
+                         dt.datetime(2024, 12, 25, 1, 23, 45, tzinfo=dt.timezone.utc))
+        self.assertEqual(datetime_round(dt.datetime.strptime('2024-12-25T01:23:45.678Z', '%Y-%m-%dT%H:%M:%S.%fZ'), 'second'),
+                         dt.datetime(2024, 12, 25, 1, 23, 46, tzinfo=dt.timezone.utc))
+
+    def test_strftime_or_none(self):
+        self.assertEqual(strftime_or_none(-4722192000), '18200512')
+        self.assertEqual(strftime_or_none(0), '19700101')
+        self.assertEqual(strftime_or_none(1735084800), '20241225')
 
     def test_daterange(self):
         _20century = DateRange('19000101', '20000101')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -2673,11 +2673,7 @@ class YoutubeDL:
                 ('modified_timestamp', 'modified_date'),
         ):
             if info_dict.get(date_key) is None and info_dict.get(ts_key) is not None:
-                # Working around out-of-range timestamp values (e.g. negative ones on Windows,
-                # see http://bugs.python.org/issue1646728)
-                with contextlib.suppress(ValueError, OverflowError, OSError):
-                    upload_date = dt.datetime.fromtimestamp(info_dict[ts_key], dt.timezone.utc)
-                    info_dict[date_key] = upload_date.strftime('%Y%m%d')
+                info_dict[date_key] = strftime_or_none(info_dict[ts_key])
 
         if not info_dict.get('release_year'):
             info_dict['release_year'] = traverse_obj(info_dict, ('release_date', {lambda x: int(x[:4])}))


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

We have already applied some patches for this bug:

- a55e36f48d1f0dc5454b144c7373361f284b9236 fixes https://github.com/ytdl-org/youtube-dl/issues/5826
- d509c1f5a347d0247593f116fa5cad2ff4f9a3de fixes #5185
- a35af4306d24c56c6358f89cdf204860d1cd62b4 fixes #6706

Now it's time to get the K.O.!

Refs: 

- [python - Timestamp out of range for platform localtime()/gmtime() function - Stack Overflow](https://stackoverflow.com/q/36179914)
- [arcpy - how to create datetime from a negative epoch in Python - Stack Overflow](https://stackoverflow.com/q/17231711)


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
