### PR TITLE
[cookies] Fix `--cookies-from-browser` for new installs of Firefox 147+

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -217,8 +217,10 @@ def _firefox_browser_dirs():
             os.path.join(_config_home(), 'mozilla/firefox'),
             # Existing FF version<=146 installations
             '~/.mozilla/firefox',
+            # Flatpak XDG: https://docs.flatpak.org/en/latest/conventions.html#xdg-base-directories
             '~/.var/app/org.mozilla.firefox/config/mozilla/firefox',
             '~/.var/app/org.mozilla.firefox/.mozilla/firefox',
+            # Snap installations do not respect the XDG base directory specification
             '~/snap/firefox/common/.mozilla/firefox',
         ))
 


### PR DESCRIPTION
New installations of Firefox 147+ respect the XDG base directory specification.

Profile data will be stored in `${XDG_CONFIG_HOME:-~/.config}/mozilla/firefox` instead of `~/.mozilla/firefox`.

Pre-existing installations that upgrade to FF147+ will keep their profile data in `~/.mozilla/firefox`.

Refs:
- https://bugzilla.mozilla.org/show_bug.cgi?id=259356
- https://hg-edge.mozilla.org/integration/autoland/diff/8a6d6c094cb5a842d415c60bb8395db03b36e531/xpcom/io/nsAppFileLocationProvider.cpp#l1.31

Per @mbway in https://github.com/yt-dlp/yt-dlp/pull/13198#discussion_r2592565917, snap installs are not affected by this change, whereas flatpak installs are (and a path has been added accordingly).

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
