### PR TITLE
Add per-fragment rate limiting for concurrent fragments

### DIFF
--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -825,6 +825,7 @@ def parse_options(argv=None):
         'force_generic_extractor': opts.force_generic_extractor,
         'allowed_extractors': opts.allowed_extractors or ['default'],
         'ratelimit': opts.ratelimit,
+        'ratelimit_per_fragment': opts.ratelimit_per_fragment,
         'throttledratelimit': opts.throttledratelimit,
         'overwrites': opts.overwrites,
         'retries': opts.retries,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -969,6 +969,16 @@ def create_parser():
         dest='ratelimit', metavar='RATE',
         help='Maximum download rate in bytes per second, e.g. 50K or 4.2M')
     downloader.add_option(
+        '--rate-limit-per-fragment',
+        action='store_true', dest='ratelimit_per_fragment', default=None,
+        help='Divide rate limit by number of concurrent fragments for smoother rate limiting with HLS/DASH. '
+             'When enabled, each fragment gets its fair share of the rate limit, preventing network bursts. '
+             'Automatically enabled for fragmented downloads when --limit-rate is set (default: auto)')
+    downloader.add_option(
+        '--no-rate-limit-per-fragment',
+        action='store_false', dest='ratelimit_per_fragment',
+        help='Disable automatic per-fragment rate limiting for fragmented downloads')
+    downloader.add_option(
         '--throttled-rate',
         dest='throttledratelimit', metavar='RATE',
         help='Minimum download rate in bytes per second below which throttling is assumed and the video data is re-extracted, e.g. 100K')


### PR DESCRIPTION
### Description of your *pull request* and other information

Implements per-fragment rate limiting for concurrent fragment downloads to prevent network bursts when downloading HLS/DASH videos with `--limit-rate` and `--concurrent-fragments`.

**Problem**: 
When downloading fragmented videos (HLS/DASH) with `--limit-rate` and `--concurrent-fragments`, each fragment downloads at maximum speed then pauses to average out the rate. With concurrent fragments, this creates network bursts that disrupt other users on shared networks (see issue #10525).

**Solution**:
Divide the rate limit by the number of concurrent fragments, ensuring each fragment gets its fair share. This prevents network bursts by distributing the rate limit evenly across all concurrent downloads.

**Key Changes**:
- Modify `slow_down()` method in `downloader/common.py` to divide rate limit by concurrent fragments when `ratelimit_per_fragment` is enabled
- Auto-enable per-fragment rate limiting in `FragmentFD._prepare_frag_download()` when `rate_limit` is set and `concurrent_fragments > 1`
- Add `--rate-limit-per-fragment` and `--no-rate-limit-per-fragment` CLI options in `options.py`
- Pass `ratelimit_per_fragment` parameter through `ydl_opts` in `__init__.py`
- Display informative messages showing total and per-fragment rate limits

**Technical Details**:
- Simple division: `rate_limit_per_fragment = rate_limit / concurrent_fragments`
- Example: `--limit-rate 2M` with `--concurrent-fragments 4` → 0.5M per fragment
- Each fragment independently enforces its share of the rate limit
- Backward compatible: Falls back to original behavior when disabled or single fragment

**Testing**:
- Code follows yt-dlp coding conventions
- No linter errors
- Backward compatible
- Simple, maintainable implementation

Fixes #10525

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly

    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])

    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:

- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)

- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/).
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
