### PR TITLE
[fd/hls] Support loading m3u8 from `manifest_data` format field

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -596,7 +596,7 @@ class YoutubeDL:
 
     _format_fields = {
         # NB: Keep in sync with the docstring of extractor/common.py
-        'url', 'manifest_url', 'manifest_stream_number', 'ext', 'format', 'format_id', 'format_note',
+        'url', 'manifest_url', 'manifest_data', 'manifest_stream_number', 'ext', 'format', 'format_id', 'format_note',
         'width', 'height', 'aspect_ratio', 'resolution', 'dynamic_range', 'tbr', 'abr', 'acodec', 'asr', 'audio_channels',
         'vbr', 'fps', 'vcodec', 'container', 'filesize', 'filesize_approx', 'rows', 'columns',
         'player_url', 'protocol', 'fragment_base_url', 'fragments', 'is_from_start', 'is_dash_periods', 'request_data',

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -72,11 +72,15 @@ class HlsFD(FragmentFD):
 
     def real_download(self, filename, info_dict):
         man_url = info_dict['url']
-        self.to_screen(f'[{self.FD_NAME}] Downloading m3u8 manifest')
 
-        urlh = self.ydl.urlopen(self._prepare_url(info_dict, man_url))
-        man_url = urlh.url
-        s = urlh.read().decode('utf-8', 'ignore')
+        s = info_dict.get('manifest_data')
+        if s:
+            self.to_screen(f'[{self.FD_NAME}] Loading cached m3u8 manifest')
+        else:
+            self.to_screen(f'[{self.FD_NAME}] Downloading m3u8 manifest')
+            urlh = self.ydl.urlopen(self._prepare_url(info_dict, man_url))
+            man_url = urlh.url
+            s = urlh.read().decode('utf-8', 'ignore')
 
         can_download, message = self.can_download(s, info_dict, self.params.get('allow_unplayable_formats')), None
         if can_download:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -151,6 +151,11 @@ class InfoExtractor:
                                    for HDS - URL of the F4M manifest,
                                    for DASH - URL of the MPD manifest,
                                    for MSS - URL of the ISM manifest.
+                    * manifest_data
+                                The media playlist m3u8 data as a string,
+                                only if needed due to the data fetched from the
+                                manifest URL needing to be modified by the extractor.
+                                Only applicable to the native HLS downloader
                     * manifest_stream_number  (For internal use only)
                                  The index of the stream in the manifest file
                     * ext        Will be calculated from URL if missing


### PR DESCRIPTION
Adds support to the native HLS downloader for loading m3u8 media playlist data from a `manifest_data` field in the info/format dict instead of requesting it from the manifest URL. This will be useful for extractors where the m3u8 data needs to be modified in some way: to remove ad segments, fix problems, or decrypt the m3u8 itself (as reported on discord).

Note that any extractor which sets `manifest_data` will need to request every variant m3u8 in advance. Additionally, the extractor should request the data using `_download_webpage_handle()`, so that we can set the format's `url` field with the response URL in case of a redirect; this is necessary because the `url` field could still be used as a base URL for constructing fragment URLs.

I considered adding an `extract_manifest_data` parameter to the `_extract_m3u8_formats` helpers, to make it so that any extractor wanting to use `manifest_data` wouldn't need to write the same fetching `for` loop, but I decided against this. The number of sites requiring this is so few currently, and future sites may need to make specialized requests to fetch the manifest data, which would defeat the purpose of generalizing the fetch logic.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
