### PR TITLE
[ie/youtube] Detect when account cookies are rotated

### DIFF
--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -616,10 +616,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         # Check that we are still logged-in and cookies have not rotated after every request
         if self._had_cookie_auth and not self._has_auth_cookies():
-            self.report_warning(
+            raise ExtractorError(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '
-                f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .')
+                f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .',
+                expected=True)
 
         return response
 

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -611,7 +611,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         # YouTube doesn't appear to clear 3PSAPISID when rotating cookies (as of 2025-04-26)
         # But LOGIN_INFO is cleared and should exist if logged in
         has_login_info = 'LOGIN_INFO' in self._youtube_cookies
-        return has_login_info and (yt_sapisid or yt_1psapisid or yt_3psapisid)
+        return bool(has_login_info and (yt_sapisid or yt_1psapisid or yt_3psapisid))
 
     def _request_webpage(self, *args, **kwargs):
         response = super()._request_webpage(*args, **kwargs)

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -621,7 +621,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             self.report_warning(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '
-                f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .',
+                f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL} .',
                 only_once=False)
 
         return response

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -616,11 +616,10 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         # Check that we are still logged-in and cookies have not rotated after every request
         if self._had_cookie_auth and not self._has_auth_cookies():
-            raise ExtractorError(
+            self.report_warning(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '
-                f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .',
-                expected=True)
+                f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .')
 
         return response
 

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -600,9 +600,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         return ' '.join(authorizations)
 
-    @functools.cached_property
+    @property
     def is_authenticated(self):
-        return bool(self._has_auth_cookies())
+        return self._has_auth_cookies()
 
     def _has_auth_cookies(self):
         yt_sapisid, yt_1psapisid, yt_3psapisid = self._get_sid_cookies()
@@ -616,11 +616,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         # Check that we are still logged-in and cookies have not rotated after every request
         if self._had_cookie_auth and not self._has_auth_cookies():
-            raise ExtractorError(
+            self.report_warning(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '
                 f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .',
-                expected=True)
+                only_once=False)
 
         return response
 

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -617,12 +617,11 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         # Check that we are still logged-in and cookies have not rotated after every request
         if self._had_cookie_auth and not self._has_auth_cookies():
             self._had_cookie_auth = False
-            # TODO: should this be an error? Since now all visitor data, etc. we have extracted would be invalid.
-            self.report_warning(
+            raise ExtractorError(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '
                 f'For tips on how to effectively export YouTube cookies, refer to  {self._COOKIE_HOWTO_WIKI_URL}  .',
-                only_once=True)
+                expected=True)
 
         return response
 

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -455,8 +455,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
     def _initialize_consent(self):
         if self._has_auth_cookies:
             return
-        cookies = self._youtube_cookies
-        socs = cookies.get('SOCS')
+        socs = self._youtube_cookies.get('SOCS')
         if socs and not socs.value.startswith('CAA'):  # not consented
             return
         self._set_cookie('.youtube.com', 'SOCS', 'CAI', secure=True)  # accept all (required for mixes)

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -474,9 +474,9 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         self._set_cookie('.youtube.com', name='PREF', value=urllib.parse.urlencode(pref))
 
     def _initialize_cookie_auth(self):
-        self._had_cookie_auth = False
+        self._passed_auth_cookies = False
         if self._has_auth_cookies:
-            self._had_cookie_auth = True
+            self._passed_auth_cookies = True
             self.write_debug('Found YouTube account cookies')
 
     def _real_initialize(self):
@@ -617,7 +617,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         response = super()._request_webpage(*args, **kwargs)
 
         # Check that we are still logged-in and cookies have not rotated after every request
-        if self._had_cookie_auth and not self._has_auth_cookies:
+        if self._passed_auth_cookies and not self._has_auth_cookies:
             self.report_warning(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -462,8 +462,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         self._set_cookie('.youtube.com', 'SOCS', 'CAI', secure=True)  # accept all (required for mixes)
 
     def _initialize_pref(self):
-        cookies = self._youtube_cookies
-        pref_cookie = cookies.get('PREF')
+        pref_cookie = self._youtube_cookies.get('PREF')
         pref = {}
         if pref_cookie:
             try:

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -453,16 +453,16 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         return preferred_lang
 
     def _initialize_consent(self):
-        if self._has_auth_cookies():
+        if self._has_auth_cookies:
             return
-        cookies = self._youtube_cookies()
+        cookies = self._youtube_cookies
         socs = cookies.get('SOCS')
         if socs and not socs.value.startswith('CAA'):  # not consented
             return
         self._set_cookie('.youtube.com', 'SOCS', 'CAI', secure=True)  # accept all (required for mixes)
 
     def _initialize_pref(self):
-        cookies = self._youtube_cookies()
+        cookies = self._youtube_cookies
         pref_cookie = cookies.get('PREF')
         pref = {}
         if pref_cookie:
@@ -475,7 +475,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     def _initialize_cookie_auth(self):
         self._had_cookie_auth = False
-        if self._has_auth_cookies():
+        if self._has_auth_cookies:
             self._had_cookie_auth = True
             self.write_debug('Found YouTube account cookies')
 
@@ -555,6 +555,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         return f'{scheme} {"_".join(parts)}'
 
+    @property
     def _youtube_cookies(self):
         return self._get_cookies('https://www.youtube.com')
 
@@ -563,7 +564,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         Get SAPISID, 1PSAPISID, 3PSAPISID cookie values
         @returns sapisid, 1psapisid, 3psapisid
         """
-        yt_cookies = self._youtube_cookies()
+        yt_cookies = self._youtube_cookies
         yt_sapisid = try_call(lambda: yt_cookies['SAPISID'].value)
         yt_3papisid = try_call(lambda: yt_cookies['__Secure-3PAPISID'].value)
         yt_1papisid = try_call(lambda: yt_cookies['__Secure-1PAPISID'].value)
@@ -602,20 +603,21 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
     @property
     def is_authenticated(self):
-        return self._has_auth_cookies()
+        return self._has_auth_cookies
 
+    @property
     def _has_auth_cookies(self):
         yt_sapisid, yt_1psapisid, yt_3psapisid = self._get_sid_cookies()
         # YouTube doesn't appear to clear 3PSAPISID when rotating cookies (as of 2025-04-26)
         # But LOGIN_INFO is cleared and should exist if logged in
-        has_login_info = 'LOGIN_INFO' in self._youtube_cookies()
+        has_login_info = 'LOGIN_INFO' in self._youtube_cookies
         return has_login_info and (yt_sapisid or yt_1psapisid or yt_3psapisid)
 
     def _request_webpage(self, *args, **kwargs):
         response = super()._request_webpage(*args, **kwargs)
 
         # Check that we are still logged-in and cookies have not rotated after every request
-        if self._had_cookie_auth and not self._has_auth_cookies():
+        if self._had_cookie_auth and not self._has_auth_cookies:
             self.report_warning(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -615,7 +615,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         response = super()._request_webpage(*args, **kwargs)
 
         # Check that we are still logged-in and cookies have not rotated after every request
-        if self._passed_auth_cookies and not self._has_auth_cookies:
+        if getattr(self, '_passed_auth_cookies', None) and not self._has_auth_cookies:
             self.report_warning(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '

--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -616,7 +616,6 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
 
         # Check that we are still logged-in and cookies have not rotated after every request
         if self._had_cookie_auth and not self._has_auth_cookies():
-            self._had_cookie_auth = False
             raise ExtractorError(
                 'The provided YouTube account cookies are no longer valid. '
                 'They have likely been rotated in the browser as a security measure. '


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Detect and warn when YouTube account cookies that were provided to yt-dlp are invalidated due to being rotated in the browser. This points users to https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies.

Related: https://github.com/yt-dlp/yt-dlp/issues/8227

```
[debug] [youtube:playlist] Found YouTube account cookies
[youtube:playlist] Extracting URL: LL
[debug] [youtube:tab] Found YouTube account cookies
[youtube:tab] Extracting URL: https://www.youtube.com/playlist?list=LL
[youtube:tab] LL: Downloading webpage
WARNING: [youtube:tab] The provided YouTube account cookies are no longer valid. They have likely been rotated in the browser as a security measure. For tips on how to effectively export YouTube cookies, refer to  https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies  .
WARNING: [youtube:tab] YouTube said: The playlist does not exist.
ERROR: [youtube:tab] LL: YouTube said: The playlist does not exist
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
