### PR TITLE
[core] Improved --trim-filenames behavior with reasonable defaults

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -717,7 +717,7 @@ class TestYoutubeDL(unittest.TestCase):
             ydl._num_downloads = 1
             self.assertEqual(ydl.validate_outtmpl(tmpl), None)
 
-            out = ydl.evaluate_outtmpl(tmpl, info or self.outtmpl_info)
+            out = ydl.evaluate_outtmpl_for_filename(tmpl, info or self.outtmpl_info)
             fname = ydl.prepare_filename(info or self.outtmpl_info)
 
             if not isinstance(expected, (list, tuple)):
@@ -791,7 +791,7 @@ class TestYoutubeDL(unittest.TestCase):
                 self.assertEqual(got_dict.get(info_field), expected, info_field)
             return True
 
-        test('%()j', (expect_same_infodict, None))
+        test('%()j', (expect_same_infodict, None), trim_file_name=0)
 
         # NA placeholder
         NA_TEST_OUTTMPL = '%(uploader_date)s-%(width)d-%(x|def)s-%(id)s.%(ext)s'

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1458,10 +1458,16 @@ class YoutubeDL:
             else:
                 raise ValueError("--trim-filenames must end with 'b' or 'c'")
 
-        max_file_name = self.params.get('trim_file_name') or DEFAULT_MAX_FILE_NAME
+        max_file_name = self.params.get('trim_file_name')
+        if max_file_name is None:
+            max_file_name = DEFAULT_MAX_FILE_NAME
         mode, max_file_name = parse_max_file_name(max_file_name)
-        if max_file_name < 1:
+        if max_file_name < 0:
             raise ValueError('Invalid --trim-filenames specified')
+        if max_file_name == 0:
+            # no maximum
+            return filename + suffix
+
         encoding = self.params.get('filesystem_encoding') or sys.getfilesystemencoding()
 
         def trim_filename(name: str, length: int):

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -886,6 +886,8 @@ def parse_options(argv=None):
         'max_downloads': opts.max_downloads,
         'prefer_free_formats': opts.prefer_free_formats,
         'trim_file_name': opts.trim_file_name,
+        'max_file_name': opts.max_file_name,
+        'filesystem_encoding': opts.filesystem_encoding,
         'verbose': opts.verbose,
         'dump_intermediate_pages': opts.dump_intermediate_pages,
         'write_pages': opts.write_pages,

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -886,7 +886,6 @@ def parse_options(argv=None):
         'max_downloads': opts.max_downloads,
         'prefer_free_formats': opts.prefer_free_formats,
         'trim_file_name': opts.trim_file_name,
-        'max_file_name': opts.max_file_name,
         'filesystem_encoding': opts.filesystem_encoding,
         'verbose': opts.verbose,
         'dump_intermediate_pages': opts.dump_intermediate_pages,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1378,12 +1378,8 @@ def create_parser():
         help='Sanitize filenames only minimally')
     filesystem.add_option(
         '--trim-filenames', '--trim-file-names', metavar='LENGTH',
-        dest='trim_file_name', default=0, type=int,
-        help='Limit the filename length (excluding extension) to the specified number of characters')
-    filesystem.add_option(
-        '--max-filename-length', metavar='LENGTH',
-        dest='max_file_name',
-        help='Limit the filename length (including extension) to the specified number of characters or bytes')
+        dest='trim_file_name',
+        help='Limit the filename length (excluding extension) to the specified number of characters or bytes')
     filesystem.add_option(
         '--filesystem-encoding', metavar='ENCODING',
         dest='filesystem_encoding',

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1381,6 +1381,14 @@ def create_parser():
         dest='trim_file_name', default=0, type=int,
         help='Limit the filename length (excluding extension) to the specified number of characters')
     filesystem.add_option(
+        '--max-filename-length', metavar='LENGTH',
+        dest='max_file_name',
+        help='Limit the filename length (including extension) to the specified number of characters or bytes')
+    filesystem.add_option(
+        '--filesystem-encoding', metavar='ENCODING',
+        dest='filesystem_encoding',
+        help='Override filesystem encoding used when calculating filename length in bytes')
+    filesystem.add_option(
         '-w', '--no-overwrites',
         action='store_false', dest='overwrites', default=None,
         help='Do not overwrite any files')

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -2854,9 +2854,9 @@ OUTTMPL_TYPES = {
 
 # https://en.m.wikipedia.org/wiki/Comparison_of_file_systems#Limits
 if platform.system() in ('Darwin', 'Windows'):
-    DEFAULT_MAX_FILE_NAME = '255c'
+    DEFAULT_MAX_FILE_NAME = f'{255 - len(".annotations.xml")}c'
 else:
-    DEFAULT_MAX_FILE_NAME = '255b'
+    DEFAULT_MAX_FILE_NAME = f'{255 - len(".annotations.xml".encode(sys.getfilesystemencoding()))}b'
 
 # As of [1] format syntax is:
 #  %[mapping_key][conversion_flags][minimum_width][.precision][length_modifier]type

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -2852,6 +2852,12 @@ OUTTMPL_TYPES = {
     'pl_infojson': 'info.json',
 }
 
+# https://en.m.wikipedia.org/wiki/Comparison_of_file_systems#Limits
+if platform.system() in ('Darwin', 'Windows'):
+    DEFAULT_MAX_FILE_NAME = '255c'
+else:
+    DEFAULT_MAX_FILE_NAME = '255b'
+
 # As of [1] format syntax is:
 #  %[mapping_key][conversion_flags][minimum_width][.precision][length_modifier]type
 # 1. https://docs.python.org/2/library/stdtypes.html#string-formatting


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

This PR modifies the behavior of `--trim-filenames` so that it properly trims filenames without their extensions (by expanding the template string without the extension, trimming, and then adding the extension on after). It also adds the ability to trim by characters or by bytes, with the encoding able to be specified by a new option, `--filesystem-encoding`, by letting the value of `--trim-filenames` end with a `c` (for characters) or `b` (for bytes). If no suffix is added, it will default to trimming by characters, to preserve compatibility with the old option.

Furthermore, I have added (what I believe to be) reasonable default values for `--trim-filenames` based on the platform of the user. Based on this [table](https://en.m.wikipedia.org/wiki/Comparison_of_file_systems#Limits), it seems that for Windows and Mac filesystems (NTFS, FAT32, exFAT, HFS+, APFS) the maximum filename length is 255 characters, while the majority of other filesystems have a maximum filename length of 255 bytes. I also subtracted the length of what I think is the longest possible extension (`.annotations.xml`). I think these defaults will be fine for the majority of users and will prevent filename too long errors.

I left some comments in the code where I have questions.

Related:
- https://github.com/yt-dlp/yt-dlp/issues/3494
- https://github.com/yt-dlp/yt-dlp/issues/2314
- https://github.com/yt-dlp/yt-dlp/issues/1136


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
