### PR TITLE
[embedthumbnail] add new cli option '--force-convert-thumbnails'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,6 +1006,8 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
                                     syntax as "--remux-video". Use "--convert-
                                     thumbnails none" to disable conversion
                                     (default)
+    --force-convert-thumbnails      Convert the thumbnails to another format even
+                                    if it's already in this format
     --split-chapters                Split video into multiple files based on
                                     internal chapters. The "chapter:" prefix can
                                     be used with "--paths" and "--output" to set

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -638,6 +638,7 @@ def get_postprocessors(opts):
         yield {
             'key': 'FFmpegThumbnailsConvertor',
             'format': opts.convertthumbnails,
+            'force_convert_thumbnails': opts.force_convert_thumbnails,
             'when': 'before_dl',
         }
     if opts.extractaudio:

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1749,6 +1749,11 @@ def create_parser():
             'You can specify multiple rules using similar syntax as "--remux-video". '
             'Use "--convert-thumbnails none" to disable conversion (default)'))
     postproc.add_option(
+        '--force-convert-thumbnails',
+        dest='force_convert_thumbnails', action='store_true', default=False,
+        help=(
+            'Convert the thumbnails to another format even if it\'s already in this format'))
+    postproc.add_option(
         '--split-chapters', '--split-tracks',
         dest='split_chapters', action='store_true', default=False,
         help=(

--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -73,7 +73,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         # Correct extension for WebP file with wrong extension (see #25687, #25717)
         convertor = FFmpegThumbnailsConvertorPP(self._downloader)
-        convertor.fixup_webp(info, idx)
+        convertor.fixup_thumbnail(info, idx)
 
         original_thumbnail = thumbnail_filename = info['thumbnails'][idx]['filepath']
 


### PR DESCRIPTION
The problem: previews from some sites downloads with 'jpg' extension but it's actually is a 'png'.

I add a new cli option '--force-convert-thumbnails' to ignore cases then preview extension is same as value from '--convert-thumbnails' and still do conversion.
One of example of such site is https://boosty.to/ there thumbnails can be 4 MiB size PNG but with 'JPG' extension in "Content-Disposition" header of this thumbnail response.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
