### PR TITLE
[ie/twitcasting] Fix password-protected livestream extraction

### DIFF
--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import itertools
 import re
 
@@ -16,6 +17,7 @@ from ..utils import (
     str_to_int,
     try_get,
     unified_timestamp,
+    update_url_query,
     url_or_none,
     urlencode_postdata,
     urljoin,
@@ -171,6 +173,10 @@ class TwitCastingIE(InfoExtractor):
                     'player': 'pc_web',
                 })
 
+            password_params = {
+                'word': hashlib.md5(video_password.encode()).hexdigest(),
+            } if video_password else {}
+
             formats = []
             # low: 640x360, medium: 1280x720, high: 1920x1080
             qq = qualities(['low', 'medium', 'high'])
@@ -178,7 +184,7 @@ class TwitCastingIE(InfoExtractor):
                 'tc-hls', 'streams', {dict.items}, lambda _, v: url_or_none(v[1]),
             )):
                 formats.append({
-                    'url': m3u8_url,
+                    'url': update_url_query(m3u8_url, password_params),
                     'format_id': f'hls-{quality}',
                     'ext': 'mp4',
                     'quality': qq(quality),
@@ -192,7 +198,7 @@ class TwitCastingIE(InfoExtractor):
                     'llfmp4', 'streams', {dict.items}, lambda _, v: url_or_none(v[1]),
                 )):
                     formats.append({
-                        'url': ws_url,
+                        'url': update_url_query(ws_url, password_params),
                         'format_id': f'ws-{mode}',
                         'ext': 'mp4',
                         'quality': qq(mode),


### PR DESCRIPTION
Needs testing

Closes #13096


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
