### PR TITLE
[ie/youtube] Fix `--live-from-start` support for premieres

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -1812,14 +1812,17 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 with lock:
                     refetch_manifest(format_id, delay)
 
-                f = next((f for f in formats if f.get('format_id') == format_id and 'manifest_url' in f), None)
+                f = next((f for f in formats if f.get('format_id') == format_id), None)
                 if not f:
-                    # still no manifest_url → retry
                     if not is_live:
                         retry.error = f'{video_id}: Video is no longer live'
                     else:
                         retry.error = f'Cannot find refreshed manifest for format {format_id}{bug_reports_message()}'
                     continue
+
+                if not isinstance(f, dict) or not f.get('manifest_url'):
+                    break
+
                 return f.get('manifest_url'), f.get('manifest_stream_number'), is_live
             return None
 

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -1820,10 +1820,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         retry.error = f'Cannot find refreshed manifest for format {format_id}{bug_reports_message()}'
                     continue
 
-                if not isinstance(f, dict) or not f.get('manifest_url'):
+                if not f.get('manifest_url'):
                     break
 
-                return f.get('manifest_url'), f.get('manifest_stream_number'), is_live
+                return f['manifest_url'], f['manifest_stream_number'], is_live
             return None
 
         for f in formats:

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -1812,7 +1812,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 with lock:
                     refetch_manifest(format_id, delay)
 
-                f = next((f for f in formats if f.get('format_id') == format_id), None)
+                f = next((f for f in formats if f['format_id'] == format_id), None)
                 if not f:
                     if not is_live:
                         retry.error = f'{video_id}: Video is no longer live'

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -1812,14 +1812,15 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 with lock:
                     refetch_manifest(format_id, delay)
 
-                f = next((f for f in formats if f['format_id'] == format_id), None)
+                f = next((f for f in formats if f.get('format_id') == format_id and 'manifest_url' in f), None)
                 if not f:
+                    # still no manifest_url → retry
                     if not is_live:
                         retry.error = f'{video_id}: Video is no longer live'
                     else:
                         retry.error = f'Cannot find refreshed manifest for format {format_id}{bug_reports_message()}'
                     continue
-                return f['manifest_url'], f['manifest_stream_number'], is_live
+                return f.get('manifest_url'), f.get('manifest_stream_number'), is_live
             return None
 
         for f in formats:

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -1820,6 +1820,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         retry.error = f'Cannot find refreshed manifest for format {format_id}{bug_reports_message()}'
                     continue
 
+                # Formats from ended premieres will be missing a manifest_url
+                # See https://github.com/yt-dlp/yt-dlp/issues/8543
                 if not f.get('manifest_url'):
                     break
 


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR fixes the issue with youtube extractor, where if `--live-from-start` is used against YouTube premiere video and the download was happening during premiering, it will result in the following error.

```
ERROR: 'manifest_url'
Traceback (most recent call last):
  File "yt_dlp/YoutubeDL.py", line 1587, in wrapper
  File "yt_dlp/YoutubeDL.py", line 1743, in __extract_info
  File "yt_dlp/YoutubeDL.py", line 1802, in process_ie_result
  File "yt_dlp/YoutubeDL.py", line 2952, in process_video_result
  File "yt_dlp/YoutubeDL.py", line 3365, in process_info
  File "yt_dlp/YoutubeDL.py", line 3139, in dl
  File "yt_dlp/downloader/common.py", line 455, in download
  File "yt_dlp/downloader/dash.py", line 63, in real_download
  File "yt_dlp/downloader/fragment.py", line 421, in download_and_append_fragments_multiple
  File "yt_dlp/downloader/fragment.py", line 404, in future_result
  File "concurrent/futures/_base.py", line 458, in result
  File "concurrent/futures/_base.py", line 403, in __get_result
  File "concurrent/futures/thread.py", line 58, in run
  File "yt_dlp/downloader/fragment.py", line 385, in thread_func
  File "yt_dlp/downloader/fragment.py", line 510, in download_and_append_fragments
  File "yt_dlp/downloader/fragment.py", line 407, in interrupt_trigger_iter
  File "yt_dlp/downloader/dash.py", line 74, in _get_fragments
  File "yt_dlp/extractor/youtube.py", line 2892, in _live_dash_fragments
  File "yt_dlp/extractor/youtube.py", line 2848, in _extract_sequence_from_mpd
  File "yt_dlp/extractor/youtube.py", line 2810, in mpd_feed
KeyError: 'manifest_url'
```

Fixes #8543

I have tested against premiere videos plus two normal live streams, all of them worked as expected.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
