### PR TITLE
[NHK] Follow redirection from TV page URLs to ondemand URLs

### DIFF
--- a/yt_dlp/extractor/nhk.py
+++ b/yt_dlp/extractor/nhk.py
@@ -86,7 +86,10 @@ class NhkBaseIE(InfoExtractor):
 
     def _extract_episode_info(self, url, episode=None):
         fetch_episode = episode is None
-        lang, m_type, episode_id = NhkVodIE._match_valid_url(url).group('lang', 'type', 'id')
+        match = NhkVodIE._match_valid_url(url)
+        lang = match.group('lang')
+        m_type = match.group('type') or 'video'  # Default to video if type not specified
+        episode_id = match.group('id')
         is_video = m_type != 'audio'
 
         if is_video:
@@ -163,7 +166,7 @@ class NhkVodIE(NhkBaseIE):
     _VALID_URL = [
         rf'{NhkBaseIE._BASE_URL_REGEX}shows/(?:(?P<type>video)/)?(?P<id>\d{{4}}[\da-z]\d+)/?(?:$|[?#])',
         rf'{NhkBaseIE._BASE_URL_REGEX}(?:ondemand|shows)/(?P<type>audio)/(?P<id>[^/?#]+?-\d{{8}}-[\da-z]+)',
-        rf'{NhkBaseIE._BASE_URL_REGEX}ondemand/(?P<type>video)/(?P<id>\d{{4}}[\da-z]\d+)',  # deprecated
+        rf'{NhkBaseIE._BASE_URL_REGEX}ondemand/(?P<type>video)/(?P<id>\d{{4}}[\da-z]\d+)/?',  # deprecated
         rf'{NhkBaseIE._BASE_URL_REGEX}tv/[^/]+/\d+/(?P<id>\d{{4}}[\da-z]\d+)/?',  # TV page URLs
     ]
     # Content available only for a limited period of time. Visit


### PR DESCRIPTION
   Fixes #5760

   This adds support for TV page URLs like:
   `https://www3.nhk.or.jp/nhkworld/en/tv/72hours/20221129/4026171`

   These URLs should redirect to:
   `https://www3.nhk.or.jp/nhkworld/en/ondemand/video/4026171`

   The fix detects the TV page pattern (`tv/[category]/[date]/[videoID]`) and constructs the corresponding ondemand URL before extracting episode info.