### PR TITLE
Southpark de fix

### DIFF
--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -111,14 +111,13 @@ class SouthParkDeIE(SouthParkIE):  # XXX: Do not subclass from concrete IE
         data = self._parse_json(self._search_regex(
             r'window\.__DATA__\s*=\s*({.+?});', webpage, 'data'), display_id)
 
-        # Try multiple paths to find the video data, handling both regular and special episodes
-        video_detail = traverse_obj(data, [
-            # Path for regular episodes (more complex)
+        # CORRECTED: Provide paths as separate arguments, not a list
+        video_detail = traverse_obj(data,
+            # Path for regular episodes
             ('children', lambda _, v: v.get('type') == 'MainContainer',
              'children', 0, 'children', 0, 'props', 'videoDetail'),
-            # Fallback path for special episodes (simpler)
-            ('children', 0, 'videoDetail'),
-        ])
+            # Fallback path for special episodes
+            ('children', 0, 'videoDetail'))
 
         if not video_detail:
             raise ExtractorError('Could not find video data in page')

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -1,9 +1,5 @@
 from .mtv import MTVServicesInfoExtractor
-from ..utils import (
-    random_uuidv4,
-    traverse_obj,
-    ExtractorError, # Added ExtractorError import
-)
+from ..utils import random_uuidv4, traverse_obj, ExtractorError
 
 
 class SouthParkIE(MTVServicesInfoExtractor):
@@ -114,7 +110,7 @@ class SouthParkDeIE(SouthParkIE):  # XXX: Do not subclass from concrete IE
         video_detail = traverse_obj(data, (
             'children', lambda _, v: v.get('type') == 'MainContainer',
             'children', 0, 'children', 0, 'props', 'videoDetail'
-        ), ('children', 0, 'videoDetail'), get_all=False)
+        ), ('children', 0, 'videoDetail'), get_all=False,)
 
         if not video_detail:
             raise ExtractorError('Could not find video data in page')

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -1,5 +1,5 @@
-from ..utils import random_uuidv4, traverse_obj, ExtractorError
 from .mtv import MTVServicesInfoExtractor
+from ..utils import ExtractorError, random_uuidv4, traverse_obj
 
 
 class SouthParkIE(MTVServicesInfoExtractor):

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -2,6 +2,7 @@ from .mtv import MTVServicesInfoExtractor
 from ..utils import (
     random_uuidv4,
     traverse_obj,
+    ExtractorError, # Added ExtractorError import
 )
 
 

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -1,5 +1,5 @@
-from .mtv import MTVServicesInfoExtractor
 from ..utils import random_uuidv4, traverse_obj, ExtractorError
+from .mtv import MTVServicesInfoExtractor
 
 
 class SouthParkIE(MTVServicesInfoExtractor):
@@ -107,10 +107,15 @@ class SouthParkDeIE(SouthParkIE):  # XXX: Do not subclass from concrete IE
         data = self._parse_json(self._search_regex(
             r'window\.__DATA__\s*=\s*({.+?});', webpage, 'data'), display_id)
 
-        video_detail = traverse_obj(data, (
-            'children', lambda _, v: v.get('type') == 'MainContainer',
-            'children', 0, 'children', 0, 'props', 'videoDetail'
-        ), ('children', 0, 'videoDetail'), get_all=False,)
+        video_detail = traverse_obj(
+            data,
+            # Path for regular episodes
+            ('children', lambda _, v: v.get('type') == 'MainContainer',
+             'children', 0, 'children', 0, 'props', 'videoDetail'),
+            # Fallback path for special episodes
+            ('children', 0, 'videoDetail'),
+            get_all=False,
+        )
 
         if not video_detail:
             raise ExtractorError('Could not find video data in page')

--- a/yt_dlp/extractor/southpark.py
+++ b/yt_dlp/extractor/southpark.py
@@ -111,13 +111,14 @@ class SouthParkDeIE(SouthParkIE):  # XXX: Do not subclass from concrete IE
         data = self._parse_json(self._search_regex(
             r'window\.__DATA__\s*=\s*({.+?});', webpage, 'data'), display_id)
 
-        # CORRECTED: Provide paths as separate arguments, not a list
+        # Try multiple paths and, crucially, get only the FIRST match, not a list
         video_detail = traverse_obj(data,
             # Path for regular episodes
             ('children', lambda _, v: v.get('type') == 'MainContainer',
              'children', 0, 'children', 0, 'props', 'videoDetail'),
             # Fallback path for special episodes
-            ('children', 0, 'videoDetail'))
+            ('children', 0, 'videoDetail'),
+            get_all=False)
 
         if not video_detail:
             raise ExtractorError('Could not find video data in page')
@@ -130,7 +131,7 @@ class SouthParkDeIE(SouthParkIE):  # XXX: Do not subclass from concrete IE
                 'clientPlatform': 'mobile',
             })
 
-        hls_url = traverse_obj(api_data, ('stitchedstream', 'source'), expected_type=str)
+        hls_url = traverse_obj(api_data, ('stitchedstream', 'source'), expected_type=str, get_all=False)
 
         return {
             'id': video_detail['id'],


### PR DESCRIPTION
### Description of your *pull request* and other information

The extractor for `southpark.de` is broken as the site no longer uses the old MTV feed system and has moved to a JavaScript-based data object for its player.

This commit updates the `SouthParkDeIE` extractor to use the modern extraction method:
- It scrapes the `window.__DATA__` object from the page's HTML instead of relying on an external feed.
- It robustly handles multiple page layouts (e.g., for regular episodes and special episodes like "The Pandemic Special") by using fallback paths with `traverse_obj`.
- It calls the Topaz API (`videoServiceUrl`) found within the page data to get the final video manifest.
- It correctly identifies the HLS stream URL from the API's JSON response and passes it to the downloader.
- The new implementation successfully downloads episodes and specials from `southpark.de` again.

Fixes #2621


<details open><summary>Template</summary> ### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>