### PR TITLE
Added countdown during sleep intervals (Fixes #14532)

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -870,7 +870,10 @@ class InfoExtractor:
             sleep_interval = self.get_param('sleep_interval_requests') or 0
             if sleep_interval > 0:
                 self.to_screen(f'Sleeping {sleep_interval} seconds ...')
-                time.sleep(sleep_interval)
+                for remaining in range(int(sleep_interval), 0, -1):
+                    self.to_screen(f'  [wait] {remaining:>3}s remaining', quiet=True)
+                    time.sleep(1)
+
         else:
             self._downloader._first_webpage_request = False
 


### PR DESCRIPTION
Title:
Add countdown display during sleep intervals (Fixes #14532)

Description:
This PR enhances the --sleep-requests functionality by adding a per-second countdown display during sleep intervals between requests. Currently, yt-dlp only prints a single “Sleeping X seconds …” message, making it difficult for users to know if the process is active during long sleep periods.

Changes made:

Modified yt_dlp/extractor/common.py in _request_webpage to loop over the sleep interval and display remaining seconds.

Added output format:
[youtube] Sleeping 10.0 seconds ...
[youtube]   [wait] 10s remaining
[youtube]   [wait]  9s remaining
...
[youtube]   [wait]  1s remaining


Maintains compatibility with existing verbose and quiet modes.

Benefits:

Improves UX during long sleep periods.

Provides visual confirmation that yt-dlp is active and has not hung.

Addresses issue #14532.

Testing:
Tested locally using:

python3 -m yt_dlp <video_url> --sleep-requests 10 -v


Confirmed countdown appears for each sleep interval as expected.