### PR TITLE
[ie/neteasemusic] Fix merged lyrics extraction

### DIFF
--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -184,7 +184,7 @@ class NetEaseMusicIE(NetEaseMusicBaseIE):
             'description': 'md5:deee249c8c9c3e2c54ecdab36e87d174',
             'album_artists': ['ひとひら'],
             'creators': ['ひとひら'],
-            'subtitles': {'lyrics': [{'ext': 'lrc'}]},
+            'subtitles': {'lyrics': [{'ext': 'lrc', 'data': 'md5:d32b4425a5d6c9fa249ca6e803dd0401'}]},
         },
     }, {
         'url': 'https://y.music.163.com/m/song?app_version=8.8.45&id=95670&uct2=sKnvS4+0YStsWkqsPhFijw%3D%3D&dlt=0846',


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

NetEase Music provides multilingual lyrics, and the current extractor attempts to merge them and provide the result as `lyrics_merged`. However, several cases are observed where `[MM:SS:ss]` is used in lyrics file instead of `[MM:SS.ss]`, causing the extractor to fail. These timestamps can be parsed properly in NetEase app though.

Example:

```shell
> yt-dlp https://music.163.com/\#/song\?id\=2755669235 --print subtitles
{'lyrics_merged': [{'data': '[00:00.00] 作词 : 山北せな\n[00:01.00] 作曲 : 山北せな', 'ext': 'lrc'}], 'lyrics': [{'data': '[00:00.00] 作词 : 山北せな\n[00:01.00] 作曲 : 山北せな\n[00:25:88]正しく混ざった三月の色\n[00:29:81]あなたと会った庭で積み上げてた\n[00:40:74]塔は白い\n[01:00:74]どこへ行くのどこに帰るの\n[01:09:13]余った体が鮮やかな色で汚す\n', 'ext': 'lrc'}], 'lyrics_translated': [{'data': '[by:食腐crow]\n[00:25:88]三月的色彩 恰如其分地交融\n[00:29:81]在与你相遇的庭院里 堆叠的\n[00:40:74]塔 是纯白的\n[01:00:74]要去向何方 要归往何处\n[01:09:13]多余的躯体 被鲜艳的色彩玷污\n', 'ext': 'lrc'}]}
```

This PR adds the ability to parse this kind of timestamp. Additionally, a corresponding test case has been added, and an outdated test has been fixed.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
