### PR TITLE
Add support for multi-part playlists on NZOnScreen

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1408,7 +1408,10 @@ from .nytimes import (
     NYTimesIE,
 )
 from .nzherald import NZHeraldIE
-from .nzonscreen import NZOnScreenIE
+from .nzonscreen import (
+    NZOnScreenIE,
+    NZOnScreenVideoIE,
+)
 from .nzz import NZZIE
 from .odkmedia import OnDemandChinaEpisodeIE
 from .odnoklassniki import OdnoklassnikiIE

--- a/yt_dlp/extractor/nzonscreen.py
+++ b/yt_dlp/extractor/nzonscreen.py
@@ -39,7 +39,7 @@ class NZOnScreenVideoIE(InfoExtractor):
                 raise ExtractorError('Failed to get video data')
 
         except Exception as e:
-            raise ExtractorError(f'Failed to extract video {uuid}: {str(e)}')
+            raise ExtractorError(f'Failed to extract video {uuid}: {e!s}')
 
         return {
             'id': uuid,

--- a/yt_dlp/extractor/nzonscreen.py
+++ b/yt_dlp/extractor/nzonscreen.py
@@ -41,11 +41,20 @@ class NZOnScreenVideoIE(InfoExtractor):
         except Exception as e:
             raise ExtractorError(f'Failed to extract video {uuid}: {e!s}')
 
+        # Get webpage for alt_title extraction
+        webpage = self._download_webpage(f'https://www.nzonscreen.com/title/{display_id}', uuid, fatal=False)
+        alt_title = None
+        if webpage:
+            alt_title = strip_or_none(remove_end(
+                self._html_extract_title(webpage, default=None) or self._og_search_title(webpage, default=None),
+                ' | NZ On Screen'))
+
         return {
             'id': uuid,
             'display_id': display_id,
             'title': strip_or_none(playlist.get('label')),
             'description': strip_or_none(playlist.get('description')),
+            'alt_title': alt_title,
             'thumbnail': traverse_obj(playlist, ('thumbnail', 'path')),
             'duration': float_or_none(playlist.get('duration')),
             'formats': self._extract_formats(playlist, uuid),

--- a/yt_dlp/extractor/nzonscreen.py
+++ b/yt_dlp/extractor/nzonscreen.py
@@ -1,5 +1,6 @@
 from .common import InfoExtractor
 from ..utils import (
+    ExtractorError,
     float_or_none,
     int_or_none,
     remove_end,
@@ -7,6 +8,70 @@ from ..utils import (
     traverse_obj,
     url_or_none,
 )
+
+
+class NZOnScreenVideoIE(InfoExtractor):
+    """Extract individual video with fresh URLs"""
+    _VALID_URL = r'nzonscreen:video:(?P<id>[^:]+):(?P<uuid>[a-f0-9]+)'
+
+    def _real_extract(self, url):
+        mobj = self._match_valid_url(url)
+        display_id = mobj.group('id')
+        uuid = mobj.group('uuid')
+
+        # Fetch fresh video data to get non-expired URLs
+        try:
+            video_data = self._download_json(
+                f'https://www.nzonscreen.com/html5/video_data/{display_id}',
+                uuid, note=f'Downloading fresh video data for {uuid}', fatal=False)
+
+            if video_data and isinstance(video_data, list):
+                # Find the specific video by UUID
+                playlist = None
+                for video in video_data:
+                    if video.get('uuid') == uuid:
+                        playlist = video
+                        break
+
+                if not playlist:
+                    raise ExtractorError(f'Video {uuid} not found in playlist')
+            else:
+                raise ExtractorError('Failed to get video data')
+
+        except Exception as e:
+            raise ExtractorError(f'Failed to extract video {uuid}: {str(e)}')
+
+        return {
+            'id': uuid,
+            'display_id': display_id,
+            'title': strip_or_none(playlist.get('label')),
+            'description': strip_or_none(playlist.get('description')),
+            'thumbnail': traverse_obj(playlist, ('thumbnail', 'path')),
+            'duration': float_or_none(playlist.get('duration')),
+            'formats': self._extract_formats(playlist, uuid),
+            'http_headers': {
+                'Referer': 'https://www.nzonscreen.com/',
+                'Origin': 'https://www.nzonscreen.com/',
+            },
+        }
+
+    def _extract_formats(self, playlist, video_id):
+        # Extract fresh stream URLs to avoid expiration issues
+        formats = []
+        for quality, (id_, url) in enumerate(traverse_obj(
+                playlist, ('h264', {'lo': 'lo_res', 'hi': 'hi_res'}), expected_type=url_or_none).items()):
+            if not url:
+                continue
+            formats.append({
+                'url': url,
+                'format_id': id_,
+                'ext': 'mp4',
+                'quality': quality,
+                'height': int_or_none(playlist.get('height')) if id_ == 'hi' else None,
+                'width': int_or_none(playlist.get('width')) if id_ == 'hi' else None,
+                'filesize_approx': float_or_none(traverse_obj(playlist, ('h264', f'{id_}_res_mb')), invscale=1024**2),
+            })
+        return formats
 
 
 class NZOnScreenIE(InfoExtractor):
@@ -53,12 +118,110 @@ class NZOnScreenIE(InfoExtractor):
             'thumbnail': r're:https://www\.nzonscreen\.com/content/images/.+\.jpg',
         },
         'params': {'skip_download': 'm3u8'},
+    }, {
+        # Multiple videos (trailer + full length)
+        'url': 'https://www.nzonscreen.com/title/the-deadly-ponies-gang-2013',
+        'info_dict': {
+            'id': 'the-deadly-ponies-gang-2013',
+            'title': 'The Deadly Ponies Gang | Film',
+        },
+        'playlist_count': 2,
+        'params': {'skip_download': 'm3u8'},
     }]
 
-    def _extract_formats(self, playlist):
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        # Try to get multiple videos from the video_data endpoint first
+        try:
+            video_data = self._download_json(
+                f'https://www.nzonscreen.com/html5/video_data/{video_id}', video_id,
+                note='Downloading video data', fatal=False)
+
+            if video_data and isinstance(video_data, list) and len(video_data) > 1:
+                # Multiple videos found, return a playlist with fresh URL delegation
+                # Each playlist entry delegates to NZOnScreenVideoIE for fresh URLs
+                entries = []
+                for video in video_data:
+                    uuid = video.get('uuid')
+                    if not uuid:
+                        continue
+                    entries.append({
+                        '_type': 'url_transparent',
+                        'url': f'nzonscreen:video:{video_id}:{uuid}',
+                        'ie_key': 'NZOnScreenVideo',
+                        'id': uuid,
+                        'title': strip_or_none(video.get('label')),
+                        'description': strip_or_none(video.get('description')),
+                        'thumbnail': traverse_obj(video, ('thumbnail', 'path')),
+                        'duration': float_or_none(video.get('duration')),
+                    })
+
+                # Get page title for the playlist
+                page_title = strip_or_none(remove_end(
+                    self._html_extract_title(webpage, default=None) or self._og_search_title(webpage),
+                    ' | NZ On Screen'))
+
+                return self.playlist_result(entries, video_id, page_title)
+
+            elif video_data and isinstance(video_data, list) and len(video_data) == 1:
+                # Single video from API - delegate to video extractor for fresh URLs
+                uuid = video_data[0].get('uuid')
+                if uuid:
+                    return {
+                        '_type': 'url_transparent',
+                        'url': f'nzonscreen:video:{video_id}:{uuid}',
+                        'ie_key': 'NZOnScreenVideo',
+                    }
+                playlist = video_data[0]
+            else:
+                # Fallback to original method
+                raise ExtractorError('No video data from API')
+
+        except Exception:
+            # Fallback to original extraction method
+            playlist = self._parse_json(self._html_search_regex(
+                r'data-video-config=\'([^\']+)\'', webpage, 'media data'), video_id)
+
+            # For fallback, also delegate to video extractor for fresh URLs
+            uuid = playlist.get('uuid')
+            if uuid:
+                return {
+                    '_type': 'url_transparent',
+                    'url': f'nzonscreen:video:{video_id}:{uuid}',
+                    'ie_key': 'NZOnScreenVideo',
+                    'title': strip_or_none(remove_end(
+                        self._html_extract_title(webpage, default=None) or self._og_search_title(webpage),
+                        ' | NZ On Screen')),
+                }
+
+            # Final fallback - extract directly but this may have expired URLs
+            return {
+                'id': uuid or video_id,
+                'display_id': video_id,
+                'title': strip_or_none(playlist.get('label')),
+                'description': strip_or_none(playlist.get('description')),
+                'alt_title': strip_or_none(remove_end(
+                    self._html_extract_title(webpage, default=None) or self._og_search_title(webpage),
+                    ' | NZ On Screen')),
+                'thumbnail': traverse_obj(playlist, ('thumbnail', 'path')),
+                'duration': float_or_none(playlist.get('duration')),
+                'formats': self._extract_legacy_formats(playlist),
+                'http_headers': {
+                    'Referer': 'https://www.nzonscreen.com/',
+                    'Origin': 'https://www.nzonscreen.com/',
+                },
+            }
+
+    def _extract_legacy_formats(self, playlist):
+        # Legacy format extraction for fallback cases
+        formats = []
         for quality, (id_, url) in enumerate(traverse_obj(
                 playlist, ('h264', {'lo': 'lo_res', 'hi': 'hi_res'}), expected_type=url_or_none).items()):
-            yield {
+            if not url:
+                continue
+            formats.append({
                 'url': url,
                 'format_id': id_,
                 'ext': 'mp4',
@@ -66,28 +229,5 @@ class NZOnScreenIE(InfoExtractor):
                 'height': int_or_none(playlist.get('height')) if id_ == 'hi' else None,
                 'width': int_or_none(playlist.get('width')) if id_ == 'hi' else None,
                 'filesize_approx': float_or_none(traverse_obj(playlist, ('h264', f'{id_}_res_mb')), invscale=1024**2),
-            }
-
-    def _real_extract(self, url):
-        video_id = self._match_id(url)
-        webpage = self._download_webpage(url, video_id)
-
-        playlist = self._parse_json(self._html_search_regex(
-            r'data-video-config=\'([^\']+)\'', webpage, 'media data'), video_id)
-
-        return {
-            'id': playlist['uuid'],
-            'display_id': video_id,
-            'title': strip_or_none(playlist.get('label')),
-            'description': strip_or_none(playlist.get('description')),
-            'alt_title': strip_or_none(remove_end(
-                self._html_extract_title(webpage, default=None) or self._og_search_title(webpage),
-                ' | NZ On Screen')),
-            'thumbnail': traverse_obj(playlist, ('thumbnail', 'path')),
-            'duration': float_or_none(playlist.get('duration')),
-            'formats': list(self._extract_formats(playlist)),
-            'http_headers': {
-                'Referer': 'https://www.nzonscreen.com/',
-                'Origin': 'https://www.nzonscreen.com/',
-            },
-        }
+            })
+        return formats


### PR DESCRIPTION
### Add support for multi-part playlists on NZOnScreen

- Add NZOnScreenVideoIE to fetch fresh stream URLs for each video part
- Fix HTTP 410 errors by delegating to video extractor for non-expired URLs
- Support multi-part playlists by extracting each part with fresh URLs
- Addresses GitHub issue #6878 where only first part was downloadable
- Stream URLs from nzonscreen.com have short expiration times requiring fresh extraction (please let me know if you prefer this to be handled reactively instead of proactively)

Fixes #6878

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
