### PR TITLE
[ie/dacast] Support tokenized URLs

### DIFF
--- a/yt_dlp/extractor/dacast.py
+++ b/yt_dlp/extractor/dacast.py
@@ -9,6 +9,7 @@ from ..utils import (
     ExtractorError,
     classproperty,
     float_or_none,
+    parse_qs,
     traverse_obj,
     url_or_none,
 )
@@ -91,11 +92,15 @@ class DacastVODIE(DacastBaseIE):
         # Rotates every so often, but hardcode a fallback in case of JS change/breakage before rotation
         return self._search_regex(
             r'\bUSP_SIGNING_SECRET\s*=\s*(["\'])(?P<secret>(?:(?!\1).)+)', player_js,
-            'usp signing secret', group='secret', fatal=False) or 'odnInCGqhvtyRTtIiddxtuRtawYYICZP'
+            'usp signing secret', group='secret', fatal=False) or 'hGDtqMKYVeFdofrAfFmBcrsakaZELajI'
 
     def _real_extract(self, url):
         user_id, video_id = self._match_valid_url(url).group('user_id', 'id')
-        query = {'contentId': f'{user_id}-vod-{video_id}', 'provider': 'universe'}
+        query = {
+            'contentId': f'{user_id}-vod-{video_id}',
+            'provider': 'universe',
+            **traverse_obj(url, ({parse_qs}, 'uss_token', {'signedKey': -1})),
+        }
         info = self._download_json(self._API_INFO_URL, video_id, query=query, fatal=False)
         access = self._download_json(
             'https://playback.dacast.com/content/access', video_id,


### PR DESCRIPTION
In hindsight we probably should've used `f'{user_id}-vod-{video_id}'` as the `id`, but oh well

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
