### PR TITLE
Fix #9970: FFmpeg requires ext in filename for FFmpegMetadataPP

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -315,6 +315,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(prepend_extension('abc', 'temp'), 'abc.temp')
         self.assertEqual(prepend_extension('.abc', 'temp'), '.abc.temp')
         self.assertEqual(prepend_extension('.abc.ext', 'temp'), '.abc.temp.ext')
+        self.assertEqual(prepend_extension('..ext', 'temp', 'temp', True), '..ext.temp.temp')
 
         # Test uncommon extensions
         self.assertEqual(prepend_extension('abc.ext', 'bin'), 'abc.bin.ext')

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3394,7 +3394,8 @@ class YoutubeDL:
                     file = self.existing_file(itertools.chain(*zip(map(converted, filepaths), filepaths)),
                                               default_overwrite=False)
                     if file:
-                        info_dict['ext'] = os.path.splitext(file)[1][1:]
+                        real_ext = os.path.splitext(file)[1][1:]
+                        info_dict['ext'] = real_ext if real_ext else info_dict['ext']
                     return file
 
                 fd, success = None, True

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -706,7 +706,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             self.to_screen('There isn\'t any metadata to add')
             return [], info
 
-        temp_filename = prepend_extension(filename, 'temp')
+        temp_filename = prepend_extension(filename, 'temp', info['ext'], True)
         self.to_screen(f'Adding metadata to "{filename}"')
         self.run_ffmpeg_multiple_files(
             (filename, metadata_filename), temp_filename,

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -2122,7 +2122,7 @@ def parse_duration(s):
         (days, 86400), (hours, 3600), (mins, 60), (secs, 1), (ms, 1)))
 
 
-def _change_extension(prepend, filename, ext, expected_real_ext=None):
+def _change_extension(prepend, filename, ext, expected_real_ext=None, must_have_ext=False):
     name, real_ext = os.path.splitext(filename)
 
     if not expected_real_ext or real_ext[1:] == expected_real_ext:
@@ -2130,6 +2130,11 @@ def _change_extension(prepend, filename, ext, expected_real_ext=None):
         if prepend and real_ext:
             _UnsafeExtensionError.sanitize_extension(ext, prepend=True)
             return f'{filename}.{ext}{real_ext}'
+
+    if not real_ext and must_have_ext and expected_real_ext and prepend:
+        _UnsafeExtensionError.sanitize_extension(ext, prepend=True)
+        _UnsafeExtensionError.sanitize_extension(expected_real_ext)
+        return f'{filename}.{ext}.{expected_real_ext}'
 
     return f'{filename}.{_UnsafeExtensionError.sanitize_extension(ext)}'
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

ADD DETAILED DESCRIPTION HERE
Output templates resulting in filenames with only dots preceding the extension would be passed to ffmpeg for embeding metadata with .temp in the extension field because os.path.splitext would not find and extension field in those filenames.
As a result ffmpeg would fail to determine what the output extension should be and fail.
To solve this a must_have_ext argument was added to _change_extension so that where a extension is required the expected extension will be used in those cases where os.path.splitext returns an empty string for the extension field.
existing_video_file in YoutubeDL.py was also changed so it won't overwrite info_dict['ext'] with an empty string if os.path.splitext returns an empty string for the extension field. 
Fixes #9970


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
