### PR TITLE
tests(_get_version_info): add MC/DC-based white-box test cases

### DIFF
--- a/test/test_update.py
+++ b/test/test_update.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Allow direct execution
+import io
 import os
 import sys
 import unittest
@@ -10,6 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from test.helper import FakeYDL, report_warning
 from yt_dlp.update import UpdateInfo, Updater
+from contextlib import redirect_stderr
 
 
 # XXX: Keep in sync with yt_dlp.update.UPDATE_SOURCES
@@ -272,63 +274,70 @@ class TestUpdate(unittest.TestCase):
         test('testing', None, current_commit='9' * 40)
         test('testing', UpdateInfo('testing', commit='9' * 40))
 
-    def test_get_version_info(self):
+    def test_get_version_info_custom_cases(self):
         updater = FakeUpdater(FakeYDL(), 'stable')
 
-        # CT1 - Tag Already in Required Format
+        # CT1 – Tag Already in Required Format
         updater._identifier = 'zip'
         updater.requested_repo = 'yt-dlp/yt-dlp'
-        version, commit = updater._get_version_info('2025.04.06', {})
+        version, commit = updater._get_version_info('2025.04.06')
         self.assertEqual(version, '2025.04.06')
         self.assertIsNone(commit)
 
-        # CT2 - Fetch Latest Release Without Commit Hash
-        tag = 'latest'
-        updater.requested_repo = 'yt-dlp/yt-dlp'
+        # CT2 – Fetch Latest Release Without Commit Hash
         updater._call_api = lambda _: {
             'tag_name': 'v2025.04.06',
             'name': 'Release 2025.04.06',
             'target_commitish': '',
             'body': '- Adds support for the new URL parser\n- Fixes bug in simultaneous downloads\n',
         }
-        version, commit = updater._get_version_info(tag, updater._call_api(tag))
+        version, commit = updater._get_version_info('latest')
         self.assertEqual(version, 'v2025.04.06')
         self.assertIsNone(commit)
 
-        # CT3 - Fallback to Commit Hash When Tag Is Empty
+        # CT3 – Fallback to Commit Hash When Tag Is Empty
         updater._call_api = lambda _: {
             'tag_name': 'v2024.02.01',
             'name': 'Release candidate',
             'target_commitish': 'a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4',
             'body': '- Implements extra parameter validation\n- Optimizes performance in date parser\n',
         }
-        version, commit = updater._get_version_info('', updater._call_api(''))
+        version, commit = updater._get_version_info('')
         self.assertIsNone(version)
         self.assertEqual(commit, 'a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4')
 
-        # CT4 - Extract Version from Name with Empty Tag and Body Hash
+        # CT4 – Extract Version from Name with Empty Tag and Body Hash
         updater._call_api = lambda _: {
             'tag_name': 'v2024.02.01',
             'name': 'Release 2024.02.01',
             'target_commitish': '',
             'body': 'a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4\n- Implements extra parameter validation\n- Optimizes performance in date parser\n',
         }
-        version, commit = updater._get_version_info('', updater._call_api(''))
+        version, commit = updater._get_version_info('')
         self.assertEqual(version, '2024.02.01')
         self.assertIsNone(commit)
 
-        # CT5 - Error on Missing Version and Commit Hash
+        # CT5 – Error on Missing Version and Commit Hash
         updater._call_api = lambda _: {
             'tag_name': 'v2024.02.01',
             'name': 'Release candidate',
             'target_commitish': '',
             'body': '- Implements extra parameter validation\n- Optimizes performance in date parser\n',
         }
-        with self.assertLogs(level='WARNING') as cm:
-            version, commit = updater._get_version_info('', updater._call_api(''))
-            self.assertIsNone(version)
-            self.assertIsNone(commit)
-            self.assertTrue(any('One of either version or commit hash must be available' in m for m in cm.output))
+
+        # captura de stderr
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            version, commit = updater._get_version_info('')
+        self.assertIsNone(version)
+        self.assertIsNone(commit)
+
+        err = stderr.getvalue()
+        self.assertIn(
+            "One of either version or commit hash must be available on the release",
+            err
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -277,14 +277,14 @@ class TestUpdate(unittest.TestCase):
     def test_get_version_info(self):
         updater = FakeUpdater(FakeYDL(), 'stable')
 
-        # CT1 – Tag Already in Required Format
+        # CT1  Tag Already in Required Format
         updater._identifier = 'zip'
         updater.requested_repo = 'yt-dlp/yt-dlp'
         version, commit = updater._get_version_info('2025.04.06')
         self.assertEqual(version, '2025.04.06')
         self.assertIsNone(commit)
 
-        # CT2 – Fetch Latest Release Without Commit Hash
+        # CT2 Fetch Latest Release Without Commit Hash
         updater._call_api = lambda _: {
             'tag_name': 'v2025.04.06',
             'name': 'Release 2025.04.06',
@@ -295,7 +295,7 @@ class TestUpdate(unittest.TestCase):
         self.assertEqual(version, 'v2025.04.06')
         self.assertIsNone(commit)
 
-        # CT3 – Fallback to Commit Hash When Tag Is Empty
+        # CT3 Fallback to Commit Hash When Tag Is Empty
         updater._call_api = lambda _: {
             'tag_name': 'v2024.02.01',
             'name': 'Release candidate',
@@ -306,7 +306,7 @@ class TestUpdate(unittest.TestCase):
         self.assertIsNone(version)
         self.assertEqual(commit, 'a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4')
 
-        # CT4 – Extract Version from Name with Empty Tag and Body Hash
+        # CT4 Extract Version from Name with Empty Tag and Body Hash
         updater._call_api = lambda _: {
             'tag_name': 'v2024.02.01',
             'name': 'Release 2024.02.01',
@@ -317,7 +317,7 @@ class TestUpdate(unittest.TestCase):
         self.assertEqual(version, '2024.02.01')
         self.assertIsNone(commit)
 
-        # CT5 – Error on Missing Version and Commit Hash
+        # CT5 Error on Missing Version and Commit Hash
         updater._call_api = lambda _: {
             'tag_name': 'v2024.02.01',
             'name': 'Release candidate',
@@ -329,7 +329,6 @@ class TestUpdate(unittest.TestCase):
             version, commit = updater._get_version_info('')
         self.assertIsNone(version)
         self.assertIsNone(commit)
-
         err = stderr.getvalue()
         self.assertIn(
             "One of either version or commit hash must be available on the release",

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -274,7 +274,7 @@ class TestUpdate(unittest.TestCase):
         test('testing', None, current_commit='9' * 40)
         test('testing', UpdateInfo('testing', commit='9' * 40))
 
-    def test_get_version_info_custom_cases(self):
+    def test_get_version_info(self):
         updater = FakeUpdater(FakeYDL(), 'stable')
 
         # CT1 – Tag Already in Required Format

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -324,8 +324,6 @@ class TestUpdate(unittest.TestCase):
             'target_commitish': '',
             'body': '- Implements extra parameter validation\n- Optimizes performance in date parser\n',
         }
-
-        # captura de stderr
         stderr = io.StringIO()
         with redirect_stderr(stderr):
             version, commit = updater._get_version_info('')


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

A test case was added for the `_get_version_info` method using white-box testing and the MC/DC technique. The results of the test cases are detailed below:



#### Decision and Condition Table

ID | Decision (line) | Condition | True Scenario | False Scenario
-- | -- | -- | -- | --
CD1 | _VERSION_RE.fullmatch(tag) (line 283) | Tag consists of digits separated by dots | Tag is only numbers and dots, e.g. 2025.04.06.233 | Tag contains other characters, e.g. v1.2.3, latest
CD2 | tag == 'latest' (line 288) | Tag equals the literal 'latest' | Tag is exactly latest | Any other tag
CD3 | re.search(rf'\s+(?P<version>{_VERSION_RE.pattern})$', api_info.get('name', '')) (line 292) | Release name ends with a version preceded by a space | name ends like "Release 2025.04.06" | No matching pattern, e.g. "Release candidate", "v2025.04.06"
CD4 | re.fullmatch(_HASH_PATTERN, api_info.get('target_commitish', '')) (line 294) | target_commitish is a valid hex SHA | A full SHA string, e.g. "48be862b32648bff5b3e553e40fca4dcc6e88b28" | Empty or non-hex, e.g. "", "main"
CD5 | _COMMIT_RE.match(api_info.get('body', '')) (line 298) | body starts with a valid SHA | Begins with "48be862b32648bff5b3e553e40fca4dcc6e88b28 Fix typo" | No SHA at start, e.g. "Changelog: added feature"
CD6 | not (requested_version or target_commitish) (line 300) | Neither requested_version nor target_commitish is set (both falsy) | Both are None or empty | At least one is non-empty

#### Truth Table and MC/DC Analysis

Decision: not (requested_version or target_commitish) (line 300)

A (requested_version) | B (target_commitish) | not (A or B)
-- | -- | --
T | T | F
T | F | F
F | T | F
F | F | T

* **Independence pairs**

  * For A: rows 4 (F,F) & 2 (T,F)
  * For B: rows 4 (F,F) & 3 (F,T)

* **MC/DC combinations derived**

  * Combination for A: row 2 (A=T, B=F)
  * Combination for B: row 3 (A=F, B=T)
  * Combination for overall true: row 4 (A=F, B=F)

<table style="border-collapse: collapse; table-layout: fixed; width: 100%;">
  <thead>
    <tr>
      <th style="width: 50px;">ID</th>
      <th>Test Name</th>
      <th>Input</th>
      <th>Expected Output</th>
      <th>Conditions Covered</th>
      <th>MC/DC Coverage</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>CT1</td>
      <td>Tag Already in Required Format</td>
      <td>tag = "2025.04.06"</pre></td>
      <td>version = "2025.04.06"<br>commit = None</pre></td>
      <td>CD1 True</td>
      <td>—</td>
    </tr>
    <tr>
      <td>CT2</td>
      <td>Fetch Latest Release Without Commit Hash</td>
      <td>tag = "latest"<br>
api_info = {<br>
  "tag_name": "v2025.04.06",<br>
  "name": "Release 2025.04.06",<br>
  "target_commitish": "",<br>
  "body": "- Adds support for the new URL parser\n- Fixes bug in simultaneous downloads\n"<br>
}</td>
      <td>version = "v2025.04.06"<br>commit = None</pre></td>
      <td>CD1 False, CD2 True, CD4 False, CD5 False, CD6 False</td>
      <td>A300 (VF) (line 2)</td>
    </tr>
    <tr>
      <td>CT3</td>
      <td>Fallback to Commit Hash When Tag Is Empty</td>
      <td>tag = ""<br>
api_info = {<br>
  "tag_name": "v2024.02.01",<br>
  "name": "Release candidate",<br>
  "target_commitish": "a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4",<br>
  "body": "- Implements extra parameter validation\n- Optimizes performance in date parser\n"<br>
}</pre></td>
      <td>version = None<br>commit = "a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4"</pre></td>
      <td>CD1 False, CD2 False, CD3 False, CD4 True, CD6 False</td>
      <td>A300 (FV) (line 3)</td>
    </tr>
    <tr>
      <td>CT4</td>
      <td>Extract Version from Name with Empty Tag and Body Hash</td>
      <td>tag = ""<br>
api_info = {<br>
  "tag_name": "v2024.02.01",<br>
  "name": "Release 2024.02.01",<br>
  "target_commitish": "",<br>
  "body": "a1b2c3d4e5f60718293a4b5c6d7e8f9012ab3cd4\n- Implements extra parameter validation\n- Optimizes performance in date parser\n"<br>
}</pre></td>
      <td>version = "2024.02.01"<br>commit = None</pre></td>
      <td>CD1 False, CD2 False, CD3 True, CD4 False, CD5 True, CD6 False</td>
      <td>A300 (VF) (line 2)</td>
    </tr>
    <tr>
      <td>CT5</td>
      <td>Error on Missing Version and Commit Hash</td>
      <td>tag = ""<br>
api_info = {<br>
  "tag_name": "v2024.02.01",<br>
  "name": "Release candidate",<br>
  "target_commitish": "",<br>
  "body": "- Implements extra parameter validation\n- Optimizes performance in date parser\n"<br>
}</pre></td>
      <td>ERROR: One of either version or commit hash must be available on the release</td>
      <td>CD1 False, CD2 False, CD3 False, CD4 False, CD5 False, CD6 True</td>
      <td>A300 (FF) (line 4)</td>
    </tr>
  </tbody>
</table>



Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X]  Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
