### PR TITLE
[test:download] Add support for `playlist_maxcount` assertion

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -199,29 +199,19 @@ def generator(test_case, tname):
 
             if 'playlist_mincount' in test_case:
                 assertGreaterEqual(
-                    self,
-                    len(res_dict['entries']),
-                    test_case['playlist_mincount'],
-                    'Expected at least %d entries in playlist %s, but got only %d' % (
-                        test_case['playlist_mincount'], test_case['url'],
-                        len(res_dict['entries'])))
+                    self, len(res_dict['entries']), test_case['playlist_mincount'],
+                    f'Expected at least {test_case["playlist_mincount"]} entries '
+                    f'in playlist {test_case["url"]}, but got only {len(res_dict["entries"])}')
             if 'playlist_count' in test_case:
                 self.assertEqual(
-                    len(res_dict['entries']),
-                    test_case['playlist_count'],
-                    'Expected exactly %d entries in playlist %s, but got %d.' % (
-                        test_case['playlist_count'],
-                        test_case['url'],
-                        len(res_dict['entries']),
-                    ))
+                    len(res_dict['entries']), test_case['playlist_count'],
+                    f'Expected exactly {test_case["playlist_count"]} entries '
+                    f'in playlist {test_case["url"]}, but got {len(res_dict["entries"])}')
             if 'playlist_maxcount' in test_case:
                 assertLessEqual(
-                    self,
-                    len(res_dict['entries']),
-                    test_case['playlist_maxcount'],
-                    'Expected at most %d entries in playlist %s, but got %d' % (
-                        test_case['playlist_maxcount'], test_case['url'],
-                        len(res_dict['entries'])))
+                    self, len(res_dict['entries']), test_case['playlist_maxcount'],
+                    f'Expected at most {test_case["playlist_maxcount"]} entries '
+                    f'in playlist {test_case["url"]}, but got {len(res_dict["entries"])}')
             if 'playlist_duration_sum' in test_case:
                 got_duration = sum(e['duration'] for e in res_dict['entries'])
                 self.assertEqual(

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -202,14 +202,14 @@ def generator(test_case, tname):
                     self,
                     len(res_dict['entries']),
                     test_case['playlist_mincount'],
-                    'Expected at least %d in playlist %s, but got only %d' % (
+                    'Expected at least %d entries in playlist %s, but got only %d' % (
                         test_case['playlist_mincount'], test_case['url'],
                         len(res_dict['entries'])))
             if 'playlist_count' in test_case:
                 self.assertEqual(
                     len(res_dict['entries']),
                     test_case['playlist_count'],
-                    'Expected %d entries in playlist %s, but got %d.' % (
+                    'Expected exactly %d entries in playlist %s, but got %d.' % (
                         test_case['playlist_count'],
                         test_case['url'],
                         len(res_dict['entries']),
@@ -219,7 +219,7 @@ def generator(test_case, tname):
                     self,
                     len(res_dict['entries']),
                     test_case['playlist_maxcount'],
-                    'Expected at most %d in playlist %s, but got %d' % (
+                    'Expected at most %d entries in playlist %s, but got %d' % (
                         test_case['playlist_maxcount'], test_case['url'],
                         len(res_dict['entries'])))
             if 'playlist_duration_sum' in test_case:

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -212,10 +212,6 @@ def generator(test_case, tname):
                     self, len(res_dict['entries']), test_case['playlist_maxcount'],
                     f'Expected at most {test_case["playlist_maxcount"]} entries '
                     f'in playlist {test_case["url"]}, but got {len(res_dict["entries"])}')
-            if 'playlist_duration_sum' in test_case:
-                got_duration = sum(e['duration'] for e in res_dict['entries'])
-                self.assertEqual(
-                    test_case['playlist_duration_sum'], got_duration)
 
             # Generalize both playlists and single videos to unified format for
             # simplicity


### PR DESCRIPTION
### Description of your *pull request* and other information

This adds support for a new property `playlist_maxcount` in playlist download tests, similar to the existing `playlist_mincount` and `playlist_count` properties.

The intended use is [yt_dlp/extractor/zdf.py#L661-L668](https://github.com/yt-dlp/yt-dlp/blob/aa863ddab9b1d104678e9cf39bb76f5b14fca660/yt_dlp/extractor/zdf.py#L661-L668), where I would like to use something like the following:

```py
# Exact count changes daily, but can at most be one per day (ergo 365 a year)
'playlist_mincount': 1,
'playlist_maxcount': 365,
```

However, there are also [some preexisting tests](https://github.com/yt-dlp/yt-dlp/blob/aa863ddab9b1d104678e9cf39bb76f5b14fca660/yt_dlp/extractor/youporn.py) that have the property currently commented-out and were presumably imported from `youtube-dl`.

I've added some additional cleanup changes for the code touched by this PR. These non-essential changes are in separate commits so that they can be reverted more easily if you want to keep the PR more minimal.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Core bug fix/improvement

</details>
