### PR TITLE
[jpfilms] add extractor jpfilms

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -935,6 +935,7 @@ from .jiosaavn import (
 from .joj import JojIE
 from .joqrag import JoqrAgIE
 from .jove import JoveIE
+from .jpfilms import JpFilmsIE
 from .jstream import JStreamIE
 from .jtbc import (
     JTBCIE,

--- a/yt_dlp/extractor/jpfilms.py
+++ b/yt_dlp/extractor/jpfilms.py
@@ -1,0 +1,58 @@
+from yt_dlp.utils._utils import ExtractorError
+from .common import InfoExtractor
+
+
+class JpFilmsIE(InfoExtractor):
+    _VALID_URL = r'https?://jp-films\.com/watch-(?P<id>[^/]+)/.+html'
+    _TESTS = [{
+        'url': 'https://jp-films.com/watch-tokyo-trial/free-sv2.html',
+        'md5': '219cc247503717c09fb65189ca4d7bda',
+        'info_dict': {
+            'id': 'tokyo-trial-8532',
+            'ext': 'mp4',
+            'title': 'Tokyo Trial',
+            'age_limit': 0
+        }
+    }]
+
+    def _real_extract(self, url):
+        url_slug = self._match_id(url)
+        webpage = self._download_webpage(url, url_slug)
+        video_data = self._search_json(
+            r'.*var halim_cfg\s*=\s*', webpage, 'videoData', url_slug)
+
+        if not video_data:
+            raise ExtractorError('Video data not found', expected=True)
+
+        nonce = self._search_regex(r'data-nonce=[\'"]([a-zA-Z0-9]+)[\'"]', webpage, 'nonce')
+        post_id = str(video_data.get('post_id'))
+        episode_slug = video_data.get('episode_slug')
+        server = video_data.get('server')
+
+        source_data = self._download_json(
+            'https://jp-films.com/wp-content/themes/halimmovies/player.php',
+            url_slug,
+            query={
+                'episode_slug': episode_slug,
+                'server_id': server,
+                'post_id': post_id,
+                'nonce': nonce
+            },
+            headers={
+                'Referer': url,
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        ).get('data')
+
+        if not source_data:
+            raise ExtractorError('Source data not found', expected=True)
+
+        m3u8_url = self._search_regex(r'<source src=[\'"]([^"]+)[\'"]', source_data.get('sources'), 'source')
+
+        return {
+            'id': url_slug + '-' + post_id,
+            'title': video_data.get('post_title')
+            or self._html_search_regex(r'<span.*class=[\'"]last[\'"].*>(.+?)</span>', webpage, 'title'),
+            'formats': self._extract_m3u8_formats(m3u8_url, url_slug, 'mp4', fatal=True),
+            'age_limit': 18 if video_data.get('is_adult') else 0
+        }

--- a/yt_dlp/extractor/jpfilms.py
+++ b/yt_dlp/extractor/jpfilms.py
@@ -1,5 +1,5 @@
 from .common import InfoExtractor
-from yt_dlp.utils._utils import ExtractorError
+from ..utils import ExtractorError
 
 
 class JpFilmsIE(InfoExtractor):

--- a/yt_dlp/extractor/jpfilms.py
+++ b/yt_dlp/extractor/jpfilms.py
@@ -1,5 +1,5 @@
-from yt_dlp.utils._utils import ExtractorError
 from .common import InfoExtractor
+from yt_dlp.utils._utils import ExtractorError
 
 
 class JpFilmsIE(InfoExtractor):
@@ -11,8 +11,8 @@ class JpFilmsIE(InfoExtractor):
             'id': 'tokyo-trial-8532',
             'ext': 'mp4',
             'title': 'Tokyo Trial',
-            'age_limit': 0
-        }
+            'age_limit': 0,
+        },
     }]
 
     def _real_extract(self, url):
@@ -36,12 +36,12 @@ class JpFilmsIE(InfoExtractor):
                 'episode_slug': episode_slug,
                 'server_id': server,
                 'post_id': post_id,
-                'nonce': nonce
+                'nonce': nonce,
             },
             headers={
                 'Referer': url,
-                'X-Requested-With': 'XMLHttpRequest'
-            }
+                'X-Requested-With': 'XMLHttpRequest',
+            },
         ).get('data')
 
         if not source_data:
@@ -54,5 +54,5 @@ class JpFilmsIE(InfoExtractor):
             'title': video_data.get('post_title')
             or self._html_search_regex(r'<span.*class=[\'"]last[\'"].*>(.+?)</span>', webpage, 'title'),
             'formats': self._extract_m3u8_formats(m3u8_url, url_slug, 'mp4', fatal=True),
-            'age_limit': 18 if video_data.get('is_adult') else 0
+            'age_limit': 18 if video_data.get('is_adult') else 0,
         }


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR adds a new extractor to support for jpfilms

Fixes #12592


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
