### PR TITLE
[ie/facebook] Fix extractor, truncate filename Fixes #12541

### DIFF
--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -32,6 +32,7 @@ from ..utils import (
 
 
 class FacebookIE(InfoExtractor):
+    _MAX_TITLE_LENGTH = 20  # Maximum title length for the video
     _VALID_URL = r'''(?x)
                 (?:
                     https?://
@@ -541,6 +542,9 @@ class FacebookIE(InfoExtractor):
             info_json_ld = self._search_json_ld(webpage, video_id, default={})
             info_json_ld['title'] = (re.sub(r'\s*\|\s*Facebook$', '', title or info_json_ld.get('title') or page_title or '')
                                      or (description or '').replace('\n', ' ') or f'Facebook video #{video_id}')
+            if len(info_json_ld.get('title')) > FacebookIE._MAX_TITLE_LENGTH:
+                self.report_warning(f'Truncating title to {FacebookIE._MAX_TITLE_LENGTH} characters')
+                info_json_ld['title'] = info_json_ld.get('title')[: FacebookIE._MAX_TITLE_LENGTH - 3] + '...'
             return merge_dicts(info_json_ld, info_dict)
 
         video_data = None


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR fixes an issue with facebook extractor, specifically when trying to download reels that often don´t have titles. The file name that is the title of the reel, in its absence falls to the description of the reel that often has big length. 
The filename is therefore too big to be used has a filename and crashes the download at file creation.
This patch tests the length of filename and truncates it if needed avoiding the problem all together. 

Fixes # 12541


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
