### PR TITLE
fix: bilibili/_get_interactive_entries errors

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -261,7 +261,7 @@ class BilibiliBaseIE(InfoExtractor):
         params = {
             'graph_version': graph_version,
             'aid': aid,
-            'buvid': '20D6FDE7-B06C-1474-DA7C-5D4A5664FEFE26722infoc'
+            'buvid': '20D6FDE7-B06C-1474-DA7C-5D4A5664FEFE26722infoc',
         }
         if edge_id != 1:
             params.update({'edge_id': edge_id})


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR fixes an issue with downloading Bilibili interactive videos.  
Currently, when fetching division information via `_get_divisions`, the request may fail.  
In my testing with ~120 interactive video links, around 50% of them failed to return division info.  
For example: https://www.bilibili.com/video/BV1s441117Cr

The root cause is that the request was missing critical parameters.  
This PR updates `_get_divisions` to include both `aid` and `buvid` parameters in the request.  
With this change, division info retrieval succeeds for all tested cases (120/120).  

No other functionality is affected.

Fixes #(no existing issue found) 


---

### Before submitting a *pull request* make sure you have:
- [√] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [√] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [√] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [√] Fix or improvement to an extractor