### PR TITLE
[cookies] Load cookies with float `expires` timestamps

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -37,6 +37,7 @@ from .utils import (
     Popen,
     error_to_str,
     expand_path,
+    float_or_none,
     is_path_like,
     sanitize_url,
     str_or_none,
@@ -1335,7 +1336,7 @@ class YoutubeDLCookieJar(http.cookiejar.MozillaCookieJar):
             if len(cookie_list) != self._ENTRY_LEN:
                 raise http.cookiejar.LoadError(f'invalid length {len(cookie_list)}')
             cookie = self._CookieFileEntry(*cookie_list)
-            if cookie.expires_at and not cookie.expires_at.isdigit():
+            if cookie.expires_at and float_or_none(cookie.expires_at) is None:
                 raise http.cookiejar.LoadError(f'invalid expires at {cookie.expires_at}')
             return line
 

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -37,7 +37,6 @@ from .utils import (
     Popen,
     error_to_str,
     expand_path,
-    float_or_none,
     is_path_like,
     sanitize_url,
     str_or_none,
@@ -1336,7 +1335,7 @@ class YoutubeDLCookieJar(http.cookiejar.MozillaCookieJar):
             if len(cookie_list) != self._ENTRY_LEN:
                 raise http.cookiejar.LoadError(f'invalid length {len(cookie_list)}')
             cookie = self._CookieFileEntry(*cookie_list)
-            if cookie.expires_at and float_or_none(cookie.expires_at) is None:
+            if cookie.expires_at and not re.fullmatch(r'[0-9]+(?:\.[0-9]+)?', cookie.expires_at):
                 raise http.cookiejar.LoadError(f'invalid expires at {cookie.expires_at}')
             return line
 


### PR DESCRIPTION
The current implementation is rejecting valid cookies because we are using `str.isdigit`, which will return `False` for a stringified float value.

Float timestamps are valid:
https://github.com/python/cpython/blob/3.13/Lib/http/cookiejar.py#L776
https://github.com/python/cpython/blob/3.9/Lib/http/cookiejar.py#L768

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
