### PR TITLE
[TubeTuGraz] Add support for new portal URL format

### DIFF
--- a/yt_dlp/extractor/tubetugraz.py
+++ b/yt_dlp/extractor/tubetugraz.py
@@ -136,8 +136,10 @@ class TubeTuGrazIE(TubeTuGrazBaseIE):
     IE_DESC = 'tube.tugraz.at'
 
     _VALID_URL = r'''(?x)
-        https?://tube\.tugraz\.at/paella/ui/watch.html\?id=
-        (?P<id>[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})
+        https?://tube\.tugraz\.at/(?:
+            paella/ui/watch\.html\?id=|
+            portal/watch/
+        )(?P<id>[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})
     '''
     _TESTS = [
         {
@@ -162,6 +164,10 @@ class TubeTuGrazIE(TubeTuGrazBaseIE):
                 'ext': 'mp4',
             },
             'expected_warnings': ['Extractor failed to obtain "title"'],
+        }, {
+            # Portal URL format
+            'url': 'https://tube.tugraz.at/portal/watch/ab28ec60-8cbe-4f1a-9b96-a95add56c612',
+            'only_matching': True,
         },
     ]
 


### PR DESCRIPTION
Fixes #14686

## Description

TU Graz Tube now uses a new portal URL format alongside the existing paella format. This PR updates the `TubeTuGrazIE` extractor to recognize both URL patterns.

## Supported URL formats

- `https://tube.tugraz.at/paella/ui/watch.html?id=<UUID>` (existing)
- `https://tube.tugraz.at/portal/watch/<UUID>` (new)

## Changes

1. Updated `_VALID_URL` regex to match both URL formats
2. Added test case for portal URL format with `only_matching: True`

## Testing

Both URL patterns correctly extract the UUID:
- Paella format: ✓ tested with existing test cases
- Portal format: ✓ tested with new test case

The video ID is extracted identically from both formats, and the rest of the extraction logic remains unchanged.