### PR TITLE
[build] Bump PyInstaller minimum version requirement to 6.17.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,23 +422,23 @@ jobs:
           runner: windows-2025
           python_version: '3.10'
           platform_tag: win_amd64
-          pyi_version: '6.16.0'
-          pyi_tag: '2025.09.13.221251'
-          pyi_hash: b6496c7630c3afe66900cfa824e8234a8c2e2c81704bd7facd79586abc76c0e5
+          pyi_version: '6.17.0'
+          pyi_tag: '2025.11.29.054325'
+          pyi_hash: e28cc13e4ad0cc74330d832202806d0c1976e9165da6047309348ca663c0ed3d
         - arch: 'x86'
           runner: windows-2025
           python_version: '3.10'
           platform_tag: win32
-          pyi_version: '6.16.0'
-          pyi_tag: '2025.09.13.221251'
-          pyi_hash: 2d881843580efdc54f3523507fc6d9c5b6051ee49c743a6d9b7003ac5758c226
+          pyi_version: '6.17.0'
+          pyi_tag: '2025.11.29.054325'
+          pyi_hash: c00f600c17de3bdd589f043f60ab64fc34fcba6dd902ad973af9c8afc74f80d1
         - arch: 'arm64'
           runner: windows-11-arm
           python_version: '3.13'  # arm64 only has Python >= 3.11 available
           platform_tag: win_arm64
-          pyi_version: '6.16.0'
-          pyi_tag: '2025.09.13.221251'
-          pyi_hash: 4250c9085e34a95c898f3ee2f764914fc36ec59f0d97c28e6a75fcf21f7b144f
+          pyi_version: '6.17.0'
+          pyi_tag: '2025.11.29.054325'
+          pyi_hash: a2033b18b4f7bc6108b5fd76a92c6c1de0a12ec4fe98a23396a9f978cb4b7d7b
     env:
       CHANNEL: ${{ inputs.channel }}
       ORIGIN: ${{ needs.process.outputs.origin }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ build = [
     "build",
     "hatchling>=1.27.0",
     "pip",
-    "setuptools>=71.0.2,<81",  # See https://github.com/pyinstaller/pyinstaller/issues/9149
+    "setuptools>=71.0.2",
     "wheel",
 ]
 dev = [
@@ -86,7 +86,7 @@ test = [
     "pytest-rerunfailures~=14.0",
 ]
 pyinstaller = [
-    "pyinstaller>=6.13.0",  # Windows temp cleanup fixed in 6.13.0
+    "pyinstaller>=6.17.0",  # 6.17.0+ needed for compat with setuptools 81+
 ]
 
 [project.urls]


### PR DESCRIPTION
setuptools warns that `pkg_resources` could be removed as early as 2025-11-30, so we need to require a PyInstaller version that will be compatible with setuptools 81+

Ref:
- https://github.com/pyinstaller/pyinstaller/issues/9149


Successful release workflow run:
- https://github.com/bashonly/yt-dlp/actions/runs/19780041197

Test executables:
- https://github.com/bashonly/yt-dlp/releases/tag/pyinst

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Maintenance

</details>
