### PR TITLE
Better windows lookalike chars

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -802,7 +802,7 @@ class TestYoutubeDL(unittest.TestCase):
         test('%(id)s', '-abcd', info={'id': '-abcd'})
         test('%(id)s', '.abcd', info={'id': '.abcd'})
         test('%(id)s', 'ab__cd', info={'id': 'ab__cd'})
-        test('%(id)s', ('ab:cd', 'ab：cd'), info={'id': 'ab:cd'})
+        test('%(id)s', ('ab:cd', 'ab։cd'), info={'id': 'ab:cd'})
         test('%(id.0)s', '-', info={'id': '--'})
 
         # Invalid templates
@@ -861,7 +861,7 @@ class TestYoutubeDL(unittest.TestCase):
         test('%(formats)j', (json.dumps(FORMATS), None))
         test('%(formats)#j', (
             json.dumps(FORMATS, indent=4),
-            json.dumps(FORMATS, indent=4).replace(':', '：').replace('"', '＂').replace('\n', ' '),
+            json.dumps(FORMATS, indent=4).replace(':', '։').replace('"', '″').replace('\n', ' '),
         ))
         test('%(title5).3B', 'á')
         test('%(title5)U', 'áéí 𝐀')
@@ -872,13 +872,13 @@ class TestYoutubeDL(unittest.TestCase):
         test('%(filesize)#D', '1Ki')
         test('%(height)5.2D', ' 1.08k')
         test('%(title4)#S', 'foo_bar_test')
-        test('%(title4).10S', ('foo ＂bar＂ ', 'foo ＂bar＂' + ('#' if os.name == 'nt' else ' ')))
+        test('%(title4).10S', ('foo ″bar″ ', 'foo ″bar″' + ('#' if os.name == 'nt' else ' ')))
         if os.name == 'nt':
             test('%(title4)q', ('"foo ""bar"" test"', None))
             test('%(formats.:.id)#q', ('"id 1" "id 2" "id 3"', None))
             test('%(formats.0.id)#q', ('"id 1"', None))
         else:
-            test('%(title4)q', ('\'foo "bar" test\'', '\'foo ＂bar＂ test\''))
+            test('%(title4)q', ('\'foo "bar" test\'', '\'foo ″bar″ test\''))
             test('%(formats.:.id)#q', "'id 1' 'id 2' 'id 3'")
             test('%(formats.0.id)#q', "'id 1'")
 
@@ -903,7 +903,7 @@ class TestYoutubeDL(unittest.TestCase):
                           for f in FORMATS])
         test('%(formats.:.{id,height.:2})j', (out, None))
         test('%(formats.:.{id,height}.id)l', ', '.join(f['id'] for f in FORMATS))
-        test('%(.{id,title})j', ('{"id": "1234"}', '{＂id＂： ＂1234＂}'))
+        test('%(.{id,title})j', ('{"id": "1234"}', '{″id″։ ″1234″}'))
 
         # Alternates
         test('%(title,id)s', '1234')

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -639,8 +639,18 @@ def sanitize_filename(s, restricted=False, is_id=NO_DEFAULT):
         elif not restricted and char == '\n':
             return '\0 '
         elif is_id is NO_DEFAULT and not restricted and char in '"*:<>?|/\\':
-            # Replace with their full-width unicode counterparts
-            return {'/': '\u29F8', '\\': '\u29f9'}.get(char, chr(ord(char) + 0xfee0))
+            # Replace with lookalike characters
+            return {
+                '"': '\u2033',
+                '*': '\uA60E',
+                ':': '\u0589',
+                '<': '\u227A',
+                '>': '\u227B',
+                '?': '\uFF1F',
+                '|': '\u01C0',
+                '/': '\u29F8',
+                '\\': '\u29f9',
+            }[char]
         elif char == '?' or ord(char) < 32 or ord(char) == 127:
             return ''
         elif char == '"':


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Changes the unicode lookalike characters used for Windows filenames to achieve a better fit.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

The first folder has the current characters, the second folder has the new characters.

Note: this is a duplicate of #11749 which I accidentally closed by deleting the fork.

![image](https://github.com/user-attachments/assets/8968a885-1e3b-4177-be9d-3ec8d5e06b02)

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement
</details>
