### PR TITLE
[ie/mlbtv] Fix radio-only extraction

### DIFF
--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -449,9 +449,7 @@ mutation initPlaybackSession(
 
         if not (m3u8_url and token):
             errors = '; '.join(traverse_obj(response, ('errors', ..., 'message', {str})))
-            if 'not entitled' in errors:
-                raise ExtractorError(errors, expected=True)
-            elif errors:  # Only warn when 'blacked out' since radio formats are available
+            if errors:  # Only warn when 'blacked out' or 'not entitled'; radio formats may be available
                 self.report_warning(f'API returned errors for {format_id}: {errors}')
             else:
                 self.report_warning(f'No formats available for {format_id} broadcast; skipping')


### PR DESCRIPTION

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
