### PR TITLE
[arte] Allow sorting by 'lang' as well as 'language' to avoid warning

### DIFF
--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -79,6 +79,9 @@ class ArteTVIE(ArteTVBaseIE):
         'skip': '404 Not Found',
     }, {
         'url': 'https://www.arte.tv/fr/videos/115495-002-A/arte-regards/',
+        'params': {
+            'skip_download': 'true',
+        },
         'info_dict': {
             'id': '115495-002-A',
             'description': 'md5:dc09a63170a452b920b705fe9340f3a2',

--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -218,6 +218,7 @@ class ArteTVIE(ArteTVBaseIE):
             'alt_title': metadata.get('subtitle') and metadata.get('title'),
             'description': metadata.get('description'),
             'duration': traverse_obj(metadata, ('duration', 'seconds')),
+            'lang': metadata.get('language'),
             'language': metadata.get('language'),
             'timestamp': traverse_obj(config, ('data', 'attributes', 'rights', 'begin'), expected_type=parse_iso8601),
             'is_live': config['data']['attributes'].get('live', False),

--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -62,6 +62,7 @@ class ArteTVIE(ArteTVBaseIE):
                 'fr-forced': 'mincount:1',
             },
         },
+        'skip': '404 Not Found',
     }, {
         'note': 'age-restricted',
         'url': 'https://www.arte.tv/de/videos/006785-000-A/the-element-of-crime/',
@@ -76,6 +77,20 @@ class ArteTVIE(ArteTVBaseIE):
             'ext': 'mp4',
         },
         'skip': '404 Not Found',
+    }, {
+        'url': 'https://www.arte.tv/fr/videos/115495-002-A/arte-regards/',
+        'info_dict': {
+            'id': '115495-002-A',
+            'description': 'md5:dc09a63170a452b920b705fe9340f3a2',
+            'title': 'Suisse : un médecin face à l’exode rural',
+            'timestamp': 1735790400,
+            'duration': 1938,
+            'thumbnail': 'https://api-cdn.arte.tv/img/v2/image/VLuRAi2YB6deooG8DESZvS/940x530',
+            'upload_date': '20250102',
+            'ext': 'mp4',
+            'alt_title': 'ARTE Regards',
+            'lang': 'fr',
+        },
     }]
 
     _GEO_BYPASS = True


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

When sorting arte by 'language' I get this warning:

```
Deprecated Feature: Using arbitrary fields (language) for format sorting is deprecated and may be removed in a future version
```

Avoid this warning by allowing to sort by 'lang' as well, which seems to be the intended format for this.

Fixes #8823


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
