### PR TITLE
[ie/LRTRadio] Fix extractor

### DIFF
--- a/yt_dlp/extractor/lrt.py
+++ b/yt_dlp/extractor/lrt.py
@@ -117,7 +117,7 @@ class LRTRadioIE(LRTBaseIE):
         'url': 'https://www.lrt.lt/radioteka/irasas/2000359728/nemarios-eiles-apie-pragarus-ir-skaistyklas-su-aiste-kiltinaviciute',
         'info_dict': {
             'id': '2000359728',
-            'ext': 'mp4',
+            'ext': 'm4a',
             'title': 'Nemarios eilės: apie pragarus ir skaistyklas su Aiste Kiltinavičiūte',
             'description': 'md5:5eee9a0e86a55bf547bd67596204625d',
             'timestamp': 1726143120,
@@ -139,7 +139,7 @@ class LRTRadioIE(LRTBaseIE):
 
         return {
             'id': video_id,
-            'formats': self._extract_m3u8_formats(media['playlist_item']['file'], video_id, 'mp4'),
+            'formats': self._extract_m3u8_formats(media['playlist_item']['file'], video_id),
             **traverse_obj(media, {
                 'title': ('title', {str}),
                 'tags': ('tags', ..., 'name', {str}),

--- a/yt_dlp/extractor/lrt.py
+++ b/yt_dlp/extractor/lrt.py
@@ -2,7 +2,6 @@ from .common import InfoExtractor
 from ..utils import (
     clean_html,
     merge_dicts,
-    str_or_none,
     traverse_obj,
     unified_timestamp,
     url_or_none,
@@ -118,7 +117,7 @@ class LRTRadioIE(LRTBaseIE):
         'url': 'https://www.lrt.lt/radioteka/irasas/2000359728/nemarios-eiles-apie-pragarus-ir-skaistyklas-su-aiste-kiltinaviciute',
         'info_dict': {
             'id': '2000359728',
-            'ext': 'm4a',
+            'ext': 'mp4',
             'title': 'Nemarios eilės: apie pragarus ir skaistyklas su Aiste Kiltinavičiūte',
             'description': 'md5:5eee9a0e86a55bf547bd67596204625d',
             'timestamp': 1726143120,
@@ -138,13 +137,15 @@ class LRTRadioIE(LRTBaseIE):
             'https://www.lrt.lt/radioteka/api/media', video_id,
             query={'url': f'/mediateka/irasas/{video_id}/{path}'})
 
-        return traverse_obj(media, {
-            'id': ('id', {int}, {str_or_none}),
-            'title': ('title', {str}),
-            'tags': ('tags', ..., 'name', {str}),
-            'categories': ('playlist_item', 'category', {str}, filter, all, filter),
-            'description': ('content', {clean_html}, {str}),
-            'timestamp': ('date', {lambda x: x.replace('.', '/')}, {unified_timestamp}),
-            'thumbnail': ('playlist_item', 'image', {urljoin('https://www.lrt.lt')}),
-            'formats': ('playlist_item', 'file', {lambda x: self._extract_m3u8_formats(x, video_id)}),
-        })
+        return {
+            'id': video_id,
+            'formats': self._extract_m3u8_formats(media['playlist_item']['file'], video_id, 'mp4'),
+            **traverse_obj(media, {
+                'title': ('title', {str}),
+                'tags': ('tags', ..., 'name', {str}),
+                'categories': ('playlist_item', 'category', {str}, filter, all, filter),
+                'description': ('content', {clean_html}, {str}),
+                'timestamp': ('date', {lambda x: x.replace('.', '/')}, {unified_timestamp}),
+                'thumbnail': ('playlist_item', 'image', {urljoin('https://www.lrt.lt')}),
+            }),
+        }


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Currently LRT.lt website is being refactored which leads to some regressions in their API introduced from time to time. Media download stopped to work from their site probably because of changed values in API.

Reproduction steps on recent "master" branch ([20f288bd](https://github.com/yt-dlp/yt-dlp/commit/20f288bdc2173c7cc58d709d25ca193c1f6001e7)) commit was used):

```shell
$ git clone git@github.com:yt-dlp/yt-dlp.git
$ make
$ ./yt-dlp https://www.lrt.lt/radioteka/irasas/2000404991/gyvates-valgo-gyvates-arba-kaip-susije-prodiuseris-roax-ir-peledu-persekiotojas\?season\=%2Fmediateka%2Faudio%2Fdrugelio-efektas%2F2025
[LRTRadio] Extracting URL: https://www.lrt.lt/radioteka/irasas/2000404991/gyvates-valgo-gyvates-arba-kaip-susije-prodiuseris...gelio-efektas%2F2025
[LRTRadio] 2000404991: Downloading JSON metadata
[LRTRadio] 2000404991: Downloading m3u8 information
ERROR: [LRTRadio] Missing "id" field in extractor result; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
```

Tests for the extractor were failing as well:
```shell
$ hatch test LRTRadioIE
Running ['pytest', '-Werror', '--tb=short', '-p', 'no:randomly', 'test/test_download.py::TestDownload::test_LRTRadio']
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.6.0 -- <...>/python3
cachedir: .pytest_cache
rootdir: /home/<...>/yt-dlp
configfile: pyproject.toml
plugins: xdist-3.6.1, rerunfailures-14.0
collected 1 item

test/test_download.py::TestDownload::test_LRTRadio FAILED                                                                                                                                                    [100%]

===================================================================================================== FAILURES =====================================================================================================
____________________________________________________________________________________________ TestDownload.test_LRTRadio ____________________________________________________________________________________________
yt_dlp/YoutubeDL.py:1653: in wrapper
    return func(self, *args, **kwargs)
yt_dlp/YoutubeDL.py:1809: in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
yt_dlp/YoutubeDL.py:1868: in process_ie_result
    ie_result = self.process_video_result(ie_result, download=download)
yt_dlp/YoutubeDL.py:2753: in process_video_result
    raise ExtractorError('Missing "id" field in extractor result', ie=info_dict['extractor'])
E   yt_dlp.utils.ExtractorError: [LRTRadio] Missing "id" field in extractor result; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
<...>
```

## Fix

This PR fixes ID extraction to reuse `video_id` that was found from the URL. Tests passing after the fix:

```shell
$ hatch test LRTRadioIE
Running ['pytest', '-Werror', '--tb=short', '-p', 'no:randomly', 'test/test_download.py::TestDownload::test_LRTRadio']
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.6.0 -- /home/<...>/bin/python3
cachedir: .pytest_cache
rootdir: /home/pawka/soft/yt-dlp
configfile: pyproject.toml
plugins: xdist-3.6.1, rerunfailures-14.0
collected 1 item

test/test_download.py::TestDownload::test_LRTRadio PASSED
```

Media download is working too with a fixed code:

```shell
$ make
$ ./yt-dlp https://www.lrt.lt/radioteka/irasas/2000404991/gyvates-valgo-gyvates-arba-kaip-susije-prodiuseris-roax-ir-peledu-persekiotojas\?season\=%2Fmediateka%2Faudio%2Fdrugelio-efektas%2F2025
[LRTRadio] Extracting URL: https://www.lrt.lt/radioteka/irasas/2000404991/gyvates-valgo-gyvates-arba-kaip-susije-prodiuseris...gelio-efektas%2F2025
[LRTRadio] 2000404991: Downloading JSON metadata
[LRTRadio] 2000404991: Downloading m3u8 information
[info] 2000404991: Downloading 1 format(s): 199
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 600
[download] Destination: Gyvatės valgo gyvates, arba Kaip susiję prodiuseris ROAX ir pelėdų persekiotojas？ [2000404991].m4a
[download]  15.5% of ~ 464.87MiB at  843.84KiB/s ETA Unknown (frag 93/600)
<...>
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>