### PR TITLE
[ie/bilibilispacevideo] extract without logging in

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -1179,7 +1179,7 @@ class BilibiliSpaceBaseIE(BilibiliBaseIE):
 
 
 class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
-    _VALID_URL = r'https?://space\.bilibili\.com/(?P<id>\d+)(?P<video>/video)?/?(?:[?#]|$)'
+    _VALID_URL = r'https?://space\.bilibili\.com/(?P<id>\d+)(?P<video>(?:/upload)?/video)?/?(?:[?#]|$)'
     _TESTS = [{
         'url': 'https://space.bilibili.com/3985676/video',
         'info_dict': {

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -25,10 +25,8 @@ from ..utils import (
     float_or_none,
     format_field,
     get_element_by_class,
-    get_element_by_id,
     int_or_none,
     join_nonempty,
-    jwt_decode_hs256,
     make_archive_id,
     merge_dicts,
     mimetype2ext,
@@ -1182,7 +1180,6 @@ class BilibiliSpaceBaseIE(BilibiliBaseIE):
 
 class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
     _VALID_URL = r'https?://space\.bilibili\.com/(?P<id>\d+)(?P<video>/video)?/?(?:[?#]|$)'
-    _W_WEBID = None
     _TESTS = [{
         'url': 'https://space.bilibili.com/3985676/video',
         'info_dict': {
@@ -1196,32 +1193,6 @@ class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
         },
         'playlist_mincount': 92,
     }]
-
-    def _get_w_webid(self, url, video_id):
-        def validate_w_webid(w_webid):
-            if not w_webid:
-                return False
-            decoded = jwt_decode_hs256(w_webid)
-            created_at, ttl = decoded.get('created_at'), decoded.get('ttl')
-            if not isinstance(created_at, int) or not isinstance(ttl, int):
-                return False
-            return time.time() < created_at + ttl
-
-        if self._W_WEBID and validate_w_webid(self._W_WEBID):
-            return self._W_WEBID
-
-        self._W_WEBID = self.cache.load(self.ie_key(), 'w_webid')
-        if self._W_WEBID and validate_w_webid(self._W_WEBID):
-            return self._W_WEBID
-        webpage = self._download_webpage(url, video_id)
-        render_data = get_element_by_id('__RENDER_DATA__', webpage)
-        if render_data is None:
-            return None
-        self._W_WEBID = traverse_obj(render_data, ({urllib.parse.unquote}, {json.loads}, 'access_id'))
-        if self._W_WEBID and validate_w_webid(self._W_WEBID):
-            return self._W_WEBID
-
-        self.cache.store(self._NETRC_MACHINE, 'w_webid', self._W_WEBID)
 
     def _real_extract(self, url):
         playlist_id, is_video_url = self._match_valid_url(url).group('id', 'video')
@@ -1246,7 +1217,6 @@ class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
                 'dm_cover_img_str': base64.b64encode(
                     ''.join(random.choices(string.printable, k=random.randint(32, 128))).encode())[:-2].decode(),
                 'dm_img_inter': '{"ds":[],"wh":[6093,6631,31],"of":[430,760,380]}',
-                'w_webid': self._get_w_webid(url, playlist_id),
             }
 
             try:

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -1257,14 +1257,14 @@ class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
             except ExtractorError as e:
                 if isinstance(e.cause, HTTPError) and e.cause.status == 412:
                     raise ExtractorError(
-                        'Request is blocked by server (412), please add cookies, wait and try later.', expected=True)
+                        'Request is blocked by server (412), please wait and try later.', expected=True)
                 raise
             status_code = response['code']
             if status_code == -401:
                 raise ExtractorError(
-                    'Request is blocked by server (401), please add cookies, wait and try later.', expected=True)
-            elif status_code == -352 and not self.is_logged_in:
-                self.raise_login_required('Request is rejected, you need to login to access playlist')
+                    'Request is blocked by server (401), please wait and try later.', expected=True)
+            elif status_code == -352:
+                raise ExtractorError('Request is rejected by server (352)', expected=True)
             elif status_code != 0:
                 raise ExtractorError(f'Request failed ({status_code}): {response.get("message") or "Unknown error"}')
             return response['data']

--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -1227,7 +1227,7 @@ class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
         playlist_id, is_video_url = self._match_valid_url(url).group('id', 'video')
         if not is_video_url:
             self.to_screen('A channel URL was given. Only the channel\'s videos will be downloaded. '
-                           'To download audios, add a "/audio" to the URL')
+                           'To download audios, add a "/upload/audio" to the URL')
 
         def fetch_page(page_idx):
             query = {
@@ -1286,9 +1286,9 @@ class BilibiliSpaceVideoIE(BilibiliSpaceBaseIE):
 
 
 class BilibiliSpaceAudioIE(BilibiliSpaceBaseIE):
-    _VALID_URL = r'https?://space\.bilibili\.com/(?P<id>\d+)/audio'
+    _VALID_URL = r'https?://space\.bilibili\.com/(?P<id>\d+)/(?:upload/)?audio'
     _TESTS = [{
-        'url': 'https://space.bilibili.com/313580179/audio',
+        'url': 'https://space.bilibili.com/313580179/upload/audio',
         'info_dict': {
             'id': '313580179',
         },
@@ -1311,7 +1311,8 @@ class BilibiliSpaceAudioIE(BilibiliSpaceBaseIE):
             }
 
         def get_entries(page_data):
-            for entry in page_data.get('data', []):
+            # data is None when the playlist is empty
+            for entry in page_data.get('data') or []:
                 yield self.url_result(f'https://www.bilibili.com/audio/au{entry["id"]}', BilibiliAudioIE, entry['id'])
 
         metadata, paged_list = self._extract_playlist(fetch_page, get_metadata, get_entries)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

this pr passes `dm_img_list`, `dm_img_str`, `dm_cover_img_str`, and `dm_img_inter` to the API endpoint to enable `BilibiliSpaceVideoIE` to extract without logging in
this pr also updates `BilibiliSpaceAudioIE` and `BilibiliSpaceVideoIE`'s `_VALID_URL` and makes `BilibiliSpaceAudioIE` handle empty playlists properly

I've also noticed a risk-control param `w_webid`(a jwt) for `https://api.bilibili.com/x/space/wbi/arc/search` but it's optional. In case someone needs it, they can use the patch below.

<details><summary>patch</summary>

```diff
diff --git a/yt_dlp/extractor/bilibili.py b/yt_dlp/extractor/bilibili.py
index 685447f10..c09b53ee6 100644
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -25,8 +25,10 @@
     float_or_none,
     format_field,
     get_element_by_class,
+    get_element_by_id,
     int_or_none,
     join_nonempty,
+    jwt_decode_hs256,
     make_archive_id,
     merge_dicts,
     mimetype2ext,
@@ -51,6 +53,7 @@ class BilibiliBaseIE(InfoExtractor):
     _FORMAT_ID_RE = re.compile(r'-(\d+)\.m4s\?')
     _WBI_KEY_CACHE_TIMEOUT = 30  # exact expire timeout is unclear, use 30s for one session
     _wbi_key_cache = {}
+    _W_WEBID = None
 
     @property
     def is_logged_in(self):
@@ -166,6 +169,31 @@ def _sign_wbi(self, params, video_id):
         params['w_rid'] = hashlib.md5(f'{query}{self._get_wbi_key(video_id)}'.encode()).hexdigest()
         return params
 
+    @staticmethod
+    def _validate_w_webid(w_webid):
+        if not w_webid:
+            return False
+        decoded = jwt_decode_hs256(w_webid)
+        created_at, ttl = decoded.get('created_at'), decoded.get('ttl')
+        if not isinstance(created_at, int) or not isinstance(ttl, int):
+            return False
+        return time.time() < created_at + ttl
+
+    def _get_w_webid(self, url, video_id):
+        if self._W_WEBID and self._validate_w_webid(self._W_WEBID):
+            return self._W_WEBID
+
+        self._W_WEBID = self.cache.load(self.ie_key(), 'w_webid')
+        if self._W_WEBID and self._validate_w_webid(self._W_WEBID):
+            return self._W_WEBID
+        webpage = self._download_webpage(url, video_id)
+        render_data = get_element_by_id('__RENDER_DATA__', webpage)
+        self._W_WEBID = traverse_obj(render_data, ({urllib.parse.unquote}, {json.loads}, 'access_id'))
+        if self._W_WEBID and self._validate_w_webid(self._W_WEBID):
+            self.cache.store(self.ie_key(), 'w_webid', self._W_WEBID)
+            return self._W_WEBID
+        return None
+
     def _download_playinfo(self, bvid, cid, headers=None, query=None):
         params = {'bvid': bvid, 'cid': cid, 'fnval': 4048, **(query or {})}
         if self.is_logged_in:
@@ -1217,6 +1245,7 @@ def fetch_page(page_idx):
                 'dm_cover_img_str': base64.b64encode(
                     ''.join(random.choices(string.printable, k=random.randint(32, 128))).encode())[:-2].decode(),
                 'dm_img_inter': '{"ds":[],"wh":[6093,6631,31],"of":[430,760,380]}',
+                'w_webid': self._get_w_webid(url, playlist_id),
             }
 
             try:
```

</details>

Fixes #12007


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
