### PR TITLE
[misc] Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ If you fork the project on GitHub, you can run your fork's [build workflow](.git
     --list-impersonate-targets      List available clients to impersonate.
     -4, --force-ipv4                Make all connections via IPv4
     -6, --force-ipv6                Make all connections via IPv6
-    --enable-file-urls              Enable file:// URLs. This is disabled by
+    --enable-file-urls              Enable file:/// URLs. This is disabled by
                                     default for security reasons.
 
 ## Geo-restriction:


### PR DESCRIPTION
### Edit `--enable-file-urls` README description to "correct" file URI schema

From https://github.com/yt-dlp/yt-dlp/issues/13159#issuecomment-2874675027.
The `file://` (double slash) notation causes issues on Windows, while appears to be occasionally accepted on Unix<sup>https://github.com/yt-dlp/yt-dlp/issues/13159#issuecomment-2871403063</sup>.
The correct notation is either `file:///` (triple slash), `file://localhost/` or `file:/`[^wikiFileUri]. The `file:/` notation is somewhat recent[^2], while the triple slash notation should be supported by all OSes.
All 3 above work on Windows 10 Powershell 7 and Ubuntu 22.04.

Closes #13159


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>

[^wikiFileUri]: https://en.wikipedia.org/wiki/File_URI_scheme#Number_of_slash_characters
[^2]: https://datatracker.ietf.org/doc/html/rfc8089#appendix-A