### PR TITLE
[ie/dlive] Fix extractor

### DIFF
--- a/yt_dlp/extractor/dlive.py
+++ b/yt_dlp/extractor/dlive.py
@@ -8,17 +8,20 @@ class DLiveVODIE(InfoExtractor):
     IE_NAME = 'dlive:vod'
     _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[^/?#&]+)'
     _TESTS = [{
-        'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
+        'url': 'https://dlive.tv/p/planesfan+wDeWRZ8HR',
         'info_dict': {
-            'id': '3mTzOl4WR',
+            'id': 'wDeWRZ8HR',
             'ext': 'mp4',
-            'title': 'Minecraft with james charles epic',
-            'upload_date': '20190701',
-            'timestamp': 1562011015,
-            'uploader_id': 'pdp',
+            'title': 'Money\'s in, guys!',
+            'upload_date': '20250712',
+            'timestamp': 1752354913,
+            'uploader_id': 'planesfan',
+            'description': '',
+            'thumbnail': 'https://images.prd.dlivecdn.com/thumbnail/34c9c404-5f67-11f0-a812-52ea47803baf',
+            'view_count': int,
         },
     }, {
-        'url': 'https://dlive.tv/p/pdpreplay+D-RD-xSZg',
+        'url': 'https://dlive.tv/p/planesfan+wDeWRZ8HR',
         'only_matching': True,
     }]
 
@@ -36,7 +39,7 @@ class DLiveVODIE(InfoExtractor):
     thumbnailUrl
     viewCount
   }
-}''' % (uploader_id, vod_id)}).encode())['data']['pastBroadcast']  # noqa: UP031
+}''' % (uploader_id, vod_id)}).encode(), headers={'content-type': 'application/json'})['data']['pastBroadcast']  # noqa: UP031
         title = broadcast['title']
         formats = self._extract_m3u8_formats(
             broadcast['playbackUrl'], vod_id, 'mp4', 'm3u8_native')
@@ -71,13 +74,20 @@ class DLiveStreamIE(InfoExtractor):
     }
     username
   }
-}''' % display_name}).encode())['data']['userByDisplayName']  # noqa: UP031
+}''' % display_name}).encode(), headers={'content-type': 'application/json'})['data']['userByDisplayName']  # noqa: UP031
         livestream = user['livestream']
         title = livestream['title']
         username = user['username']
         formats = self._extract_m3u8_formats(
             f'https://live.prd.dlive.tv/hls/live/{username}.m3u8',
             display_name, 'mp4')
+
+        for unsigned_format in formats:
+            signed_url = self._download_webpage(
+                'https://live.prd.dlive.tv/hls/sign/url', display_name,
+                data=json.dumps({'playlisturi': unsigned_format['url']}).encode())
+            unsigned_format['url'] = signed_url
+
         return {
             'id': display_name,
             'title': title,


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

* Adds "content-type: application/json" header for GraphQL queries to fix 400 Bad Request HTTP errors for VODs and live streams
* Signs the playlist URL for each format using DLive's endpoint to avoid 403 errors from AWS CloudFront (Live streams only)
* Updated tests for the VOD extractor as the old test VOD no longer exists

Fixes #12638


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
