### PR TITLE
[docs] Add note to `supportedsites.md`

### DIFF
--- a/devscripts/make_supportedsites.py
+++ b/devscripts/make_supportedsites.py
@@ -13,9 +13,9 @@ from yt_dlp.extractor import list_extractor_classes
 TEMPLATE = '''\
 # Supported sites
 
-Below is a list of all extractors that are currently part of yt-dlp.
-If a site is not listed here, it might still be supported by yt-dlp due to embed extraction or the generic extractor.
-Not all sites listed here are guaranteed to work. If websites change the extractor might stop working.
+Below is a list of all extractors that are currently included with yt-dlp.
+If a site is not listed here, it might still be supported by yt-dlp's embed extraction or generic extractor.
+Not all sites listed here are guaranteed to work; websites are constantly changing and sometimes this breaks yt-dlp's support for them.
 The only reliable way to check if a site is supported is to try it.
 
 {ie_list}

--- a/devscripts/make_supportedsites.py
+++ b/devscripts/make_supportedsites.py
@@ -21,6 +21,7 @@ The only reliable way to check if a site is supported is to try it.
 {ie_list}
 '''
 
+
 def main():
     out = '\n'.join(ie.description() for ie in list_extractor_classes() if ie.IE_DESC is not False)
     write_file(get_filename_args(), TEMPLATE.format(ie_list=out))

--- a/devscripts/make_supportedsites.py
+++ b/devscripts/make_supportedsites.py
@@ -10,10 +10,20 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from devscripts.utils import get_filename_args, write_file
 from yt_dlp.extractor import list_extractor_classes
 
+TEMPLATE = '''\
+# Supported sites
+
+Below is a list of all extractors that are currently part of yt-dlp.
+If a site is not listed here, it might still be supported by yt-dlp due to embed extraction or the generic extractor.
+Not all sites listed here are guaranteed to work. If websites change the extractor might stop working.
+The only reliable way to check if a site is supported is to try it.
+
+{ie_list}
+'''
 
 def main():
     out = '\n'.join(ie.description() for ie in list_extractor_classes() if ie.IE_DESC is not False)
-    write_file(get_filename_args(), f'# Supported sites\n{out}\n')
+    write_file(get_filename_args(), TEMPLATE.format(ie_list=out))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Add a bit of an explanation to `supportedsites.md`

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Docs


</details>
