### PR TITLE
[ie/loco] Fix extractor

### DIFF
--- a/yt_dlp/extractor/loco.py
+++ b/yt_dlp/extractor/loco.py
@@ -89,7 +89,6 @@ class LocoIE(InfoExtractor):
     # From _app.js
     _CLIENT_ID = 'TlwKp1zmF6eKFpcisn3FyR18WkhcPkZtzwPVEEC3'
     _CLIENT_SECRET = 'Kp7tYlUN7LXvtcSpwYvIitgYcLparbtsQSe5AdyyCdiEJBP53Vt9J8eB4AsLdChIpcO2BM19RA3HsGtqDJFjWmwoonvMSG3ZQmnS8x1YIM8yl82xMXZGbE3NKiqmgBVU'
-    _USER_AGENT = '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
 
     def _is_jwt_expired(self, token):
         return jwt_decode_hs256(token)['exp'] - time.time() < 300
@@ -106,11 +105,10 @@ class LocoIE(InfoExtractor):
                 'client_secret': self._CLIENT_SECRET,
                 'model': 'Mozilla',
                 'os_name': 'Win32',
-                'os_ver': self._USER_AGENT,
-                'app_ver': self._USER_AGENT,
+                'os_ver': '5.0 (Windows)',
+                'app_ver': '5.0 (Windows)',
             }).encode(), headers={
                 'Content-Type': 'application/json;charset=utf-8',
-                'user-agent': self._USER_AGENT,
                 'DEVICE-ID': ''.join(random.choices('0123456789abcdef', k=32)) + 'live',
                 'X-APP-LANG': 'en',
                 'X-APP-LOCALE': 'en-US',

--- a/yt_dlp/extractor/loco.py
+++ b/yt_dlp/extractor/loco.py
@@ -59,6 +59,31 @@ class LocoIE(InfoExtractor):
             'upload_date': '20250226',
             'modified_date': '20250226',
         },
+    }, {
+        # Requires video authorization
+        'url': 'https://loco.com/stream/ac854641-ae0f-497c-a8ea-4195f6d8cc53',
+        'md5': '0513edf85c1e65c9521f555f665387d5',
+        'info_dict': {
+            'id': 'ac854641-ae0f-497c-a8ea-4195f6d8cc53',
+            'ext': 'mp4',
+            'title': 'DUAS CONTAS DESAFIANTE, RUSH TOP 1 NO BRASIL!',
+            'description': 'md5:aa77818edd6fe00dd4b6be75cba5f826',
+            'uploader_id': '7Y9JNAZC3Q',
+            'channel': 'ayellol',
+            'channel_follower_count': int,
+            'comment_count': int,
+            'view_count': int,
+            'concurrent_view_count': int,
+            'like_count': int,
+            'duration': 1229,
+            'thumbnail': 'https://static.ivory.getloconow.com/default_thumb/f5aa678b-6d04-45d9-a89a-859af0a8028f.jpg',
+            'tags': ['Gameplay', 'Carry'],
+            'series': 'League of Legends',
+            'timestamp': 1741182253,
+            'upload_date': '20250305',
+            'modified_timestamp': 1741182419,
+            'modified_date': '20250305',
+        },
     }]
 
     # From _app.js

--- a/yt_dlp/extractor/loco.py
+++ b/yt_dlp/extractor/loco.py
@@ -61,7 +61,7 @@ class LocoIE(InfoExtractor):
         video_type, video_id = self._match_valid_url(url).group('type', 'id')
         webpage = self._download_webpage(url, video_id)
         stream = traverse_obj(self._search_nextjs_data(webpage, video_id), (
-            'props', 'pageProps', ('liveStreamData', 'stream'), {dict}, any, {require('stream info')}))
+            'props', 'pageProps', ('liveStreamData', 'stream', 'liveStream'), {dict}, any, {require('stream info')}))
 
         return {
             'formats': self._extract_m3u8_formats(stream['conf']['hls'], video_id),

--- a/yt_dlp/extractor/loco.py
+++ b/yt_dlp/extractor/loco.py
@@ -62,9 +62,9 @@ class LocoIE(InfoExtractor):
     }]
 
     # From _app.js
-    CLIENT_ID = 'TlwKp1zmF6eKFpcisn3FyR18WkhcPkZtzwPVEEC3'
-    CLIENT_SCRET = 'Kp7tYlUN7LXvtcSpwYvIitgYcLparbtsQSe5AdyyCdiEJBP53Vt9J8eB4AsLdChIpcO2BM19RA3HsGtqDJFjWmwoonvMSG3ZQmnS8x1YIM8yl82xMXZGbE3NKiqmgBVU'
-    USER_AGENT = '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
+    _CLIENT_ID = 'TlwKp1zmF6eKFpcisn3FyR18WkhcPkZtzwPVEEC3'
+    _CLIENT_SECRET = 'Kp7tYlUN7LXvtcSpwYvIitgYcLparbtsQSe5AdyyCdiEJBP53Vt9J8eB4AsLdChIpcO2BM19RA3HsGtqDJFjWmwoonvMSG3ZQmnS8x1YIM8yl82xMXZGbE3NKiqmgBVU'
+    _USER_AGENT = '5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
 
     def _is_jwt_expired(self, token):
         return jwt_decode_hs256(token)['exp'] - time.time() < 300
@@ -77,20 +77,20 @@ class LocoIE(InfoExtractor):
             'https://api.getloconow.com/v3/user/device_profile/', video_id,
             'Downloading access token', fatal=False, data=json.dumps({
                 'platform': 7,
-                'client_id': self.CLIENT_ID,
-                'client_secret': self.CLIENT_SCRET,
+                'client_id': self._CLIENT_ID,
+                'client_secret': self._CLIENT_SECRET,
                 'model': 'Mozilla',
                 'os_name': 'Win32',
-                'os_ver': self.USER_AGENT,
-                'app_ver': self.USER_AGENT,
+                'os_ver': self._USER_AGENT,
+                'app_ver': self._USER_AGENT,
             }).encode(), headers={
                 'Content-Type': 'application/json;charset=utf-8',
-                'user-agent': self.USER_AGENT,
+                'user-agent': self._USER_AGENT,
                 'DEVICE-ID': ''.join(random.choices('0123456789abcdef', k=32)) + 'live',
                 'X-APP-LANG': 'en',
                 'X-APP-LOCALE': 'en-US',
-                'X-CLIENT-ID': self.CLIENT_ID,
-                'X-CLIENT-SECRET': self.CLIENT_SCRET,
+                'X-CLIENT-ID': self._CLIENT_ID,
+                'X-CLIENT-SECRET': self._CLIENT_SECRET,
                 'X-PLATFORM': '7',
             }), 'access_token')
         if access_token and not self._is_jwt_expired(access_token):


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fixes #12930


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
