### PR TITLE
[ie/TV2DK] Fix extractor

### DIFF
--- a/yt_dlp/extractor/tv2dk.py
+++ b/yt_dlp/extractor/tv2dk.py
@@ -83,6 +83,9 @@ class TV2DKIE(InfoExtractor):
     }, {
         'url': 'https://www.tv2nord.dk/artikel/dybt-uacceptabelt',
         'only_matching': True,
+    }, {
+        'url': 'https://www.tv2kosmopol.dk/metropolen/chaufforer-beordres-til-at-kore-videre-i-ulovlige-busser-med-rode-advarselslamper',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/tv2dk.py
+++ b/yt_dlp/extractor/tv2dk.py
@@ -2,12 +2,14 @@ import json
 import re
 
 from .common import InfoExtractor
+from .jwplatform import JWPlatformIE
 from ..utils import (
+    ExtractorError,
     determine_ext,
-    extract_attributes,
     js_to_json,
     url_or_none,
 )
+from ..utils.traversal import find_element, traverse_obj
 
 
 class TV2DKIE(InfoExtractor):
@@ -21,35 +23,46 @@ class TV2DKIE(InfoExtractor):
                             tv2fyn|
                             tv2east|
                             tv2lorry|
-                            tv2nord
+                            tv2nord|
+                            tv2kosmopol
                         )\.dk/
-                        (:[^/]+/)*
+                        (?:[^/?#]+/)*
                         (?P<id>[^/?\#&]+)
                     '''
     _TESTS = [{
         'url': 'https://www.tvsyd.dk/nyheder/28-10-2019/1930/1930-28-okt-2019?autoplay=1#player',
         'info_dict': {
-            'id': '0_52jmwa0p',
+            'id': 'sPp5z21q',
             'ext': 'mp4',
             'title': '19:30 - 28. okt. 2019',
-            'timestamp': 1572290248,
+            'description': '',
+            'thumbnail': 'https://cdn.jwplayer.com/v2/media/sPp5z21q/poster.jpg?width=720',
+            'timestamp': 1572287400,
             'upload_date': '20191028',
-            'uploader_id': 'tvsyd',
-            'duration': 1347,
-            'view_count': int,
         },
-        'add_ie': ['Kaltura'],
     }, {
         'url': 'https://www.tv2lorry.dk/gadekamp/gadekamp-6-hoejhuse-i-koebenhavn',
         'info_dict': {
-            'id': '1_7iwll9n0',
+            'id': 'oD9cyq0m',
             'ext': 'mp4',
-            'upload_date': '20211027',
             'title': 'Gadekamp #6 - Højhuse i København',
-            'uploader_id': 'tv2lorry',
-            'timestamp': 1635345229,
+            'description': '',
+            'thumbnail': 'https://cdn.jwplayer.com/v2/media/oD9cyq0m/poster.jpg?width=720',
+            'timestamp': 1635348600,
+            'upload_date': '20211027',
         },
-        'add_ie': ['Kaltura'],
+    }, {
+        'url': 'https://www.tvsyd.dk/haderslev/x-factor-brodre-fulde-af-selvtillid-er-igen-hjemme-hos-mor-vores-diagnoser-har-vaeret-en-fordel',
+        'info_dict': {
+            'id': 'x-factor-brodre-fulde-af-selvtillid-er-igen-hjemme-hos-mor-vores-diagnoser-har-vaeret-en-fordel',
+        },
+        'playlist_count': 2,
+    }, {
+        'url': 'https://www.tv2ostjylland.dk/aarhus/dom-kan-fa-alvorlige-konsekvenser',
+        'info_dict': {
+            'id': 'dom-kan-fa-alvorlige-konsekvenser',
+        },
+        'playlist_count': 3,
     }, {
         'url': 'https://www.tv2ostjylland.dk/artikel/minister-gaar-ind-i-sag-om-diabetes-teknologi',
         'only_matching': True,
@@ -75,36 +88,24 @@ class TV2DKIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         webpage = self._download_webpage(url, video_id)
 
+        search_space = traverse_obj(webpage, {find_element(tag='article')}) or webpage
+        players = re.findall(r'x-data="(?:video_player|simple_player)\(({[^"]+})', search_space)
+
         entries = []
+        for player in players:
+            player_data = self._parse_json(
+                player, video_id, transform_source=js_to_json, fatal=False)
+            jwplayer_id = traverse_obj(player_data, (('jwpMediaId', 'videoId'), {str}, any))
+            if jwplayer_id:
+                entries.append(self.url_result(f'jwplatform:{jwplayer_id}', JWPlatformIE, jwplayer_id))
 
-        def add_entry(partner_id, kaltura_id):
-            entries.append(self.url_result(
-                f'kaltura:{partner_id}:{kaltura_id}', 'Kaltura',
-                video_id=kaltura_id))
-
-        for video_el in re.findall(r'(?s)<[^>]+\bdata-entryid\s*=[^>]*>', webpage):
-            video = extract_attributes(video_el)
-            kaltura_id = video.get('data-entryid')
-            if not kaltura_id:
-                continue
-            partner_id = video.get('data-partnerid')
-            if not partner_id:
-                continue
-            add_entry(partner_id, kaltura_id)
-        if not entries:
-            kaltura_id = self._search_regex(
-                (r'entry_id\s*:\s*["\']([0-9a-z_]+)',
-                 r'\\u002FentryId\\u002F(\w+)\\u002F'), webpage, 'kaltura id')
-            partner_id = self._search_regex(
-                (r'\\u002Fp\\u002F(\d+)\\u002F', r'/p/(\d+)/'), webpage,
-                'partner id')
-            add_entry(partner_id, kaltura_id)
         if len(entries) == 1:
             return entries[0]
-        return self.playlist_result(entries)
+        elif len(entries) > 1:
+            return self.playlist_result(entries, video_id)
+        raise ExtractorError(f'No video found for {video_id}', expected=True)
 
 
 class TV2DKBornholmPlayIE(InfoExtractor):


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fixes #10334


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
