### PR TITLE
[test:utils] Fix `sanitize_path` test for Windows CPython 3.11

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -39,9 +39,6 @@ jobs:
         # CPython 3.9 is in quick-test
         python-version: ['3.10', '3.11', '3.12', '3.13', pypy-3.11]
         include:
-        # TEMPORARY
-        - os: windows-latest
-          python-version: '3.11'
         # atleast one of each CPython/PyPy tests must be in windows
         - os: windows-latest
           python-version: '3.9'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -39,6 +39,9 @@ jobs:
         # CPython 3.9 is in quick-test
         python-version: ['3.10', '3.11', '3.12', '3.13', pypy-3.11]
         include:
+        # TEMPORARY
+        - os: windows-latest
+          python-version: '3.11'
         # atleast one of each CPython/PyPy tests must be in windows
         - os: windows-latest
           python-version: '3.9'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -253,11 +253,13 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sanitize_path('abc.../def...'), 'abc..#\\def..#')
         self.assertEqual(sanitize_path('C:\\abc:%(title)s.%(ext)s'), 'C:\\abc#%(title)s.%(ext)s')
 
-        # Check with nt._path_normpath if available
+        # If nt._path_normpath is available, test with os.path.normpath
         try:
-            from nt import _path_normpath as nt_path_normpath
+            from nt import _path_normpath as _  # noqa: F401
         except ImportError:
             nt_path_normpath = None
+        else:
+            from os.path import normpath as nt_path_normpath
 
         for test, expected in [
             ('C:\\', 'C:\\'),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,6 +12,7 @@ import datetime as dt
 import io
 import itertools
 import json
+import ntpath
 import pickle
 import subprocess
 import unittest
@@ -253,14 +254,6 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sanitize_path('abc.../def...'), 'abc..#\\def..#')
         self.assertEqual(sanitize_path('C:\\abc:%(title)s.%(ext)s'), 'C:\\abc#%(title)s.%(ext)s')
 
-        # If nt._path_normpath is available, test with os.path.normpath
-        try:
-            from nt import _path_normpath as _  # noqa: F401
-        except ImportError:
-            nt_path_normpath = None
-        else:
-            from os.path import normpath as nt_path_normpath
-
         for test, expected in [
             ('C:\\', 'C:\\'),
             ('../abc', '..\\abc'),
@@ -278,8 +271,7 @@ class TestUtil(unittest.TestCase):
             result = sanitize_path(test)
             assert result == expected, f'{test} was incorrectly resolved'
             assert result == sanitize_path(result), f'{test} changed after sanitizing again'
-            if nt_path_normpath:
-                assert result == nt_path_normpath(test), f'{test} does not match nt._path_normpath'
+            assert result == ntpath.normpath(test), f'{test} does not match ntpath.normpath'
 
     def test_sanitize_url(self):
         self.assertEqual(sanitize_url('//foo.bar'), 'http://foo.bar')


### PR DESCRIPTION
`test_sanitize_path` is failing on Windows CPython 3.11 because 3.11's `nt._path_normpath` implementation was wrong, and instead of fixing it properly, a workaround was patched into `os.path.normpath`. In Python 3.12+, `nt._path_normpath` was fixed and the workaround in `os.path.normpath` was removed.


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix failing CI

</details>
