### PR TITLE
[devscripts] Fix filename/directory Bash completions

### DIFF
--- a/devscripts/bash-completion.in
+++ b/devscripts/bash-completion.in
@@ -10,9 +10,13 @@ __yt_dlp()
     diropts="--cache-dir"
 
     if [[ ${prev} =~ ${fileopts} ]]; then
+        local IFS=$'\n'
+        compopt -o filenames
         COMPREPLY=( $(compgen -f -- ${cur}) )
         return 0
     elif [[ ${prev} =~ ${diropts} ]]; then
+        local IFS=$'\n'
+        compopt -o filenames
         COMPREPLY=( $(compgen -d -- ${cur}) )
         return 0
     fi

--- a/devscripts/bash-completion.in
+++ b/devscripts/bash-completion.in
@@ -11,12 +11,12 @@ __yt_dlp()
 
     if [[ ${prev} =~ ${fileopts} ]]; then
         local IFS=$'\n'
-        compopt -o filenames
+        type compopt &>/dev/null && compopt -o filenames
         COMPREPLY=( $(compgen -f -- ${cur}) )
         return 0
     elif [[ ${prev} =~ ${diropts} ]]; then
         local IFS=$'\n'
-        compopt -o filenames
+        type compopt &>/dev/null && compopt -o dirnames
         COMPREPLY=( $(compgen -d -- ${cur}) )
         return 0
     fi


### PR DESCRIPTION
Fix bash completion of file and directory names with whitespace.
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Files and directory names, as completed for yt-dlp's options `--load-info-json` and `--cache-dir` (among others), are split into words when tab-completiing in bash, instead of expanding to the full names. Additional actions are required in the completions script.

Fixes #13619

I checked the methods used by other bash-completions scripts, and found this minor modification which works very well.
<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
