### PR TITLE
fix(arte): add required info dict property `url`

### DIFF
--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -214,6 +214,7 @@ class ArteTVIE(ArteTVBaseIE):
 
         return {
             'id': metadata['providerId'],
+            'url': traverse_obj(metadata, ('link', 'url')),
             'webpage_url': traverse_obj(metadata, ('link', 'url')),
             'title': traverse_obj(metadata, 'subtitle', 'title'),
             'alt_title': metadata.get('subtitle') and metadata.get('title'),


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

The JSON info returned by the Arte extractor are:
```sh
$ yt-dlp -J https://www.arte.tv/de/videos/050526-000-A/1989-poker-am-todeszaun/ | jq | head -n 4
{
  "id": "050526-000-A",
  "webpage_url": "https://www.arte.tv/de/videos/050526-000-A/1989-poker-am-todeszaun/",
  "title": "1989 - Poker am Todeszaun",
```

The info dict documentation lists `url` as a required property:
[yt_dlp/extractor/common.py:281](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/common.py#L281)
```
    For a video, the dictionaries must include the following fields:

    id:             Video identifier.
    [… … …]
    url:            Final video URL.
    ext:            Video filename extension.
    format:         The video format, defaults to ext (used for --get-format)
    player_url:     SWF Player URL (used for rtmpdump).

    The following fields are optional:
    [… … …]
```

The extractor should also return this property.

Initially, I thought `webpage_url` would not be in the documentation,
so I renamed `webpage_url` to `url`.
Later, I learnt that there is also the optional property `webpage_url`.
This is why I'm adding the required `url` and keeping `webpage_url` as is.
This is why I changed this PR, the code change and its description.

<!--
ADD DETAILED DESCRIPTION HERE
-->

Fixes #

- [x] Add missing info dict property [url](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/common.py#L281)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code changes in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
