### PR TITLE
[ie/mlbtv] Fix device ID caching

### DIFF
--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -365,13 +365,15 @@ mutation initPlaybackSession(
                 'All videos are only available to registered users', method='password')
 
     def _set_device_id(self, username):
-        if not self._device_id:
-            self._device_id = self.cache.load(
-                self._NETRC_MACHINE, 'device_ids', default={}).get(username)
+        if self._device_id:
+            return
+        device_id_cache = self.cache.load(self._NETRC_MACHINE, 'device_ids', default={})
+        self._device_id = device_id_cache.get(username)
         if self._device_id:
             return
         self._device_id = str(uuid.uuid4())
-        self.cache.store(self._NETRC_MACHINE, 'device_ids', {username: self._device_id})
+        device_id_cache[username] = self._device_id
+        self.cache.store(self._NETRC_MACHINE, 'device_ids', device_id_cache)
 
     def _perform_login(self, username, password):
         try:


### PR DESCRIPTION
<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
