### PR TITLE
[build] Fix macOS requirements caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           path: |
             ~/yt-dlp-build-venv
-          key: cache-reqs-${{ github.job }}
+          key: cache-reqs-${{ github.job }}-${{ github.ref }}
 
       - name: Install Requirements
         run: |
@@ -331,19 +331,16 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          cache_key: cache-reqs-${{ github.job }}
-          repository: ${{ github.repository }}
-          branch: ${{ github.ref }}
+          cache_key: cache-reqs-${{ github.job }}-${{ github.ref }}
         run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache delete "${cache_key}" -R "${repository}" -B "${branch}" --confirm
+          gh cache delete "${cache_key}"
 
       - name: Cache requirements
         uses: actions/cache/save@v4
         with:
           path: |
             ~/yt-dlp-build-venv
-          key: cache-reqs-${{ github.job }}
+          key: cache-reqs-${{ github.job }}-${{ github.ref }}
 
   macos_legacy:
     needs: process


### PR DESCRIPTION
Fixes a bug in the `macos` build job when the release/build workflow is run from a non-default branch. Previously, if there was a cache hit for the cache key on the default branch, but no such cache key was found for the current branch, then `actions/cache` would restore the default branch's cache. This would make the cleanup step's conditional truthy, and then the job would fail when `gh` tried to delete the non-existent cache key for the current branch. 

Also migrates from the deprecated `gh-actions-cache` extension for the Github CLI app to the new `gh cache` functionality.

This PR moves the `github.ref` value from the CLI's `-R` argument (which is not supported by `gh cache`) to the cache key suffix (to solve the bug).

Ref: https://github.com/actions/gh-actions-cache/commit/7a697757fb65925b74116c850a371320fb4d4bcb


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
