### PR TITLE
NHK World: migrate to yet another new API/stream provider

### DIFF
--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -84,10 +84,10 @@ class NhkBaseIE(InfoExtractor):
                 'webpage_url': ('url', {urljoin(url)}),
             }),
             'extractor_key': NhkVodIE.ie_key(),
-            'extractor': NhkVodIE.ie_key(),
+            'extractor': NhkVodIE.IE_NAME,
         }
 
-        # FOOLISH ASSUMPTION: an episode can't be video and audio at the same time
+        # XXX: We are assuming that 'video' and 'audio' are mutually exclusive
         stream_info = traverse_obj(episode, (('video', 'audio'), {dict}, any)) or {}
         if not stream_info.get('url'):
             self.raise_no_formats('Stream not found; it has most likely expired', expected=True)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

well the title says it all really
they cant go 2 years without changing providers it seems

they also have a new metadata API
It doesn't provide the old IDs, so this is a breaking change

there were some tests that 404ed that i didn't know what they were meant to be testing anyway, so i removed them
or they were testing the then-new url format that all the tests use now
hope thats not too silly


ALSO
the new API has pagination, but i couldnt see any instances of anything actually hitting the limit of 100
so if i was sensible then i would have implemented pagination anyway but at the minute i havent
but i will if asked

fixes #14589

coincidentally fixes #14223

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
