### PR TITLE
[ie/youtube] Fix remote components warning

### DIFF
--- a/yt_dlp/extractor/youtube/jsc/_director.py
+++ b/yt_dlp/extractor/youtube/jsc/_director.py
@@ -181,7 +181,7 @@ class JsChallengeRequestDirector:
                 return parts[0]
             return f'{", ".join(parts[:-1])} {joiner} {parts[-1]}'
 
-        if len(descriptions) > 1:
+        if len(descriptions) == 1:
             msg = (
                 f'Remote component {descriptions[0]} was skipped. '
                 f'It may be required to solve JS challenges. '


### PR DESCRIPTION
Fix bug in 6224a3898821965a7d6a2cb9cc2de40a0fd6e6bc

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
