### PR TITLE
Add sanitation for Windows legacy devices with --windows-filenames option

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -249,6 +249,14 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sanitize_path('abc.../def...'), 'abc..#\\def..#')
         self.assertEqual(sanitize_path('C:\\abc:%(title)s.%(ext)s'), 'C:\\abc#%(title)s.%(ext)s')
 
+        self.assertEqual(sanitize_path('CON.opus'), 'CON_res.opus')
+        self.assertEqual(sanitize_path('abc\\CON\\def'), 'abc\\CON_res\\def')
+        self.assertEqual(sanitize_path('CON\\abc'), 'CON_res\\abc')
+        self.assertEqual(sanitize_path('CON.'), 'CON#')
+        self.assertEqual(sanitize_path('CON..'), 'CON_res.#')
+        self.assertEqual(sanitize_path('\\\\.\\CON'), '\\\\.\\CON')
+        self.assertEqual(sanitize_path('\\\\.\\CON\\abc'), '\\\\.\\CON_res\\abc')
+
         # Check with nt._path_normpath if available
         try:
             from nt import _path_normpath as nt_path_normpath

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -167,6 +167,18 @@ JSON_LD_RE = r'(?is)<script[^>]+type=(["\']?)application/ld\+json\1[^>]*>\s*(?P<
 
 NUMBER_RE = r'\d+(?:\.\d+)?'
 
+WINDOWS_RESERVED_NAMES_RE = fr'({'|'.join(
+    ("CON", "PRN", "AUX", "CLOCK$", "NUL")
+    + tuple(f"{name:s}{num:d}" for name, num in itertools.product(("COM", "LPT"), range(0, 10)))
+    + tuple(
+        f"{name:s}{ssd:s}"
+        for name, ssd in itertools.product(
+            ("COM", "LPT"),
+            ("\N{SUPERSCRIPT ONE}", "\N{SUPERSCRIPT TWO}", "\N{SUPERSCRIPT THREE}"),
+        )
+    )
+)})'
+
 
 @functools.cache
 def preferredencoding():
@@ -679,6 +691,19 @@ def sanitize_filename(s, restricted=False, is_id=NO_DEFAULT):
     return result
 
 
+def _sanitize_windows_reserved_names(s):
+    # Append _res to invalid path names
+    # in order to maintain easy recognizability
+    # when a user accidentally writes to device files
+    # - CON.opus => CON_res.opus
+    def suffix_sanitize(match):
+        other = match.group(3) if match.group(3) else ''
+        if not match.group(2) and other:
+            return match.group(1) + other
+        return match.group(1) + '_res' + match.group(2) + other # suffix the reserved portion only
+    return re.sub(fr'{WINDOWS_RESERVED_NAMES_RE}(\.*)(.*$)', suffix_sanitize, s)
+
+
 def _sanitize_path_parts(parts):
     sanitized_parts = []
     for part in parts:
@@ -694,6 +719,7 @@ def _sanitize_path_parts(parts):
         # - trailing dots and spaces (`asdf...` => `asdf..#`)
         # - invalid chars (`<>` => `##`)
         sanitized_part = re.sub(r'[/<>:"\|\\?\*]|[\s.]$', '#', part)
+        sanitized_part = _sanitize_windows_reserved_names(sanitized_part)
         sanitized_parts.append(sanitized_part)
 
     return sanitized_parts
@@ -713,6 +739,11 @@ def sanitize_path(s, force=False):
     if normed.startswith('\\\\'):
         # UNC path (`\\SERVER\SHARE`) or device path (`\\.`, `\\?`)
         parts = normed.split('\\')
+        # allow user to write to explicitly declared legacy devices
+        if len(parts) == 4 and re.fullmatch(WINDOWS_RESERVED_NAMES_RE, parts[3]):
+            return '\\'.join(parts[:4])
+        # sanitize legacy name device otherwise
+        parts[3] = _sanitize_windows_reserved_names(parts[3])
         root = '\\'.join(parts[:4]) + '\\'
         parts = parts[4:]
     elif normed[1:2] == ':':

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -168,7 +168,7 @@ JSON_LD_RE = r'(?is)<script[^>]+type=(["\']?)application/ld\+json\1[^>]*>\s*(?P<
 NUMBER_RE = r'\d+(?:\.\d+)?'
 
 WINDOWS_RESERVED_NAMES_RE = fr'({'|'.join(
-    ("CON", "PRN", "AUX", "CLOCK$", "NUL")
+    ("CON", "CONOUT$", "CONIN$", "PRN", "AUX", "CLOCK$", "NUL")
     + tuple(f"{name:s}{num:d}" for name, num in itertools.product(("COM", "LPT"), range(0, 10)))
     + tuple(
         f"{name:s}{ssd:s}"


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

The current sanitizer for the --windows-filenames option does not sanitize the usage of reserved names on Win10 systems.
This PR aims to resolve this by suffixing '_res' to reserved names as the sanitation option.
By suffixing instead of replacing the reserved names the sorting order is maintained and allows for the user to still find their files in a reasonable manner.
This fix still allows the user to write directly to legacy devices if they so wish in accordance to the Win11 spec found [here](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#handle-legacy-devices).

I'm a student doing my first open source contribution, any suggestions and corrections would be greatly appreciated.

Fixes #12014 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
