### PR TITLE
[ie/youtube] Improve warning for SABR-only/SSAP player responses

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -3234,12 +3234,16 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 fmt_url = url_or_none(try_get(sc, lambda x: x['url'][0]))
                 encrypted_sig = try_get(sc, lambda x: x['s'][0])
                 if not all((sc, fmt_url, player_url, encrypted_sig)):
-                    self.report_warning(
-                        f'Some {client_name} client https formats have been skipped as they are missing a url. '
-                        f'{"Your account" if self.is_authenticated else "The current session"} may have '
-                        f'the SSAP (server-side ads) experiment which interferes with yt-dlp. '
-                        f'Please see  https://github.com/yt-dlp/yt-dlp/issues/12482  for more details.',
-                        video_id, only_once=True)
+                    msg = f'Some {client_name} client https formats have been skipped as they are missing a url. '
+                    if client_name == 'web':
+                        msg += 'SABR streaming is being forced by YouTube for this client. '
+                    else:
+                        msg += (
+                            f'YouTube may have enabled the SABR-only or Server-Side Ad Placement experiment for '
+                            f'{"your account" if self.is_authenticated else "the current session"}. '
+                        )
+                    msg += 'See  https://github.com/yt-dlp/yt-dlp/issues/12482  for more details'
+                    self.report_warning(msg, video_id, only_once=True)
                     continue
                 try:
                     fmt_url += '&{}={}'.format(


### PR DESCRIPTION
Ref #12482


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
