### PR TITLE
[networking] Always add unsupported suffix on version mismatch

### DIFF
--- a/yt_dlp/networking/_requests.py
+++ b/yt_dlp/networking/_requests.py
@@ -21,9 +21,11 @@ if urllib3 is None:
 urllib3_version = tuple(int_or_none(x, default=0) for x in urllib3.__version__.split('.'))
 
 if urllib3_version < (1, 26, 17):
+    urllib3._yt_dlp__version = f'{urllib3.__version__} (unsupported)'
     raise ImportError('Only urllib3 >= 1.26.17 is supported')
 
 if requests.__build__ < 0x023202:
+    requests._yt_dlp__version = f'{requests.__version__} (unsupported)'
     raise ImportError('Only requests >= 2.32.2 is supported')
 
 import requests.adapters

--- a/yt_dlp/networking/_websockets.py
+++ b/yt_dlp/networking/_websockets.py
@@ -34,6 +34,7 @@ import websockets.version
 
 websockets_version = tuple(map(int_or_none, websockets.version.version.split('.')))
 if websockets_version < (13, 0):
+    websockets._yt_dlp__version = f'{websockets.version.version} (unsupported)'
     raise ImportError('Only websockets>=13.0 is supported')
 
 import websockets.sync.client


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Add ` (unsupported)` tag for `urllib3`, `requests` and `websockets`

Fixes #12625


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
