### PR TITLE
[jsinterp] Fix undefined variable name caching

### DIFF
--- a/test/test_jsinterp.py
+++ b/test/test_jsinterp.py
@@ -536,6 +536,11 @@ class TestJSInterpreter(unittest.TestCase):
             }
         ''', 31)
 
+    def test_undefined_varnames(self):
+        jsi = JSInterpreter('function f(){ var a = undefined; return [a, b]; }')
+        self._test(jsi, [JS_Undefined, JS_Undefined])
+        self.assertEqual(jsi._undefined_varnames, {'b'})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -677,8 +677,9 @@ class JSInterpreter:
                 # Set value as JS_Undefined or its pre-existing value
                 local_vars.set_local(var, ret)
             else:
-                ret = local_vars.get(var, JS_Undefined)
-                if ret is JS_Undefined:
+                ret = local_vars.get(var, NO_DEFAULT)
+                if ret is NO_DEFAULT:
+                    ret = JS_Undefined
                     self._undefined_varnames.add(var)
             return ret, should_return
 


### PR DESCRIPTION
Fixes b342d27f3f82d913976509ddf5bff539ad8567ec


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
