### PR TITLE
Make extractor-designated impersonation override `--impersonate`

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3232,15 +3232,6 @@ class YoutubeDL:
         else:
             params = self.params
 
-        impersonate = info.pop('impersonate', None)
-        # Do not override --impersonate with extractor-specified impersonation
-        if params.get('impersonate') is None:
-            available_target, requested_targets = self._parse_impersonate_targets(impersonate)
-            if available_target:
-                info['impersonate'] = available_target
-            elif requested_targets:
-                self.report_warning(self._unavailable_targets_message(requested_targets), only_once=True)
-
         fd = get_suitable_downloader(info, params, to_stdout=(name == '-'))(self, params)
         if not test:
             for ph in self._progress_hooks:

--- a/yt_dlp/downloader/common.py
+++ b/yt_dlp/downloader/common.py
@@ -495,3 +495,11 @@ class FileDownloader:
             exe = os.path.basename(args[0])
 
         self.write_debug(f'{exe} command line: {shell_quote(args)}')
+
+    def _get_impersonate_target(self, impersonate):
+        available_target, requested_targets = self.ydl._parse_impersonate_targets(impersonate)
+        if available_target:
+            return available_target
+        elif requested_targets:
+            self.report_warning(self.ydl._unavailable_targets_message(requested_targets), only_once=True)
+        return None

--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -28,8 +28,9 @@ class HttpFD(FileDownloader):
         url = info_dict['url']
         request_data = info_dict.get('request_data', None)
         request_extensions = {}
-        if info_dict.get('impersonate') is not None:
-            request_extensions['impersonate'] = info_dict['impersonate']
+        impersonate_target = self._get_impersonate_target(info_dict.get('impersonate'))
+        if impersonate_target is not None:
+            request_extensions['impersonate'] = impersonate_target
 
         class DownloadContext(dict):
             __getattr__ = dict.get


### PR DESCRIPTION
Fix bug in 32809eb2da92c649e540a5b714f6235036026161


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
