### PR TITLE
Update reddit.py

### DIFF
--- a/yt_dlp/extractor/reddit.py
+++ b/yt_dlp/extractor/reddit.py
@@ -404,6 +404,23 @@ class RedditIE(InfoExtractor):
                 'display_id': video_id,
             }
 
+        # Hosted on reddit as an image (most likely gif)
+        if parsed_url.netloc == 'i.redd.it':
+            formats = [{
+                'url': video_url,
+                'acodec': 'none',
+                'ext': video_url.rsplit('.', 1)[-1],
+                'format_id': video_url.rsplit('.', 1)[-1],
+                # Must GET only accepting raw file content
+                'http_headers': {'Accept': 'video/*,image/*'},
+            }]
+            return {
+                **info,
+                'id': parsed_url.path.split('/')[1],
+                'display_id': video_id,
+                'formats': formats,
+            }
+
         # Not hosted on reddit, must continue extraction
         return {
             **info,


### PR DESCRIPTION
[reddit] Add explicit support for GIF files

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

This PR attempts to properly implement downloading of served image animation files from Reddit. Much of the existing Reddit extractor falls back on the generic extractor if a video does not exist, which is supposed to handle this, however (unsure if this was a recent change) Reddit's GIF files are hosted on a sever that will always return a HTML file unless you request it with a custom `Accept` HTTP header.
The generic extractor will attempt to follow its image/video meta tags as redirects; if you follow this manually you will find an endless loop (www.reddit.com -> i.redd.it -> www.reddit.com/media?url= -> i.redd.it -> www.reddit.com/media?url=) and in practice, the extractor will error saying the `/media` endpoint is unsupported.

Note that this bug is similar to https://github.com/yt-dlp/yt-dlp/pull/3427 however the proposed solution (https://github.com/yt-dlp/yt-dlp/pull/3427#issuecomment-2402788496) does not account for all videos; only ones that do have a MP4 alternate link.
As an example, here is what occurs using the link provided by user [pzhlkj6612](https://github.com/pzhlkj6612):
```
[Reddit] Extracting URL: https://www.reddit.com/r/memes/comments/18dyw5t/the_perfect_opportunity_to_use_this_gif/
[Reddit] 18dyw5t: Downloading JSON metadata
[Reddit] 18dyw5t: Downloading m3u8 information
[Reddit] 18dyw5t: Downloading MPD manifest
[info] zz7f20nog55c1: Downloading 1 format(s): hls-1667
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 1
[download] Destination: The perfect opportunity to use this GIF [zz7f20nog55c1].mp4
[download] 100% of  753.10KiB in 00:00:00 at 7.38MiB/s
[FixupM3u8] Fixing MPEG-TS in MP4 container of "The perfect opportunity to use this GIF [zz7f20nog55c1].mp4"
```
Here is one that does **NOT** work (the hosted file is a true GIF):
```
[Reddit] Extracting URL: https://www.reddit.com/r/gifs/comments/1f61uzo/tiger_shenanigans/
[Reddit] 1f61uzo: Downloading JSON metadata
[generic] Extracting URL: https://i.redd.it/a31csdy1f3md1.gif
[generic] a31csdy1f3md1: Downloading webpage
[redirect] Following redirect to https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fa31csdy1f3md1.gif&rdt=33019
[generic] Extracting URL: https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fa31csdy1f3md1.gif&rdt=33019
[generic] media?url=https://i.redd.it/a31csdy1f3md1: Downloading webpage
WARNING: [generic] Falling back on generic information extractor
[generic] media?url=https://i.redd.it/a31csdy1f3md1: Extracting information
ERROR: Unsupported URL: https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fa31csdy1f3md1.gif&rdt=33019
```
And here is what happens with this patch applied:
```
[Reddit] Extracting URL: https://www.reddit.com/r/gifs/comments/1f61uzo/tiger_shenanigans/
[Reddit] 1f61uzo: Downloading JSON metadata
[info] a31csdy1f3md1.gif: Downloading 1 format(s): gif
[download] Destination: Tiger Shenanigans  [a31csdy1f3md1.gif].gif
[download] 100% of   20.06MiB in 00:00:02 at 9.19MiB/s
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
