### PR TITLE
[ie/loom] Fix extractor

### DIFF
--- a/yt_dlp/extractor/loom.py
+++ b/yt_dlp/extractor/loom.py
@@ -349,7 +349,7 @@ class LoomIE(InfoExtractor):
 
     def _get_subtitles(self, video_id):
         subs_data = self._call_graphql_api(
-            'FetchVideoTranscript', video_id, 'Downloading GraphQL subtitles data')
+            'FetchVideoTranscript', video_id, 'Downloading GraphQL subtitles JSON', fatal=False)
         return filter_dict({
             'en': traverse_obj(subs_data, (
                 'data', 'fetchVideoTranscript',


### PR DESCRIPTION
Loom's GraphQL API only accepts one query/operation per request now.

This PR does not fix `LoomFolderIE`, which is apparently completely broken now.

Closes #15141


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
