### PR TITLE
[pp/XAttrMetadata] Only set "Where From" attribute on macOS

### DIFF
--- a/yt_dlp/postprocessor/xattrpp.py
+++ b/yt_dlp/postprocessor/xattrpp.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from .common import PostProcessor
 from ..utils import (
@@ -54,8 +55,8 @@ class XAttrMetadataPP(PostProcessor):
                     if infoname == 'upload_date':
                         value = hyphenate_date(value)
                     elif xattrname == 'com.apple.metadata:kMDItemWhereFroms':
-                        # NTFS ADS doesn't support colons in names
-                        if os.name == 'nt':
+                        # Colon in xattr name throws errors on Windows/NTFS and Linux
+                        if sys.platform != 'darwin':
                             continue
                         value = self.APPLE_PLIST_TEMPLATE % value
                     write_xattr(info['filepath'], xattrname, value.encode())


### PR DESCRIPTION
Fixes a regression introduced in 3e918d825d7ff367812658957b281b8cda8f9ebb

Closes #14004

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
