### PR TITLE
Add aiyifan tests

### DIFF
--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -1,9 +1,7 @@
 import hashlib
 import time
-
-from .common import InfoExtractor
 from yt_dlp.utils import ExtractorError
-
+from .common import InfoExtractor
 
 class AiyifanIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?(yfsp|iyf|aiyifan)\.tv/play/(?P<id>[^/?#]+)(?:\?id=(?P<alt_id>[^&#]+))?'

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -61,11 +61,9 @@ class AiyifanIE(InfoExtractor):
             'pub': detail_pub,
         }
 
-        detail = self._download_webpage(
+        detail_json = self._download_json(
             'https://m10.yfsp.tv/v3/video/detail', video_id, note='Downloading detail info',
             query=detail_params)
-
-        detail_json = self._download_json(detail, video_id)
         title = detail_json['data']['info'][0]['title']
 
         a = 1 if video_id == alt_id else 0
@@ -86,7 +84,7 @@ class AiyifanIE(InfoExtractor):
         info_json = self._parse_json(info, video_id)
         m3u8_url = info_json['data']['info'][0]['clarity'][-1]['path']['rtmp']
 
-        episode = re.search('dhp-[A-Za-z0-9]+-(\d+)-', m3u8_url).group(1)
+        episode = re.search(r'dhp-[A-Za-z0-9]+-(\d+)-', m3u8_url).group(1)
         title = f'{title}_{episode}'
 
         formats = self._extract_m3u8_formats(

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -16,7 +16,7 @@ class AiyifanIE(InfoExtractor):
                 'title': '工作细胞_dhp-gzxb-06-03AC62667',
                 'ext': 'mp4',
             },
-            'params': {'skip_download': True}
+            'params': {'skip_download': True},
         },
         {
             'url': 'https://www.yfsp.tv/play/tFAWlkx5kr9',
@@ -25,7 +25,7 @@ class AiyifanIE(InfoExtractor):
                 'title': '工作细胞_dhp-gzxb-01-006E900E1',
                 'ext': 'mp4',
             },
-            'params': {'skip_download': True}
+            'params': {'skip_download': True},
         },
         {
             'url': 'https://www.yfsp.tv/play/TtAyF6XpjfC',
@@ -34,7 +34,7 @@ class AiyifanIE(InfoExtractor):
                 'title': '大猿魂_dhp-dyh-01-008FFFF84',
                 'ext': 'mp4',
             },
-            'params': {'skip_download': True}
+            'params': {'skip_download': True},
         },
     ]
 
@@ -93,7 +93,7 @@ class AiyifanIE(InfoExtractor):
         m3u8_base = re.match(r'(https://.*/mp4:[^/]+/[^/]+/[^/]+\.mp4)/', m3u8_url)
         if m3u8_base:
             fmt_str = m3u8_base.group(1).split('/')[-1].replace('.mp4', '')
-            title = f"{title}_{fmt_str}"
+            title = f'{title}_{fmt_str}'
 
         formats = self._extract_m3u8_formats(
             m3u8_url, video_id, 'mp4',

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -7,7 +7,6 @@ from yt_dlp.extractor.common import InfoExtractor
 
 class AiyifanIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?yfsp\.tv/play/(?P<id>[^/?#]+)(?:\?id=(?P<alt_id>[^&#]+))?'
-    # All the three domains are the same
     _TESTS = [
         {
             'url': 'https://www.yfsp.tv/play/tFAWlkx5kr9?id=GB7vRUxjOn5',

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -68,7 +68,7 @@ class AiyifanIE(InfoExtractor):
                 'https://m10.yfsp.tv/v3/video/languagesplaylist',
                 collection_id, query={
                     'vid': collection_id,
-                    'cid':'0,',
+                    'cid': '0,',
                     'vv': vv,
                     'pub': pub,
                 }, note='Downloading playlist info')
@@ -136,4 +136,3 @@ class AiyifanIE(InfoExtractor):
             'title': title,
             'formats': formats,
         }
-

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -1,6 +1,6 @@
-import time
 import hashlib
 import re
+import time
 
 from yt_dlp.extractor.common import InfoExtractor
 
@@ -35,17 +35,17 @@ class AiyifanIE(InfoExtractor):
                 'ext': 'mp4',
             },
             'params': {'skip_download': True}
-        }
+        },
     ]
 
     def compute_vv(self, query_str):
         public_key = int(time.time() * 1000)
         private_keys = [
-            "version001", "vers1on001", "vers1on00i", "bersion001",
-            "vcrsion001", "versi0n001", "versio_001", "version0o1"
+            'version001', 'vers1on001', 'vers1on00i', 'bersion001',
+            'vcrsion001', 'versi0n001', 'versio_001', 'version0o1',
         ]
         private_key = private_keys[public_key % len(private_keys)]
-        merge_str = f"{public_key}&{query_str.lower()}&{private_key}"
+        merge_str = f'{public_key}&{query_str.lower()}&{private_key}'
         return hashlib.md5(merge_str.encode('utf-8')).hexdigest(), public_key
 
     def _real_extract(self, url):
@@ -53,7 +53,7 @@ class AiyifanIE(InfoExtractor):
         video_id = mobj.group('id')
         alt_id = mobj.group('alt_id') or video_id
 
-        detail_query = f"tech=HLS&id={video_id}"
+        detail_query = f'tech=HLS&id={video_id}'
         detail_vv, detail_pub = self.compute_vv(detail_query)
         detail_params = {
             'tech': 'HLS',
@@ -71,7 +71,7 @@ class AiyifanIE(InfoExtractor):
         title = detail_json['data']['info'][0]['title']
 
         a = 1 if video_id == alt_id else 0
-        download_query = f"id={alt_id}&a={a}&usersign=1"
+        download_query = f'id={alt_id}&a={a}&usersign=1'
         download_vv, download_pub = self.compute_vv(download_query)
         download_params = {
             'id': alt_id,
@@ -87,12 +87,12 @@ class AiyifanIE(InfoExtractor):
             query=download_params)
 
         info_json = self._parse_json(info, video_id)
-        m3u8_url = info_json["data"]["info"][0]["clarity"][-1]["path"]["rtmp"]
+        m3u8_url = info_json['data']['info'][0]['clarity'][-1]['path']['rtmp']
 
         # optional: try to infer format
-        m3u8_base = re.match(r"(https://.*/mp4:[^/]+/[^/]+/[^/]+\.mp4)/", m3u8_url)
+        m3u8_base = re.match(r'(https://.*/mp4:[^/]+/[^/]+/[^/]+\.mp4)/', m3u8_url)
         if m3u8_base:
-            fmt_str = m3u8_base.group(1).split("/")[-1].replace(".mp4", "")
+            fmt_str = m3u8_base.group(1).split('/')[-1].replace('.mp4', '')
             title = f"{title}_{fmt_str}"
 
         formats = self._extract_m3u8_formats(

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -1,7 +1,10 @@
 import hashlib
 import time
+
 from yt_dlp.utils import ExtractorError
+
 from .common import InfoExtractor
+
 
 class AiyifanIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?(yfsp|iyf|aiyifan)\.tv/play/(?P<id>[^/?#]+)(?:\?id=(?P<alt_id>[^&#]+))?'

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -12,7 +12,7 @@ class AiyifanIE(InfoExtractor):
             'url': 'https://www.yfsp.tv/play/tFAWlkx5kr9?id=GB7vRUxjOn5',
             'info_dict': {
                 'id': 'GB7vRUxjOn5',
-                'title': '工作细胞_dhp-gzxb-06-03AC62667',
+                'title': '工作细胞_06',
                 'ext': 'mp4',
             },
             'params': {'skip_download': True},
@@ -21,7 +21,7 @@ class AiyifanIE(InfoExtractor):
             'url': 'https://www.yfsp.tv/play/tFAWlkx5kr9',
             'info_dict': {
                 'id': 'tFAWlkx5kr9',
-                'title': '工作细胞_dhp-gzxb-01-006E900E1',
+                'title': '工作细胞_01',
                 'ext': 'mp4',
             },
             'params': {'skip_download': True},
@@ -31,6 +31,15 @@ class AiyifanIE(InfoExtractor):
             'info_dict': {
                 'id': 'TtAyF6XpjfC',
                 'title': '大猿魂_dhp-dyh-01-008FFFF84',
+                'ext': 'mp4',
+            },
+            'params': {'skip_download': True},
+        },
+        {
+            'url': 'https://www.yfsp.tv/play/hezikWmgrKC?id=8u1rb9IxuQE',
+            'info_dict': {
+                'id': 'hezikWmgrKC',
+                'title': 'NBA美国职业篮球赛_20210515qishivsqicai',
                 'ext': 'mp4',
             },
             'params': {'skip_download': True},
@@ -84,7 +93,8 @@ class AiyifanIE(InfoExtractor):
         info_json = self._parse_json(info, video_id)
         m3u8_url = info_json['data']['info'][0]['clarity'][-1]['path']['rtmp']
 
-        episode = re.search(r'dhp-[A-Za-z0-9]+-(\d+)-', m3u8_url).group(1)
+        print(m3u8_url)
+        episode = re.search(r'[A-Za-z0-9]+-[A-Za-z0-9]+-([A-Za-z0-9]*)-[A-Za-z0-9]+\.', m3u8_url).group(1)
         title = f'{title}_{episode}'
 
         formats = self._extract_m3u8_formats(

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -93,7 +93,6 @@ class AiyifanIE(InfoExtractor):
         info_json = self._parse_json(info, video_id)
         m3u8_url = info_json['data']['info'][0]['clarity'][-1]['path']['rtmp']
 
-        print(m3u8_url)
         episode = re.search(r'[A-Za-z0-9]+-[A-Za-z0-9]+-([A-Za-z0-9]*)-[A-Za-z0-9]+\.', m3u8_url).group(1)
         title = f'{title}_{episode}'
 

--- a/yt_dlp/extractor/aiyifan.py
+++ b/yt_dlp/extractor/aiyifan.py
@@ -100,8 +100,6 @@ class AiyifanIE(InfoExtractor):
             entry_protocol='m3u8_native',
             m3u8_id='hls', fatal=True)
 
-
-
         return {
             'id': video_id,
             'title': title,


### PR DESCRIPTION
I have improved the Aiyifan extractor to handle URLs without the `?id=` parameter correctly.

- When the URL contains only the collection ID without a specific video `id`, the extractor now fetches and downloads the entire playlist (all episodes) instead of just the first video.
- If the `?id=` parameter is provided, the extractor downloads the specified single video as before.
- This behavior aligns with the conventional yt-dlp playlist handling, and supports the `--no-playlist` option to restrict to a single video if desired.
