### PR TITLE
[ie/bandcamp] smuggle track_info when page doesn't have a usable one

### DIFF
--- a/yt_dlp/extractor/bandcamp.py
+++ b/yt_dlp/extractor/bandcamp.py
@@ -351,6 +351,15 @@ class BandcampAlbumIE(BandcampIE):  # XXX: Do not subclass from concrete IE
             'description': 'md5:b3cf845ee41b2b1141dc7bde9237255f',
         },
         'playlist_count': 2,
+    }, {
+        # tracks need track_info smuggled because they don't have a usable one on the pages
+        'url': 'https://wetleg.bandcamp.com/album/wet-leg',
+        'info_dict': {
+            'id': 'wet-leg',
+            'title': 'Wet Leg',
+            'uploader_id': 'wetleg',
+        },
+        'playlist_count': 12,
     }]
 
     @classmethod

--- a/yt_dlp/extractor/bandcamp.py
+++ b/yt_dlp/extractor/bandcamp.py
@@ -368,12 +368,17 @@ class BandcampAlbumIE(BandcampIE):  # XXX: Do not subclass from concrete IE
         if not track_info:
             raise ExtractorError('The page doesn\'t contain any tracks')
         # Only tracks with duration info have songs
-        entries = [
-            self.url_result(
-                smuggle_url(urljoin(url, t['title_link']), t), BandcampIE.ie_key(),
-                str_or_none(t.get('track_id') or t.get('id')), t.get('title'))
-            for t in track_info
-            if t.get('duration')]
+        entries = []
+        for t in track_info:
+            if t.get('duration'):
+                url = urljoin(url, t['title_link'])
+                if t.get('track_license_id'):
+                    # tracks with this set don't have a usable tralbum on their pages
+                    url = smuggle_url(url, t)
+                entries.append(self.url_result(
+                    url, BandcampIE.ie_key(),
+                    str_or_none(t.get('track_id') or t.get('id')), t.get('title'),
+                ))
 
         current = tralbum.get('current') or {}
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Some bandcamp tracks don't have usable track info on their pages, so we have to smuggle it from the album page.

the ones that don't work all have `track_license_id` set, while ones that do work just have it as null
so it might be possible to only do this workaround when it's actually needed
idk if this catches everything, or if it gets false positives
but the workaround doesn't hurt so it's probably fine™

[per bashonly](https://github.com/yt-dlp/yt-dlp/issues/13729#issuecomment-3068168454) this may not be an issue everywhere in the world, idk if the workaround still happens then

Fixes #13729


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
