### PR TITLE
[iceporn] add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -839,6 +839,7 @@ from .hypem import HypemIE
 from .hypergryph import MonsterSirenHypergryphMusicIE
 from .hytale import HytaleIE
 from .icareus import IcareusIE
+from .iceporn import IcePornIE
 from .ichinanalive import (
     IchinanaLiveClipIE,
     IchinanaLiveIE,

--- a/yt_dlp/extractor/iceporn.py
+++ b/yt_dlp/extractor/iceporn.py
@@ -1,0 +1,50 @@
+from .common import InfoExtractor
+from ..utils import int_or_none, parse_duration
+
+
+class IcePornIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?iceporn\.com/video/(?P<id>[0-9]+)/(?P<display_id>[\w-]+)'
+    _TESTS = [{
+        'url': 'https://www.iceporn.com/video/2296835/eva-karera-gets-her-trimmed-cunt-plowed',
+        'md5': '844482e1c3c45831859748550a1b8dcf',
+        'info_dict': {
+            'id': '2296835',
+            'display_id': 'eva-karera-gets-her-trimmed-cunt-plowed',
+            'title': 'Eva Karera gets her trimmed cunt plowed',
+            'description': 're:Eva Karera Gets Her Trimmed Cunt Plowed - Pornstar, Milf, Blowjob, Big Boobs Porn Movies - 2296835',
+            'thumbnail': 're:https?://g\\d.iceppsn.com/media/videos/tmb/\\d+/preview/\\d+.jpg',
+            'ext': 'mp4',
+            'duration': 2178
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id, display_id = self._match_valid_url(url).group('id', 'display_id')
+
+        webpage = self._download_webpage(url, video_id)
+        video_data = self._download_json('https://www.iceporn.com/player_config_json/', video_id, query={
+            'vid': video_id, 'aid': 0, 'domain_id': 0, 'embed': 0, 'ref': 'null', 'check_speed': 0
+        }, headers={
+            'Accept': 'application/json'
+        })
+
+        formats = []
+        for quality_id, video_url in video_data.get('files', {}).items():
+            if video_url:
+                formats.append({
+                    'url': video_url,
+                    'format_id': quality_id
+                })
+
+        return {
+            'id': video_id,
+            'display_id': display_id,
+            'title': video_data.get('title')
+            or self._html_search_regex(r'<div.*class=[\'"]caption[\'"].*?><h2>(.+?)</h2>',
+                                       webpage, 'title'),
+            'formats': formats,
+            'thumbnail': video_data.get('poster'),
+            'duration': int_or_none(video_data.get('duration'))
+            or parse_duration(video_data.get('duration_format')),
+            'description': self._html_search_meta('description', webpage),
+        }


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR adds support for a new extractor, iceporn

Fixes #12478


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
