### PR TITLE
[ie/xhamster] Fix extractor

### DIFF
--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -245,6 +245,8 @@ class XHamsterIE(InfoExtractor):
                                     standard_url = bytes(
                                         a ^ b for a, b in
                                         zip(decoded[4:], itertools.cycle(b'xh7999'))).decode()
+                                if decoded and decoded[:6] == b'rot13_':
+                                    standard_url=codecs.decode(decoded[6:].decode('ascii'), 'rot_13')
                                 standard_url = urljoin(url, standard_url)
                                 if not standard_url or standard_url in format_urls:
                                     continue

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -232,14 +232,6 @@ class XHamsterIE(InfoExtractor):
                                 standard_url = standard_format.get(standard_format_key)
                                 if not standard_url:
                                     continue
-                                    if standard_url.startswith('eG9yXxAcQ0'):  # base64 of 'xor'
-                                        xor_url_content = base64.b64decode(standard_url)[4:]
-                                        standard_url = '';
-                                    for t in range(len(xor_url_content)):
-                                        standard_url += chr(xor_url_content[t] ^ b'xh7999'[t % 6])
-                                if standard_url.startswith('cm90MT'):  # base64 for 'rot13'
-                                    rot13_url_content = base64.b64decode(standard_url)[6:]
-                                    standard_url = codecs.decode(rot13_url_content.decode('ascii'), 'rot_13')
                                 decoded = try_call(lambda: base64.b64decode(standard_url))
                                 if decoded and decoded[:4] == b'xor_':
                                     standard_url = bytes(

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -234,7 +234,7 @@ class XHamsterIE(InfoExtractor):
                                     continue
                                     if standard_url.startswith('eG9yXxAcQ0'): # base64 of 'xor'
                                         xor_url_content=base64.b64decode(standard_url)[4:]
-                                        standard_url = '';
+                                        standard_url = ''
                                     for t in range(len(xor_url_content)):
                                         standard_url += chr( xor_url_content[t] ^ b'xh7999'[ t % 6 ] )
                                 if standard_url.startswith('cm90MT'): # base64 for 'rot13'

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -232,21 +232,21 @@ class XHamsterIE(InfoExtractor):
                                 standard_url = standard_format.get(standard_format_key)
                                 if not standard_url:
                                     continue
-                                    if standard_url.startswith('eG9yXxAcQ0'): # base64 of 'xor'
-                                        xor_url_content=base64.b64decode(standard_url)[4:]
-                                        standard_url = ''
+                                    if standard_url.startswith('eG9yXxAcQ0'):  # base64 of 'xor'
+                                        xor_url_content = base64.b64decode(standard_url)[4:]
+                                        standard_url = '';
                                     for t in range(len(xor_url_content)):
-                                        standard_url += chr( xor_url_content[t] ^ b'xh7999'[ t % 6 ] )
-                                if standard_url.startswith('cm90MT'): # base64 for 'rot13'
-                                    rot13_url_content=base64.b64decode(standard_url)[6:]
-                                    standard_url=codecs.decode(rot13_url_content.decode('ascii'), 'rot_13')
+                                        standard_url += chr(xor_url_content[t] ^ b'xh7999'[t % 6])
+                                if standard_url.startswith('cm90MT'):  # base64 for 'rot13'
+                                    rot13_url_content = base64.b64decode(standard_url)[6:]
+                                    standard_url = codecs.decode(rot13_url_content.decode('ascii'), 'rot_13')
                                 decoded = try_call(lambda: base64.b64decode(standard_url))
                                 if decoded and decoded[:4] == b'xor_':
                                     standard_url = bytes(
                                         a ^ b for a, b in
                                         zip(decoded[4:], itertools.cycle(b'xh7999'))).decode()
                                 if decoded and decoded[:6] == b'rot13_':
-                                    standard_url=codecs.decode(decoded[6:].decode('ascii'), 'rot_13')
+                                    standard_url = codecs.decode(decoded[6:].decode('ascii'), 'rot_13')
                                 standard_url = urljoin(url, standard_url)
                                 if not standard_url or standard_url in format_urls:
                                     continue

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -1,6 +1,7 @@
-import base64
 import itertools
 import re
+import base64
+import codecs
 
 from .common import InfoExtractor
 from ..utils import (
@@ -231,6 +232,14 @@ class XHamsterIE(InfoExtractor):
                                 standard_url = standard_format.get(standard_format_key)
                                 if not standard_url:
                                     continue
+                                    if standard_url.startswith("eG9yXxAcQ0"): # base64 of 'xor'
+                                        xor_url_content=base64.b64decode(standard_url)[4:]
+                                        standard_url = "";
+                                    for t in range( 0, len(xor_url_content) ):
+                                        standard_url += chr( xor_url_content[t] ^ b"xh7999"[ t % 6 ] );
+                                if standard_url.startswith("cm90MT"): # base64 for 'rot13'
+                                    rot13_url_content=base64.b64decode(standard_url)[6:]
+                                    standard_url=codecs.decode(rot13_url_content.decode("ascii"), "rot_13")
                                 decoded = try_call(lambda: base64.b64decode(standard_url))
                                 if decoded and decoded[:4] == b'xor_':
                                     standard_url = bytes(

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -1,7 +1,7 @@
-import itertools
-import re
 import base64
 import codecs
+import itertools
+import re
 
 from .common import InfoExtractor
 from ..utils import (
@@ -232,14 +232,14 @@ class XHamsterIE(InfoExtractor):
                                 standard_url = standard_format.get(standard_format_key)
                                 if not standard_url:
                                     continue
-                                    if standard_url.startswith("eG9yXxAcQ0"): # base64 of 'xor'
+                                    if standard_url.startswith('eG9yXxAcQ0'): # base64 of 'xor'
                                         xor_url_content=base64.b64decode(standard_url)[4:]
-                                        standard_url = "";
-                                    for t in range( 0, len(xor_url_content) ):
-                                        standard_url += chr( xor_url_content[t] ^ b"xh7999"[ t % 6 ] );
-                                if standard_url.startswith("cm90MT"): # base64 for 'rot13'
+                                        standard_url = '';
+                                    for t in range(len(xor_url_content)):
+                                        standard_url += chr( xor_url_content[t] ^ b'xh7999'[ t % 6 ] )
+                                if standard_url.startswith('cm90MT'): # base64 for 'rot13'
                                     rot13_url_content=base64.b64decode(standard_url)[6:]
-                                    standard_url=codecs.decode(rot13_url_content.decode("ascii"), "rot_13")
+                                    standard_url=codecs.decode(rot13_url_content.decode('ascii'), 'rot_13')
                                 decoded = try_call(lambda: base64.b64decode(standard_url))
                                 if decoded and decoded[:4] == b'xor_':
                                     standard_url = bytes(

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -245,7 +245,7 @@ class XHamsterIE(InfoExtractor):
                                     standard_url = bytes(
                                         a ^ b for a, b in
                                         zip(decoded[4:], itertools.cycle(b'xh7999'))).decode()
-                                if decoded and decoded[:6] == b'rot13_':
+                                elif decoded and decoded[:6] == b'rot13_':
                                     standard_url = codecs.decode(decoded[6:].decode('ascii'), 'rot_13')
                                 standard_url = urljoin(url, standard_url)
                                 if not standard_url or standard_url in format_urls:

--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -12,13 +12,13 @@ from ..utils import (
     extract_attributes,
     float_or_none,
     int_or_none,
+    join_nonempty,
     parse_duration,
     str_or_none,
     try_call,
     try_get,
     unified_strdate,
     url_or_none,
-    urljoin,
 )
 
 
@@ -143,6 +143,27 @@ class XHamsterIE(InfoExtractor):
         'only_matching': True,
     }]
 
+    _XOR_KEY = b'xh7999'
+
+    def _decipher_format_url(self, format_url, format_id):
+        cipher_type, _, ciphertext = try_call(
+            lambda: base64.b64decode(format_url).decode().partition('_')) or [None] * 3
+
+        if not cipher_type or not ciphertext:
+            self.report_warning(f'Skipping format "{format_id}": failed to decipher URL')
+            return None
+
+        if cipher_type == 'xor':
+            return bytes(
+                a ^ b for a, b in
+                zip(ciphertext.encode(), itertools.cycle(self._XOR_KEY))).decode()
+
+        if cipher_type == 'rot13':
+            return codecs.decode(ciphertext, cipher_type)
+
+        self.report_warning(f'Skipping format "{format_id}": unsupported cipher type "{cipher_type}"')
+        return None
+
     def _real_extract(self, url):
         mobj = self._match_valid_url(url)
         video_id = mobj.group('id') or mobj.group('id_2')
@@ -213,7 +234,7 @@ class XHamsterIE(InfoExtractor):
                         hls_url = hls_sources.get(hls_format_key)
                         if not hls_url:
                             continue
-                        hls_url = urljoin(url, hls_url)
+                        hls_url = self._decipher_format_url(hls_url, f'hls-{hls_format_key}')
                         if not hls_url or hls_url in format_urls:
                             continue
                         format_urls.add(hls_url)
@@ -222,7 +243,7 @@ class XHamsterIE(InfoExtractor):
                             m3u8_id='hls', fatal=False))
                 standard_sources = xplayer_sources.get('standard')
                 if isinstance(standard_sources, dict):
-                    for format_id, formats_list in standard_sources.items():
+                    for identifier, formats_list in standard_sources.items():
                         if not isinstance(formats_list, list):
                             continue
                         for standard_format in formats_list:
@@ -232,14 +253,11 @@ class XHamsterIE(InfoExtractor):
                                 standard_url = standard_format.get(standard_format_key)
                                 if not standard_url:
                                     continue
-                                decoded = try_call(lambda: base64.b64decode(standard_url))
-                                if decoded and decoded[:4] == b'xor_':
-                                    standard_url = bytes(
-                                        a ^ b for a, b in
-                                        zip(decoded[4:], itertools.cycle(b'xh7999'))).decode()
-                                elif decoded and decoded[:6] == b'rot13_':
-                                    standard_url = codecs.decode(decoded[6:].decode('ascii'), 'rot_13')
-                                standard_url = urljoin(url, standard_url)
+                                quality = (str_or_none(standard_format.get('quality'))
+                                           or str_or_none(standard_format.get('label'))
+                                           or '')
+                                format_id = join_nonempty(identifier, quality)
+                                standard_url = self._decipher_format_url(standard_url, format_id)
                                 if not standard_url or standard_url in format_urls:
                                     continue
                                 format_urls.add(standard_url)
@@ -249,11 +267,9 @@ class XHamsterIE(InfoExtractor):
                                         standard_url, video_id, 'mp4', entry_protocol='m3u8_native',
                                         m3u8_id='hls', fatal=False))
                                     continue
-                                quality = (str_or_none(standard_format.get('quality'))
-                                           or str_or_none(standard_format.get('label'))
-                                           or '')
+
                                 formats.append({
-                                    'format_id': f'{format_id}-{quality}',
+                                    'format_id': format_id,
                                     'url': standard_url,
                                     'ext': ext,
                                     'height': get_height(quality),


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fix 404 errors on XHamster video downloads by handling base64-encoded XOR-encrypted URLs.

The site now encodes some video URLs using base64 with an XOR cipher using the key 'xh7999'. This change detects base64-encoded URLs starting with 'xor_', decodes the content, and applies XOR decryption before processing the URL. (patch by [arand](https://github.com/arand))

Fixes #14145 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [ ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (The patch was provided by [arand](https://github.com/arand) in issue https://github.com/yt-dlp/yt-dlp/issues/14145)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
