### PR TITLE
Fix #6303: --max-downloads generates a warning even when the limit

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -5,6 +5,7 @@ import os
 import sys
 import unittest
 from unittest.mock import patch
+from yt_dlp.utils import MaxDownloadsReached
 
 from yt_dlp.globals import all_plugins_loaded
 
@@ -1434,6 +1435,16 @@ class TestYoutubeDL(unittest.TestCase):
         all_plugins_loaded.value = False
         FakeYDL().close()
         assert all_plugins_loaded.value
+
+    def test_max_downloads_reached_not_exceeded(self):
+        ydl = YDL({'max_downloads': 1})
+        info_dict = _make_result([{'format_id': '1', 'ext': 'mp4', 'url': TEST_URL}])
+
+        try:
+            ydl.process_ie_result(info_dict)
+        except MaxDownloadsReached:
+            self.fail('MaxDownloadsReached exception was raised unexpectedly')
+        assert True
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

When the --max-downloads limit is reached but not exceeded, the program currently displays a message indicating that remaining downloads are being interrupted, even in cases where no downloads remain. This behavior can be misleading, as it implies that there are pending downloads being skipped when there are none. In addition, the program exits with error code 101.

This change updates the logic so that the download limit is checked at the beginning of the next extraction step, rather than immediately after reaching the limit. This ensures the program only exits and displays the "aborting remaining downloads" message when there are actually more downloads to process.

By deferring the check to just before the next extraction, the program can determine whether there really is anything left to skip. The goal is to make the output more accurate and intuitive for the user, avoiding confusion in cases like --max-downloads 1, where downloading a single item should not suggest that others were skipped.

Additionally, I’ve added a test case to verify that when the number of downloads exactly matches the specified limit, no MaxDownloadsReached exception is raised, which should help prevent regressions.

Fixes #6303

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
