### PR TITLE
[utils] Add improved `jwt_encode` function 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,7 @@ banned-from = [
 "yt_dlp.utils.error_to_compat_str".msg = "Use `str` instead."
 "yt_dlp.utils.bytes_to_intlist".msg = "Use `list` instead."
 "yt_dlp.utils.intlist_to_bytes".msg = "Use `bytes` instead."
+"yt_dlp.utils.jwt_encode_hs256".msg = "Use `yt_dlp.utils.jwt_encode` instead."
 "yt_dlp.utils.decodeArgument".msg = "Do not use"
 "yt_dlp.utils.decodeFilename".msg = "Do not use"
 "yt_dlp.utils.encodeFilename".msg = "Do not use"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -71,6 +71,8 @@ from yt_dlp.utils import (
     iri_to_uri,
     is_html,
     js_to_json,
+    jwt_decode_hs256,
+    jwt_encode_hs256,
     limit_length,
     locked_file,
     lowercase_escape,
@@ -2179,6 +2181,25 @@ Line 1
         assert int_or_none(10, scale=0.1) == 100, 'positionally passed argument should call function'
         assert int_or_none(v=10) == 10, 'keyword passed positional should call function'
         assert int_or_none(scale=0.1)(10) == 100, 'call after partial application should call the function'
+
+    _JWT_KEY = '12345678'
+    _JWT_HEADERS = {'a': 'b'}
+    _JWT_DECODED = {
+        'foo': 'bar',
+        'qux': 'baz',
+    }
+    _JWT_UNSAFE_WITH_WHITESPACE = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIiwgInF1eCI6ICJiYXoifQ==.vxdOBui/tWcdlkzmERQBTF90PlRx5yfqbwGvYPPqYmU='
+    _JWT_UNSAFE_WITH_WHITESPACE_AND_HEADERS = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCIsICJhIjogImIifQ==.eyJmb28iOiAiYmFyIiwgInF1eCI6ICJiYXoifQ==.S1Aa5AB5BlSlc7Ohm7qR0ePuvw4meHQWxZWAD2I1plg='
+
+    def test_jwt_encode_hs256(self):
+        def test(inp, expected, headers={}):
+            self.assertEqual(jwt_encode_hs256(inp, self._JWT_KEY, headers), expected)
+
+        test(self._JWT_DECODED, self._JWT_UNSAFE_WITH_WHITESPACE.encode())
+        test(self._JWT_DECODED, self._JWT_UNSAFE_WITH_WHITESPACE_AND_HEADERS.encode(), headers=self._JWT_HEADERS)
+
+    def test_jwt_decode_hs256(self):
+        self.assertEqual(jwt_decode_hs256(self._JWT_UNSAFE_WITH_WHITESPACE), self._JWT_DECODED)
 
 
 if __name__ == '__main__':

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -73,7 +73,7 @@ from yt_dlp.utils import (
     js_to_json,
     jwt_decode_hs256,
     jwt_encode,
-    jwt_encode_hs256,
+    jwt_encode_hs256,  # noqa: TID251
     limit_length,
     locked_file,
     lowercase_escape,

--- a/yt_dlp/extractor/atvat.py
+++ b/yt_dlp/extractor/atvat.py
@@ -4,7 +4,7 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     float_or_none,
-    jwt_encode_hs256,
+    jwt_encode,
     try_get,
 )
 
@@ -83,7 +83,7 @@ class ATVAtIE(InfoExtractor):
             'nbf': int(not_before.timestamp()),
             'exp': int(expire.timestamp()),
         }
-        jwt_token = jwt_encode_hs256(payload, self._ENCRYPTION_KEY, headers={'kid': self._ACCESS_ID})
+        jwt_token = jwt_encode(payload, self._ENCRYPTION_KEY, headers={'kid': self._ACCESS_ID})
         videos = self._download_json(
             'https://vas-v4.p7s1video.net/4.0/getsources',
             content_id, 'Downloading videos JSON', query={

--- a/yt_dlp/extractor/vrt.py
+++ b/yt_dlp/extractor/vrt.py
@@ -14,7 +14,7 @@ from ..utils import (
     get_element_html_by_class,
     int_or_none,
     jwt_decode_hs256,
-    jwt_encode_hs256,
+    jwt_encode,
     make_archive_id,
     merge_dicts,
     parse_age_limit,
@@ -98,7 +98,7 @@ class VRTBaseIE(InfoExtractor):
                 'Content-Type': 'application/json',
             }, data=json.dumps({
                 'identityToken': id_token or '',
-                'playerInfo': jwt_encode_hs256(player_info, self._JWT_SIGNING_KEY, headers={
+                'playerInfo': jwt_encode(player_info, self._JWT_SIGNING_KEY, headers={
                     'kid': self._JWT_KEY_ID,
                 }).decode(),
             }, separators=(',', ':')).encode())['vrtPlayerToken']

--- a/yt_dlp/utils/_deprecated.py
+++ b/yt_dlp/utils/_deprecated.py
@@ -1,4 +1,8 @@
 """Deprecated - New code should avoid these"""
+import base64
+import hashlib
+import hmac
+import json
 import warnings
 
 from ..compat.compat_utils import passthrough_module
@@ -26,6 +30,20 @@ def intlist_to_bytes(xs):
     if not xs:
         return b''
     return struct.pack('%dB' % len(xs), *xs)
+
+
+def jwt_encode_hs256(payload_data, key, headers={}):
+    header_data = {
+        'alg': 'HS256',
+        'typ': 'JWT',
+    }
+    if headers:
+        header_data.update(headers)
+    header_b64 = base64.b64encode(json.dumps(header_data).encode())
+    payload_b64 = base64.b64encode(json.dumps(payload_data).encode())
+    h = hmac.new(key.encode(), header_b64 + b'.' + payload_b64, hashlib.sha256)
+    signature_b64 = base64.b64encode(h.digest())
+    return header_b64 + b'.' + payload_b64 + b'.' + signature_b64
 
 
 compiled_regex_type = type(re.compile(''))

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4765,6 +4765,7 @@ def jwt_encode(payload_data, key, *, alg='HS256', headers=None):
     payload_b64 = jwt_b64encode(jwt_json_bytes(payload_data))
     h = hmac.new(key.encode(), header_b64 + b'.' + payload_b64, hashlib.sha256)
 
+    # XXX: Should we return bytes or str? Old impl returned bytes
     return header_b64 + b'.' + payload_b64 + b'.' + jwt_b64encode(h.digest())
 
 

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4739,22 +4739,39 @@ def time_seconds(**kwargs):
     return time.time() + dt.timedelta(**kwargs).total_seconds()
 
 
-# create a JSON Web Signature (jws) with HS256 algorithm
-# the resulting format is in JWS Compact Serialization
 # implemented following JWT https://www.rfc-editor.org/rfc/rfc7519.html
 # implemented following JWS https://www.rfc-editor.org/rfc/rfc7515.html
-def jwt_encode_hs256(payload_data, key, headers={}):
+def jwt_encode(payload_data, key, *, alg='HS256', headers=None, _urlsafe=True, _no_whitespace=True, _rstrip=True):
+    assert alg in ('HS256',), f'Unsupported algorithm "{alg}"'
+
+    def jwt_json_bytes(obj):
+        return json.dumps(obj, separators=(',', ':') if _no_whitespace else None)
+
+    def jwt_b64encode(bytestring):
+        encoder = base64.urlsafe_b64encode if _urlsafe else base64.b64encode
+        return encoder(bytestring).rstrip(b'=') if _rstrip else encoder(bytestring)
+
     header_data = {
-        'alg': 'HS256',
+        'alg': alg,
         'typ': 'JWT',
     }
     if headers:
-        header_data.update(headers)
-    header_b64 = base64.b64encode(json.dumps(header_data).encode())
-    payload_b64 = base64.b64encode(json.dumps(payload_data).encode())
+        # Allow re-ordering of keys if both 'alg' and 'typ' are present
+        if 'alg' in headers and 'typ' in headers:
+            header_data = headers
+        else:
+            header_data.update(headers)
+
+    header_b64 = jwt_b64encode(jwt_json_bytes(header_data).encode())
+    payload_b64 = jwt_b64encode(jwt_json_bytes(payload_data).encode())
     h = hmac.new(key.encode(), header_b64 + b'.' + payload_b64, hashlib.sha256)
-    signature_b64 = base64.b64encode(h.digest())
-    return header_b64 + b'.' + payload_b64 + b'.' + signature_b64
+
+    return header_b64 + b'.' + payload_b64 + b'.' + jwt_b64encode(h.digest())
+
+
+def jwt_encode_hs256(payload_data, key, headers={}):
+    # TODO: Deprecate
+    return jwt_encode(payload_data, key, headers=headers, _urlsafe=False, _no_whitespace=False, _rstrip=False)
 
 
 # can be extended in future to verify the signature and parse header and return the algorithm used if it's not HS256

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4768,21 +4768,6 @@ def jwt_encode(payload_data, key, *, alg='HS256', headers=None):
     return header_b64 + b'.' + payload_b64 + b'.' + jwt_b64encode(h.digest())
 
 
-def jwt_encode_hs256(payload_data, key, headers={}):
-    # TODO: Deprecate
-    header_data = {
-        'alg': 'HS256',
-        'typ': 'JWT',
-    }
-    if headers:
-        header_data.update(headers)
-    header_b64 = base64.b64encode(json.dumps(header_data).encode())
-    payload_b64 = base64.b64encode(json.dumps(payload_data).encode())
-    h = hmac.new(key.encode(), header_b64 + b'.' + payload_b64, hashlib.sha256)
-    signature_b64 = base64.b64encode(h.digest())
-    return header_b64 + b'.' + payload_b64 + b'.' + signature_b64
-
-
 # can be extended in future to verify the signature and parse header and return the algorithm used if it's not HS256
 def jwt_decode_hs256(jwt):
     header_b64, payload_b64, signature_b64 = jwt.split('.')

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4741,15 +4741,14 @@ def time_seconds(**kwargs):
 
 # implemented following JWT https://www.rfc-editor.org/rfc/rfc7519.html
 # implemented following JWS https://www.rfc-editor.org/rfc/rfc7515.html
-def jwt_encode(payload_data, key, *, alg='HS256', headers=None, _urlsafe=True, _no_whitespace=True, _rstrip=True):
+def jwt_encode(payload_data, key, *, alg='HS256', headers=None):
     assert alg in ('HS256',), f'Unsupported algorithm "{alg}"'
 
     def jwt_json_bytes(obj):
-        return json.dumps(obj, separators=(',', ':') if _no_whitespace else None)
+        return json.dumps(obj, separators=(',', ':')).encode()
 
     def jwt_b64encode(bytestring):
-        encoder = base64.urlsafe_b64encode if _urlsafe else base64.b64encode
-        return encoder(bytestring).rstrip(b'=') if _rstrip else encoder(bytestring)
+        return base64.urlsafe_b64encode(bytestring).rstrip(b'=')
 
     header_data = {
         'alg': alg,
@@ -4762,8 +4761,8 @@ def jwt_encode(payload_data, key, *, alg='HS256', headers=None, _urlsafe=True, _
         else:
             header_data.update(headers)
 
-    header_b64 = jwt_b64encode(jwt_json_bytes(header_data).encode())
-    payload_b64 = jwt_b64encode(jwt_json_bytes(payload_data).encode())
+    header_b64 = jwt_b64encode(jwt_json_bytes(header_data))
+    payload_b64 = jwt_b64encode(jwt_json_bytes(payload_data))
     h = hmac.new(key.encode(), header_b64 + b'.' + payload_b64, hashlib.sha256)
 
     return header_b64 + b'.' + payload_b64 + b'.' + jwt_b64encode(h.digest())
@@ -4771,7 +4770,17 @@ def jwt_encode(payload_data, key, *, alg='HS256', headers=None, _urlsafe=True, _
 
 def jwt_encode_hs256(payload_data, key, headers={}):
     # TODO: Deprecate
-    return jwt_encode(payload_data, key, headers=headers, _urlsafe=False, _no_whitespace=False, _rstrip=False)
+    header_data = {
+        'alg': 'HS256',
+        'typ': 'JWT',
+    }
+    if headers:
+        header_data.update(headers)
+    header_b64 = base64.b64encode(json.dumps(header_data).encode())
+    payload_b64 = base64.b64encode(json.dumps(payload_data).encode())
+    h = hmac.new(key.encode(), header_b64 + b'.' + payload_b64, hashlib.sha256)
+    signature_b64 = base64.b64encode(h.digest())
+    return header_b64 + b'.' + payload_b64 + b'.' + signature_b64
 
 
 # can be extended in future to verify the signature and parse header and return the algorithm used if it's not HS256


### PR DESCRIPTION
Deprecates the incorrectly implemented `jwt_encode_hs256` util and replaces it with an improved `jwt_encode` function.

Problems with the original `jwt_encode_hs256` implementation:
- It encodes with `base64.b64encode` (wrong) instead of `base64.urlsafe_b64encode`
- It doesn't strip trailing `=`s from the encoded token segments (wrong)
- It leaves whitespace in the JSON (not exactly wrong, but most real world implementations don't do this)
- It doesn't allow changing the header order of `alg` and `typ` (annoying)

`jwt_encode` fixes all of the above problems, and has an algorithm-agnostic name and extensible signature.

The new implementation can be particularly useful when we need an identical JWT string, e.g. https://github.com/yt-dlp/yt-dlp/pull/13229#discussion_r2283684628

This PR also adds tests for all the JWT utils, for which there weren't any before.

The old `jwt_encode_hs256` returns bytes instead of a string, and this is the one questionable behavior I retained in the new implementation. I'm open to changing it though.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
