### PR TITLE
Remove broken m3u8 manifest for charlierose.com

### DIFF
--- a/yt_dlp/extractor/charlierose.py
+++ b/yt_dlp/extractor/charlierose.py
@@ -6,7 +6,7 @@ class CharlieRoseIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?charlierose\.com/(?:video|episode)(?:s|/player)/(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://charlierose.com/videos/27996',
-        'md5': 'fda41d49e67d4ce7c2411fd2c4702e09',
+        'md5': '4405b662f557f94aa256fa6a7baf7426',
         'info_dict': {
             'id': '27996',
             'ext': 'mp4',
@@ -28,6 +28,9 @@ class CharlieRoseIE(InfoExtractor):
     }]
 
     _PLAYER_BASE = 'https://charlierose.com/video/player/%s'
+
+    def _extract_m3u8_formats(self, *args, **kwargs):
+        return ()
 
     def _real_extract(self, url):
         video_id = self._match_id(url)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

---

### Description of your *pull request* and other information

When one conventionally attempts to use yt-dlp on, say, an interview, from charlierose.com, the download seems to always result in an HTTP 400. Example:

```
$ yt-dlp --verbose https://charlierose.com/videos/27996
[debug] Command-line config: ['--verbose', 'https://charlierose.com/videos/27996']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version nightly@2025.08.30.232839 from yt-dlp/yt-dlp-nightly-builds [d925e92b7] (win_exe)
[debug] Python 3.10.11 (CPython AMD64 64bit) - Windows-10-10.0.26100-SP0 (OpenSSL 1.1.1t  7 Feb 2023)
[debug] exe versions: ffmpeg N-115572-g9576a00527-20240604 (setts), ffprobe N-115572-g9576a00527-20240604
[debug] Optional libraries: Cryptodome-3.23.0, brotli-1.1.0, certifi-2025.08.03, curl_cffi-0.13.0, mutagen-1.47.0, requests-2.32.5, sqlite3-3.40.1, urllib3-2.5.0, websockets-15.0.1
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets, curl_cffi
[debug] Plugin directories: none
[debug] Loaded 1842 extractors
[CharlieRose] Extracting URL: https://charlierose.com/videos/27996
[CharlieRose] 27996: Downloading webpage
[CharlieRose] 27996: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec, channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] 27996: Downloading 1 format(s): 1962
[debug] Invoking hlsnative downloader on "https://pfm1hyus01-vh.akamaihd.net/i/MMF/I/1HYMMFI_003_xp.f4v/index_0_av.m3u8"
[hlsnative] Downloading m3u8 manifest
ERROR: unable to download video data: HTTP Error 400: Bad Request
Traceback (most recent call last):
  File "yt_dlp\YoutubeDL.py", line 3534, in process_info
  File "yt_dlp\YoutubeDL.py", line 3254, in dl
  File "yt_dlp\downloader\common.py", line 480, in download
  File "yt_dlp\downloader\hls.py", line 82, in real_download
  File "yt_dlp\YoutubeDL.py", line 4239, in urlopen
  File "yt_dlp\networking\common.py", line 117, in send
  File "yt_dlp\networking\_helper.py", line 194, in wrapper
  File "yt_dlp\networking\common.py", line 359, in send
  File "yt_dlp\networking\_requests.py", line 357, in _send
yt_dlp.networking.exceptions.HTTPError: HTTP Error 400: Bad Request
```

In this case, the bad request lies in the information given by the manifest that is found in a source tag for the video player at `https://charlierose.com/video/player/27996`:

```
#EXTM3U

#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1962000,RESOLUTION=768x432,CODECS="avc1.64001f, mp4a.40.2"
https://pfm1hyus01-vh.akamaihd.net/i/MMF/I/1HYMMFI_003_xp.f4v/index_0_av.m3u8

#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=762000,RESOLUTION=480x270,CODECS="avc1.64001f, mp4a.40.2"
https://pfm1hyus01-vh.akamaihd.net/i/MMF/I/1HYMMFI_003_lp.f4v/index_0_av.m3u8
```

Because the highest quality _known_ format lies herein, yt-dlp attempts to access one of these malformed URLs. Consequently...

The MP4 stream that is directly specified as a source for the player, however, remains valid, and can be opted for as is (without this patch/PR):

```
$ yt-dlp --verbose -f 0 https://charlierose.com/videos/27996
[debug] Command-line config: ['--verbose', '-f', '0', 'https://charlierose.com/videos/27996']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version nightly@2025.08.30.232839 from yt-dlp/yt-dlp-nightly-builds [d925e92b7] (win_exe)
[debug] Python 3.10.11 (CPython AMD64 64bit) - Windows-10-10.0.26100-SP0 (OpenSSL 1.1.1t  7 Feb 2023)
[debug] exe versions: ffmpeg N-115572-g9576a00527-20240604 (setts), ffprobe N-115572-g9576a00527-20240604
[debug] Optional libraries: Cryptodome-3.23.0, brotli-1.1.0, certifi-2025.08.03, curl_cffi-0.13.0, mutagen-1.47.0, requests-2.32.5, sqlite3-3.40.1, urllib3-2.5.0, websockets-15.0.1
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets, curl_cffi
[debug] Plugin directories: none
[debug] Loaded 1842 extractors
[CharlieRose] Extracting URL: https://charlierose.com/videos/27996
[CharlieRose] 27996: Downloading webpage
[CharlieRose] 27996: Downloading m3u8 information
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec, channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id
[info] 27996: Downloading 1 format(s): 0
[debug] Invoking http downloader on "https://pfm1hycdn01-a.akamaihd.net/MMF/I/1HYMMFI_003_xp.f4v"
[debug] File locking is not supported. Proceeding without locking
[download] Destination: Remembering Zaha Hadid [27996].mp4
[download] 100% of   36.88MiB in 00:00:02 at 16.76MiB/s
```

Less tech-savvy users may very well might not know to do this. Therefore, I propose the following changes in light of the aforementioned issues:

### Fixes

- Disable M3U8 stream information until further notice.
- Alter developer tests to reflect the MD5 checksum(s) of the one available format.
