### PR TITLE
[ie/stacommu] Avoid partial stream formats

### DIFF
--- a/yt_dlp/extractor/stacommu.py
+++ b/yt_dlp/extractor/stacommu.py
@@ -4,6 +4,7 @@ from .wrestleuniverse import WrestleUniverseBaseIE
 from ..utils import (
     int_or_none,
     traverse_obj,
+    url_basename,
     url_or_none,
 )
 
@@ -65,9 +66,19 @@ class StacommuBaseIE(WrestleUniverseBaseIE):
         hls_info, decrypt = self._call_encrypted_api(
             video_id, ':watchArchive', 'stream information', data={'method': 1})
 
+        formats = self._get_formats(hls_info, ('hls', 'urls', ..., {url_or_none}), video_id)
+        for f in formats:
+            # bitrates are exaggerated in PPV playlists, so avoid wrong/huge filesize_approx values
+            if f.get('tbr'):
+                f['tbr'] = int(f['tbr'] / 2.5)
+            # prefer variants with the same basename as the master playlist to avoid partial streams
+            f['format_id'] = url_basename(f['url']).partition('.')[0]
+            if not f['format_id'].startswith(url_basename(f['manifest_url']).partition('.')[0]):
+                f['preference'] = -10
+
         return {
             'id': video_id,
-            'formats': self._get_formats(hls_info, ('hls', 'urls', ..., {url_or_none}), video_id),
+            'formats': formats,
             'hls_aes': self._extract_hls_key(hls_info, 'hls', decrypt),
             **traverse_obj(video_info, {
                 'title': ('displayName', {str}),


### PR DESCRIPTION
Fixes the same issue as #9800 except for the Stacommu and TheaterComplexTown extractors


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x]  [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
