### PR TITLE
Fix 10play extractor for higher quality streams and outdated app error

### DIFF
--- a/yt_dlp/extractor/tenplay.py
+++ b/yt_dlp/extractor/tenplay.py
@@ -103,13 +103,13 @@ class TenPlayIE(InfoExtractor):
             f'https://vod.ten.com.au/api/videos/bcquery?command=find_videos_by_id&video_id={data["altId"]}',
             content_id, 'Downloading video JSON')
         m3u8_url = self._request_webpage(
-            HEADRequest(video_data['items'][0]['HLSURL']),
+            HEADRequest(video_data['items'][0]['dashManifestUrl'].replace('manifest=mpeg-dash', 'manifest=m3u')),
             content_id, 'Checking stream URL').url
         if '10play-not-in-oz' in m3u8_url:
             self.raise_geo_restricted(countries=['AU'])
         # Attempt to get a higher quality stream
         formats = self._extract_m3u8_formats(
-            m3u8_url.replace(',150,75,55,0000', ',300,150,75,55,0000'),
+            m3u8_url.replace(',150,75,55,0000', ',500,300,150,75,55,0000'),
             content_id, 'mp4', fatal=False)
         if not formats:
             formats = self._extract_m3u8_formats(m3u8_url, content_id, 'mp4')


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This commit fixes the 10play extractor to work with the updated API structure and enable access to higher quality streams.

Changes:
- Replace deprecated HLSURL with dashManifestUrl
- Convert DASH manifest to HLS format by replacing "manifest=mpeg-dash" with "manifest=m3u"
- Add 500 kbps option to bitrate selection: ,150,75,55,0000 → ,500,300,150,75,55,0000

Fixes #14212


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
