### PR TITLE
[myfreecams] add new extractor myfreecams

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1219,6 +1219,7 @@ from .mxplayer import (
     MxplayerIE,
     MxplayerShowIE,
 )
+from .myfreecams import MyFreeCamsIE
 from .myspace import (
     MySpaceAlbumIE,
     MySpaceIE,

--- a/yt_dlp/extractor/myfreecams.py
+++ b/yt_dlp/extractor/myfreecams.py
@@ -1,0 +1,101 @@
+from yt_dlp.utils._utils import ExtractorError
+from .common import InfoExtractor
+
+
+class MyFreeCamsIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:app|share|www)\.myfreecams\.com(?:/room)?/#?(?P<id>[^/?&#]+)'
+    _TESTS = [{
+        'url': 'https://app.myfreecams.com/room/stacy_x3',
+        'info_dict': {
+            'id': 'stacy_x3',
+            'title': 're:^stacy_x3 [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$',
+            'ext': 'mp4',
+            'live_status': 'is_live',
+            'age_limit': 18,
+            'thumbnail': 're:https://img.mfcimg.com/photos2/121/12172602/avatar.300x300.jpg\\?nc=\\d+'
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'skip': 'Model offline'
+    }, {
+        'url': 'https://share.myfreecams.com/BUSTY_EMA',
+        'info_dict': {
+            'id': 'BUSTY_EMA',
+            'title': 're:^BUSTY_EMA [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$',
+            'ext': 'mp4',
+            'live_status': 'is_live',
+            'age_limit': 18,
+            'thumbnail': 're:https://img.mfcimg.com/photos2/295/29538300/avatar.300x300.jpg\\?nc=\\d+'
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'skip': 'Model offline'
+    }, {
+        'url': 'https://www.myfreecams.com/#notbeckyhecky',
+        'info_dict': {
+            'id': 'notbeckyhecky',
+            'title': 're:^notbeckyhecky [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$',
+            'ext': 'mp4',
+            'is_live': True,
+            'age_limit': 18,
+            'thumbnail': 're:https://img.mfcimg.com/photos2/243/24308977/avatar.300x300.jpg\\?nc=\\d+'
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'skip': 'Model offline'
+    }]
+
+    def get_required_params(self, webpage):
+        sid = self._search_regex(
+            [r'data-campreview-sid=["\'](\d+)["\']', r'data-cam-preview-server-id-value=["\'](\d+)["\']'],
+            webpage, 'sid'
+        )
+
+        mid = self._search_regex(
+            [r'data-campreview-mid=["\'](\d+)["\']', r'data-cam-preview-model-id-value=["\'](\d+)["\']'],
+            webpage, 'mid'
+        )
+
+        webrtc = self._search_regex(
+            [r'data-is-webrtc=["\']([^"\']+)["\']', r'data-cam-preview-is-webrtc-value=["\']([^"\']+)["\']'],
+            webpage, 'webrtc', default='false'
+        )
+
+        snap_url = self._search_regex(
+            r'data-cam-preview-snap-url-value=["\']([^"\']+)["\']',
+            webpage, 'snap_url'
+        )
+
+        webrtc = 'true' if 'mfc_a_' in snap_url else 'false'
+
+        return {
+            'sid': sid,
+            'mid': str(int(mid) + 100_000_000),
+            'a': 'a_' if webrtc == 'true' else ''
+        }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage('https://share.myfreecams.com/' + video_id, video_id)
+
+        if not self._search_regex(r'https://www.myfreecams.com/php/tracking.php\?[^\'"]*model_id=(\d+)[^\'"]*',
+                                  webpage, 'model id'):
+            raise ExtractorError('Model not found')
+
+        params = self.get_required_params(webpage)
+        if not params['sid']:
+            raise ExtractorError('Model offline')
+
+        return {
+            'id': video_id,
+            'title': video_id,
+            'is_live': True,
+            'formats': self._extract_m3u8_formats(
+                'https://edgevideo.myfreecams.com/hls/NxServer/' + params['sid'] + '/ngrp:mfc_' + params['a'] + params['mid'] + '.f4v_mobile/playlist.m3u8',
+                video_id, 'mp4', live=True),
+            'age_limit': 18,
+            'thumbnail': self._search_regex(r'(https?://img\.mfcimg\.com/photos2?/\d+/\d+/avatar\.\d+x\d+.jpg(?:\?nc=\d+)?)', webpage, 'thumbnail', fatal=False),
+        }


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR adds support for myfreecams

Fixes #1784


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
