### PR TITLE
[ie/niconico] Fix format sorting

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -445,9 +445,9 @@ class NiconicoIE(InfoExtractor):
         min_abr = min(traverse_obj(audios, (..., 'bitRate', {float_or_none})), default=0) / 1000
         for video_fmt in video_fmts:
             video_fmt['tbr'] -= min_abr
-            video_fmt['id'] = url_basename(video_fmt['url']).rpartition('.')[0]
+            video_fmt['format_id'] = url_basename(video_fmt['url']).rpartition('.')[0]
             video_fmt['quality'] = traverse_obj(videos, (
-                lambda _, v: v['id'] == video_fmt['id'], 'qualityLevel', {int_or_none}, any)) or -1
+                lambda _, v: v['id'] == video_fmt['format_id'], 'qualityLevel', {int_or_none}, any)) or -1
             yield video_fmt
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -28,9 +28,10 @@ from ..utils import (
     try_get,
     unescapeHTML,
     update_url_query,
+    url_basename,
     url_or_none,
     urlencode_postdata,
-    urljoin, url_basename,
+    urljoin,
 )
 
 
@@ -440,7 +441,6 @@ class NiconicoIE(InfoExtractor):
         # Sort before removing dupes to keep the format dicts with the lowest tbr
         video_fmts = sorted((fmt for fmt in dms_fmts if fmt['vcodec'] != 'none'), key=lambda f: f['tbr'])
         self._remove_duplicate_formats(video_fmts)
-
         # Calculate the true vbr/tbr by subtracting the lowest abr
         min_abr = min(traverse_obj(audios, (..., 'bitRate', {float_or_none})), default=0) / 1000
         for video_fmt in video_fmts:


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information
#### Changes in this PR
Use the name provided by the server as the video format name instead of the generated name
Added `quality` fields for each format for video and audio, modified so that the correct format is selected.

#### Problem
Format selection logic during download ignores server's qualityLevel field.
The server's response includes a qualityLevel item, and a format with a higher value is considered to have higher video quality.
However, the current logic refers only to the resolution of the video and may select the wrong format

Also, the format name of the video should respect the server's id

#### Example
新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師 ( https://www.nicovideo.jp/watch/sm9 )
This video has `video-h264-360p`(`360p`) and `video-h264-360p-lowest`(`低画質`/`low resolution`).
(However, the current yt-dlp displays the generated format name, which is incompatible with the server name.)
Of these two formats, `video-h264-360p` has the higher QualityLevel, but `video-h264-360p-lowest` has the higher resolution, so yt-dlp selects `video-h264-360p-lowest`.
Should respect the quality Level and choose `video-h264-360p`.


<details open><summary>nicovideo's response</summary> <!-- OPEN is intentional -->

https://www.nicovideo.jp/watch/sm9?responseType=json
```json
      "media": {
        "domand": {
          "videos": [
            {
              "id": "video-h264-360p",
              "isAvailable": true,
              "label": "360p",
              "bitRate": 602592,
              "width": 320,
              "height": 240,
              "qualityLevel": 1,
              "recommendedHighestAudioQualityLevel": 1
            },
            {
              "id": "video-h264-360p-lowest",
              "isAvailable": true,
              "label": "低画質", // low quality video
              "bitRate": 302594,
              "width": 480,
              "height": 360,
              "qualityLevel": 0,
              "recommendedHighestAudioQualityLevel": 1
            }
          ],
          "audios": [
            {
              "id": "audio-aac-128kbps",
              "isAvailable": true,
              "bitRate": 104747,
              "qualityLevel": 1,
              "label": {
                "quality": "標準音質", // standard quality audio
                "bitrate": "128kbps"
              }
            },
            {
              "id": "audio-aac-64kbps",
              "isAvailable": true,
              "bitRate": 78056,
              "qualityLevel": 0,
              "label": {
                "quality": "低音質", //low quality sound
                "bitrate": "64kbps"
              }
            }
          ],
        },
      },
```

</details>

<details open><summary>latest release output</summary> <!-- OPEN is intentional -->

```shell
> yt-dlp --version
2025.02.19

> yt-dlp -F https://www.nicovideo.jp/watch/sm9
[niconico] Extracting URL: https://www.nicovideo.jp/watch/sm9
[niconico] sm9: Downloading webpage
[niconico] sm9: Downloading JSON metadata
[niconico] sm9: Downloading m3u8 information
[info] Available formats for sm9:
ID                EXT RESOLUTION FPS │  FILESIZE  TBR PROTO │ VCODEC       VBR ACODEC      ABR ASR MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
audio-aac-64kbps  mp4 audio only     │ ~ 2.98MiB  78k m3u8  │ audio only       aac         78k 44k Main Audio
audio-aac-128kbps mp4 audio only     │ ~ 4.00MiB 105k m3u8  │ audio only       aac        105k 44k Main Audio
video-602         mp4 320x240     30 │ ~22.97MiB 602k m3u8  │ avc1.4d401e 602k video only #incompatible with server's id
video-302         mp4 480x360     30 │ ~11.53MiB 302k m3u8  │ avc1.42c01e 302k video only #incompatible with server's id

> yt-dlp  https://www.nicovideo.jp/watch/sm9
[niconico] Extracting URL: https://www.nicovideo.jp/watch/sm9
[niconico] sm9: Downloading webpage
[niconico] sm9: Downloading JSON metadata
[niconico] sm9: Downloading m3u8 information
[info] sm9: Downloading 1 format(s): video-302+audio-aac-128kbps #choosing lower quality level format video
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 54
[download] Destination: Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].fvideo-302.mp4
[download] 100% of   11.54MiB in 00:00:01 at 7.83MiB/s
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 54
[download] Destination: Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].faudio-aac-128kbps.mp4
[download] 100% of    3.99MiB in 00:00:01 at 2.93MiB/s
[Merger] Merging formats into "Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].mp4"
Deleting original file Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].fvideo-302.mp4 (pass -k to keep)
Deleting original file Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].faudio-aac-128kbps.mp4 (pass -k to keep)
```
</details>

<details open><summary>this pr output</summary> <!-- OPEN is intentional -->

```shell
> python -m yt_dlp -F https://nicovideo.jp/watch/sm9                       
[niconico] Extracting URL: https://nicovideo.jp/watch/sm9 
[niconico] sm9: Downloading webpage
[niconico] sm9: Downloading JSON metadata 
[niconico] sm9: Downloading m3u8 information 
[info] Available formats for sm9: 
ID                     EXT RESOLUTION FPS │  FILESIZE  TBR PROTO │ VCODEC       VBR ACODEC      ABR ASR MORE INFO
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
audio-aac-64kbps       mp4 audio only     │ ~ 2.98MiB  78k m3u8  │ audio only       aac         78k 44k Main Audio
audio-aac-128kbps      mp4 audio only     │ ~ 4.00MiB 105k m3u8  │ audio only       aac        105k 44k Main Audio
video-h264-360p-lowest mp4 480x360     30 │ ~11.53MiB 302k m3u8  │ avc1.42c01e 302k video only #compatible with server's id
video-h264-360p        mp4 320x240     30 │ ~22.97MiB 602k m3u8  │ avc1.4d401e 602k video only #compatible with server's id

> python -m yt_dlp https://nicovideo.jp/watch/sm9
[niconico] Extracting URL: https://nicovideo.jp/watch/sm9 
[niconico] sm9: Downloading webpage
[niconico] sm9: Downloading JSON metadata 
[niconico] sm9: Downloading m3u8 information 
[info] sm9: Downloading 1 format(s): video-h264-360p+audio-aac-128kbps  #choosing best quality format video
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 54 
[download] Destination: Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].fvideo-h264-360p.mp4
[download] 100% of   22.99MiB in 00:00:03 at 6.34MiB/s
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 54 
[download] Destination: Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].faudio-aac-128kbps.mp4
[download] 100% of    3.99MiB in 00:00:02 at 1.39MiB/s
[Merger] Merging formats into "Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].mp4" 
Deleting original file Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].faudio-aac-128kbps.mp4 (pass -k to keep) 
Deleting original file Shin Gōketsuji Ichizoku： Bonnō Kaihō - Let's Go! Onmyōji [sm9].fvideo-h264-360p.mp4 (pass -k to keep)
```
</details>


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
