### PR TITLE
[ie/youtube] Refactor cookie SID auth

### DIFF
--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -667,7 +667,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         if not self._3PSAPISID:
             self._3PSAPISID = yt_3papisid
 
-    def _generate_sid_authorization(self, origin='https://www.youtube.com', user_session_id=None):
+    def _get_sid_authorization_header(self, origin='https://www.youtube.com', user_session_id=None):
         """
         Generate API Session ID Authorization for Innertube requests. Assumes all requests are secure (https).
         @param origin: Origin URL
@@ -793,7 +793,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     @functools.cached_property
     def is_authenticated(self):
-        return bool(self._generate_sid_authorization())
+        return bool(self._get_sid_authorization_header())
 
     def extract_ytcfg(self, video_id, webpage):
         if not webpage:
@@ -813,7 +813,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         if delegated_session_id or session_index is not None:
             headers['X-Goog-AuthUser'] = session_index if session_index is not None else 0
 
-        auth = self._generate_sid_authorization(origin, user_session_id=user_session_id or self._extract_user_session_id(ytcfg))
+        auth = self._get_sid_authorization_header(origin, user_session_id=user_session_id or self._extract_user_session_id(ytcfg))
         if auth is not None:
             headers['Authorization'] = auth
             headers['X-Origin'] = origin

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -689,17 +689,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         self._load_sid_cookies()
 
-        if self._SAPISID:
-            authorizations.append(
-                self._make_sid_authorization('SAPISIDHASH', self._SAPISID, origin, additional_parts))
-
-        if self._1PSAPISID:
-            authorizations.append(
-                self._make_sid_authorization('SAPISID1PHASH', self._1PSAPISID, origin, additional_parts))
-
-        if self._3PSAPISID:
-            authorizations.append(
-                self._make_sid_authorization('SAPISID3PHASH', self._3PSAPISID, origin, additional_parts))
+        for scheme, sid in (('SAPISIDHASH', self._SAPISID),
+                            ('SAPISID1PHASH', self._1PSAPISID),
+                            ('SAPISID3PHASH', self._3PSAPISID)):
+            if sid:
+                authorizations.append(self._make_sid_authorization(scheme, sid, origin, additional_parts))
 
         if not authorizations:
             return

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -567,9 +567,15 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         pref.update({'hl': self._preferred_lang or 'en', 'tz': 'UTC'})
         self._set_cookie('.youtube.com', name='PREF', value=urllib.parse.urlencode(pref))
 
+    def _initialize_cookie_auth(self):
+        self._load_sid_cookies()
+        if self._SAPISID or self._1PSAPISID or self._3PSAPISID:
+            self.write_debug('Logged in using cookies')
+
     def _real_initialize(self):
         self._initialize_pref()
         self._initialize_consent()
+        self._initialize_cookie_auth()
         self._check_login_required()
 
     def _perform_login(self, username, password):
@@ -800,10 +806,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     @functools.cached_property
     def is_authenticated(self):
-        if bool(self._generate_sid_authorization()):
-            self.write_debug('Logged in using cookies')
-            return True
-        return False
+        return bool(self._generate_sid_authorization())
 
     def extract_ytcfg(self, video_id, webpage):
         if not webpage:

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -645,7 +645,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         parts = [timestamp, sidhash]
         if additional_parts:
-            parts.append(''.join(additional_parts.keys()))
+            parts.append(''.join(additional_parts))
 
         return f'{scheme} {"_".join(parts)}'
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -657,19 +657,16 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 yt_cookies, ('SAPISID', '__Secure-3PAPISID'))
             if sapisid_cookie and sapisid_cookie.value:
                 self._SAPISID = sapisid_cookie.value
-                self.write_debug('Found SAPISID cookie')
 
         if self._1PSAPISID is None:
             _1papisid_cookie = yt_cookies.get('__Secure-1PAPISID')
             if _1papisid_cookie and _1papisid_cookie.value:
                 self._1PSAPISID = _1papisid_cookie.value
-                self.write_debug('Found 1PAPISID cookie')
 
         if self._3PSAPISID is None:
             _3papisid_cookie = yt_cookies.get('__Secure-3PAPISID')
             if _3papisid_cookie and _3papisid_cookie.value:
                 self._3PSAPISID = _3papisid_cookie.value
-                self.write_debug('Found 3PAPISID cookie')
 
     def _generate_sid_authorization(self, origin='https://www.youtube.com', user_session_id=None):
         """

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -569,7 +569,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def _initialize_cookie_auth(self):
         self._load_sid_cookies()
         if self._SAPISID or self._1PSAPISID or self._3PSAPISID:
-            self.write_debug('Logged in using cookies')
+            self.write_debug('Found YouTube account cookies')
 
     def _real_initialize(self):
         self._initialize_pref()

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -831,6 +831,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             headers['Authorization'] = auth
             headers['X-Origin'] = origin
 
+        if traverse_obj(ytcfg, 'LOGGED_IN', expected_type=bool):
+            headers['X-Youtube-Bootstrap-Logged-In'] = 'true'
+
         return headers
 
     def generate_api_headers(
@@ -3909,7 +3912,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             visitor_data=visitor_data,
             session_index=self._extract_session_index(master_ytcfg, player_ytcfg),
             account_syncid=(
-                self._parse_data_sync_id(data_sync_id)
+                self._parse_data_sync_id(data_sync_id)[0]
                 or self._extract_delegated_session_id(master_ytcfg, initial_pr, player_ytcfg)
             ),
         )

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -696,7 +696,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 authorizations.append(self._make_sid_authorization(scheme, sid, origin, additional_parts))
 
         if not authorizations:
-            return
+            return None
 
         return ' '.join(authorizations)
 

--- a/yt_dlp/extractor/youtube.py
+++ b/yt_dlp/extractor/youtube.py
@@ -741,7 +741,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         if not data_sync_id:
             return None, None
         first, _, second = data_sync_id.partition('||')
-        return first if second else None, second if second else first
+        if second:
+            return first, second
+        return None, first
 
     def _extract_delegated_session_id(self, *args):
         """


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED


Update to reflect what youtube web does these days.

It creates hashes for the other SID cookies as well as includes the user session id in the hash


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
