### PR TITLE
[soundcloud] prefer 'x-amz-meta-file-type' for 'download' format file extension

### DIFF
--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -276,9 +276,10 @@ class SoundcloudBaseIE(InfoExtractor):
                 if urlh:
                     format_url = urlh.url
                     format_urls.add(format_url)
+                    ext = urlh.headers.get('x-amz-meta-file-type') or urlhandle_detect_ext(urlh)
                     formats.append({
                         'format_id': 'download',
-                        'ext': urlhandle_detect_ext(urlh),
+                        'ext': ext,
                         'filesize': int_or_none(urlh.headers.get('Content-Length')),
                         'url': format_url,
                         'quality': 10,


### PR DESCRIPTION


<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

The file extension for the "[Download file](https://help.soundcloud.com/hc/en-us/articles/115003448787-Downloading-tracks)" option on Soundcloud songs can sometimes be incorrect. For example, downloading [this song](https://soundcloud.com/lilbeshramko/her-smash-pt-2) in Chrome* gives "her_smash pt.2" instead of "her_smash pt.2.wav" This is because of the `Conent-Disposition` header:  
`content-disposition: attachment;filename="her%2Fsmash%20pt.2"; filename*=utf-8''her%2Fsmash%20pt.2`

*Firefox detects the MIME type and sets the correct file extension automatically.

yt-dlp fails to download the file due to this bad file extension:
```
[soundcloud] Extracting URL: https://soundcloud.com/lilbeshramko/her-smash-pt-2
[soundcloud] lilbeshramko/her-smash-pt-2: Downloading info JSON
[soundcloud] 1023096076: Downloading original download format info JSON
[soundcloud] 1023096076: Checking original download format availability
[soundcloud] 1023096076: Downloading hls_aac format info JSON
[debug] [soundcloud] Skipping broken "hls_abr" format
[soundcloud] 1023096076: Downloading hls_aac format info JSON
[soundcloud] 1023096076: Downloading http_aac format info JSON
[soundcloud] 1023096076: Downloading hls_aac format info JSON
[debug] [soundcloud] Skipping broken "hls_abr" format
[soundcloud] 1023096076: Downloading hls_mp3 format info JSON
[soundcloud] 1023096076: Downloading http_mp3 format info JSON
[soundcloud] 1023096076: Downloading hls_opus format info JSON
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec, channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 1023096076: Downloading 1 format(s): download
ERROR: The extracted extension ('2') is unusual and will be skipped for safety reasons. If you believe this is an error, please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
Traceback (most recent call last):
  File "C:\Users\owner\AppData\Local\Programs\Python\Python313\Lib\site-packages\yt_dlp\YoutubeDL.py", line 185, in wrapper
    return func(self, *args, **kwargs)
  File "C:\Users\owner\AppData\Local\Programs\Python\Python313\Lib\site-packages\yt_dlp\YoutubeDL.py", line 3526, in process_info
    dl_filename = existing_video_file(full_filename, temp_filename)
  File "C:\Users\owner\AppData\Local\Programs\Python\Python313\Lib\site-packages\yt_dlp\YoutubeDL.py", line 3418, in existing_video_file
    file = self.existing_file(itertools.chain(*zip(map(converted, filepaths), filepaths)),
                              ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\owner\AppData\Local\Programs\Python\Python313\Lib\site-packages\yt_dlp\YoutubeDL.py", line 3417, in <lambda>
    converted = lambda file: replace_extension(file, self.params.get('final_ext') or ext, ext)
                             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\owner\AppData\Local\Programs\Python\Python313\Lib\site-packages\yt_dlp\utils\_utils.py", line 2134, in _change_extension
    return f'{filename}.{_UnsafeExtensionError.sanitize_extension(ext)}'
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "C:\Users\owner\AppData\Local\Programs\Python\Python313\Lib\site-packages\yt_dlp\utils\_utils.py", line 5208, in sanitize_extension
    raise cls(extension)
```

I tried uploading a new file, and the `filename` appears to be generic now. `filename*` has an extension, but this isn't checked by [`urlhandle_detect_ext`](https://github.com/bashonly/yt-dlp/blob/f799a4b4728e54dbe0d35e604a15238c13648600/yt_dlp/utils/_utils.py#L3115)
`content-disposition: attachment;filename="SoundCloud%20Download"; filename*=utf-8''test%20pt.2.flac`

**TLDR:** `x-amz-meta-file-type` seems to be the most accurate way to get the file extension, since it's based on the actual MIME type. A FLAC source file with a `.wav` extension will have `flac` as the `x-amz-meta-file-type`, and vice versa. It fixes the download error mentioned above.

I didn't add a test for this since it would require account credentials.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
