### PR TITLE
[utils] `sanitize_path`: Fix some incorrect behavior

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -249,16 +249,33 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sanitize_path('abc/def...'), 'abc\\def..#')
         self.assertEqual(sanitize_path('abc.../def'), 'abc..#\\def')
         self.assertEqual(sanitize_path('abc.../def...'), 'abc..#\\def..#')
-
-        self.assertEqual(sanitize_path('../abc'), '..\\abc')
-        self.assertEqual(sanitize_path('../../abc'), '..\\..\\abc')
-        self.assertEqual(sanitize_path('./abc'), 'abc')
-        self.assertEqual(sanitize_path('./../abc'), '..\\abc')
-
-        self.assertEqual(sanitize_path('\\abc'), '\\abc')
-        self.assertEqual(sanitize_path('C:abc'), 'C:abc')
-        self.assertEqual(sanitize_path('C:abc\\..\\'), 'C:..')
         self.assertEqual(sanitize_path('C:\\abc:%(title)s.%(ext)s'), 'C:\\abc#%(title)s.%(ext)s')
+
+        # Check with nt._path_normpath if available
+        try:
+            import nt
+
+            nt_path_normpath = getattr(nt, '_path_normpath', None)
+        except Exception:
+            nt_path_normpath = None
+
+        for test, expected in [
+            ('C:\\', 'C:\\'),
+            ('../abc', '..\\abc'),
+            ('../../abc', '..\\..\\abc'),
+            ('./abc', 'abc'),
+            ('./../abc', '..\\abc'),
+            ('\\abc', '\\abc'),
+            ('C:abc', 'C:abc'),
+            ('C:abc\\..\\', 'C:'),
+            ('C:abc\\..\\def\\..\\..\\', 'C:..'),
+            ('C:\\abc\\xyz///..\\def\\', 'C:\\abc\\def'),
+        ]:
+            result = sanitize_path(test)
+            assert result == expected, f'{test} was incorrectly resolved'
+            assert result == sanitize_path(result), f'{test} changed after sanitizing again'
+            if nt_path_normpath:
+                assert result == nt_path_normpath(test), f'{test} does not match nt._path_normpath'
 
     def test_sanitize_url(self):
         self.assertEqual(sanitize_url('//foo.bar'), 'http://foo.bar')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -270,6 +270,8 @@ class TestUtil(unittest.TestCase):
             ('C:abc\\..\\', 'C:'),
             ('C:abc\\..\\def\\..\\..\\', 'C:..'),
             ('C:\\abc\\xyz///..\\def\\', 'C:\\abc\\def'),
+            ('abc/../', '.'),
+            ('./abc/../', '.'),
         ]:
             result = sanitize_path(test)
             assert result == expected, f'{test} was incorrectly resolved'

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -685,7 +685,8 @@ def _sanitize_path_parts(parts):
         elif part == '..':
             if sanitized_parts and sanitized_parts[-1] != '..':
                 sanitized_parts.pop()
-            sanitized_parts.append('..')
+            else:
+                sanitized_parts.append('..')
             continue
         # Replace invalid segments with `#`
         # - trailing dots and spaces (`asdf...` => `asdf..#`)

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -703,7 +703,8 @@ def sanitize_path(s, force=False):
         if not force:
             return s
         root = '/' if s.startswith('/') else ''
-        return root + '/'.join(_sanitize_path_parts(s.split('/')))
+        path = '/'.join(_sanitize_path_parts(s.split('/')))
+        return root + path if root or path else '.'
 
     normed = s.replace('/', '\\')
 
@@ -722,7 +723,8 @@ def sanitize_path(s, force=False):
         root = '\\' if normed[:1] == '\\' else ''
         parts = normed.split('\\')
 
-    return root + '\\'.join(_sanitize_path_parts(parts))
+    path = '\\'.join(_sanitize_path_parts(parts))
+    return root + path if root or path else '.'
 
 
 def sanitize_url(url, *, scheme='http'):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->
Fixes the following sanitization behaviors:
- `sanitize_path('C:abc\\..\\')` => `'C:'` (was `'C:..'`)
- `sanitize_path('./abc/..')` => `'.'` (was `''`)

To further test the sanitization function, for the non replacement tests, we double check that it matches the `nt._path_normpath` result.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
