### PR TITLE
Add Jutsu extractor to support jut.su video extraction

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -935,8 +935,8 @@ from .jiosaavn import (
 from .joj import JojIE
 from .joqrag import JoqrAgIE
 from .jove import JoveIE
-from .jutsu import JutsuIE
 from .jstream import JStreamIE
+from .jutsu import JutsuIE
 from .jtbc import (
     JTBCIE,
     JTBCProgramIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -935,6 +935,7 @@ from .jiosaavn import (
 from .joj import JojIE
 from .joqrag import JoqrAgIE
 from .jove import JoveIE
+from .jutsu import JutsuIE
 from .jstream import JStreamIE
 from .jtbc import (
     JTBCIE,

--- a/yt_dlp/extractor/jutsu.py
+++ b/yt_dlp/extractor/jutsu.py
@@ -56,7 +56,8 @@ class JutsuIE(InfoExtractor):
 
         # Extract video sources from <source> tags
         sources = re.findall(
-            r'<source[^>]+src="([^"]+?)"[^>]*label="([^"]+)?"', episode_page
+            r'<source[^>]+src="([^"]+?)"[^>]*label="([^"]+)?",',
+            episode_page,
         )
 
         formats = []

--- a/yt_dlp/extractor/jutsu.py
+++ b/yt_dlp/extractor/jutsu.py
@@ -1,0 +1,126 @@
+import re
+from yt_dlp.extractor.common import InfoExtractor, ExtractorError
+
+
+class JutsuIE(InfoExtractor):
+    # Regex to match URLs for full series pages or individual episodes/films
+    _VALID_URL = (
+        r'https?://(?:www\.)?jut\.su/(?P<id>[^/]+)'
+        r'(?:/(?:season-(?P<season>\d+)/)?(?P<episode>(?:episode|film)-(?P<epnum>\d+))\.html)?/?'
+    )
+
+    _TESTS = [{
+        'url': 'https://jut.su/apocalypse-hotel/',
+        'playlist_mincount': 1,
+        'info_dict': {
+            'id': 'apocalypse-hotel',
+            'title': 'Отель в Апокалипсис',
+        },
+    }, {
+        'url': 'https://jut.su/apocalypse-hotel/episode-4.html',
+        'info_dict': {
+            'id': 'episode-4',
+            'title': 'Отель в Апокалипсис 4 серия',
+        },
+    }]
+
+    def _extract_episode(self, url, video_id, season=None, episode_number=None, episode_page=None):
+        # Download the episode page if not provided
+        if episode_page is None:
+            episode_page = self._download_webpage(
+                url, video_id,
+                note=f'Downloading episode page {url}',
+                headers={
+                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
+                })
+
+        # Extract episode title from <h1> tag
+        episode_title = self._html_search_regex(
+            r'<h1[^>]*>\s*<span[^>]*>\s*(?:<i>\s*Смотреть\s*</i>)?\s*(.+?)\s*</span>',
+            episode_page, 'episode title', fatal=False) or video_id
+
+        # Headers used for downloading video files
+        video_headers = {
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0',
+            'Accept': 'video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5'
+        }
+
+        # Extract video sources from <source> tags
+        sources = re.findall(
+            r'<source[^>]+src="([^"]+?)"[^>]*label="([^"]+)?"', episode_page)
+
+        formats = []
+        for src, label in sources:
+            height = int(label.rstrip('p')) if label and label.endswith('p') else None
+            formats.append({
+                'url': src,
+                'format_id': label,
+                'height': height,
+                'ext': 'mp4',
+                'http_headers': video_headers
+            })
+
+        if not formats:
+            self.report_warning(f'No video formats found in {url}')
+            return None
+
+        # Use the last part of the URL as unique episode ID
+        ep_id = url.rstrip('/').split('/')[-1].replace('.html', '')
+        return {
+            'id': ep_id,
+            'title': episode_title,
+            'formats': formats,
+        }
+
+    def _real_extract(self, url):
+        # Parse the URL with regex and extract metadata
+        mobj = self._match_valid_url(url)
+        video_id = mobj.group('id')
+        season = mobj.group('season')
+        episode = mobj.group('episode')
+        episode_number = mobj.group('epnum')
+
+        # If this is a single episode or film page
+        if episode_number:
+            return self._extract_episode(url, video_id, season, episode_number)
+
+        # Otherwise treat it as a playlist (series page)
+        webpage = self._download_webpage(url, video_id, headers={
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
+        })
+
+        # Try to extract series title from <title> tag
+        title = self._html_search_regex(
+            r'<title>\s*(.+?)\s*(?:все\s+серии|смотреть онлайн)?\s*</title>',
+            webpage, 'title', fatal=False) or video_id
+
+        entries = []
+        # Find all episode links from buttons on the page
+        episode_links = re.finditer(
+            r'<a[^>]+href="([^"]+)"[^>]*class="[^\"]*short-btn[^\"]*(?:black|green)[^\"]*video[^\"]*"[^>]*>'
+            r'(?:<i>[^<]*</i>)?[^<]*(\d+)\s*(?:серия|фильм)</a>',
+            webpage
+        )
+
+        for ep_link in episode_links:
+            episode_url = ep_link.group(1)
+            if not episode_url.startswith('http'):
+                episode_url = 'https://jut.su' + episode_url if episode_url.startswith('/') else 'https://jut.su/' + episode_url
+
+            episode_page = self._download_webpage(
+                episode_url, video_id,
+                note=f'Downloading episode page {episode_url}',
+                headers={
+                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
+                })
+
+            info = self._extract_episode(episode_url, video_id, episode_page=episode_page)
+            if info:
+                entries.append(info)
+
+        return {
+            '_type': 'playlist',
+            'id': video_id,
+            'title': title,
+            'entries': entries,
+        }

--- a/yt_dlp/extractor/jutsu.py
+++ b/yt_dlp/extractor/jutsu.py
@@ -1,5 +1,6 @@
 import re
-from yt_dlp.extractor.common import InfoExtractor, ExtractorError
+
+from yt_dlp.extractor.common import InfoExtractor
 
 
 class JutsuIE(InfoExtractor):
@@ -9,45 +10,54 @@ class JutsuIE(InfoExtractor):
         r'(?:/(?:season-(?P<season>\d+)/)?(?P<episode>(?:episode|film)-(?P<epnum>\d+))\.html)?/?'
     )
 
-    _TESTS = [{
-        'url': 'https://jut.su/apocalypse-hotel/',
-        'playlist_mincount': 1,
-        'info_dict': {
-            'id': 'apocalypse-hotel',
-            'title': 'Отель в Апокалипсис',
+    _TESTS = [
+        {
+            'url': 'https://jut.su/apocalypse-hotel/',
+            'playlist_mincount': 1,
+            'info_dict': {
+                'id': 'apocalypse-hotel',
+                'title': 'Отель в Апокалипсис',
+            },
         },
-    }, {
-        'url': 'https://jut.su/apocalypse-hotel/episode-4.html',
-        'info_dict': {
-            'id': 'episode-4',
-            'title': 'Отель в Апокалипсис 4 серия',
+        {
+            'url': 'https://jut.su/apocalypse-hotel/episode-4.html',
+            'info_dict': {
+                'id': 'episode-4',
+                'title': 'Отель в Апокалипсис 4 серия',
+            },
         },
-    }]
+    ]
 
     def _extract_episode(self, url, video_id, season=None, episode_number=None, episode_page=None):
         # Download the episode page if not provided
         if episode_page is None:
             episode_page = self._download_webpage(
-                url, video_id,
+                url,
+                video_id,
                 note=f'Downloading episode page {url}',
                 headers={
-                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
-                })
+                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0',
+                },
+            )
 
         # Extract episode title from <h1> tag
         episode_title = self._html_search_regex(
             r'<h1[^>]*>\s*<span[^>]*>\s*(?:<i>\s*Смотреть\s*</i>)?\s*(.+?)\s*</span>',
-            episode_page, 'episode title', fatal=False) or video_id
+            episode_page,
+            'episode title',
+            fatal=False,
+        ) or video_id
 
         # Headers used for downloading video files
         video_headers = {
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0',
-            'Accept': 'video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5'
+            'Accept': 'video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5',
         }
 
         # Extract video sources from <source> tags
         sources = re.findall(
-            r'<source[^>]+src="([^"]+?)"[^>]*label="([^"]+)?"', episode_page)
+            r'<source[^>]+src="([^"]+?)"[^>]*label="([^"]+)?"', episode_page
+        )
 
         formats = []
         for src, label in sources:
@@ -57,7 +67,7 @@ class JutsuIE(InfoExtractor):
                 'format_id': label,
                 'height': height,
                 'ext': 'mp4',
-                'http_headers': video_headers
+                'http_headers': video_headers,
             })
 
         if not formats:
@@ -77,7 +87,6 @@ class JutsuIE(InfoExtractor):
         mobj = self._match_valid_url(url)
         video_id = mobj.group('id')
         season = mobj.group('season')
-        episode = mobj.group('episode')
         episode_number = mobj.group('epnum')
 
         # If this is a single episode or film page
@@ -85,21 +94,28 @@ class JutsuIE(InfoExtractor):
             return self._extract_episode(url, video_id, season, episode_number)
 
         # Otherwise treat it as a playlist (series page)
-        webpage = self._download_webpage(url, video_id, headers={
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
-        })
+        webpage = self._download_webpage(
+            url,
+            video_id,
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0',
+            },
+        )
 
         # Try to extract series title from <title> tag
         title = self._html_search_regex(
             r'<title>\s*(.+?)\s*(?:все\s+серии|смотреть онлайн)?\s*</title>',
-            webpage, 'title', fatal=False) or video_id
+            webpage,
+            'title',
+            fatal=False,
+        ) or video_id
 
         entries = []
         # Find all episode links from buttons on the page
         episode_links = re.finditer(
             r'<a[^>]+href="([^"]+)"[^>]*class="[^\"]*short-btn[^\"]*(?:black|green)[^\"]*video[^\"]*"[^>]*>'
             r'(?:<i>[^<]*</i>)?[^<]*(\d+)\s*(?:серия|фильм)</a>',
-            webpage
+            webpage,
         )
 
         for ep_link in episode_links:
@@ -108,11 +124,13 @@ class JutsuIE(InfoExtractor):
                 episode_url = 'https://jut.su' + episode_url if episode_url.startswith('/') else 'https://jut.su/' + episode_url
 
             episode_page = self._download_webpage(
-                episode_url, video_id,
+                episode_url,
+                video_id,
                 note=f'Downloading episode page {episode_url}',
                 headers={
-                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
-                })
+                    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0',
+                },
+            )
 
             info = self._extract_episode(episode_url, video_id, episode_page=episode_page)
             if info:


### PR DESCRIPTION
### Description
This PR introduces a new extractor for jut.su, a video streaming platform primarily focused on anime content. The extractor supports:

- Individual episode/film pages extraction
- Full series playlist extraction
- Multiple video quality formats
- Proper metadata extraction (titles, episode numbers)

Key features:
- Handles both single episode URLs (e.g., `https://jut.su/anime-name/episode-1.html`) and full series URLs (e.g., `https://jut.su/anime-name/`)
- Extracts video formats from source tags with quality labels
- Supports season information in URLs
- Properly handles relative and absolute URLs
- Includes comprehensive test cases
- Uses appropriate User-Agent headers for compatibility

### Technical Details
- Added new `JutsuIE` class inheriting from `InfoExtractor`
- Implemented URL pattern matching for various page types
- Added format extraction with quality parsing
- Handles both individual episodes and playlist extraction
- Added test cases for both single episodes and playlists
- Updated `_extractors.py` to include the new extractor

### Checklist
- [x] At least skimmed through contributing guidelines including yt-dlp coding conventions
- [x] Searched the bugtracker for similar pull requests
- [x] I am the original author of the code in this PR, and I am willing to release it under Unlicense
- [x] New extractor

### Additional Information
- The website is a legitimate streaming platform with official content
- Test cases are included and cover both single video and playlist scenarios
- The extractor follows yt-dlp coding conventions and best practices
