### PR TITLE
Deprecate `linux_armv7l_exe` support

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -153,6 +153,12 @@ def _get_system_deprecation():
             f'{variant} (the PyInstaller-bundled executable for macOS versions older than 10.15)',
             'issues/13856', STOP_MSG)
 
+    # Temporary until linux_armv7l executable builds are discontinued
+    if variant in ('linux_armv7l_exe'):
+        return EXE_MSG_TMPL.format(
+            f'{variant} (the PyInstaller-bundled executable for the Linux armv7l platform)',
+            'issues/13976', STOP_MSG)
+
     if sys.version_info > MIN_RECOMMENDED:
         return None
 
@@ -161,13 +167,6 @@ def _get_system_deprecation():
 
     if sys.version_info < MIN_SUPPORTED:
         return f'Python version {major}.{minor} is no longer supported! {PYTHON_MSG}'
-
-    # Temporary until aarch64/armv7l build flow is bumped to Ubuntu 22.04 and Python 3.10
-    if variant in ('linux_aarch64_exe', 'linux_armv7l_exe'):
-        libc_ver = version_tuple(os.confstr('CS_GNU_LIBC_VERSION').partition(' ')[2])
-        if libc_ver < (2, 35):
-            return EXE_MSG_TMPL.format('system glibc version < 2.35', 'issues/13858', STOP_MSG)
-        return None
 
     return f'Support for Python version {major}.{minor} has been deprecated. {PYTHON_MSG}'
 


### PR DESCRIPTION
Ref: https://github.com/yt-dlp/yt-dlp/issues/13976


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Maintenance
</details>
