### PR TITLE
SVT sv-forced subtitles for forced subtitles

### DIFF
--- a/yt_dlp/extractor/svt.py
+++ b/yt_dlp/extractor/svt.py
@@ -88,7 +88,7 @@ class SVTBaseIE(InfoExtractor):
             'id': video_id,
             'title': title,
             'formats': formats,
-            'subtitles': subtitles,
+            'subtitles': self._fixup_subtitles(subtitles),
             'duration': duration,
             'timestamp': timestamp,
             'age_limit': age_limit,
@@ -98,6 +98,16 @@ class SVTBaseIE(InfoExtractor):
             'episode_number': episode_number,
             'is_live': is_live,
         }
+
+    @staticmethod
+    def _fixup_subtitles(subtitles):
+        # See: https://github.com/yt-dlp/yt-dlp/issues/14020
+        fixed_subtitles = {}
+        for lang, subs in subtitles.items():
+            for sub in subs:
+                fixed_lang = f'{lang}-forced' if 'text-open' in sub['url'] else lang
+                fixed_subtitles.setdefault(fixed_lang, []).append(sub)
+        return fixed_subtitles
 
 
 class SVTPlayIE(SVTBaseIE):
@@ -115,6 +125,26 @@ class SVTPlayIE(SVTBaseIE):
                     )
                     '''
     _TESTS = [{
+        'url': 'https://www.svtplay.se/video/eXYgwZb/sverige-och-kriget/1-utbrottet',
+        'md5': '2382036fd6f8c994856c323fe51c426e',
+        'info_dict': {
+            'id': 'ePBvGRq',
+            'ext': 'mp4',
+            'title': '1. Utbrottet',
+            'description': 'md5:02291cc3159dbc9aa95d564e77a8a92b',
+            'series': 'Sverige och kriget',
+            'episode': '1. Utbrottet',
+            'timestamp': 1746921600,
+            'upload_date': '20250511',
+            'duration': 3585,
+            'thumbnail': r're:^https?://(?:.*[\.-]jpg|www.svtstatic.se/image/.*)$',
+            'age_limit': 0,
+            'subtitles': {'sv': 'count:3', 'sv-forced': 'count:3'},
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }, {
         'url': 'https://www.svtplay.se/video/30479064',
         'md5': '2382036fd6f8c994856c323fe51c426e',
         'info_dict': {


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR improves the `SVTPlay` extractor to differentiate between *forced* subtitles and closed caption/SDH. In the same fashion as the [SBS extractor](https://github.com/yt-dlp/yt-dlp/blob/404bd889d0e0b62ad72b7281e3fefdc0497080b3/yt_dlp/extractor/sbs.py#L131) and the [Arte extractor](https://github.com/yt-dlp/yt-dlp/blob/404bd889d0e0b62ad72b7281e3fefdc0497080b3/yt_dlp/extractor/arte.py#L137), it adds "-forced" after the language code. This means that by default, the language subtitles that are downloaded are the closed caption ones. 

Fixes #14020 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
