### PR TITLE
[pp/XAttrMetadata] Add macOS "Where from" attribute

### DIFF
--- a/yt_dlp/postprocessor/xattrpp.py
+++ b/yt_dlp/postprocessor/xattrpp.py
@@ -29,11 +29,11 @@ class XAttrMetadataPP(PostProcessor):
         'user.dublincore.date': 'upload_date',
         'user.dublincore.contributor': 'uploader',
         'user.dublincore.format': 'format',
-        'com.apple.metadata:kMDItemWhereFroms': 'webpage_url',
         # We do this last because it may get us close to the xattr limits
         # (e.g., 4kB on ext4), and we don't want to have the other ones fail
         'user.dublincore.description': 'description',
         # 'user.xdg.comment': 'description',
+        'com.apple.metadata:kMDItemWhereFroms': 'webpage_url',
     }
 
     APPLE_PLIST_TEMPLATE = '''<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Update the xattr post-processor on macOS to set the [`kMDItemWhereFroms`](https://developer.apple.com/documentation/coreservices/kmditemwherefroms) extended attribute to the URL where the file originated, which displays nicely as the "Where from" attribute:

<details><summary>Example of metadata display in Finder</summary>
<img width="851" alt="Screenshot 2025-03-18 at 11 17 37 PM" src="https://github.com/user-attachments/assets/641b83c3-4a13-46d2-ba08-47aca110f61d" />
</details>

Since the value has to be formatted [as an array in a plist](https://discussions.apple.com/thread/5521669?answerId=23654882022#23654882022) for macOS to recognize it correctly, I needed to reorganize a couple of things in `XAttrMetadataPP` to add platform-specific attributes and per-attribute formatting.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
