### PR TITLE
[test] Load Plugins for Testing

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -87,6 +87,8 @@ class FakeYDL(YoutubeDL):
 
 
 def gettestcases(include_onlymatching=False):
+    import yt_dlp.plugins
+    yt_dlp.plugins.load_all_plugins()
     for ie in yt_dlp.extractor.gen_extractors():
         yield from ie.get_testcases(include_onlymatching)
 


### PR DESCRIPTION
### Description of your *pull request* and other information

This pr adds a `--plugins` option to devscripts/run_test.py
now you can do hatch test with --plugins

- `test/test_download` => loads plugins
- `hatch test --plugins` => loads plugins
- `hatch test` => no plugins

Fixes 4445f37a7a66b248dbd8376c43137e6e441f138e


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
coauthored by @Grub4K 
https://discord.com/channels/807245652072857610/1112613156934668338/1364214129543483424

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
