### PR TITLE
[misc] Clarify that the issue template cannot be removed

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_broken_site.yml
+++ b/.github/ISSUE_TEMPLATE/1_broken_site.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_site_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_site_support_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/3_site_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/3_site_feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/4_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/4_bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/5_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/6_question.yml
+++ b/.github/ISSUE_TEMPLATE/6_question.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
   - type: markdown
     attributes:
       value: |

--- a/devscripts/make_issue_template.py
+++ b/devscripts/make_issue_template.py
@@ -56,7 +56,7 @@ NO_SKIP = '''
     attributes:
       value: |
         > [!IMPORTANT]
-        > Not providing the required (*) information will result in your issue being closed and ignored.
+        > Not providing the required (*) information or removing the template will result in your issue being closed and ignored.
 '''.strip()
 
 


### PR DESCRIPTION
Fix 517ddf3c3f12560ab93e3d36244dc82db9f97818


see https://github.com/yt-dlp/yt-dlp/issues/12326#issuecomment-2648898464

Technically, the OP of that issue didn't do anything wrong because we no longer say "do not remove the issue template." I want to eliminate that technicality

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Avoiding gruel
</details>
