### PR TITLE
[ie] Add `_download_firefox_webpage` helper

### DIFF
--- a/yt_dlp/extractor/francaisfacile.py
+++ b/yt_dlp/extractor/francaisfacile.py
@@ -1,9 +1,7 @@
 import urllib.parse
 
 from .common import InfoExtractor
-from ..networking.exceptions import HTTPError
 from ..utils import (
-    ExtractorError,
     float_or_none,
     url_or_none,
 )
@@ -58,16 +56,8 @@ class FrancaisFacileIE(InfoExtractor):
 
     def _real_extract(self, url):
         display_id = urllib.parse.unquote(self._match_id(url))
-
-        try:  # yt-dlp's default user-agents are too old and blocked by the site
-            webpage = self._download_webpage(url, display_id, headers={
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; rv:136.0) Gecko/20100101 Firefox/136.0',
-            })
-        except ExtractorError as e:
-            if not isinstance(e.cause, HTTPError) or e.cause.status != 403:
-                raise
-            # Retry with impersonation if hardcoded UA is insufficient
-            webpage = self._download_webpage(url, display_id, impersonate=True)
+        # yt-dlp's default Chrome user-agents are too old and blocked by akamai
+        webpage = self._download_firefox_webpage(url, display_id, impersonate=True)
 
         data = self._search_json(
             r'<script[^>]+\bdata-media-id=[^>]+\btype="application/json"[^>]*>',

--- a/yt_dlp/extractor/mitele.py
+++ b/yt_dlp/extractor/mitele.py
@@ -79,7 +79,8 @@ class MiTeleIE(TelecincoBaseIE):
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
-        webpage = self._download_akamai_webpage(url, display_id)
+        # yt-dlp's default Chrome user-agents are too old and blocked by akamai
+        webpage = self._download_firefox_webpage(url, display_id, impersonate=True)
         pre_player = self._search_json(
             r'window\.\$REACTBASE_STATE\.prePlayer_mtweb\s*=',
             webpage, 'Pre Player', display_id)['prePlayer']

--- a/yt_dlp/extractor/telecinco.py
+++ b/yt_dlp/extractor/telecinco.py
@@ -63,17 +63,6 @@ class TelecincoBaseIE(InfoExtractor):
             'http_headers': headers,
         }
 
-    def _download_akamai_webpage(self, url, display_id):
-        try:  # yt-dlp's default user-agents are too old and blocked by akamai
-            return self._download_webpage(url, display_id, headers={
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; rv:136.0) Gecko/20100101 Firefox/136.0',
-            })
-        except ExtractorError as e:
-            if not isinstance(e.cause, HTTPError) or e.cause.status != 403:
-                raise
-            # Retry with impersonation if hardcoded UA is insufficient to bypass akamai
-            return self._download_webpage(url, display_id, impersonate=True)
-
 
 class TelecincoIE(TelecincoBaseIE):
     IE_DESC = 'telecinco.es, cuatro.com and mediaset.es'
@@ -151,7 +140,8 @@ class TelecincoIE(TelecincoBaseIE):
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
-        webpage = self._download_akamai_webpage(url, display_id)
+        # yt-dlp's default Chrome user-agents are too old and blocked by akamai
+        webpage = self._download_firefox_webpage(url, display_id, impersonate=True)
         article = self._search_json(
             r'window\.\$REACTBASE_STATE\.article(?:_multisite)?\s*=',
             webpage, 'article', display_id)['article']


### PR DESCRIPTION
Some websites (and akamai) simply require a newer user-agent than our default Chrome UAs, rather than full-blown browser impersonation.

Bumping our default Chrome UA versions is highly likely to be problematic, since newer versions could carry the expectation for yt-dlp to include the newer & more intricate `sec-*` headers with its requests.

Firefox doesn't have that problem (as much), and we can also programmatically retrieve the latest Firefox release version so that we don't need to constantly bump it manually.

This PR adds new `_download_firefox_webpage` and `_get_latest_firefox_user_agent` helper methods to `InfoExtractor`.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
