### PR TITLE
[ci] Bump supported PyPy version to 3.11

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # CPython 3.9 is in quick-test
-        python-version: ['3.10', '3.11', '3.12', '3.13', pypy-3.10]
+        python-version: ['3.10', '3.11', '3.12', '3.13', pypy-3.11]
         include:
         # atleast one of each CPython/PyPy tests must be in windows
         - os: windows-latest
@@ -49,7 +49,7 @@ jobs:
         - os: windows-latest
           python-version: '3.13'
         - os: windows-latest
-          python-version: pypy-3.10
+          python-version: pypy-3.11
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -28,13 +28,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', pypy-3.10]
+        python-version: ['3.10', '3.11', '3.12', '3.13', pypy-3.11]
         include:
         # atleast one of each CPython/PyPy tests must be in windows
         - os: windows-latest
           python-version: '3.9'
         - os: windows-latest
-          python-version: pypy-3.10
+          python-version: pypy-3.11
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/signature-tests.yml
+++ b/.github/workflows/signature-tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', pypy-3.10, pypy-3.11]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', pypy-3.11]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,7 +272,7 @@ After you have ensured this site is distributing its content legally, you can fo
 
     You can use `hatch fmt` to automatically fix problems. Rules that the linter/formatter enforces should not be disabled with `# noqa` unless a maintainer requests it. The only exception allowed is for old/printf-style string formatting in GraphQL query templates (use `# noqa: UP031`).
 
-1. Make sure your code works under all [Python](https://www.python.org/) versions supported by yt-dlp, namely CPython >=3.9 and PyPy >=3.10. Backward compatibility is not required for even older versions of Python.
+1. Make sure your code works under all [Python](https://www.python.org/) versions supported by yt-dlp, namely CPython >=3.9 and PyPy >=3.11. Backward compatibility is not required for even older versions of Python.
 1. When the tests pass, [add](https://git-scm.com/docs/git-add) the new files, [commit](https://git-scm.com/docs/git-commit) them and [push](https://git-scm.com/docs/git-push) the result, like this:
 
     ```shell

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ python3 -m pip install -U --pre "yt-dlp[default]"
 ```
 
 ## DEPENDENCIES
-Python versions 3.9+ (CPython) and 3.10+ (PyPy) are supported. Other versions and implementations may or may not work correctly.
+Python versions 3.9+ (CPython) and 3.11+ (PyPy) are supported. Other versions and implementations may or may not work correctly.
 
 <!-- Python 3.5+ uses VC++14 and it is already embedded in the binary created
 <!x-- https://www.microsoft.com/en-us/download/details.aspx?id=26999 --x>


### PR DESCRIPTION
On 2025-07-04, PyPy released v7.3.20, which added stable support for Python 3.11 and dropped support for Python 3.10. We only need to support what is currently supported by PyPy itself.

Ref:
- [**PyPy v7.3.19 release** (2025-02-26)](https://pypy.org/posts/2025/02/pypy-v7319-release.html)
    - > In the next release we will drop 3.10
- [**PyPy v7.3.20 release** (2025-07-04)](https://pypy.org/posts/2025/07/pypy-v7320-release.html)
    - > PyPy v7.3.20: release of python 2.7, 3.11

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] CI & documentation update

</details>
