### PR TITLE
[ie/youtube]: Fix partial `--mark-watched`

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -2399,6 +2399,11 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         return sts
 
     def _mark_watched(self, video_id, player_responses):
+        # cpn generation algorithm is reverse engineered from base.js.
+        # In fact it works even with dummy cpn.
+        CPN_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+        cpn = ''.join(CPN_ALPHABET[random.randint(0, 256) & 63] for _ in range(16))
+
         for is_full, key in enumerate(('videostatsPlaybackUrl', 'videostatsWatchtimeUrl')):
             label = 'fully ' if is_full else ''
             url = get_first(player_responses, ('playbackTracking', key, 'baseUrl'),
@@ -2408,11 +2413,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 return
             parsed_url = urllib.parse.urlparse(url)
             qs = urllib.parse.parse_qs(parsed_url.query)
-
-            # cpn generation algorithm is reverse engineered from base.js.
-            # In fact it works even with dummy cpn.
-            CPN_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
-            cpn = ''.join(CPN_ALPHABET[random.randint(0, 256) & 63] for _ in range(16))
 
             # # more consistent results setting it to right before the end
             video_length = [str(float((qs.get('len') or ['1.5'])[0]) - 1)]


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

I was able to reproduce this with both the stock tv client, and a safari client with my POT.
```
❯ ./yt-dlp.cmd -Uv https://www.youtube.com/watch?v=Aof3f58xw9E --config-locations="$(scoop prefix yt-dlp-master)/yt-dlp.conf"
[debug] Command-line config: ['-Uv', 'https://www.youtube.com/watch?v=Aof3f58xw9E', '--config-locations=~\\scoop\\apps\\yt-dlp-master\\current/yt-dlp.conf']
[debug] | Config "~\scoop\apps\yt-dlp-master\current/yt-dlp.conf": ['--cookies-from-browser', 'firefox:%APPDATA%/librewolf/Profiles/xxxxxxxx.dev-edition-default', '--mark-watched', '--simulate']
[debug] Encodings: locale cp65001, fs utf-8, pref cp65001, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2025.04.30 from yt-dlp/yt-dlp [505b40079] (source)
[debug] Lazy loading extractors is disabled
[debug] Git HEAD: 663116738
[debug] Python 3.12.8 (CPython AMD64 64bit) - Windows-10-10.0.19044-SP0 (OpenSSL 3.0.15 3 Sep 2024)
[debug] exe versions: ffmpeg N-119584-g06cee0c681-20250518 (setts), ffprobe N-119584-g06cee0c681-20250518
[debug] Optional libraries: Cryptodome-3.23.0, brotli-1.1.0, certifi-2025.04.26, curl_cffi-0.10.0, mutagen-1.47.0, requests-2.32.3, sqlite3-3.47.1, urllib3-2.4.0, websockets-15.0.1
[debug] Proxy map: {}
Extracting cookies from firefox
[debug] Extracting cookies from: "~\AppData\Roaming\librewolf\Profiles\xxxxxxxx.dev-edition-default\cookies.sqlite"
Extracted 1133 cookies from firefox
[debug] Request Handlers: urllib, requests, websockets, curl_cffi
[debug] Plugin directories: none
[debug] Loaded 1858 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
Latest version: stable@2025.04.30 from yt-dlp/yt-dlp
yt-dlp is up to date (stable@2025.04.30 from yt-dlp/yt-dlp)
[debug] [youtube] Found YouTube account cookies
[debug] [youtube] [pot] PO Token Providers: none
[debug] [youtube] [pot] PO Token Cache Providers: memory
[debug] [youtube] [pot] PO Token Cache Spec Providers: webpo
[youtube] Extracting URL: https://www.youtube.com/watch?v=Aof3f58xw9E
[youtube] Aof3f58xw9E: Downloading webpage
[youtube] Aof3f58xw9E: Downloading tv client config
[debug] Loading youtube-sts.b2858d36-main from cache
[youtube] Aof3f58xw9E: Downloading tv player API JSON
[debug] Loading youtube-nsig.b2858d36-main from cache
[debug] [youtube] Decrypted nsig U5AmRc1NfjKF7g4U => yl06u3RpmdD6EQ
[debug] [youtube] Decrypted nsig kSZ2IMHhlRk9trER => r5JEAT0NRRcs7g
[youtube] Aof3f58xw9E: Marking watched
[youtube] Aof3f58xw9E: Marking fully watched
[debug] Sort order given by extractor: quality, res, fps, hdr:12, source, vcodec, channels, acodec, lang, proto
[debug] Formats sorted by: hasvid, ie_pref, quality, res, fps, hdr:12(7), source, vcodec, channels, acodec, lang, proto, size, br, asr, vext, aext, hasaud, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] Aof3f58xw9E: Downloading 1 format(s): 401+251
```

![](https://github.com/user-attachments/assets/1d887273-72ad-47db-99ab-bba6a232c315)
Fixes #11532


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [ ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence). [Authored By: @iednod55](https://github.com/yt-dlp/yt-dlp/issues/11532#issuecomment-2848694248). They have to add a license, the fix's just moving already existing code out of a loop, so I'm not sure how much this matters. They haven't responded for nearly 3 weeks, so 🤷‍♂️.

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
</details>
