### PR TITLE
[build] Bump run-on-arch-action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           path: ./repo
       - name: Virtualized Install, Prepare & Build
-        uses: yt-dlp/run-on-arch-action@v2
+        uses: yt-dlp/run-on-arch-action@v3
         with:
           # Ref: https://github.com/uraimo/run-on-arch-action/issues/55
           env: |


### PR DESCRIPTION
From https://github.com/uraimo/run-on-arch-action:
> [!NOTE]
> **New major release addressing sporadic segmentation faults**
> 
> The release 3.0.0 addresses sporadic segmentation faults noticed with recent kernel releases, please update your action to this new major release (e.g. @v3) if you start noticing random or systematic CI failures.

We've definitely been experiencing this :point_up: with the Linux ARM builds.

<details open><summary>Template</summary> <!-- OPEN is intentional -->



### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Build improvements

</details>
