### PR TITLE
[pp/FFmpegThumbnailsConvertor] Correct the extension of all thumbnails

### DIFF
--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -73,7 +73,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         # Correct extension for WebP file with wrong extension (see #25687, #25717)
         convertor = FFmpegThumbnailsConvertorPP(self._downloader)
-        convertor.fixup_webp(info, idx)
+        convertor.fixup_thumbnail_ext(info, idx)
 
         original_thumbnail = thumbnail_filename = info['thumbnails'][idx]['filepath']
 

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -1063,17 +1063,21 @@ class FFmpegThumbnailsConvertorPP(FFmpegPostProcessor):
         deprecation_warning(f'{cls.__module__}.{cls.__name__}.is_webp is deprecated')
         return imghdr.what(path) == 'webp'
 
-    def fixup_webp(self, info, idx=-1):
+    def fixup_thumbnail_ext(self, info, idx=-1):
         thumbnail_filename = info['thumbnails'][idx]['filepath']
+        actual_format = imghdr.what(thumbnail_filename)
+        if not actual_format:
+            return
+
         _, thumbnail_ext = os.path.splitext(thumbnail_filename)
-        if thumbnail_ext:
-            if thumbnail_ext.lower() != '.webp' and imghdr.what(thumbnail_filename) == 'webp':
-                self.to_screen(f'Correcting thumbnail "{thumbnail_filename}" extension to webp')
-                webp_filename = replace_extension(thumbnail_filename, 'webp')
-                os.replace(thumbnail_filename, webp_filename)
-                info['thumbnails'][idx]['filepath'] = webp_filename
-                info['__files_to_move'][webp_filename] = replace_extension(
-                    info['__files_to_move'].pop(thumbnail_filename), 'webp')
+        thumbnail_ext = thumbnail_ext.removeprefix('.').lower()
+        if thumbnail_ext != actual_format and not (actual_format == 'jpeg' and thumbnail_ext == 'jpg'):
+            self.to_screen(f'Correcting thumbnail "{thumbnail_filename}" extension to {actual_format}')
+            correct_filename = replace_extension(thumbnail_filename, actual_format)
+            os.replace(thumbnail_filename, correct_filename)
+            info['thumbnails'][idx]['filepath'] = correct_filename
+            info['__files_to_move'][correct_filename] = replace_extension(
+                info['__files_to_move'].pop(thumbnail_filename), actual_format)
 
     @staticmethod
     def _options(target_ext):
@@ -1100,7 +1104,7 @@ class FFmpegThumbnailsConvertorPP(FFmpegPostProcessor):
             if not original_thumbnail:
                 continue
             has_thumbnail = True
-            self.fixup_webp(info, idx)
+            self.fixup_thumbnail_ext(info, idx)
             original_thumbnail = thumbnail_dict['filepath']  # Path can change during fixup
             thumbnail_ext = os.path.splitext(original_thumbnail)[1][1:].lower()
             if thumbnail_ext == 'jpeg':


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR makes it so every thumbnail is renamed to the right extension, instead of only doing so for WebP images (as suggested in [this comment](https://github.com/yt-dlp/yt-dlp/issues/6866#issuecomment-1515668253)).

Fixes #6866.

(Is there a problem with me renaming `fixup_webp`? Is it part of the public API?)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
