### PR TITLE
[ie/kika] Do not extract subtitles that don't actually exist

### DIFF
--- a/yt_dlp/extractor/kika.py
+++ b/yt_dlp/extractor/kika.py
@@ -17,57 +17,60 @@ class KikaIE(InfoExtractor):
     _GEO_COUNTRIES = ['DE']
 
     _TESTS = [{
-        'url': 'https://www.kika.de/logo/videos/logo-vom-samstag-einunddreissig-august-zweitausendvierundzwanzig-100',
-        'md5': 'fbfc8da483719ef06f396e5e5b938c69',
+        # Video without season/episode info
+        'url': 'https://www.kika.de/logo/videos/logo-vom-dienstag-achtundzwanzig-oktober-zweitausendfuenfundzwanzig-100',
+        'md5': '4a9f6e0f9c6bfcc82394c294f186d6db',
         'info_dict': {
-            'id': 'logo-vom-samstag-einunddreissig-august-zweitausendvierundzwanzig-100',
+            'id': 'logo-vom-dienstag-achtundzwanzig-oktober-zweitausendfuenfundzwanzig-100',
             'ext': 'mp4',
-            'upload_date': '20240831',
-            'timestamp': 1725126600,
-            'season_number': 2024,
-            'modified_date': '20240831',
-            'episode': 'Episode 476',
-            'episode_number': 476,
-            'season': 'Season 2024',
-            'duration': 634,
-            'title': 'logo! vom Samstag, 31. August 2024',
-            'modified_timestamp': 1725129983,
+            'title': 'logo! vom Dienstag, 28. Oktober 2025',
+            'description': 'md5:4d28b92cef423bec99740ffaa3e7ec04',
+            'duration': 651,
+            'timestamp': 1761678000,
+            'upload_date': '20251028',
+            'modified_timestamp': 1761682624,
+            'modified_date': '20251028',
         },
     }, {
+        # Video with season/episode info
+        # Also: Video with subtitles
         'url': 'https://www.kika.de/kaltstart/videos/video92498',
-        'md5': '710ece827e5055094afeb474beacb7aa',
+        'md5': 'e58073070acb195906c55c4ad31dceb3',
         'info_dict': {
             'id': 'video92498',
             'ext': 'mp4',
             'title': '7. Wo ist Leo?',
             'description': 'md5:fb48396a5b75068bcac1df74f1524920',
             'duration': 436,
+            'season': 'Season 1',
+            'season_number': 1,
+            'episode': 'Episode 7',
+            'episode_number': 7,
             'timestamp': 1702926876,
             'upload_date': '20231218',
-            'episode_number': 7,
-            'modified_date': '20240319',
             'modified_timestamp': 1710880610,
-            'episode': 'Episode 7',
-            'season_number': 1,
-            'season': 'Season 1',
+            'modified_date': '20240319',
+            'subtitles': 'count:1',
         },
     }, {
-        'url': 'https://www.kika.de/bernd-das-brot/astrobrot/videos/video90088',
-        'md5': 'ffd1b700d7de0a6616a1d08544c77294',
+        # Video without subtitles
+        'url': 'https://www.kika.de/die-pfefferkoerner/videos/abgezogen-102',
+        'md5': '62e97961ce5343c19f0f330a1b6dd736',
         'info_dict': {
-            'id': 'video90088',
+            'id': 'abgezogen-102',
             'ext': 'mp4',
-            'upload_date': '20221102',
-            'timestamp': 1667390580,
-            'duration': 197,
-            'modified_timestamp': 1711093771,
-            'episode_number': 8,
-            'title': 'Es ist nicht leicht, ein Astrobrot zu sein',
-            'modified_date': '20240322',
-            'description': 'md5:d3641deaf1b5515a160788b2be4159a9',
-            'season_number': 1,
-            'episode': 'Episode 8',
+            'title': '1. Abgezogen',
+            'description': 'md5:42d87963364391f9f8eba8affcb30bd2',
+            'duration': 1574,
             'season': 'Season 1',
+            'season_number': 1,
+            'episode': 'Episode 1',
+            'episode_number': 1,
+            'timestamp': 1735382700,
+            'upload_date': '20241228',
+            'modified_timestamp': 1757344051,
+            'modified_date': '20250908',
+            'subtitles': 'count:0',
         },
     }]
 
@@ -78,16 +81,19 @@ class KikaIE(InfoExtractor):
         video_assets = self._download_json(doc['assets']['url'], video_id)
 
         subtitles = {}
-        if ttml_resource := url_or_none(video_assets.get('videoSubtitle')):
-            subtitles['de'] = [{
-                'url': ttml_resource,
-                'ext': 'ttml',
-            }]
-        if webvtt_resource := url_or_none(video_assets.get('webvttUrl')):
-            subtitles.setdefault('de', []).append({
-                'url': webvtt_resource,
-                'ext': 'vtt',
-            })
+        # Subtitle API endpoints may be present in the JSON even if there are no subtitles.
+        # They then return HTTP 200 with invalid data. So we must check explicitly.
+        if doc.get('hasSubtitle'):
+            if ttml_resource := url_or_none(video_assets.get('videoSubtitle')):
+                subtitles['de'] = [{
+                    'url': ttml_resource,
+                    'ext': 'ttml',
+                }]
+            if webvtt_resource := url_or_none(video_assets.get('webvttUrl')):
+                subtitles.setdefault('de', []).append({
+                    'url': webvtt_resource,
+                    'ext': 'vtt',
+                })
 
         return {
             'id': video_id,


### PR DESCRIPTION
### Description of your *pull request* and other information

The KIKA extractor would always add subtitle URLs to the info-dict, even if they are no subtitles for a video. These URLs return a HTTP 200 response, but only contain the string `empty response` instead of actual subtitles. This can lead to errors from ffmpeg when asking it to embed or convert such a subtitle file (see [original report](https://discord.com/channels/807245652072857610/807247901981016094/1432879336565772419)).

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
