### PR TITLE
[ie/mlbtv] Make formats downloadable with ffmpeg

### DIFF
--- a/yt_dlp/extractor/mlb.py
+++ b/yt_dlp/extractor/mlb.py
@@ -457,12 +457,9 @@ mutation initPlaybackSession(
                 self.report_warning(f'No formats available for {format_id} broadcast; skipping')
             return [], {}
 
-        cdn_headers = {'x-cdn-token': token}
         fmts, subs = self._extract_m3u8_formats_and_subtitles(
-            m3u8_url.replace(f'/{token}/', '/'), video_id, 'mp4',
-            m3u8_id=format_id, fatal=False, headers=cdn_headers)
+            m3u8_url, video_id, 'mp4', m3u8_id=format_id, fatal=False)
         for fmt in fmts:
-            fmt['http_headers'] = cdn_headers
             fmt.setdefault('format_note', join_nonempty(feed, medium, delim=' '))
             fmt.setdefault('language', language)
             if fmt.get('vcodec') == 'none' and fmt['language'] == 'en':


### PR DESCRIPTION
Currently, the extractor removes the token segment from the m3u8 URL path and passes the token as a custom http header instead. This seems to be an unnecessary step with the undesirable side effect of breaking downloads via ffmpeg (or playback via ffmpeg-based media players such as mpv), since ffmpeg apparently struggles with sending the custom header with all requests. This PR removes the unnecessary step, thus eliminating this side effect.

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
