### PR TITLE
[ie/instagram] Fix extraction of older private posts

### DIFF
--- a/yt_dlp/extractor/instagram.py
+++ b/yt_dlp/extractor/instagram.py
@@ -33,8 +33,10 @@ def _pk_to_id(media_id):
 
 
 def _id_to_pk(shortcode):
-    """Covert a shortcode to a numeric value"""
-    return decode_base_n(shortcode[:11], table=_ENCODING_CHARS)
+    """Convert a shortcode to a numeric value"""
+    if len(shortcode) > 28:
+        shortcode = shortcode[:-28]
+    return decode_base_n(shortcode, table=_ENCODING_CHARS)
 
 
 class InstagramBaseIE(InfoExtractor):


### PR DESCRIPTION
IG adds a 28 character suffix to all private posts' shortcodes. Private posts from >3 years ago have a "true" shortcode that's fewer than 11 characters (the numeric PK is an ascending database ID; the lower the PK value is the shorter the shortcode will be). So when converting the shortcode to the numeric PK, instead of slicing `shortcode[:11]` we should slice `shortcode[:-28]` (but only if the length of the shortcode is `>28`)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
