### PR TITLE
Abstract facebook _extract_metadata method out from inside '_extract_from_url'

### DIFF
--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -477,71 +477,71 @@ class FacebookIE(InfoExtractor):
         except network_exceptions as err:
             self.report_warning(f'unable to log in: {err}')
             return
+        
+    def _extract_metadata(self, webpage, video_id):
+        post_data = [self._parse_json(j, video_id, fatal=False) for j in re.findall(
+            r'data-sjs>({.*?ScheduledServerJS.*?})</script>', webpage)]
+        post = traverse_obj(post_data, (
+            ..., 'require', ..., ..., ..., '__bbox', 'require', ..., ..., ..., '__bbox', 'result', 'data'), expected_type=dict) or []
+        media = traverse_obj(post, (..., 'attachments', ..., lambda k, v: (
+            k == 'media' and str(v['id']) == video_id and v['__typename'] == 'Video')), expected_type=dict)
+        title = get_first(media, ('title', 'text'))
+        description = get_first(media, ('creation_story', 'comet_sections', 'message', 'story', 'message', 'text'))
+        page_title = title or self._html_search_regex((
+            r'<h2\s+[^>]*class="uiHeaderTitle"[^>]*>(?P<content>[^<]*)</h2>',
+            r'(?s)<span class="fbPhotosPhotoCaption".*?id="fbPhotoPageCaption"><span class="hasCaption">(?P<content>.*?)</span>',
+            self._meta_regex('og:title'), self._meta_regex('twitter:title'), r'<title>(?P<content>.+?)</title>',
+        ), webpage, 'title', default=None, group='content')
+        description = description or self._html_search_meta(
+            ['description', 'og:description', 'twitter:description'],
+            webpage, 'description', default=None)
+        uploader_data = (
+            get_first(media, ('owner', {dict}))
+            or get_first(post, ('video', 'creation_story', 'attachments', ..., 'media', lambda k, v: k == 'owner' and v['name']))
+            or get_first(post, (..., 'video', lambda k, v: k == 'owner' and v['name']))
+            or get_first(post, ('node', 'actors', ..., {dict}))
+            or get_first(post, ('event', 'event_creator', {dict}))
+            or get_first(post, ('video', 'creation_story', 'short_form_video_context', 'video_owner', {dict})) or {})
+        uploader = uploader_data.get('name') or (
+            clean_html(get_element_by_id('fbPhotoPageAuthorName', webpage))
+            or self._search_regex(
+                (r'ownerName\s*:\s*"([^"]+)"', *self._og_regexes('title')), webpage, 'uploader', fatal=False))
+        timestamp = int_or_none(self._search_regex(
+            r'<abbr[^>]+data-utime=["\'](\d+)', webpage,
+            'timestamp', default=None))
+        thumbnail = self._html_search_meta(
+            ['og:image', 'twitter:image'], webpage, 'thumbnail', default=None)
+        # some webpages contain unretrievable thumbnail urls
+        # like https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=10155168902769113&get_thumbnail=1
+        # in https://www.facebook.com/yaroslav.korpan/videos/1417995061575415/
+        if thumbnail and not re.search(r'\.(?:jpg|png)', thumbnail):
+            thumbnail = None
+        info_dict = {
+            'description': description,
+            'uploader': uploader,
+            'uploader_id': uploader_data.get('id'),
+            'timestamp': timestamp,
+            'thumbnail': thumbnail,
+            'view_count': parse_count(self._search_regex(
+                (r'\bviewCount\s*:\s*["\']([\d,.]+)', r'video_view_count["\']\s*:\s*(\d+)'),
+                webpage, 'view count', default=None)),
+            'concurrent_view_count': get_first(post, (
+                ('video', (..., ..., 'attachments', ..., 'media')), 'liveViewerCount', {int_or_none})),
+            **traverse_obj(post, (lambda _, v: video_id in v['url'], 'feedback', {
+                'like_count': ('likers', 'count', {int}),
+                'comment_count': ('total_comment_count', {int}),
+                'repost_count': ('share_count_reduced', {parse_count}),
+            }), get_all=False),
+        }
+
+        info_json_ld = self._search_json_ld(webpage, video_id, default={})
+        info_json_ld['title'] = (re.sub(r'\s*\|\s*Facebook$', '', title or info_json_ld.get('title') or page_title or '')
+                                    or (description or '').replace('\n', ' ') or f'Facebook video #{video_id}')
+        return merge_dicts(info_json_ld, info_dict)
 
     def _extract_from_url(self, url, video_id):
         webpage = self._download_webpage(
             url.replace('://m.facebook.com/', '://www.facebook.com/'), video_id)
-
-        def extract_metadata(webpage):
-            post_data = [self._parse_json(j, video_id, fatal=False) for j in re.findall(
-                r'data-sjs>({.*?ScheduledServerJS.*?})</script>', webpage)]
-            post = traverse_obj(post_data, (
-                ..., 'require', ..., ..., ..., '__bbox', 'require', ..., ..., ..., '__bbox', 'result', 'data'), expected_type=dict) or []
-            media = traverse_obj(post, (..., 'attachments', ..., lambda k, v: (
-                k == 'media' and str(v['id']) == video_id and v['__typename'] == 'Video')), expected_type=dict)
-            title = get_first(media, ('title', 'text'))
-            description = get_first(media, ('creation_story', 'comet_sections', 'message', 'story', 'message', 'text'))
-            page_title = title or self._html_search_regex((
-                r'<h2\s+[^>]*class="uiHeaderTitle"[^>]*>(?P<content>[^<]*)</h2>',
-                r'(?s)<span class="fbPhotosPhotoCaption".*?id="fbPhotoPageCaption"><span class="hasCaption">(?P<content>.*?)</span>',
-                self._meta_regex('og:title'), self._meta_regex('twitter:title'), r'<title>(?P<content>.+?)</title>',
-            ), webpage, 'title', default=None, group='content')
-            description = description or self._html_search_meta(
-                ['description', 'og:description', 'twitter:description'],
-                webpage, 'description', default=None)
-            uploader_data = (
-                get_first(media, ('owner', {dict}))
-                or get_first(post, ('video', 'creation_story', 'attachments', ..., 'media', lambda k, v: k == 'owner' and v['name']))
-                or get_first(post, (..., 'video', lambda k, v: k == 'owner' and v['name']))
-                or get_first(post, ('node', 'actors', ..., {dict}))
-                or get_first(post, ('event', 'event_creator', {dict}))
-                or get_first(post, ('video', 'creation_story', 'short_form_video_context', 'video_owner', {dict})) or {})
-            uploader = uploader_data.get('name') or (
-                clean_html(get_element_by_id('fbPhotoPageAuthorName', webpage))
-                or self._search_regex(
-                    (r'ownerName\s*:\s*"([^"]+)"', *self._og_regexes('title')), webpage, 'uploader', fatal=False))
-            timestamp = int_or_none(self._search_regex(
-                r'<abbr[^>]+data-utime=["\'](\d+)', webpage,
-                'timestamp', default=None))
-            thumbnail = self._html_search_meta(
-                ['og:image', 'twitter:image'], webpage, 'thumbnail', default=None)
-            # some webpages contain unretrievable thumbnail urls
-            # like https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=10155168902769113&get_thumbnail=1
-            # in https://www.facebook.com/yaroslav.korpan/videos/1417995061575415/
-            if thumbnail and not re.search(r'\.(?:jpg|png)', thumbnail):
-                thumbnail = None
-            info_dict = {
-                'description': description,
-                'uploader': uploader,
-                'uploader_id': uploader_data.get('id'),
-                'timestamp': timestamp,
-                'thumbnail': thumbnail,
-                'view_count': parse_count(self._search_regex(
-                    (r'\bviewCount\s*:\s*["\']([\d,.]+)', r'video_view_count["\']\s*:\s*(\d+)'),
-                    webpage, 'view count', default=None)),
-                'concurrent_view_count': get_first(post, (
-                    ('video', (..., ..., 'attachments', ..., 'media')), 'liveViewerCount', {int_or_none})),
-                **traverse_obj(post, (lambda _, v: video_id in v['url'], 'feedback', {
-                    'like_count': ('likers', 'count', {int}),
-                    'comment_count': ('total_comment_count', {int}),
-                    'repost_count': ('share_count_reduced', {parse_count}),
-                }), get_all=False),
-            }
-
-            info_json_ld = self._search_json_ld(webpage, video_id, default={})
-            info_json_ld['title'] = (re.sub(r'\s*\|\s*Facebook$', '', title or info_json_ld.get('title') or page_title or '')
-                                     or (description or '').replace('\n', ' ') or f'Facebook video #{video_id}')
-            return merge_dicts(info_json_ld, info_dict)
 
         video_data = None
 
@@ -753,7 +753,7 @@ class FacebookIE(InfoExtractor):
                     return self.playlist_result(entries, video_id)
 
                 video_info = entries[0] if entries else {'id': video_id}
-                webpage_info = extract_metadata(webpage)
+                webpage_info = self._extract_metadata(webpage, video_id)
                 # honor precise duration in video info
                 if video_info.get('duration'):
                     webpage_info['duration'] = video_info['duration']
@@ -885,7 +885,7 @@ class FacebookIE(InfoExtractor):
             'subtitles': subtitles,
         }
         process_formats(info_dict)
-        info_dict.update(extract_metadata(webpage))
+        info_dict.update(self._extract_metadata(webpage, video_id))
 
         return info_dict
 

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -536,7 +536,7 @@ class FacebookIE(InfoExtractor):
 
         info_json_ld = self._search_json_ld(webpage, video_id, default={})
         info_json_ld['title'] = (re.sub(r'\s*\|\s*Facebook$', '', title or info_json_ld.get('title') or page_title or '')
-                                    or (description or '').replace('\n', ' ') or f'Facebook video #{video_id}')
+                                 or (description or '').replace('\n', ' ') or f'Facebook video #{video_id}')
         return merge_dicts(info_json_ld, info_dict)
 
     def _extract_from_url(self, url, video_id):

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -477,7 +477,7 @@ class FacebookIE(InfoExtractor):
         except network_exceptions as err:
             self.report_warning(f'unable to log in: {err}')
             return
-        
+
     def _extract_metadata(self, webpage, video_id):
         post_data = [self._parse_json(j, video_id, fatal=False) for j in re.findall(
             r'data-sjs>({.*?ScheduledServerJS.*?})</script>', webpage)]


### PR DESCRIPTION

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

I may be pushing my luck with this change, but this abstracts the very useful `_extract_metadata` method out from inside the `_extract_from_url` method. This is similar to what was merged for the bluesky extractor last week [here](https://github.com/yt-dlp/yt-dlp/pull/12194).

This allows external 3rd party apps to call into this, of course with the caveats that this is a private API and it may change at any point.


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
