### PR TITLE
Deprecate `darwin_legacy_exe` support

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -141,6 +141,17 @@ def _get_binary_name():
 def _get_system_deprecation():
     MIN_SUPPORTED, MIN_RECOMMENDED = (3, 9), (3, 9)
 
+    EXE_MSG_TMPL = ('Support for {} has been deprecated. '
+                    'See  https://github.com/yt-dlp/yt-dlp/{}  for details.\n{}')
+    STOP_MSG = 'You may stop receiving updates on this version at any time!'
+    variant = detect_variant()
+
+    # Temporary until macos_legacy executable builds are discontinued
+    if variant == 'darwin_legacy_exe':
+        return EXE_MSG_TMPL.format(
+            f'{variant} (the PyInstaller-bundled executable for macOS versions older than 10.15)',
+            'issues/13856', STOP_MSG)
+
     if sys.version_info > MIN_RECOMMENDED:
         return None
 


### PR DESCRIPTION
Related: #13856


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Deprecation

</details>
