### PR TITLE
[devscripts] `install_deps`: Align options/terms with PEP 735

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,14 +343,14 @@ jobs:
           brew uninstall --ignore-dependencies python3
           python3 -m venv ~/yt-dlp-build-venv
           source ~/yt-dlp-build-venv/bin/activate
-          python3 devscripts/install_deps.py --only-optional-groups --include-group build
-          python3 devscripts/install_deps.py --print --include-group pyinstaller > requirements.txt
+          python3 devscripts/install_deps.py --omit-default --include-extra build
+          python3 devscripts/install_deps.py --print --include-extra pyinstaller > requirements.txt
           # We need to ignore wheels otherwise we break universal2 builds
           python3 -m pip install -U --no-binary :all: -r requirements.txt
           # We need to fuse our own universal2 wheels for curl_cffi
           python3 -m pip install -U 'delocate==0.11.0'
           mkdir curl_cffi_whls curl_cffi_universal2
-          python3 devscripts/install_deps.py --print --only-optional-groups --include-group curl-cffi > requirements.txt
+          python3 devscripts/install_deps.py --print --omit-default --include-extra curl-cffi > requirements.txt
           for platform in "macosx_11_0_arm64" "macosx_11_0_x86_64"; do
             python3 -m pip download \
               --only-binary=:all: \
@@ -484,11 +484,11 @@ jobs:
           mkdir /pyi-wheels
           python -m pip download -d /pyi-wheels --no-deps --require-hashes "pyinstaller@${Env:PYI_URL}#sha256=${Env:PYI_HASH}"
           python -m pip install --force-reinstall -U "/pyi-wheels/${Env:PYI_WHEEL}"
-          python devscripts/install_deps.py --only-optional-groups --include-group build
+          python devscripts/install_deps.py --omit-default --include-extra build
           if ("${Env:ARCH}" -eq "x86") {
             python devscripts/install_deps.py
           } else {
-            python devscripts/install_deps.py --include-group curl-cffi
+            python devscripts/install_deps.py --include-extra curl-cffi
           }
 
       - name: Prepare

--- a/.github/workflows/challenge-tests.yml
+++ b/.github/workflows/challenge-tests.yml
@@ -67,7 +67,7 @@ jobs:
           unzip quickjs.zip
     - name: Install test requirements
       run: |
-        python ./devscripts/install_deps.py --print --only-optional-groups --include-group test > requirements.txt
+        python ./devscripts/install_deps.py --print --omit-default --include-extra test > requirements.txt
         python ./devscripts/install_deps.py --print -c certifi -c requests -c urllib3 -c yt-dlp-ejs >> requirements.txt
         python -m pip install -U -r requirements.txt
     - name: Run tests

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test requirements
-      run: python ./devscripts/install_deps.py --include-group test --include-group curl-cffi
+      run: python ./devscripts/install_deps.py --include-extra test --include-extra curl-cffi
     - name: Run tests
       timeout-minutes: 15
       continue-on-error: False

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install test requirements
-      run: python ./devscripts/install_deps.py --include-group dev
+      run: python ./devscripts/install_deps.py --include-extra dev
     - name: Run tests
       continue-on-error: true
       run: python ./devscripts/run_tests.py download
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test requirements
-      run: python ./devscripts/install_deps.py --include-group dev
+      run: python ./devscripts/install_deps.py --include-extra dev
     - name: Run tests
       continue-on-error: true
       run: python ./devscripts/run_tests.py download

--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install test requirements
-      run: python ./devscripts/install_deps.py --only-optional-groups --include-group test
+      run: python ./devscripts/install_deps.py --omit-default --include-extra test
     - name: Run tests
       timeout-minutes: 15
       run: |
@@ -31,7 +31,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install dev dependencies
-      run: python ./devscripts/install_deps.py --only-optional-groups --include-group static-analysis
+      run: python ./devscripts/install_deps.py --omit-default --include-extra static-analysis
     - name: Make lazy extractors
       run: python ./devscripts/make_lazy_extractors.py
     - name: Run ruff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install Requirements
         run: |
           sudo apt -y install pandoc man
-          python devscripts/install_deps.py --only-optional-groups --include-group build
+          python devscripts/install_deps.py --omit-default --include-extra build
 
       - name: Prepare
         env:

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           ACTIONLINT_TARBALL: ${{ format('actionlint_{0}_linux_amd64.tar.gz', env.ACTIONLINT_VERSION) }}
         run: |
-          python -m devscripts.install_deps --only-optional-groups --include-group test
+          python -m devscripts.install_deps --omit-default --include-extra test
           sudo apt -y install shellcheck
           python -m pip install -U pyflakes
           curl -LO "${ACTIONLINT_REPO}/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_TARBALL}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ While it is strongly recommended to use `hatch` for yt-dlp development, if you a
 
 ```shell
 # To only install development dependencies:
-$ python -m devscripts.install_deps --include-group dev
+$ python -m devscripts.install_deps --include-extra dev
 
 # Or, for an editable install plus dev dependencies:
 $ python -m pip install -e ".[default,dev]"

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ To build the standalone executable, you must have Python and `pyinstaller` (plus
 You can run the following commands:
 
 ```
-python devscripts/install_deps.py --include-group pyinstaller
+python devscripts/install_deps.py --include-extra pyinstaller
 python devscripts/make_lazy_extractors.py
 python -m bundle.pyinstaller
 ```

--- a/bundle/docker/linux/build.sh
+++ b/bundle/docker/linux/build.sh
@@ -15,12 +15,12 @@ function venvpy {
 }
 
 INCLUDES=(
-    --include-group pyinstaller
-    --include-group secretstorage
+    --include-extra pyinstaller
+    --include-extra secretstorage
 )
 
 if [[ -z "${EXCLUDE_CURL_CFFI:-}" ]]; then
-    INCLUDES+=(--include-group curl-cffi)
+    INCLUDES+=(--include-extra curl-cffi)
 fi
 
 runpy -m venv /yt-dlp-build-venv
@@ -28,7 +28,7 @@ runpy -m venv /yt-dlp-build-venv
 source /yt-dlp-build-venv/bin/activate
 # Inside the venv we use venvpy instead of runpy
 venvpy -m ensurepip --upgrade --default-pip
-venvpy -m devscripts.install_deps --only-optional-groups --include-group build
+venvpy -m devscripts.install_deps --omit-default --include-extra build
 venvpy -m devscripts.install_deps "${INCLUDES[@]}"
 venvpy -m devscripts.make_lazy_extractors
 venvpy devscripts/update-version.py -c "${CHANNEL}" -r "${ORIGIN}" "${VERSION}"


### PR DESCRIPTION
[PEP 735](https://peps.python.org/pep-0735/) introduced "dependency groups," which is something completely new and different from "extras" (a.k.a. the `project.optional-dependencies` table in `pyproject.toml`).

Some of our documentation and code referred to the old optional dependency "extras" as "dependency groups," which is now incorrect and potentially confusing.

There is one small documentation fix in #15016, otherwise everything else is being fixed in this pull request. The renaming of options in `devscripts.install_deps` is a breaking change, so I decided this patch should have its own PR instead of smuggling this change in the cleanup PR.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Code cleanup/maintenance

</details>
