### PR TITLE
Fix YouTube Language Parameter Translation

### DIFF
--- a/test/test_youtube_language.py
+++ b/test/test_youtube_language.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from test.helper import FakeYDL
+from yt_dlp.extractor import YoutubeIE
+from yt_dlp.utils import ExtractorError
+
+
+class TestYoutubeLanguage(unittest.TestCase):
+    """Test cases for YouTube language parameter functionality"""
+
+    def test_youtube_language_parameter_spanish(self):
+        """Test Spanish language parameter for title translation"""
+        dl = FakeYDL()
+        dl.params['extractor_args'] = {'youtube': {'lang': ['es']}}
+        ie = YoutubeIE(dl)
+        
+        # Test with a video that has Spanish translations
+        result = ie.extract('https://www.youtube.com/watch?v=0aNa_xESK1A')
+        
+        # Verify the title is in Spanish
+        self.assertIsNotNone(result.get('title'))
+        # Check if the title contains Spanish text (basic validation)
+        title = result.get('title', '').lower()
+        self.assertTrue(any(spanish_word in title for spanish_word in ['episodio', 'temporada', 'es']),
+                       f"Title '{title}' does not appear to be Spanish")
+
+    def test_youtube_language_parameter_english_fallback(self):
+        """Test English fallback when no translation available"""
+        dl = FakeYDL()
+        dl.params['extractor_args'] = {'youtube': {'lang': ['en']}}
+        ie = YoutubeIE(dl)
+        
+        result = ie.extract('https://www.youtube.com/watch?v=0aNa_xESK1A')
+        
+        # Should fall back to original title
+        self.assertIsNotNone(result.get('title'))
+        self.assertIsInstance(result.get('title'), str)
+
+    def test_youtube_language_parameter_no_language(self):
+        """Test behavior when no language parameter is provided"""
+        dl = FakeYDL()
+        # No extractor_args specified
+        ie = YoutubeIE(dl)
+        
+        result = ie.extract('https://www.youtube.com/watch?v=0aNa_xESK1A')
+        
+        # Should use original title
+        self.assertIsNotNone(result.get('title'))
+        self.assertIsInstance(result.get('title'), str)
+
+    def test_youtube_description_language_spanish(self):
+        """Test Spanish language parameter for description translation"""
+        dl = FakeYDL()
+        dl.params['extractor_args'] = {'youtube': {'lang': ['es']}}
+        ie = YoutubeIE(dl)
+        
+        result = ie.extract('https://www.youtube.com/watch?v=0aNa_xESK1A')
+        
+        # Verify description is present
+        description = result.get('description', '')
+        self.assertIsNotNone(description)
+        self.assertIsInstance(description, str)
+        
+        # Basic check for Spanish content
+        if description:
+            spanish_indicators = ['episodio', 'temporada', 'español', 'pokémon']
+            has_spanish = any(indicator in description.lower() for indicator in spanish_indicators)
+            # Note: this is a basic test - actual Spanish content depends on video availability
+
+    def test_youtube_language_parameter_multiple_languages(self):
+        """Test different language parameters"""
+        languages = ['es', 'fr', 'de']
+        
+        for lang in languages:
+            with self.subTest(language=lang):
+                dl = FakeYDL()
+                dl.params['extractor_args'] = {'youtube': {'lang': [lang]}}
+                ie = YoutubeIE(dl)
+                
+                try:
+                    result = ie.extract('https://www.youtube.com/watch?v=0aNa_xESK1A')
+                    self.assertIsNotNone(result.get('title'))
+                    self.assertIsInstance(result.get('title'), str)
+                except ExtractorError:
+                    # Some videos may not be available in all regions
+                    pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -3795,8 +3795,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             return None, None
             
         try:
-            url = "https://www.youtube.com/youtubei/v1/get_watch?prettyPrint=false"
-            
+            url = 'https://www.youtube.com/youtubei/v1/get_watch?prettyPrint=false'
+
             # Headers para simular navegador y forzar idioma
             headers = {
                 'accept': '*/*',
@@ -3810,13 +3810,13 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             
             # Datos del payload con idioma forzado
             data = {
-                "context": {
-                    "client": {
-                        "hl": preferred_lang,  # Forzar idioma
-                        "gl": preferred_lang.upper(),  # Forzar región
-                        "clientName": "WEB",
-                        "clientVersion": "2.20250725.01.00",
-                        "acceptLanguage": f'{preferred_lang}-{preferred_lang.upper()},{preferred_lang};q=0.9',
+                'context': {
+                    'client': {
+                        'hl': preferred_lang,  # Forzar idioma
+                        'gl': preferred_lang.upper(),  # Forzar región
+                        'clientName': 'WEB',
+                        'clientVersion': '2.20250725.01.00',
+                        'acceptLanguage': f'{preferred_lang}-{preferred_lang.upper()},{preferred_lang};q=0.9',
                     },
                     "user": {
                         "lockedSafetyMode": False


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### This PR fixes the issue where the --extractor-args "youtube:lang=" parameter was not providing automatic translations of titles and descriptions in YouTube videos.

The lang= parameter in extractor-args wasn't translating metadata even though the web showed translations
YouTube doesn't provide automatic translations in the standard JSON data used by yt-dlp


Fixes 
- New method  _get_translated_metadata_from_api() in YoutubeIE
- Integration with internal API youtubei/v1/get_watch with specific headers
- Smart extraction that prioritizes:
    - Manual translations from microformats
    - Automatic translations via internal API
    - Fallback to original content


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
