### PR TITLE
Implement playlist handling for ERRJupiterIE sites

### DIFF
--- a/yt_dlp/extractor/err.py
+++ b/yt_dlp/extractor/err.py
@@ -239,7 +239,7 @@ class ERRJupiterIE(InfoExtractor):
             # XXX: Apparently we need to fill out the playlist_id
             if self._yes_playlist('dummy-id', video_id, idata):
                 playlist_type = season_data.get('type')
-                if playlist_type in ('seasonal', 'monthly'):
+                if playlist_type in ('seasonal', 'monthly', 'shortSeriesList'):
                     active_season = next(season for season in season_data.get('items') if season.get('contents'))
                     entries = [
                         self.url_result(smuggle_url(episode['url'], {'force_noplaylist': True}))


### PR DESCRIPTION
Implement support for playlists for ERR sites.

Existing tests still work, though I'm not really sure how to add the playlist info there.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>