### PR TITLE
[ie/RTP] Support for episodes split into multiple parts

### DIFF
--- a/yt_dlp/extractor/rtp.py
+++ b/yt_dlp/extractor/rtp.py
@@ -16,7 +16,7 @@ from ..utils.traversal import traverse_obj
 
 
 class RTPIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?rtp\.pt/play/(?:[^/#?]+/)?p(?P<program_id>\d+)/(?P<id>e\d+)'
+    _VALID_URL = r'https?://(?:www\.)?rtp\.pt/play/(?:[^/#?]+/)?p(?P<program_id>\d+)/(?P<id>e\d+)(?:/[A-Za-z0-9_-]+/(?P<part_id>\d+))?'
     _TESTS = [{
         'url': 'http://www.rtp.pt/play/p405/e174042/paixoes-cruzadas',
         'md5': 'e736ce0c665e459ddb818546220b4ef8',
@@ -50,6 +50,22 @@ class RTPIE(InfoExtractor):
             'episode_number': 2,
             'episode': 'Estudar ou não estudar',
             'modified_date': '20240404',
+        },
+    }, {
+        'url': 'https://www.rtp.pt/play/p14263/e819812/telejornal/1297689',
+        'md5': '46b303dfe1be1d85222b9689d4dd6659',
+        'info_dict': {
+            'id': 'e819812_2',
+            'ext': 'mp4',
+            'title': 'Telejornal',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'timestamp': 1735764807,
+            'duration': 4191.0,
+            'upload_date': '20250101',
+            'modified_timestamp': 1735766883,
+            'series': 'Telejornal',
+            'modified_date': '20250101',
+            'season': '2025'
         },
     }, {
         # Episode not accessible through API
@@ -114,7 +130,7 @@ class RTPIE(InfoExtractor):
                 })
         return formats, subtitles
 
-    def _extract_from_api(self, program_id, episode_id):
+    def _extract_from_api(self, program_id, episode_id, part_id):
         auth_token = self._fetch_auth_token()
         if not auth_token:
             return
@@ -128,7 +144,15 @@ class RTPIE(InfoExtractor):
             }, fatal=False), 'result', {dict})
         if not episode_data:
             return
-        asset_urls = traverse_obj(episode_data, ('assets', 0, 'asset_url', {dict}))
+
+        asset_index = 0
+        if part_id:
+            for idx, asset in enumerate(traverse_obj(episode_data, ('assets', ..., {dict})) or []):
+                if str(traverse_obj(asset, ('asset_id', {int_or_none}))) == part_id:
+                    asset_index = idx
+                    break
+
+        asset_urls = traverse_obj(episode_data, ('assets', asset_index, 'asset_url', {dict}))
         media_urls = traverse_obj(asset_urls, (
             ((('hls', 'dash'), 'stream_url'), ('multibitrate', ('url_hls', 'url_dash'))),))
         formats, subtitles = self._extract_formats(media_urls, episode_id)
@@ -140,10 +164,10 @@ class RTPIE(InfoExtractor):
             })
 
         return {
-            'id': episode_id,
+            'id': f"{episode_id}_{asset_index + 1}" if asset_index > 0 else episode_id,
             'formats': formats,
             'subtitles': subtitles,
-            'thumbnail': traverse_obj(episode_data, ('assets', 0, 'asset_thumbnail', {url_or_none})),
+            'thumbnail': traverse_obj(episode_data, ('assets', asset_index, 'asset_thumbnail', {url_or_none})),
             **traverse_obj(episode_data, ('episode', {
                 'title': (('episode_title', 'program_title'), {str}, filter, any),
                 'alt_title': ('episode_subtitle', {str}, filter),
@@ -192,5 +216,5 @@ class RTPIE(InfoExtractor):
         }
 
     def _real_extract(self, url):
-        program_id, episode_id = self._match_valid_url(url).group('program_id', 'id')
-        return self._extract_from_api(program_id, episode_id) or self._extract_from_html(url, episode_id)
+        program_id, episode_id, part_id = self._match_valid_url(url).group('program_id', 'id', 'part_id')
+        return self._extract_from_api(program_id, episode_id, part_id) or self._extract_from_html(url, episode_id)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR adds support for downloading individual parts of episodes that are split into multiple parts. Currently, the extractor fetches only the first part because it is hardcoded to retrieve the first asset from the API response.

Additional parts can be inferred from variations in the URL suffix. Episode’s part number will be appended to the episode ID - easier to read by users.

With this PR, unlike the current behaviour, this will work as expected:
- https://www.rtp.pt/play/p14263/e819812/telejornal -> Download first part
- https://www.rtp.pt/play/p14263/e819812/telejornal/1297689 -> Download second part

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
