### PR TITLE
[test:download] Validate and sort info dict fields

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -237,6 +237,20 @@ def sanitize_got_info_dict(got_dict):
 
 
 def expect_info_dict(self, got_dict, expected_dict):
+    ALLOWED_KEYS_SORT_ORDER = (
+        # NB: Keep in sync with the docstring of extractor/common.py
+        'id', 'ext', 'direct', 'display_id', 'title', 'alt_title', 'description', 'media_type',
+        'uploader', 'uploader_id', 'uploader_url', 'channel', 'channel_id', 'channel_url', 'channel_is_verified',
+        'channel_follower_count', 'comment_count', 'view_count', 'concurrent_view_count',
+        'like_count', 'dislike_count', 'repost_count', 'average_rating', 'age_limit', 'duration', 'thumbnail', 'heatmap',
+        'chapters', 'chapter', 'chapter_number', 'chapter_id', 'start_time', 'end_time', 'section_start', 'section_end',
+        'categories', 'tags', 'cast', 'composers', 'artists', 'album_artists', 'creators', 'genres',
+        'track', 'track_number', 'track_id', 'album', 'album_type', 'disc_number',
+        'series', 'series_id', 'season', 'season_number', 'season_id', 'episode', 'episode_number', 'episode_id',
+        'timestamp', 'upload_date', 'release_timestamp', 'release_date', 'release_year', 'modified_timestamp', 'modified_date',
+        'playable_in_embed', 'availability', 'live_status', 'location', 'license', '_old_archive_ids',
+    )
+
     expect_dict(self, got_dict, expected_dict)
     # Check for the presence of mandatory fields
     if got_dict.get('_type') not in ('playlist', 'multi_video'):
@@ -252,7 +266,13 @@ def expect_info_dict(self, got_dict, expected_dict):
 
     test_info_dict = sanitize_got_info_dict(got_dict)
 
-    missing_keys = sorted(set(test_info_dict.keys()) - set(expected_dict.keys()))
+    # Check for invalid/misspelled field names being returned by the extractor
+    invalid_keys = sorted(set(test_info_dict.keys()) - set(ALLOWED_KEYS_SORT_ORDER))
+    self.assertFalse(invalid_keys, f'Invalid fields returned by the extractor: {", ".join(invalid_keys)}')
+
+    missing_keys = sorted(
+        set(test_info_dict.keys()) - set(expected_dict.keys()),
+        key=lambda x: ALLOWED_KEYS_SORT_ORDER.index(x))
     if missing_keys:
         def _repr(v):
             if isinstance(v, str):

--- a/test/helper.py
+++ b/test/helper.py
@@ -267,11 +267,11 @@ def expect_info_dict(self, got_dict, expected_dict):
     test_info_dict = sanitize_got_info_dict(got_dict)
 
     # Check for invalid/misspelled field names being returned by the extractor
-    invalid_keys = sorted(set(test_info_dict.keys()) - set(ALLOWED_KEYS_SORT_ORDER))
+    invalid_keys = sorted(test_info_dict.keys() - ALLOWED_KEYS_SORT_ORDER)
     self.assertFalse(invalid_keys, f'Invalid fields returned by the extractor: {", ".join(invalid_keys)}')
 
     missing_keys = sorted(
-        set(test_info_dict.keys()) - set(expected_dict.keys()),
+        test_info_dict.keys() - expected_dict.keys(),
         key=lambda x: ALLOWED_KEYS_SORT_ORDER.index(x))
     if missing_keys:
         def _repr(v):
@@ -293,7 +293,7 @@ def expect_info_dict(self, got_dict, expected_dict):
         write_string(info_dict_str.replace('\n', '\n        '), out=sys.stderr)
         self.assertFalse(
             missing_keys,
-            'Missing keys in test definition: {}'.format(', '.join(missing_keys)))
+            'Missing keys in test definition: {}'.format(', '.join(sorted(missing_keys))))
 
 
 def assertRegexpMatches(self, text, regexp, msg=None):

--- a/test/helper.py
+++ b/test/helper.py
@@ -252,7 +252,7 @@ def expect_info_dict(self, got_dict, expected_dict):
 
     test_info_dict = sanitize_got_info_dict(got_dict)
 
-    missing_keys = set(test_info_dict.keys()) - set(expected_dict.keys())
+    missing_keys = sorted(set(test_info_dict.keys()) - set(expected_dict.keys()))
     if missing_keys:
         def _repr(v):
             if isinstance(v, str):
@@ -273,7 +273,7 @@ def expect_info_dict(self, got_dict, expected_dict):
         write_string(info_dict_str.replace('\n', '\n        '), out=sys.stderr)
         self.assertFalse(
             missing_keys,
-            'Missing keys in test definition: {}'.format(', '.join(sorted(missing_keys))))
+            'Missing keys in test definition: {}'.format(', '.join(missing_keys)))
 
 
 def assertRegexpMatches(self, text, regexp, msg=None):


### PR DESCRIPTION
**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

These `missing_keys` in the hint have not been sorted since it was added (a9c2896e2252839c2e4801189f10acce7ff6413e).

```
[info] Writing video metadata as JSON to: ....json

        'info_dict': {
            'id': '...',
            'title': '...',

            'upload_date': '...',
            'age_limit': ...,
            'timestamp': ...,
        },
        F
======================================================================
FAIL: test_Webpage_all (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
  File ".../yt-dlp/test/helper.py", line 274, in expect_info_dict
    self.assertFalse(
    ~~~~~~~~~~~~~~~~^
        missing_keys,
        ^^^^^^^^^^^^^
        'Missing keys in test definition: {}'.format(', '.join(sorted(missing_keys))))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: {'upload_date', 'age_limit', 'timestamp'} is not false : Missing keys in test definition: age_limit, timestamp, upload_date

```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check all of the following options that apply:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
