### PR TITLE
[ModifyChapters] add --round-cuts-to-keyframes option

### DIFF
--- a/test/test_postprocessors.py
+++ b/test/test_postprocessors.py
@@ -558,6 +558,53 @@ class TestModifyChaptersPP(unittest.TestCase):
                 '[SponsorBlock]: Sponsor', 'c',
             ]), [])
 
+    def test_round_remove_chapter_Common(self):
+        keyframes = [1, 3, 5, 7]
+        chapters = self._pp._round_remove_chapters(keyframes, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 2, 'end_time': 6, 'remove': True},
+            {'start_time': 6, 'end_time': 10, 'remove': False},
+        ])
+        self.assertEqual(chapters, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 3, 'end_time': 5, 'remove': True},
+            {'start_time': 6, 'end_time': 10, 'remove': False},
+        ])
+
+    def test_round_remove_chapter_AlreadyKeyframe(self):
+        keyframes = [1, 3, 5, 7]
+        chapters = self._pp._round_remove_chapters(keyframes, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 3, 'end_time': 7, 'remove': True},
+            {'start_time': 6, 'end_time': 10, 'remove': False},
+        ])
+        self.assertEqual(chapters, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 3, 'end_time': 7, 'remove': True},
+            {'start_time': 6, 'end_time': 10, 'remove': False},
+        ])
+
+    def test_round_remove_chapter_RemoveEnd(self):
+        keyframes = [1, 3, 5, 7]
+        chapters = self._pp._round_remove_chapters(keyframes, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 3, 'end_time': 8, 'remove': True},
+        ])
+        self.assertEqual(chapters, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 3, 'end_time': 8, 'remove': True},
+        ])
+
+    def test_round_remove_chapter_RemoveAfterLast(self):
+        keyframes = [1, 3, 5, 7]
+        chapters = self._pp._round_remove_chapters(keyframes, [
+            {'start_time': 0, 'end_time': 2},
+            {'start_time': 8, 'end_time': 9, 'remove': True},
+        ])
+        self.assertEqual(chapters, [
+            {'start_time': 0, 'end_time': 2},
+        ])
+
     def test_make_concat_opts_CommonCase(self):
         sponsor_chapters = [self._chapter(1, 2, 's1'), self._chapter(10, 20, 's2')]
         expected = '''ffconcat version 1.0

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -677,6 +677,7 @@ def get_postprocessors(opts):
             'remove_ranges': opts.remove_ranges,
             'sponsorblock_chapter_title': opts.sponsorblock_chapter_title,
             'force_keyframes': opts.force_keyframes_at_cuts,
+            'round_to_keyframes': opts.round_cuts_to_keyframes,
         }
     # FFmpegMetadataPP should be run after FFmpegVideoConvertorPP and
     # FFmpegExtractAudioPP as containers before conversion may not support

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1778,6 +1778,17 @@ def create_parser():
         '--no-force-keyframes-at-cuts',
         action='store_false', dest='force_keyframes_at_cuts',
         help='Do not force keyframes around the chapters when cutting/splitting (default)')
+    postproc.add_option(
+        '--round-cuts-to-keyframes',
+        action='store_true', dest='round_cuts_to_keyframes', default=False,
+        help=(
+            'Rounds cuts to the nearest keyframe when removing sections. '
+            'This may result in some more content being included than specified, but makes problems around cuts '
+            'less likely'))
+    postproc.add_option(
+        '--no-round-cuts-to-keyframes',
+        action='store_false', dest='round_cuts_to_keyframes',
+        help='Do not rounds cuts to the nearest keyframe when removing sections (default)')
     _postprocessor_opts_parser = lambda key, val='': (
         *(item.split('=', 1) for item in (val.split(';') if val else [])),
         ('key', remove_end(key, 'PP')))

--- a/yt_dlp/postprocessor/modify_chapters.py
+++ b/yt_dlp/postprocessor/modify_chapters.py
@@ -1,3 +1,4 @@
+import bisect
 import copy
 import heapq
 import os
@@ -13,13 +14,16 @@ DEFAULT_SPONSORBLOCK_CHAPTER_TITLE = '[SponsorBlock]: %(category_names)l'
 
 class ModifyChaptersPP(FFmpegPostProcessor):
     def __init__(self, downloader, remove_chapters_patterns=None, remove_sponsor_segments=None, remove_ranges=None,
-                 *, sponsorblock_chapter_title=DEFAULT_SPONSORBLOCK_CHAPTER_TITLE, force_keyframes=False):
+                 *, sponsorblock_chapter_title=DEFAULT_SPONSORBLOCK_CHAPTER_TITLE, force_keyframes=False,
+                 round_to_keyframes=False):
         FFmpegPostProcessor.__init__(self, downloader)
         self._remove_chapters_patterns = set(remove_chapters_patterns or [])
-        self._remove_sponsor_segments = set(remove_sponsor_segments or []) - set(SponsorBlockPP.NON_SKIPPABLE_CATEGORIES.keys())
+        self._remove_sponsor_segments = set(remove_sponsor_segments or []) - set(
+            SponsorBlockPP.NON_SKIPPABLE_CATEGORIES.keys())
         self._ranges_to_remove = set(remove_ranges or [])
         self._sponsorblock_chapter_title = sponsorblock_chapter_title
         self._force_keyframes = force_keyframes
+        self._round_to_keyframes = round_to_keyframes
 
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
@@ -35,7 +39,12 @@ class ModifyChaptersPP(FFmpegPostProcessor):
         if not chapters:
             chapters = [{'start_time': 0, 'end_time': info.get('duration') or real_duration, 'title': info['title']}]
 
-        info['chapters'], cuts = self._remove_marked_arrange_sponsors(chapters + sponsor_chapters)
+        chapters += sponsor_chapters
+        if self._round_to_keyframes:
+            keyframes = self.get_keyframe_timestamps(info['filepath'])
+            self._round_remove_chapters(keyframes, chapters)
+
+        info['chapters'], cuts = self._remove_marked_arrange_sponsors(chapters)
         if not cuts:
             return [], info
         elif not info['chapters']:
@@ -54,7 +63,8 @@ class ModifyChaptersPP(FFmpegPostProcessor):
                 self.write_debug('Expected and actual durations mismatch')
 
         concat_opts = self._make_concat_opts(cuts, real_duration)
-        self.write_debug('Concat spec = {}'.format(', '.join(f'{c.get("inpoint", 0.0)}-{c.get("outpoint", "inf")}' for c in concat_opts)))
+        self.write_debug('Concat spec = {}'.format(
+            ', '.join(f'{c.get("inpoint", 0.0)}-{c.get("outpoint", "inf")}' for c in concat_opts)))
 
         def remove_chapters(file, is_sub):
             return file, self.remove_chapters(file, cuts, concat_opts, self._force_keyframes and not is_sub)
@@ -117,7 +127,8 @@ class ModifyChaptersPP(FFmpegPostProcessor):
                 continue
             ext = sub['ext']
             if ext not in FFmpegSubtitlesConvertorPP.SUPPORTED_EXTS:
-                self.report_warning(f'Cannot remove chapters from external {ext} subtitles; "{sub_file}" is now out of sync')
+                self.report_warning(
+                    f'Cannot remove chapters from external {ext} subtitles; "{sub_file}" is now out of sync')
                 continue
             # TODO: create __real_download for subs?
             yield sub_file
@@ -314,12 +325,32 @@ class ModifyChaptersPP(FFmpegPostProcessor):
         in_file = filename
         out_file = prepend_extension(in_file, 'temp')
         if force_keyframes:
-            in_file = self.force_keyframes(in_file, (t for c in ranges_to_cut for t in (c['start_time'], c['end_time'])))
+            in_file = self.force_keyframes(in_file,
+                                           (t for c in ranges_to_cut for t in (c['start_time'], c['end_time'])))
         self.to_screen(f'Removing chapters from {filename}')
         self.concat_files([in_file] * len(concat_opts), out_file, concat_opts)
         if in_file != filename:
             self._delete_downloaded_files(in_file, msg=None)
         return out_file
+
+    @staticmethod
+    def _round_remove_chapters(keyframes, chapters):
+        result = []
+        for c in chapters:
+            if not c.get('remove', False) or not keyframes:
+                result.append(c)
+                continue
+
+            start_frame = bisect.bisect_left(keyframes, c['start_time'])
+            if start_frame >= len(keyframes):
+                continue
+
+            c['start_time'] = keyframes[start_frame]
+            if c['end_time'] < keyframes[-1]:
+                c['end_time'] = keyframes[bisect.bisect_right(keyframes, c['end_time']) - 1]
+            result.append(c)
+
+        return result
 
     @staticmethod
     def _make_concat_opts(chapters_to_remove, duration):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
There are occasions when `ffmpeg` cuts the video weirdly when the offsets are not at keyframes, resulting in audio desync. For example, on the current `master` branch at the time of writing, this results in a video that plays back incorrectly in `mpv`:

```console
$ ./yt-dlp.sh -vU --sponsorblock-remove sponsor --sponsorblock-mark all https://www.youtube.com/watch?v=pU9sHwNKc2c 
[debug] Command-line config: ['-vU', '--sponsorblock-remove', 'sponsor', '--sponsorblock-mark', 'all', 'https://www.youtube.com/watch?v=pU9sHwNKc2c']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2024.12.23 from yt-dlp/yt-dlp [65cf46cdd] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 3905f6492
[debug] Python 3.11.2 (CPython x86_64 64bit) - Linux-6.1.0-28-amd64-x86_64-with-glibc2.36 (OpenSSL 3.0.15 3 Sep 2024, glibc 2.36)
[debug] exe versions: ffmpeg 6.0.1 (fdk,setts), ffprobe 6.0.1, phantomjs 2.1.1, rtmpdump 2.4
[debug] Optional libraries: Cryptodome-3.11.0, brotli-1.0.9, certifi-2022.09.24, mutagen-1.46.0, pyxattr-0.8.1, requests-2.28.1, secretstorage-3.3.3, sqlite3-3.40.1, urllib3-1.26.12, websockets-10.4
[debug] Proxy map: {}
[debug] Request Handlers: urllib
[debug] Loaded 1837 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Latest version: stable@2024.12.23 from yt-dlp/yt-dlp
yt-dlp is up to date (stable@2024.12.23 from yt-dlp/yt-dlp)
[youtube] Extracting URL: https://www.youtube.com/watch?v=pU9sHwNKc2c
[youtube] pU9sHwNKc2c: Downloading webpage
[youtube] pU9sHwNKc2c: Downloading ios player API JSON
[youtube] pU9sHwNKc2c: Downloading mweb player API JSON
[debug] [youtube] pU9sHwNKc2c: ios client https formats require a PO Token which was not provided. They will be skipped as they may yield HTTP Error 403. You can manually pass a PO Token for this client with --extractor-args "youtube:po_token=ios+XXX. For more information, refer to  https://github.com/yt-dlp/yt-dlp/wiki/Extractors#po-token-guide . To enable these broken formats anyway, pass --extractor-args "youtube:formats=missing_pot"
[debug] Loading youtube-nsig.03dbdfab from cache
[debug] [youtube] Decrypted nsig 5P7x89hj630_U0PCg => KL9m06eJ7_9p7w
[debug] Loading youtube-nsig.03dbdfab from cache
[debug] [youtube] Decrypted nsig 206ewqoKNzGNR2tTu => Zc62paqftTXJFA
[youtube] pU9sHwNKc2c: Downloading m3u8 information
[debug] Sort order given by extractor: quality, res, fps, hdr:12, source, vcodec, channels, acodec, lang, proto
[debug] Formats sorted by: hasvid, ie_pref, quality, res, fps, hdr:12(7), source, vcodec, channels, acodec, lang, proto, size, br, asr, vext, aext, hasaud, id
[SponsorBlock] Fetching SponsorBlock segments
[debug] SponsorBlock query: https://sponsor.ajay.app/api/skipSegments/b14d?service=YouTube&categories=%5B%22filler%22%2C+%22chapter%22%2C+%22poi_highlight%22%2C+%22outro%22%2C+%22interaction%22%2C+%22sponsor%22%2C+%22preview%22%2C+%22intro%22%2C+%22selfpromo%22%2C+%22music_offtopic%22%5D&actionTypes=%5B%22skip%22%2C+%22poi%22%2C+%22chapter%22%5D
[SponsorBlock] Found 5 segments in the SponsorBlock database
[debug] Default format spec: bestvideo*+bestaudio/best
[info] pU9sHwNKc2c: Downloading 1 format(s): 401+251
[debug] Invoking http downloader on "https://rr3---sn-tt1elnel.googlevideo.com/videoplayback?expire=1735195590&ei=ZqdsZ_qeMa6Vlu8P9prokAs&ip=[redacted]&id=o-AGgSNL9Htd9TVywKPyc5VUVC9TRIVk2f99Dx5VwwWqdx&itag=401&aitags=133%2C134%2C135%2C136%2C137%2C160%2C242%2C243%2C244%2C247%2C248%2C271%2C278%2C313%2C394%2C395%2C396%2C397%2C398%2C399%2C400%2C401%2C597%2C598&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&met=1735173990%2C&mh=Bp&mm=31%2C26&mn=sn-tt1elnel%2Csn-vgqsknls&ms=au%2Conr&mv=u&mvi=3&pl=48&rms=au%2Cau&bui=AfMhrI8p2bp_6CHcX-GlTVVe8gRyQQsxw4YRGHCzVuycxadn9iO8MfTUN4nKjhpu-C8OlJJdyIHy1xbT&vprv=1&svpuc=1&mime=video%2Fmp4&ns=HnRiK-pGolcOSZM6B02KsbcQ&rqh=1&gir=yes&clen=516263348&dur=505.800&lmt=1734306187237244&mt=1735172773&fvip=2&keepalive=yes&fexp=51326932%2C51331020%2C51335594%2C51371294&c=MWEB&sefc=1&txp=5532434&n=Zc62paqftTXJFA&sparams=expire%2Cei%2Cip%2Cid%2Caitags%2Csource%2Crequiressl%2Cxpc%2Cbui%2Cvprv%2Csvpuc%2Cmime%2Cns%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AJfQdSswRQIgPaXhROT2KfZ1r3UVQmzIg5GKEsqCQ02bVl1GjuaBv3YCIQDccnoHiF5lICD3JFn_mWiJkq7HNUooVxm8UhLvc1JXWQ%3D%3D&lsparams=met%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms&lsig=AGluJ3MwRgIhAOwEn6fiubsJdBUHaELucTNsp4vh3HcHsWDVN5PxD_jCAiEA-ippADium3_OBchiSTRcwDdcfg4SyBAMSRvQKqr2BkA%3D"
[download] Destination: Why don't subtitles match dubbing？ [pU9sHwNKc2c].f401.mp4
[download] 100% of  492.35MiB in 00:00:20 at 23.75MiB/s
[debug] Invoking http downloader on "https://rr3---sn-tt1elnel.googlevideo.com/videoplayback?expire=1735195590&ei=ZqdsZ_qeMa6Vlu8P9prokAs&ip=[redacted]&id=o-AGgSNL9Htd9TVywKPyc5VUVC9TRIVk2f99Dx5VwwWqdx&itag=251&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&met=1735173990%2C&mh=Bp&mm=31%2C26&mn=sn-tt1elnel%2Csn-vgqsknls&ms=au%2Conr&mv=u&mvi=3&pl=48&rms=au%2Cau&bui=AfMhrI8p2bp_6CHcX-GlTVVe8gRyQQsxw4YRGHCzVuycxadn9iO8MfTUN4nKjhpu-C8OlJJdyIHy1xbT&vprv=1&svpuc=1&xtags=acont%3Doriginal%3Alang%3Den&mime=audio%2Fwebm&ns=HnRiK-pGolcOSZM6B02KsbcQ&rqh=1&gir=yes&clen=6557798&dur=505.821&lmt=1701716437049674&mt=1735172773&fvip=2&keepalive=yes&fexp=51326932%2C51331020%2C51335594%2C51371294&c=MWEB&sefc=1&txp=5532434&n=Zc62paqftTXJFA&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cbui%2Cvprv%2Csvpuc%2Cxtags%2Cmime%2Cns%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AJfQdSswRgIhAMqFArO9jtHpKy0nTL_Tn7ynruDTiMTuTYTaj6tUzOVfAiEA_d5VjN1DvAG7Rps_xWEuL9uwDyvDrvxTloMCSzGajYM%3D&lsparams=met%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms&lsig=AGluJ3MwRgIhAOwEn6fiubsJdBUHaELucTNsp4vh3HcHsWDVN5PxD_jCAiEA-ippADium3_OBchiSTRcwDdcfg4SyBAMSRvQKqr2BkA%3D"
[download] Destination: Why don't subtitles match dubbing？ [pU9sHwNKc2c].f251.webm
[download] 100% of    6.25MiB in 00:00:00 at 16.53MiB/s
[Merger] Merging formats into "Why don't subtitles match dubbing？ [pU9sHwNKc2c].webm"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].f401.mp4' -i 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].f251.webm' -c copy -map 0:v:0 -map 1:a:0 -movflags +faststart 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].temp.webm'
Deleting original file Why don't subtitles match dubbing？ [pU9sHwNKc2c].f401.mp4 (pass -k to keep)
Deleting original file Why don't subtitles match dubbing？ [pU9sHwNKc2c].f251.webm (pass -k to keep)
[debug] ffprobe command line: ffprobe -hide_banner -show_format -show_streams -print_format json 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].webm'
[debug] Concat spec = 0.0-26.631000, 47.604000-439.800000
[ModifyChapters] Removing chapters from Why don't subtitles match dubbing？ [pU9sHwNKc2c].webm
[debug] Writing concat spec to Why don't subtitles match dubbing？ [pU9sHwNKc2c].temp.webm.concat
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -hide_banner -nostdin -f concat -safe 0 -i 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].temp.webm.concat' -map 0 -dn -ignore_unknown -c copy -movflags +faststart 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].temp.webm'
Deleting original file Why don't subtitles match dubbing？ [pU9sHwNKc2c].uncut.webm (pass -k to keep)
[Metadata] Adding metadata to "Why don't subtitles match dubbing？ [pU9sHwNKc2c].webm"
[debug] ffmpeg command line: ffmpeg -y -loglevel repeat+info -i 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].webm' -i 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].meta' -map 0 -dn -ignore_unknown -c copy -map_metadata 1 -movflags +faststart 'file:Why don'"'"'t subtitles match dubbing？ [pU9sHwNKc2c].temp.webm'
```

The resulting video plays back incorrectly at around 25 seconds in `mpv`: the audio gets out of sync until you manually seek the file. A similar issue has been documented on jmbannon/ytdl-sub#831.

This PR introduces the new option `--round-cuts-to-keyframes`. When this is used, all the cuts will be rounded to the nearest keyframe, eliminating any potential `ffmpeg` jankiness with splicing videos at non-keyframes. The rounding logic always favours including more content, which may result in a little bit of sponsor segments being included, but ensures no real content will be lost.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
