### PR TITLE
[ie/zdf] Fix language extraction and format sorting

### DIFF
--- a/yt_dlp/extractor/dreisat.py
+++ b/yt_dlp/extractor/dreisat.py
@@ -64,7 +64,7 @@ class DreiSatIE(ZDFBaseIE):
             'title': 'dein buch  - Das Beste von der Leipziger Buchmesse 2025 - Teil 1',
             'description': 'md5:bae51bfc22f15563ce3acbf97d2e8844',
             'duration': 5399.0,
-            'thumbnail': 'https://www.3sat.de/assets/buchmesse-kerkeling-100~original?cb=1743329640903',
+            'thumbnail': 'https://www.3sat.de/assets/buchmesse-kerkeling-100~original?cb=1747256996338',
             'chapters': 'count:24',
             'episode': 'dein buch  - Das Beste von der Leipziger Buchmesse 2025 - Teil 1',
             'episode_id': 'POS_1ef236cc-b390-401e-acd0-4fb4b04315fb',

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -333,12 +333,13 @@ class ZDFIE(ZDFBaseIE):
             'title': 'Dobrindt schließt Steuererhöhungen aus',
             'description': 'md5:9a117646d7b8df6bc902eb543a9c9023',
             'duration': 325,
-            'thumbnail': 'https://www.zdf.de/assets/dobrindt-csu-berlin-direkt-100~1920x1080?cb=1743357653736',
+            'thumbnail': 'https://www.zdfheute.de/assets/dobrindt-csu-berlin-direkt-100~1920x1080?cb=1743357653736',
             'timestamp': 1743374520,
             'upload_date': '20250330',
             '_old_archive_ids': ['zdf 250330_clip_2_bdi'],
         },
     }, {
+        # FUNK video (hosted on a different CDN, has atypical PTMD and HLS files)
         'url': 'https://www.zdf.de/funk/druck-11790/funk-alles-ist-verzaubert-102.html',
         'md5': '57af4423db0455a3975d2dc4578536bc',
         'info_dict': {
@@ -651,6 +652,7 @@ class ZDFChannelIE(ZDFBaseIE):
             'description': 'md5:6edad39189abf8431795d3d6d7f986b3',
         },
         'playlist_count': 242,
+        'skip': 'Video count changes daily, needs support for playlist_maxcount',
     }]
 
     _PAGE_SIZE = 24

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -138,19 +138,19 @@ class ZDFBaseIE(InfoExtractor):
                         for f in fmts:
                             f_lang = ISO639Utils.short2long(
                                 (f.get('language') or variant.get('language') or '').lower())
-                            has_video = (f.get('vcodec') or 'none') != 'none'
+                            is_audio_only = f.get('vcodec') == 'none'
                             formats.append({
                                 **f,
                                 'format_id': join_nonempty(f['format_id'], is_dgs and 'dgs'),
                                 'format_note': join_nonempty(
-                                    has_video and f_class,
+                                    not is_audio_only and f_class,
                                     is_dgs and 'German Sign Language',
                                     f.get('format_note'), delim=', '),
                                 'preference': -2 if is_dgs else -1,
                                 'language': f_lang,
                                 'language_preference': (
-                                    -10 if ((not has_video and f.get('format_note') == 'Audiodeskription')
-                                            or (has_video and f_class == 'ad'))
+                                    -10 if ((is_audio_only and f.get('format_note') == 'Audiodeskription')
+                                            or (not is_audio_only and f_class == 'ad'))
                                     else 10 if f_lang == 'deu' and f_class == 'main'
                                     else 5 if f_lang == 'deu'
                                     else 1 if f_class == 'main'

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -131,7 +131,7 @@ class ZDFBaseIE(InfoExtractor):
                                 'tbr': int_or_none(self._search_regex(r'_(\d+)k_', format_url, 'tbr', default=None)),
                             }]
                         else:
-                            self.write_debug(f'Unsupported extension {ext} ({format_url}).')
+                            self.report_warning(f'Skipping unsupported extension "{ext}"', video_id=video_id)
                             fmts = []
 
                         f_class = variant.get('class')

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -118,10 +118,7 @@ class ZDFBaseIE(InfoExtractor):
                         if ext == 'm3u8':
                             fmts = self._extract_m3u8_formats(
                                 format_url, video_id, 'mp4', m3u8_id='hls', fatal=False)
-                        elif ext == 'mpd':
-                            fmts = self._extract_mpd_formats(
-                                format_url, video_id, mpd_id='dash', fatal=False)
-                        else:
+                        elif ext in ('mp4', 'webm'):
                             height = int_or_none(quality.get('highestVerticalResolution'))
                             width = round(aspect_ratio * height) if aspect_ratio and height else None
                             fmts = [{
@@ -132,6 +129,10 @@ class ZDFBaseIE(InfoExtractor):
                                 'format_id': join_nonempty('http', stream.get('type')),
                                 'tbr': int_or_none(self._search_regex(r'_(\d+)k_', format_url, 'tbr', default=None)),
                             }]
+                        else:
+                            self.write_debug(f'Unsupported extension {ext} ({format_url}).')
+                            fmts = []
+
                         f_class = variant.get('class')
                         for f in fmts:
                             formats.append({

--- a/yt_dlp/extractor/zdf.py
+++ b/yt_dlp/extractor/zdf.py
@@ -143,7 +143,9 @@ class ZDFBaseIE(InfoExtractor):
                                 **f,
                                 'format_id': join_nonempty(f['format_id'], is_dgs and 'dgs'),
                                 'format_note': join_nonempty(
-                                    f_class, is_dgs and 'German Sign Language', f.get('format_note'), delim=', '),
+                                    has_video and f_class,
+                                    is_dgs and 'German Sign Language',
+                                    f.get('format_note'), delim=', '),
                                 'preference': -2 if is_dgs else -1,
                                 'language': f_lang,
                                 'language_preference': (


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR fixes an issue where the reported language for some audio-only files was incorrect. Additionally some more changes have been done to improve the format sorting and provided metadata for those formats. Additional details can be found in the individual commit messages.

Fixes #13118


<details><summary>Format comparison</summary> 

Before:
```
$ yt-dlp -qF https://www.zdf.de/video/serien/the-tourist-110/iren-sind-menschlich-100
ID                                 EXT  RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC     MORE INFO
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
hls-audio0-Originalton_englisch-0  mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Originalton englisch
hls-audio0-Originalton_englisch-1  mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Originalton englisch
hls-audio0-Originalton_englisch-2  mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Originalton englisch
hls-audio0-Originalton_englisch-3  mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Originalton englisch
hls-audio0-TV_Ton-0                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, TV Ton
hls-audio0-TV_Ton-1                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, TV Ton
hls-audio0-TV_Ton-2                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, TV Ton
hls-audio0-TV_Ton-3                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, TV Ton
hls-audio0-Audiodeskription-0      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Audiodeskription
hls-audio0-Audiodeskription-1      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Audiodeskription
hls-audio0-Audiodeskription-2      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Audiodeskription
hls-audio0-Audiodeskription-3      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] ad, Audiodeskription
hls-audio0-Audiodeskription-4      mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Audiodeskription
hls-audio0-Audiodeskription-5      mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Audiodeskription
hls-audio0-Audiodeskription-6      mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Audiodeskription
hls-audio0-Audiodeskription-7      mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Audiodeskription
hls-audio0-TV_Ton-4                mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, TV Ton
hls-audio0-TV_Ton-5                mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, TV Ton
hls-audio0-TV_Ton-6                mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, TV Ton
hls-audio0-TV_Ton-7                mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, TV Ton
hls-audio0-Originalton_englisch-4  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Originalton englisch
hls-audio0-Originalton_englisch-5  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Originalton englisch
hls-audio0-Originalton_englisch-6  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Originalton englisch
hls-audio0-Originalton_englisch-7  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] ot, Originalton englisch
hls-audio0-Audiodeskription-8      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Audiodeskription
hls-audio0-Audiodeskription-9      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Audiodeskription
hls-audio0-Audiodeskription-10     mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Audiodeskription
hls-audio0-Audiodeskription-11     mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Audiodeskription
hls-audio0-Originalton_englisch-8  mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Originalton englisch
hls-audio0-Originalton_englisch-9  mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Originalton englisch
hls-audio0-Originalton_englisch-10 mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Originalton englisch
hls-audio0-Originalton_englisch-11 mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, Originalton englisch
hls-audio0-TV_Ton-8                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, TV Ton
hls-audio0-TV_Ton-9                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, TV Ton
hls-audio0-TV_Ton-10               mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, TV Ton
hls-audio0-TV_Ton-11               mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] main, TV Ton
```

After:
```sh
$ yt-dlp -qF https://www.zdf.de/video/serien/the-tourist-110/iren-sind-menschlich-100
ID                                 EXT  RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC          VBR ACODEC     MORE INFO
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
hls-audio0-Audiodeskription-0      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-1      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-2      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-3      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-4      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-5      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-6      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-7      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-8      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-9      mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-10     mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Audiodeskription-11     mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] Audiodeskription
hls-audio0-Originalton_englisch-0  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-1  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-2  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-3  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-4  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-5  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-6  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-7  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-8  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-9  mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-10 mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-Originalton_englisch-11 mp4  audio only     │                  m3u8  │ audio only          unknown    [eng] Originalton englisch
hls-audio0-TV_Ton-0                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-1                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-2                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-3                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-4                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-5                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-6                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-7                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-8                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-9                mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-10               mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
hls-audio0-TV_Ton-11               mp4  audio only     │                  m3u8  │ audio only          unknown    [deu] TV Ton
```
</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
  - The PR is based on a [patch provided by bashonly](https://github.com/yt-dlp/yt-dlp/issues/13118#issuecomment-2856436277) in the corresponding issue. 

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
