### PR TITLE
[ie/PrankCastPost] Rework extractor

### DIFF
--- a/yt_dlp/extractor/prankcast.py
+++ b/yt_dlp/extractor/prankcast.py
@@ -100,7 +100,6 @@ class PrankCastPostIE(InfoExtractor):
             'duration': 263.287,
             'cast': ['despicabledogs'],
             'description': 'https://imgur.com/a/vtxLvKU',
-            'categories': [],
             'upload_date': '20240104',
         },
     }, {
@@ -116,7 +115,6 @@ class PrankCastPostIE(InfoExtractor):
             'duration': 2176.464,
             'cast': ['DrTomServo'],
             'description': '',
-            'categories': [],
             'upload_date': '20250803',
         },
     }, {
@@ -132,7 +130,6 @@ class PrankCastPostIE(InfoExtractor):
             'duration': 19018.392,
             'cast': ['DrTomServo'],
             'description': '',
-            'categories': [],
             'upload_date': '20250817',
         },
     }]


### PR DESCRIPTION
### Description of your *pull request* and other information

Add a new field for the release date and also add a new URL field.

At some point in the past months a new timestamp field was added, but the previous two were not only not removed but they are still sometimes in use (and when they are used the new "created_at" field doesn't get set...). This new field seems to be replacing the old ones, but older shows don't get updated to use it and also sometimes new shows still use the older fields for whatever reason. I kept the old checks for "crdate" and "start_date" because of this.

Also, some shows are not available when using the "url" field, it returns a 403, in those cases if the "secure_url" is set we need to use that one.

I've also added two new test for these changes. The first one is a show that uses the "created_at" field for it's timestamp. The second one is a show that won't play using the "url" field, but does play using the "secure_url".


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
