### PR TITLE
twitch-no-sub

### DIFF
--- a/yt_dlp/extractor/twitch.py:Zone.Identifier
+++ b/yt_dlp/extractor/twitch.py:Zone.Identifier
@@ -1,0 +1,2 @@
+[ZoneTransfer]
+ZoneId=3


### PR DESCRIPTION
### Description of your *pull request* and other information

This pull request introduces a bypass for subscriber-only Twitch VODs within the `twitch:vod` extractor. The implementation is heavily inspired by the "TwitchNoSub" browser extension. 
https://github.com/besuper/TwitchNoSub.git

When a standard VOD extraction attempt results in a 403 or 401 HTTP error (indicating a subscriber-only restriction), the extractor now attempts to fetch VOD metadata using Twitch's GQL API. It then constructs a "fake" M3U8 playlist by generating direct access URLs to the VOD's preview segments across various resolutions, bypassing the subscription requirement.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>