### PR TITLE
[xhamster] Fix 404 errors on video downloads (Fixes #14145)

### DIFF
--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -1,3 +1,4 @@
+import base64
 import itertools
 import re
 
@@ -12,6 +13,7 @@ from ..utils import (
     int_or_none,
     parse_duration,
     str_or_none,
+    try_call,
     try_get,
     unified_strdate,
     url_or_none,
@@ -48,6 +50,28 @@ class XHamsterIE(InfoExtractor):
             'description': '',
             'view_count': int,
             'comment_count': int,
+        },
+    }, {
+        'url': 'https://xhamster.com/videos/my-first-anal-sex-with-brother-in-law-he-fucked-my-tight-asshole-xh8PgSB',
+        'info_dict': {
+            'id': 'xh8PgSB',
+            'ext': 'mp4',
+            'title': 'My first anal sex with brother in law he fucked my tight asshole',
+            'display_id': 'my-first-anal-sex-with-brother-in-law-he-fucked-my-tight-asshole',
+            'description': str,
+            'age_limit': 18,
+            'duration': 845,
+            'view_count': int,
+            'comment_count': int,
+            'thumbnail': r're:https?://.+\.(?:jpg|webp)',
+            'timestamp': 1755947414,
+            'upload_date': '20250823',
+            'uploader': 'Indiansfuckers10',
+            'uploader_id': 'indiansfuckers10',
+            'uploader_url': 'https://xhamster.com/users/indiansfuckers10',
+        },
+        'params': {
+            'skip_download': True,
         },
     }, {
         'url': 'https://xhamster.com/videos/britney-spears-sexy-booty-2221348?hd=',
@@ -229,6 +253,13 @@ class XHamsterIE(InfoExtractor):
                                 standard_url = standard_format.get(standard_format_key)
                                 if not standard_url:
                                     continue
+                                if standard_url.startswith('eG9yXxAcQ0'):  # base64 of 'xor'
+                                    decoded = try_call(lambda: base64.b64decode(standard_url))
+                                    if decoded and decoded[:4] == b'xor_':
+                                        xor_url_content = decoded[4:]
+                                        standard_url = ''
+                                        for t in range(len(xor_url_content)):
+                                            standard_url += chr(xor_url_content[t] ^ b'xh7999'[t % 6])
                                 standard_url = urljoin(url, standard_url)
                                 if not standard_url or standard_url in format_urls:
                                     continue


### PR DESCRIPTION
### Description
This PR fixes the 404 errors occurring when downloading videos from xhamster.com (issue #14145). The site has started encrypting some video URLs using base64+XOR encryption. This PR implements the patch provided by nicolaasjan in the issue.

Changes made:
- Added detection and decryption of base64+XOR encrypted URLs in the xhamster extractor (patch by nicolaasjan)
- Added a test case to verify the functionality
- The decryption uses the site's known XOR key "xh7999"

Testing:
- Tested with multiple videos including ones that were previously failing with 404 errors
- Verified that both encrypted and non-encrypted URLs continue to work
- Added automated test case for future verification

Credit: This implementation is based on the patch provided by nicolaasjan in issue #14145

Fixes #14145

### Checklist
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### License
- [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (The patch was provided by nicolaasjan in issue #14145)

### Purpose
- [x] Fix or improvement to an extractor (Make sure to add/update tests)