### PR TITLE
[pp/ffmpeg] Fix uncaught error when bad --ffmpeg-location is given

### DIFF
--- a/yt_dlp/downloader/external.py
+++ b/yt_dlp/downloader/external.py
@@ -457,6 +457,8 @@ class FFmpegFD(ExternalFD):
 
     @classmethod
     def available(cls, path=None):
+        # TODO: Fix path for ffmpeg
+        # Fixme: This may be wrong when --ffmpeg-location is used
         return FFmpegPostProcessor().available
 
     def on_process_started(self, proc, stdin):

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -192,7 +192,10 @@ class FFmpegPostProcessor(PostProcessor):
 
     @property
     def available(self):
-        return bool(self._ffmpeg_location.get()) or self.basename is not None
+        # If we return that ffmpeg is available, then the basename property *must* be run
+        # (as doing so has side effects), and its value can never be None
+        # See: https://github.com/yt-dlp/yt-dlp/issues/12829
+        return self.basename is not None
 
     @property
     def executable(self):


### PR DESCRIPTION
Revert 9f77e04c76e36e1cbbf49bc9eb385fa6ef804b67

Closes #12829

### Description of your *pull request* and other information

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
