### PR TITLE
[ie/ntv.ru] Rework extractor

### DIFF
--- a/yt_dlp/extractor/ntvru.py
+++ b/yt_dlp/extractor/ntvru.py
@@ -159,8 +159,8 @@ class NTVRuIE(InfoExtractor):
             'id': video_id,
             'formats': formats,
             **traverse_obj(metadata, {
-                'title': ('{*}title/text()', ..., {unescapeHTML}, any),
-                'description': ('{*}description/text()', ..., {unescapeHTML}, any),
+                'title': ('{*}title/text()', ..., {str}, {unescapeHTML}, any),
+                'description': ('{*}description/text()', ..., {str}, {unescapeHTML}, any),
                 'duration': ('{*}duration/text()', ..., {int_or_none}, any),
                 'timestamp': ('{*}create_date/text()', ..., {parse_iso8601}, any),
                 'release_timestamp': ('{*}upload_date/text()', ..., {parse_iso8601}, any),
@@ -170,8 +170,8 @@ class NTVRuIE(InfoExtractor):
                 'comment_count': ('{*}stats/comments/text()', ..., {int_or_none}, any),
             }),
             **traverse_obj(player, {
-                'title': ('data/title/text()', ..., {unescapeHTML}, any),
-                'description': ('data/description/text()', ..., {unescapeHTML}, any),
+                'title': ('data/title/text()', ..., {str}, {unescapeHTML}, any),
+                'description': ('data/description/text()', ..., {str}, {unescapeHTML}, any),
                 'duration': ('data/video/totaltime/text()', ..., {int_or_none}, any),
                 'view_count': ('data/video/views/text()', ..., {int_or_none}, any),
                 'thumbnail': ('data/video/splash/text()', ..., {url_or_none}, any),


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Closes #14929, Fixes #14761

#14929 is incomplete, as it does not remove the existing faulty video_id extraction logic. I would have just pushed to their branch, but they disallowed that.

While at it I also added more metadata extraction

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence) @anlar
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
