### PR TITLE
[jsinterp] Add `js_number_to_string`

### DIFF
--- a/test/test_jsinterp.py
+++ b/test/test_jsinterp.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import math
 
-from yt_dlp.jsinterp import JS_Undefined, JSInterpreter
+from yt_dlp.jsinterp import JS_Undefined, JSInterpreter, js_number_to_string
 
 
 class NaN:
@@ -430,6 +430,27 @@ class TestJSInterpreter(unittest.TestCase):
         self._test('function f(){return "012345678".slice(1, -1)}', '1234567')
         self._test('function f(){return "012345678".slice(-1, 1)}', '')
         self._test('function f(){return "012345678".slice(-3, -1)}', '67')
+
+    def test_js_number_to_string(self):
+        for test, radix, expected in [
+            (0, None, '0'),
+            (-0, None, '0'),
+            (0.0, None, '0'),
+            (-0.0, None, '0'),
+            (math.nan, None, 'NaN'),
+            (-math.nan, None, 'NaN'),
+            (math.inf, None, 'Infinity'),
+            (-math.inf, None, '-Infinity'),
+            (10 ** 21.5, 8, '526665530627250154000000'),
+            (6, 2, '110'),
+            (254, 16, 'fe'),
+            (-10, 2, '-1010'),
+            (-0xff, 2, '-11111111'),
+            (0.1 + 0.2, 16, '0.4cccccccccccd'),
+            (1234.1234, 10, '1234.1234'),
+            # (1000000000000000128, 10, "1000000000000000100")
+        ]:
+            assert js_number_to_string(test, radix) == expected
 
 
 if __name__ == '__main__':

--- a/test/test_jsinterp.py
+++ b/test/test_jsinterp.py
@@ -448,7 +448,7 @@ class TestJSInterpreter(unittest.TestCase):
             (-0xff, 2, '-11111111'),
             (0.1 + 0.2, 16, '0.4cccccccccccd'),
             (1234.1234, 10, '1234.1234'),
-            # (1000000000000000128, 10, "1000000000000000100")
+            # (1000000000000000128, 10, '1000000000000000100')
         ]:
             assert js_number_to_string(test, radix) == expected
 

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -95,6 +95,62 @@ def _js_ternary(cndn, if_true=True, if_false=False):
     return if_true
 
 
+# Ref: https://es5.github.io/#x9.8.1
+def js_number_to_string(val: float, radix: int = 10):
+    if radix in (JS_Undefined, None):
+        radix = 10
+    assert radix in range(2, 37), 'radix must be an integer at least 2 and no greater than 36'
+
+    if math.isnan(val):
+        return 'NaN'
+    if val == 0:
+        return '0'
+    if math.isinf(val):
+        return '-Infinity' if val < 0 else 'Infinity'
+    if radix == 10:
+        # TODO: implement special cases
+        ...
+
+    ALPHABET = b'0123456789abcdefghijklmnopqrstuvwxyz.-'
+
+    result = collections.deque()
+    sign = val < 0
+    val = abs(val)
+    fraction, integer = math.modf(val)
+    delta = max(math.nextafter(.0, math.inf), math.ulp(val) / 2)
+
+    if fraction >= delta:
+        result.append(-2)
+    while fraction >= delta:
+        delta *= radix
+        fraction, digit = math.modf(fraction * radix)
+        result.append(int(digit))
+        # rounding cringe
+        needs_rounding = fraction > 0.5 or (fraction == 0.5 and int(digit) & 1)
+        if needs_rounding and fraction + delta > 1:
+            for index in reversed(range(1, len(result))):
+                if result[index] + 1 < radix:
+                    result[index] += 1
+                    break
+                result.pop()
+
+            else:
+                integer += 1
+                break
+            break
+
+    integer, digit = divmod(int(integer), radix)
+    result.appendleft(digit)
+    while integer > 0:
+        integer, digit = divmod(integer, radix)
+        result.appendleft(digit)
+
+    if sign:
+        result.appendleft(-1)
+
+    return bytes(ALPHABET[digit] for digit in result).decode('ascii')
+
+
 # Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
 _OPERATORS = {  # None => Defined in JSInterpreter._operator
     '?': None,

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -120,7 +120,7 @@ def js_number_to_string(val: float, radix: int = 10):
     delta = max(math.nextafter(.0, math.inf), math.ulp(val) / 2)
 
     if fraction >= delta:
-        result.append(-2)
+        result.append(-2)  # `.`
     while fraction >= delta:
         delta *= radix
         fraction, digit = math.modf(fraction * radix)
@@ -145,7 +145,7 @@ def js_number_to_string(val: float, radix: int = 10):
         result.appendleft(digit)
 
     if sign:
-        result.appendleft(-1)
+        result.appendleft(-1)  # `-`
 
     return bytes(ALPHABET[digit] for digit in result).decode('ascii')
 

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -125,7 +125,7 @@ def js_number_to_string(val: float, radix: int = 10):
         delta *= radix
         fraction, digit = math.modf(fraction * radix)
         result.append(int(digit))
-        # rounding cringe
+        # if we need to round, propagate potential carry through fractional part
         needs_rounding = fraction > 0.5 or (fraction == 0.5 and int(digit) & 1)
         if needs_rounding and fraction + delta > 1:
             for index in reversed(range(1, len(result))):
@@ -136,7 +136,6 @@ def js_number_to_string(val: float, radix: int = 10):
 
             else:
                 integer += 1
-                break
             break
 
     integer, digit = divmod(int(integer), radix)


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Helper method, implementing `Number.prototype.toString(radix)` (and by extend some of `ToString(Number)`)

See https://es5.github.io/#x9.8.1

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Core bug fix/improvement

</details>
