### PR TITLE
[ie/twitch:clips] Fix uploader metadata extraction

### DIFF
--- a/yt_dlp/extractor/twitch.py
+++ b/yt_dlp/extractor/twitch.py
@@ -1225,8 +1225,8 @@ class TwitchClipsIE(TwitchBaseIE):
                 'channel_id': ('broadcaster', 'id', {str}),
                 'channel_follower_count': ('broadcaster', 'followers', 'totalCount', {int_or_none}),
                 'channel_is_verified': ('broadcaster', 'isPartner', {bool}),
-                'uploader': ('broadcaster', 'displayName', {str}),
-                'uploader_id': ('broadcaster', 'id', {str}),
+                'uploader': ('curator', 'displayName', {str}),
+                'uploader_id': ('curator', 'id', {str}),
                 'categories': ('game', 'displayName', {str}, filter, all, filter),
             }),
         }


### PR DESCRIPTION
### Description of your *pull request* and other information

ADD DETAILED DESCRIPTION HERE

Fixes regression introduced in 61046c31612b30c749cbdae934b7fe26abe659d7


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (extractor don't have tests)

</details>

Briefly about the correction: in the last published yt-dlp, the information about the author of the clip was removed (by mistake, I hope). I returned it back.