### PR TITLE
Update runtime path determination to use shutil.which

### DIFF
--- a/yt_dlp/utils/_jsruntime.py
+++ b/yt_dlp/utils/_jsruntime.py
@@ -16,7 +16,7 @@ def runtime_version_tuple(v):
 
 def _determine_runtime_path(path, basename):
     if not path:
-        return shutil.which(basename)
+        return shutil.which(basename) or basename
     if os.path.isdir(path):
         return os.path.join(path, basename)
     return path


### PR DESCRIPTION
this fixed issue #15043 on my machine

<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fixes #15043;

copied from my comment:
If you install deno via npm, npm puts 3 files in path; on my system, it's at `C:\Users\me\AppData\Roaming\npm`
- `deno` - a unix shell script beginning with `#!/bin/sh`
- `deno.cmd` - a batch script
- `deno.ps1` - a powershell script

if I manually specify the path on the cli with `--verbose --js-runtimes deno:C:\Users\me\AppData\Roaming\npm\deno.cmd`, only that file with the `.cmd` extension works with loading: `[debug] JS runtimes: deno-2.5.6`

I was curious how `Popen` was resolving the executable name, and saw `shutil.which` in the docs. running `shutil.which("deno")` in my REPL correctly returned `'C:\\Users\\me\\AppData\\Roaming\\npm\\deno.CMD'`, so using that might be a solution for fixing this.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
