### PR TITLE
[utils] `find_element`: Accept empty strings for class values

### DIFF
--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -45,6 +45,7 @@ _TEST_HTML = '''<html><body>
     <div class="b" data-id="y" custom="z">3</div>
     <p class="a">4</p>
     <p id="d" custom="e">5</p>
+    <p class="">123</p>
 </body></html>'''
 
 
@@ -593,6 +594,7 @@ class TestTraversalHelpers:
         assert find_element(attr='data-id', value='y(?:es)?', regex=True)(_TEST_HTML) == '3'
         assert find_element(
             attr='data-id', value='y', html=True)(_TEST_HTML) == '<div class="b" data-id="y" custom="z">3</div>'
+        assert find_element(cls='')(_TEST_HTML) == '123'
 
     def test_find_elements(self):
         for improper_kwargs in [

--- a/yt_dlp/utils/traversal.py
+++ b/yt_dlp/utils/traversal.py
@@ -397,16 +397,16 @@ def find_element(*, tag: str, html=False, regex=False): ...
 
 def find_element(*, tag=None, id=None, cls=None, attr=None, value=None, html=False, regex=False):
     # deliberately using `id=` and `cls=` for ease of readability
-    assert tag or id or cls or (attr and value), 'One of tag, id, cls or (attr AND value) is required'
+    assert tag or id or cls is not None or (attr and value), 'One of tag, id, cls or (attr AND value) is required'
     ANY_TAG = r'[\w:.-]+'
 
     if attr and value:
-        assert not cls, 'Cannot match both attr and cls'
+        assert cls is None, 'Cannot match both attr and cls'
         assert not id, 'Cannot match both attr and id'
         func = get_element_html_by_attribute if html else get_element_by_attribute
         return functools.partial(func, attr, value, tag=tag or ANY_TAG, escape_value=not regex)
 
-    elif cls:
+    elif cls is not None:
         assert not id, 'Cannot match both cls and id'
         assert tag is None, 'Cannot match both cls and tag'
         assert not regex, 'Cannot use regex with cls'


### PR DESCRIPTION
Would benefit #13369

I attempted to do the same for an attribute's `value`, but it's not possible with the current implementation of `get_elements_text_and_html_by_attribute`, which I don't want to touch.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
