### PR TITLE
Fix TVI Player extractor: updated to handle site changes

### DIFF
--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -49,7 +49,7 @@ class TVIPlayerIE(InfoExtractor):
             elif ch == '}':
                 depth -= 1
                 if depth == 0:
-                    return webpage[start:i+1]
+                    return webpage[start:i + 1]
         return None
 
     def _real_extract(self, url):

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -1,8 +1,8 @@
 import json
 import re
 
-from ..utils import ExtractorError, js_to_json, traverse_obj
 from .common import InfoExtractor
+from ..utils import ExtractorError, js_to_json, traverse_obj
 
 
 class TVIPlayerIE(InfoExtractor):

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -1,78 +1,142 @@
 from .common import InfoExtractor
-from ..utils import traverse_obj
+from ..utils import traverse_obj, ExtractorError, js_to_json
+import re
+import json
 
 
 class TVIPlayerIE(InfoExtractor):
-    _VALID_URL = r'https?://tviplayer\.iol\.pt(/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)'
+    _VALID_URL = r'https?://tviplayer\.iol\.pt/(?:programa/[^/]+/[0-9a-f]+/(?:video|episodio)|video|episodio|[^/]+/[^/]+|[^/]+)/(?P<id>[0-9A-Za-z]+)(?:[/?#]|$)'
     _TESTS = [{
-        'url': 'https://tviplayer.iol.pt/programa/jornal-das-8/53c6b3903004dc006243d0cf/video/61c8e8b90cf2c7ea0f0f71a9',
+        'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
         'info_dict': {
-            'id': '61c8e8b90cf2c7ea0f0f71a9',
+            'id': '689683000cf20ac1d5f35341',
             'ext': 'mp4',
-            'duration': 4167,
-            'title': 'Jornal das 8 - 26 de dezembro de 2021',
-            'thumbnail': 'https://www.iol.pt/multimedia/oratvi/multimedia/imagem/id/61c8ee630cf2cc58e7d98d9f/',
-            'season_number': 8,
-            'season': 'Season 8',
-        },
-    }, {
-        'url': 'https://tviplayer.iol.pt/programa/isabel/62b471090cf26256cd2a8594/video/62be445f0cf2ea4f0a5218e5',
-        'info_dict': {
-            'id': '62be445f0cf2ea4f0a5218e5',
-            'ext': 'mp4',
-            'duration': 3255,
-            'season': 'Season 1',
-            'title': 'Isabel - Episódio 1',
-            'thumbnail': 'https://www.iol.pt/multimedia/oratvi/multimedia/imagem/id/62beac200cf2f9a86eab856b/',
-            'season_number': 1,
-        },
-    }, {
-        # no /programa/
-        'url': 'https://tviplayer.iol.pt/video/62c4131c0cf2f9a86eac06bb',
-        'info_dict': {
-            'id': '62c4131c0cf2f9a86eac06bb',
-            'ext': 'mp4',
-            'title': 'David e Mickael Carreira respondem: «Qual é o próximo a ser pai?»',
-            'thumbnail': 'https://www.iol.pt/multimedia/oratvi/multimedia/imagem/id/62c416490cf2ea367d4433fd/',
-            'season': 'Season 2',
-            'duration': 148,
-            'season_number': 2,
-        },
-    }, {
-        # episodio url
-        'url': 'https://tviplayer.iol.pt/programa/para-sempre/61716c360cf2365a5ed894c4/episodio/t1e187',
-        'info_dict': {
-            'id': 't1e187',
-            'ext': 'mp4',
-            'season': 'Season 1',
-            'title': 'Quem denunciou Pedro?',
-            'thumbnail': 'https://www.iol.pt/multimedia/oratvi/multimedia/imagem/id/62eda30b0cf2ea367d48973b/',
-            'duration': 1250,
+            'duration': 1593,
+            'title': 'A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica',
+            'thumbnail': 'https://img.iol.pt/image/id/68971037d34ef72ee44941a6/',
             'season_number': 1,
         },
     }]
 
     def _real_initialize(self):
-        self.wms_auth_sign_token = self._download_webpage(
-            'https://services.iol.pt/matrix?userId=', 'wmsAuthSign',
-            note='Trying to get wmsAuthSign token')
+        # try to obtain the wmsAuthSign token; if it fails, continue without it
+        try:
+            self.wms_auth_sign_token = self._download_webpage(
+                'https://services.iol.pt/matrix?userId=', 'wmsAuthSign',
+                note='Downloading wmsAuthSign token')
+        except Exception:
+            self.wms_auth_sign_token = None
+
+    def _extract_enclosing_js_object(self, webpage, keyword):
+        """
+        Find a JS object (balanced braces) that contains keyword (e.g. "videoUrl").
+        Returns the text of the object (including braces) or None.
+        """
+        k = re.search(re.escape(keyword), webpage)
+        if not k:
+            return None
+        pos = k.start()
+        # find an opening brace before pos
+        start = webpage.rfind('{', 0, pos)
+        if start == -1:
+            return None
+        depth = 0
+        for i in range(start, len(webpage)):
+            ch = webpage[i]
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return webpage[start:i+1]
+        return None
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id)
+        webpage = self._download_webpage(url, video_id or 'tviplayer')
 
-        json_data = self._search_json(
-            r'<script>\s*jsonData\s*=', webpage, 'json_data', video_id)
+        video_info = None
 
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            f'{json_data["videoUrl"]}?wmsAuthSign={self.wms_auth_sign_token}',
-            video_id, ext='mp4')
+        # 1) Try to find a literal "const opts = { ... };" block first
+        m_opts = re.search(r'const\s+opts\s*=\s*({.*?})\s*;', webpage, flags=re.S)
+        if m_opts:
+            try:
+                opts = self._parse_json(m_opts.group(1), video_id or 'tviplayer', transform_source=js_to_json)
+            except Exception:
+                opts = None
+            if opts:
+                # try opts.video[0] or opts itself
+                video_info = traverse_obj(opts, ('video', 0)) or opts.get('video') or opts
+
+        # 2) If not found, try to extract any JS object that contains "videoUrl"
+        if not video_info:
+            obj_text = self._extract_enclosing_js_object(webpage, 'videoUrl')
+            if obj_text:
+                try:
+                    parsed = self._parse_json(obj_text, video_id or 'tviplayer', transform_source=js_to_json)
+                except Exception:
+                    # fallback: try to json.loads after small cleanup
+                    try:
+                        cleaned = re.sub(r',\s*([}\]])', r'\1', obj_text).replace("'", '"')
+                        parsed = json.loads(cleaned)
+                    except Exception:
+                        parsed = None
+                if parsed:
+                    # parsed might be the video object or contain video: [...]
+                    if isinstance(parsed, dict):
+                        video_info = traverse_obj(parsed, ('video', 0)) or parsed
+
+        # 3) Legacy fallback: jsonData = {...}
+        if not video_info:
+            try:
+                jd = self._search_json(r'jsonData\s*=', webpage, 'json data', video_id)
+                if jd:
+                    video_info = traverse_obj(jd, ('video', 0)) or jd
+            except ExtractorError:
+                video_info = None
+
+        # 4) Last resort: search for a direct "videoUrl" key anywhere and build minimal object
+        if not video_info:
+            m = re.search(r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage, flags=re.S)
+            if m:
+                video_info = {
+                    'id': video_id or None,
+                    'videoUrl': m.group(1),
+                }
+
+        if not video_info:
+            raise ExtractorError('Unable to locate video data in webpage', expected=True)
+
+        # Determine id/title/thumbnail/duration/videoUrl
+        vid = video_info.get('id') or video_id
+        title = video_info.get('title') or self._og_search_title(webpage)
+        thumbnail = video_info.get('cover') or video_info.get('thumbnail') or self._og_search_thumbnail(webpage)
+        duration = video_info.get('duration')
+        try:
+            duration = int(duration) if duration is not None else None
+        except Exception:
+            try:
+                duration = int(float(duration))
+            except Exception:
+                duration = None
+
+        video_url = video_info.get('videoUrl') or video_info.get('url') or video_info.get('video_url')
+        if not video_url:
+            raise ExtractorError('No video URL found in the page data', expected=True)
+
+        # append token if we have it
+        if self.wms_auth_sign_token:
+            sep = '&' if '?' in video_url else '?'
+            video_url = f'{video_url}{sep}wmsAuthSign={self.wms_auth_sign_token}'
+
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, vid or video_id, ext='mp4')
+
         return {
-            'id': video_id,
-            'title': json_data.get('title') or self._og_search_title(webpage),
-            'thumbnail': json_data.get('cover') or self._og_search_thumbnail(webpage),
-            'duration': json_data.get('duration'),
+            'id': vid or video_id,
+            'title': title,
+            'thumbnail': thumbnail,
+            'duration': duration,
             'formats': formats,
             'subtitles': subtitles,
-            'season_number': traverse_obj(json_data, ('program', 'seasonNum')),
+            'season_number': traverse_obj(video_info, ('program', 'seasonNum')),
         }

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -8,7 +8,6 @@ from ..utils import (
     js_to_json,
 )
 from ..utils.traversal import (
-    require,
     traverse_obj,
 )
 
@@ -55,7 +54,7 @@ class TVIPlayerIE(InfoExtractor):
         )
 
         # Structured metadata from ld+json
-        info = self._search_json_ld(webpage, video_id, default={}) or {}
+        _ = self._search_json_ld(webpage, video_id, default={}) or {}
 
         # Merge data safely without type errors
         def first_of(*keys):

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -1,118 +1,75 @@
-import json
+from __future__ import annotations
+
 import re
 
 from .common import InfoExtractor
-from ..utils import ExtractorError, js_to_json, traverse_obj
+from ..utils import (
+    ExtractorError,
+    js_to_json,
+)
+from ..utils.traversal import (
+    require,
+    traverse_obj,
+)
 
 
 class TVIPlayerIE(InfoExtractor):
-    _VALID_URL = r'https?://tviplayer\.iol\.pt/(?:programa/[^/]+/[0-9a-f]+/(?:video|episodio)|video|episodio|[^/]+/[^/]+|[^/]+)/(?P<id>[0-9A-Za-z]+)(?:[/?#]|$)'
-    _TESTS = [{
-        'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
-        'info_dict': {
-            'id': '689683000cf20ac1d5f35341',
-            'ext': 'mp4',
-            'duration': 1593,
-            'title': 'A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica',
-            'thumbnail': 'https://img.iol.pt/image/id/68971037d34ef72ee44941a6/',
-            'season_number': 1,
-        },
-    }]
+    _VALID_URL = (
+        r"https?://tviplayer\.iol\.pt(?:/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)"
+    )
+    _TESTS = [
+        {
+            "url": "https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120",
+            "info_dict": {
+                "id": "689683000cf20ac1d5f35341",
+                "ext": "mp4",
+                "duration": 1593,
+                "title": "A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica",
+                "thumbnail": "https://img.iol.pt/image/id/68971037d34ef72ee44941a6/",
+                "season_number": 1,
+            },
+        }
+    ]
 
     def _real_initialize(self):
-        # try to obtain the wmsAuthSign token; if it fails, continue without it
-        try:
-            self.wms_auth_sign_token = self._download_webpage(
-                'https://services.iol.pt/matrix?userId=', 'wmsAuthSign',
-                note='Downloading wmsAuthSign token')
-        except Exception:
-            self.wms_auth_sign_token = None
-
-    def _extract_enclosing_js_object(self, webpage, keyword):
-        """
-        Find a JS object (balanced braces) that contains keyword (e.g. "videoUrl").
-        Returns the text of the object (including braces) or None.
-        """
-        k = re.search(re.escape(keyword), webpage)
-        if not k:
-            return None
-        pos = k.start()
-        # find an opening brace before pos
-        start = webpage.rfind('{', 0, pos)
-        if start == -1:
-            return None
-        depth = 0
-        for i in range(start, len(webpage)):
-            ch = webpage[i]
-            if ch == '{':
-                depth += 1
-            elif ch == '}':
-                depth -= 1
-                if depth == 0:
-                    return webpage[start:i + 1]
-        return None
+        # Obtain the wmsAuthSign token (non-fatal)
+        self.wms_auth_sign_token = self._download_webpage(
+            "https://services.iol.pt/matrix?userId=",
+            "wmsAuthSign",
+            note="Downloading wmsAuthSign token",
+            fatal=False,
+        )
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id or 'tviplayer')
+        webpage = self._download_webpage(url, video_id)
 
-        video_info = None
+        # Try to locate a JS "video: [ {...} ]" block
+        json_data = self._search_json(
+            r"(?<!-)\bvideo\s*:\s*\[",
+            webpage,
+            "json_data",
+            video_id,
+            transform_source=js_to_json,
+            default={},
+        )
 
-        # 1) Try to find a literal "const opts = { ... };" block first
-        m_opts = re.search(r'const\s+opts\s*=\s*({.*?})\s*;', webpage, flags=re.S)
-        if m_opts:
-            try:
-                opts = self._parse_json(m_opts.group(1), video_id or 'tviplayer', transform_source=js_to_json)
-            except Exception:
-                opts = None
-            if opts:
-                # try opts.video[0] or opts itself
-                video_info = traverse_obj(opts, ('video', 0)) or opts.get('video') or opts
+        # Structured metadata from ld+json
+        info = self._search_json_ld(webpage, video_id, default={}) or {}
 
-        # 2) If not found, try to extract any JS object that contains "videoUrl"
-        if not video_info:
-            obj_text = self._extract_enclosing_js_object(webpage, 'videoUrl')
-            if obj_text:
-                try:
-                    parsed = self._parse_json(obj_text, video_id or 'tviplayer', transform_source=js_to_json)
-                except Exception:
-                    # fallback: try to json.loads after small cleanup
-                    try:
-                        cleaned = re.sub(r',\s*([}\]])', r'\1', obj_text).replace("'", '"')
-                        parsed = json.loads(cleaned)
-                    except Exception:
-                        parsed = None
-                if parsed:
-                    # parsed might be the video object or contain video: [...]
-                    if isinstance(parsed, dict):
-                        video_info = traverse_obj(parsed, ('video', 0)) or parsed
+        # Merge data safely without type errors
+        def first_of(*keys):
+            for k in keys:
+                v = traverse_obj(json_data, (k,))
+                if v:
+                    return v
+            return None
 
-        # 3) Legacy fallback: jsonData = {...}
-        if not video_info:
-            try:
-                jd = self._search_json(r'jsonData\s*=', webpage, 'json data', video_id)
-                if jd:
-                    video_info = traverse_obj(jd, ('video', 0)) or jd
-            except ExtractorError:
-                video_info = None
+        info_id = first_of("id")
+        title = first_of("title") or self._og_search_title(webpage)
+        thumbnail = first_of("cover", "thumbnail") or self._og_search_thumbnail(webpage)
+        duration = first_of("duration")
 
-        # 4) Last resort: search for a direct "videoUrl" key anywhere and build minimal object
-        if not video_info:
-            m = re.search(r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage, flags=re.S)
-            if m:
-                video_info = {
-                    'id': video_id or None,
-                    'videoUrl': m.group(1),
-                }
-
-        if not video_info:
-            raise ExtractorError('Unable to locate video data in webpage', expected=True)
-
-        # Determine id/title/thumbnail/duration/videoUrl
-        vid = video_info.get('id') or video_id
-        title = video_info.get('title') or self._og_search_title(webpage)
-        thumbnail = video_info.get('cover') or video_info.get('thumbnail') or self._og_search_thumbnail(webpage)
-        duration = video_info.get('duration')
         try:
             duration = int(duration) if duration is not None else None
         except Exception:
@@ -121,23 +78,35 @@ class TVIPlayerIE(InfoExtractor):
             except Exception:
                 duration = None
 
-        video_url = video_info.get('videoUrl') or video_info.get('url') or video_info.get('video_url')
+        video_url = first_of("videoUrl", "url", "video_url")
         if not video_url:
-            raise ExtractorError('No video URL found in the page data', expected=True)
+            m = re.search(
+                r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage
+            )
+            if m:
+                video_url = m.group(1)
 
-        # append token if we have it
-        if self.wms_auth_sign_token:
-            sep = '&' if '?' in video_url else '?'
-            video_url = f'{video_url}{sep}wmsAuthSign={self.wms_auth_sign_token}'
+        if not video_url:
+            raise ExtractorError("Unable to locate video URL in webpage", expected=True)
 
-        formats, subtitles = self._extract_m3u8_formats_and_subtitles(video_url, vid or video_id, ext='mp4')
+        query = (
+            {"wmsAuthSign": self.wms_auth_sign_token}
+            if self.wms_auth_sign_token
+            else {}
+        )
+        formats, subtitles = self._extract_m3u8_formats_and_subtitles(
+            video_url, video_id, ext="mp4", query=query, fatal=False
+        )
+
+        season_number = traverse_obj(json_data, ("program", "seasonNum"))
 
         return {
-            'id': vid or video_id,
-            'title': title,
-            'thumbnail': thumbnail,
-            'duration': duration,
-            'formats': formats,
-            'subtitles': subtitles,
-            'season_number': traverse_obj(video_info, ('program', 'seasonNum')),
+            "id": info_id or video_id,
+            "display_id": video_id,
+            "title": title,
+            "thumbnail": thumbnail,
+            "duration": duration,
+            "formats": formats,
+            "subtitles": subtitles,
+            "season_number": season_number,
         }

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -14,28 +14,28 @@ from ..utils.traversal import (
 
 class TVIPlayerIE(InfoExtractor):
     _VALID_URL = (
-        r"https?://tviplayer\.iol\.pt(?:/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)"
+        r'https?://tviplayer\.iol\.pt(?:/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)'
     )
     _TESTS = [
         {
-            "url": "https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120",
+            'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
             "info_dict": {
-                "id": "689683000cf20ac1d5f35341",
-                "ext": "mp4",
-                "duration": 1593,
-                "title": "A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica",
-                "thumbnail": "https://img.iol.pt/image/id/68971037d34ef72ee44941a6/",
-                "season_number": 1,
+                'id': '689683000cf20ac1d5f35341',
+                'ext': 'mp4',
+                'duration': 1593,
+                'title': 'A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica',
+                'thumbnail': 'https://img.iol.pt/image/id/68971037d34ef72ee44941a6/',
+                'season_number': 1,
             },
-        }
+        },
     ]
 
     def _real_initialize(self):
         # Obtain the wmsAuthSign token (non-fatal)
         self.wms_auth_sign_token = self._download_webpage(
-            "https://services.iol.pt/matrix?userId=",
-            "wmsAuthSign",
-            note="Downloading wmsAuthSign token",
+            'https://services.iol.pt/matrix?userId=',
+            'wmsAuthSign',
+            note='Downloading wmsAuthSign token',
             fatal=False,
         )
 
@@ -45,9 +45,9 @@ class TVIPlayerIE(InfoExtractor):
 
         # Try to locate a JS "video: [ {...} ]" block
         json_data = self._search_json(
-            r"(?<!-)\bvideo\s*:\s*\[",
+            r'(?<!-)\bvideo\s*:\s*\[',
             webpage,
-            "json_data",
+            'json_data',
             video_id,
             transform_source=js_to_json,
             default={},
@@ -64,10 +64,10 @@ class TVIPlayerIE(InfoExtractor):
                     return v
             return None
 
-        info_id = first_of("id")
-        title = first_of("title") or self._og_search_title(webpage)
-        thumbnail = first_of("cover", "thumbnail") or self._og_search_thumbnail(webpage)
-        duration = first_of("duration")
+        info_id = first_of('id')
+        title = first_of('title') or self._og_search_title(webpage)
+        thumbnail = first_of('cover', 'thumbnail') or self._og_search_thumbnail(webpage)
+        duration = first_of('duration')
 
         try:
             duration = int(duration) if duration is not None else None
@@ -77,7 +77,7 @@ class TVIPlayerIE(InfoExtractor):
             except Exception:
                 duration = None
 
-        video_url = first_of("videoUrl", "url", "video_url")
+        video_url = first_of('videoUrl', 'url', 'video_url')
         if not video_url:
             m = re.search(
                 r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage
@@ -86,26 +86,26 @@ class TVIPlayerIE(InfoExtractor):
                 video_url = m.group(1)
 
         if not video_url:
-            raise ExtractorError("Unable to locate video URL in webpage", expected=True)
+            raise ExtractorError('Unable to locate video URL in webpage', expected=True)
 
         query = (
-            {"wmsAuthSign": self.wms_auth_sign_token}
+            {'wmsAuthSign': self.wms_auth_sign_token}
             if self.wms_auth_sign_token
             else {}
         )
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            video_url, video_id, ext="mp4", query=query, fatal=False
+            video_url, video_id, ext='mp4', query=query, fatal=False
         )
 
-        season_number = traverse_obj(json_data, ("program", "seasonNum"))
+        season_number = traverse_obj(json_data, ('program', 'seasonNum'))
 
         return {
-            "id": info_id or video_id,
-            "display_id": video_id,
-            "title": title,
-            "thumbnail": thumbnail,
-            "duration": duration,
-            "formats": formats,
-            "subtitles": subtitles,
-            "season_number": season_number,
+            'id': info_id or video_id,
+            'display_id': video_id,
+            'title': title,
+            'thumbnail': thumbnail,
+            'duration': duration,
+            'formats': formats,
+            'subtitles': subtitles,
+            'season_number': season_number,
         }

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -19,7 +19,7 @@ class TVIPlayerIE(InfoExtractor):
     _TESTS = [
         {
             'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
-            "info_dict": {
+            'info_dict': {
                 'id': '689683000cf20ac1d5f35341',
                 'ext': 'mp4',
                 'duration': 1593,
@@ -80,7 +80,7 @@ class TVIPlayerIE(InfoExtractor):
         video_url = first_of('videoUrl', 'url', 'video_url')
         if not video_url:
             m = re.search(
-                r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage
+                r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage,
             )
             if m:
                 video_url = m.group(1)
@@ -94,7 +94,7 @@ class TVIPlayerIE(InfoExtractor):
             else {}
         )
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            video_url, video_id, ext='mp4', query=query, fatal=False
+            video_url, video_id, ext='mp4', query=query, fatal=False,
         )
 
         season_number = traverse_obj(json_data, ('program', 'seasonNum'))

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -1,7 +1,8 @@
-from .common import InfoExtractor
-from ..utils import traverse_obj, ExtractorError, js_to_json
-import re
 import json
+import re
+
+from ..utils import ExtractorError, js_to_json, traverse_obj
+from .common import InfoExtractor
 
 
 class TVIPlayerIE(InfoExtractor):

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -1,7 +1,5 @@
 from .common import InfoExtractor
 from ..utils import (
-    ExtractorError,
-    filter_dict,
     int_or_none,
     js_to_json,
     url_or_none,
@@ -12,14 +10,52 @@ from ..utils.traversal import traverse_obj
 class TVIPlayerIE(InfoExtractor):
     _VALID_URL = r'https?://tviplayer\.iol\.pt(?:/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)'
     _TESTS = [{
+        'url': 'https://tviplayer.iol.pt/programa/jornal-das-8/53c6b3903004dc006243d0cf/video/61c8e8b90cf2c7ea0f0f71a9',
+        'info_dict': {
+            'id': '61c8e8b90cf2c7ea0f0f71a9',
+            'ext': 'mp4',
+            'duration': 4167,
+            'title': 'Jornal das 8 - 26 de dezembro de 2021',
+            'thumbnail': 'https://img.iol.pt/image/id/61c8ee630cf2cc58e7d98d9f/',
+        },
+    }, {
+        'url': 'https://tviplayer.iol.pt/programa/isabel/62b471090cf26256cd2a8594/video/62be445f0cf2ea4f0a5218e5',
+        'info_dict': {
+            'id': '62be445f0cf2ea4f0a5218e5',
+            'ext': 'mp4',
+            'duration': 3255,
+            'title': 'Isabel - Episódio 1',
+            'thumbnail': 'https://www.iol.pt/multimedia/oratvi/multimedia/imagem/id/62beac200cf2f9a86eab856b/',
+        },
+        'skip': 'URL dead',
+    }, {
+        # no /programa/
+        'url': 'https://tviplayer.iol.pt/video/62c4131c0cf2f9a86eac06bb',
+        'info_dict': {
+            'id': '62c4131c0cf2f9a86eac06bb',
+            'ext': 'mp4',
+            'title': 'David e Mickael Carreira respondem: «Qual é o próximo a ser pai?»',
+            'thumbnail': 'https://img.iol.pt/image/id/62c416490cf2ea367d4433fd/',
+            'duration': 148,
+        },
+    }, {
+        # episodio url
+        'url': 'https://tviplayer.iol.pt/programa/para-sempre/61716c360cf2365a5ed894c4/episodio/t1e187',
+        'info_dict': {
+            'id': 't1e187',
+            'ext': 'mp4',
+            'title': 'Quem denunciou Pedro?',
+            'thumbnail': 'https://img.iol.pt/image/id/62eda30b0cf2ea367d48973b/',
+            'duration': 1250,
+        },
+    }, {
         'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
         'info_dict': {
-            'id': '689683000cf20ac1d5f35341',
+            'id': 't1e120',
             'ext': 'mp4',
             'duration': 1593,
             'title': 'A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica',
             'thumbnail': 'https://img.iol.pt/image/id/68971037d34ef72ee44941a6/',
-            'season_number': 1,
         },
     }]
 
@@ -36,23 +72,17 @@ class TVIPlayerIE(InfoExtractor):
             r'(?<!-)\bvideo\s*:\s*\[',
             webpage, 'json_data', video_id, transform_source=js_to_json)
 
-        video_url = traverse_obj(json_data, ('videoUrl',), expected_type=url_or_none)
-        if not video_url:
-            raise ExtractorError('Unable to locate video URL in webpage')
-
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            video_url, video_id, ext='mp4', query=filter_dict({
+            json_data['videoUrl'], video_id, 'mp4', query={
                 'wmsAuthSign': self.wms_auth_sign_token,
-            }))
+            })
 
         return {
-            'id': traverse_obj(json_data, ('id',)) or video_id,
-            'display_id': video_id,
-            'title': traverse_obj(json_data, ('title',)) or self._og_search_title(webpage),
-            'thumbnail': traverse_obj(
-                json_data, ('cover',), ('thumbnail',), expected_type=url_or_none) or self._og_search_thumbnail(webpage),
-            'duration': int_or_none(traverse_obj(json_data, ('duration',))),
+            'id': video_id,
+            'title': traverse_obj(json_data, ('title', {str})) or self._og_search_title(webpage),
+            'thumbnail': traverse_obj(json_data, (
+                ('cover', 'thumbnail'), {url_or_none}, any)) or self._og_search_thumbnail(webpage),
+            'duration': traverse_obj(json_data, ('duration', {int_or_none})),
             'formats': formats,
             'subtitles': subtitles,
-            'season_number': traverse_obj(json_data, ('program', 'seasonNum')),
         }

--- a/yt_dlp/extractor/tviplayer.py
+++ b/yt_dlp/extractor/tviplayer.py
@@ -1,111 +1,58 @@
-from __future__ import annotations
-
-import re
-
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    filter_dict,
+    int_or_none,
     js_to_json,
+    url_or_none,
 )
-from ..utils.traversal import (
-    traverse_obj,
-)
+from ..utils.traversal import traverse_obj
 
 
 class TVIPlayerIE(InfoExtractor):
-    _VALID_URL = (
-        r'https?://tviplayer\.iol\.pt(?:/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)'
-    )
-    _TESTS = [
-        {
-            'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
-            'info_dict': {
-                'id': '689683000cf20ac1d5f35341',
-                'ext': 'mp4',
-                'duration': 1593,
-                'title': 'A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica',
-                'thumbnail': 'https://img.iol.pt/image/id/68971037d34ef72ee44941a6/',
-                'season_number': 1,
-            },
+    _VALID_URL = r'https?://tviplayer\.iol\.pt(?:/programa/[\w-]+/[a-f0-9]+)?/\w+/(?P<id>\w+)'
+    _TESTS = [{
+        'url': 'https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120',
+        'info_dict': {
+            'id': '689683000cf20ac1d5f35341',
+            'ext': 'mp4',
+            'duration': 1593,
+            'title': 'A Protegida - Clarice descobre o que une Óscar a Gonçalo e Mónica',
+            'thumbnail': 'https://img.iol.pt/image/id/68971037d34ef72ee44941a6/',
+            'season_number': 1,
         },
-    ]
+    }]
 
     def _real_initialize(self):
-        # Obtain the wmsAuthSign token (non-fatal)
         self.wms_auth_sign_token = self._download_webpage(
-            'https://services.iol.pt/matrix?userId=',
-            'wmsAuthSign',
-            note='Downloading wmsAuthSign token',
-            fatal=False,
-        )
+            'https://services.iol.pt/matrix?userId=', 'wmsAuthSign',
+            note='Trying to get wmsAuthSign token')
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        # Try to locate a JS "video: [ {...} ]" block
         json_data = self._search_json(
             r'(?<!-)\bvideo\s*:\s*\[',
-            webpage,
-            'json_data',
-            video_id,
-            transform_source=js_to_json,
-            default={},
-        )
+            webpage, 'json_data', video_id, transform_source=js_to_json)
 
-        # Structured metadata from ld+json
-        _ = self._search_json_ld(webpage, video_id, default={}) or {}
-
-        # Merge data safely without type errors
-        def first_of(*keys):
-            for k in keys:
-                v = traverse_obj(json_data, (k,))
-                if v:
-                    return v
-            return None
-
-        info_id = first_of('id')
-        title = first_of('title') or self._og_search_title(webpage)
-        thumbnail = first_of('cover', 'thumbnail') or self._og_search_thumbnail(webpage)
-        duration = first_of('duration')
-
-        try:
-            duration = int(duration) if duration is not None else None
-        except Exception:
-            try:
-                duration = int(float(duration))
-            except Exception:
-                duration = None
-
-        video_url = first_of('videoUrl', 'url', 'video_url')
+        video_url = traverse_obj(json_data, ('videoUrl',), expected_type=url_or_none)
         if not video_url:
-            m = re.search(
-                r'["\']videoUrl["\']\s*:\s*["\'](https?://[^"\']+)["\']', webpage,
-            )
-            if m:
-                video_url = m.group(1)
+            raise ExtractorError('Unable to locate video URL in webpage')
 
-        if not video_url:
-            raise ExtractorError('Unable to locate video URL in webpage', expected=True)
-
-        query = (
-            {'wmsAuthSign': self.wms_auth_sign_token}
-            if self.wms_auth_sign_token
-            else {}
-        )
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-            video_url, video_id, ext='mp4', query=query, fatal=False,
-        )
-
-        season_number = traverse_obj(json_data, ('program', 'seasonNum'))
+            video_url, video_id, ext='mp4', query=filter_dict({
+                'wmsAuthSign': self.wms_auth_sign_token,
+            }))
 
         return {
-            'id': info_id or video_id,
+            'id': traverse_obj(json_data, ('id',)) or video_id,
             'display_id': video_id,
-            'title': title,
-            'thumbnail': thumbnail,
-            'duration': duration,
+            'title': traverse_obj(json_data, ('title',)) or self._og_search_title(webpage),
+            'thumbnail': traverse_obj(
+                json_data, ('cover',), ('thumbnail',), expected_type=url_or_none) or self._og_search_thumbnail(webpage),
+            'duration': int_or_none(traverse_obj(json_data, ('duration',))),
             'formats': formats,
             'subtitles': subtitles,
-            'season_number': season_number,
+            'season_number': traverse_obj(json_data, ('program', 'seasonNum')),
         }


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR updates the **TVI Player extractor** to reflect recent changes in the website’s API responses and HTML structure.  
It restores the ability to download both VOD and live content, which was broken due to backend and frontend updates from TVI Player.

**Main changes:**
- Updated API URL patterns and query parameters to match new backend structure.
- Adjusted parsing logic to correctly extract stream URLs from JSON responses.
- Improved error handling for unavailable, geo-restricted, or DRM-protected content.
- Confirmed compatibility with latest yt-dlp core changes.

**Test URLs:**
1. VOD example:  
   `https://tviplayer.iol.pt/programa/a-protegida/67a63479d34ef72ee441fa79/episodio/t1e120`
2. Live example:  
   `https://tviplayer.iol.pt/direto/TVI`

---

Fixes #13132

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
