### PR TITLE
[ie/youtube] Detect player JS variants for any locale

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -1982,7 +1982,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def _player_js_cache_key(self, player_url):
         player_id = self._extract_player_info(player_url)
         player_path = remove_start(urllib.parse.urlparse(player_url).path, f'/s/player/{player_id}/')
-        variant = self._INVERSE_PLAYER_JS_VARIANT_MAP.get(player_path)
+        variant = self._INVERSE_PLAYER_JS_VARIANT_MAP.get(player_path) or next((
+            v for k, v in self._INVERSE_PLAYER_JS_VARIANT_MAP.items()
+            if re.fullmatch(re.escape(k).replace('en_US', r'[a-zA-Z0-9_]+'), player_path)), None)
         if not variant:
             self.write_debug(
                 f'Unable to determine player JS variant\n'


### PR DESCRIPTION
If the user is passing the `lang` extractor-arg, they'll get a player JS variant with a different locale in the URL path (e.g. `uk_UA` instead of `en_US` when passing `--extractor-arg "youtube:lang=uk"`; [log](https://github.com/yt-dlp/yt-dlp/issues/12994#issue-3015353889)). We were previously only hardcoding `en_US` in our variant detection code, which would cause player JS variants from other locales to not be properly detected. This PR fixes that

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
