### PR TITLE
BeaconTv: detect and parse JWPlayer chapter VTT tracks

### DIFF
--- a/yt_dlp/extractor/beacon.py
+++ b/yt_dlp/extractor/beacon.py
@@ -1,4 +1,6 @@
+import html
 import json
+import re
 
 from .common import InfoExtractor
 from ..utils import (
@@ -6,6 +8,67 @@ from ..utils import (
     parse_iso8601,
     traverse_obj,
 )
+
+_VTT_TIMESTAMP_RE = re.compile(r'(?:(\d+):)?(\d{2}):(\d{2}\.\d{3})')
+
+
+def _vtt_time_to_seconds(ts):
+    if not ts:
+        return None
+    m = _VTT_TIMESTAMP_RE.match(ts)
+    if not m:
+        try:
+            return float(ts)
+        except Exception:
+            return None
+    hours = int(m.group(1)) if m.group(1) else 0
+    minutes = int(m.group(2))
+    seconds = float(m.group(3))
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def parse_vtt_chapters(vtt_text):
+    """
+    Minimal WebVTT chapter parser.
+    Returns list of dicts: {'start_time': float, 'end_time': float, 'title': str}
+    """
+    chapters = []
+    if not vtt_text:
+        return chapters
+    lines = vtt_text.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+    i = 0
+    if i < len(lines) and lines[i].strip().upper().startswith('WEBVTT'):
+        i += 1
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+
+    while i < len(lines):
+        if lines[i].strip() and '-->' not in lines[i]:
+            i += 1
+            if i >= len(lines):
+                break
+        if i < len(lines) and '-->' in lines[i]:
+            timing = lines[i].strip()
+            parts = timing.split('-->')
+            start_ts = parts[0].strip()
+            end_ts = parts[1].split()[0].strip() if len(parts) > 1 else None
+            start = _vtt_time_to_seconds(start_ts)
+            end = _vtt_time_to_seconds(end_ts) if end_ts else None
+            i += 1
+            text_lines = []
+            while i < len(lines) and lines[i].strip():
+                text_lines.append(lines[i])
+                i += 1
+            title = html.unescape(' '.join(l.strip() for l in text_lines)).strip()
+            if start is not None:
+                chapters.append({
+                    'start_time': start,
+                    'end_time': end,
+                    'title': title or None,
+                })
+        else:
+            i += 1
+    return chapters
 
 
 class BeaconTvIE(InfoExtractor):
@@ -58,11 +121,90 @@ class BeaconTvIE(InfoExtractor):
                 self.raise_login_required('This video/podcast is for members only')
             raise ExtractorError('Failed to extract content')
 
-        return {
-            **self._parse_jwplayer_data(jwplayer_data, video_id),
-            **traverse_obj(content_data, {
-                'title': ('title', {str}),
-                'description': ('description', {str}),
-                'timestamp': ('publishedAt', {parse_iso8601}),
-            }),
-        }
+        info = {**self._parse_jwplayer_data(jwplayer_data, video_id),
+                **traverse_obj(content_data, {
+                    'title': ('title', {str}),
+                    'description': ('description', {str}),
+                    'timestamp': ('publishedAt', {parse_iso8601}),
+                })}
+
+        chapter_url = None
+
+        def pick_from_track_obj(t):
+            file_url = (t.get('file') or t.get('src') or t.get('url') or '').strip()
+            kind = (t.get('kind') or '').lower()
+            label = (t.get('label') or t.get('name') or '').lower()
+            if not file_url or not file_url.lower().endswith('.vtt'):
+                return None
+            if kind == 'chapters' or 'chapter' in label or 'chapter' in file_url.lower() or 'chapters' in file_url.lower():
+                return file_url
+            return None
+
+        tracks = None
+        if isinstance(jwplayer_data, dict):
+            tracks = jwplayer_data.get('tracks') or jwplayer_data.get('textTracks') or None
+        if isinstance(tracks, list):
+            for t in tracks:
+                candidate = pick_from_track_obj(t)
+                if candidate:
+                    chapter_url = candidate
+                    break
+
+        if not chapter_url:
+            subs = info.get('subtitles') if isinstance(info, dict) else None
+            if isinstance(subs, dict):
+                for _lang, tracks_list in subs.items():
+                    if not isinstance(tracks_list, list):
+                        continue
+                    for t in tracks_list:
+                        candidate = pick_from_track_obj(t)
+                        if candidate:
+                            chapter_url = candidate
+                            break
+                    if chapter_url:
+                        break
+
+        def scan_for_tracks(obj):
+            if isinstance(obj, dict):
+                if 'tracks' in obj and isinstance(obj['tracks'], list):
+                    for t in obj['tracks']:
+                        if isinstance(t, dict):
+                            candidate = pick_from_track_obj(t)
+                            if candidate:
+                                return candidate
+                for _k, v in obj.items():
+                    if isinstance(v, str):
+                        if ('{' in v and '}' in v):
+                            try:
+                                parsed = json.loads(v)
+                                res = scan_for_tracks(parsed)
+                                if res:
+                                    return res
+                            except Exception:
+                                pass
+                    else:
+                        res = scan_for_tracks(v)
+                        if res:
+                            return res
+            elif isinstance(obj, list):
+                for item in obj:
+                    res = scan_for_tracks(item)
+                    if res:
+                        return res
+            return None
+
+        if not chapter_url:
+            chapter_url = scan_for_tracks(content_data)
+
+        if chapter_url:
+            try:
+                vtt_text = self._download_webpage(chapter_url, video_id, note='Downloading chapter VTT', fatal=False)
+                if vtt_text:
+                    chapters = parse_vtt_chapters(vtt_text)
+                    if chapters:
+                        if not info.get('chapters'):
+                            info['chapters'] = chapters
+            except Exception:
+                self.report_warning('Failed to download/parse chapter VTT', video_id)
+
+        return info


### PR DESCRIPTION
**Problem**
-------
Beacon has recently started adding official chapters to new Campaign 4 episodes and some one-shots. These videos include JWPlayer chapter tracks inside nested or JSON-encoded fields (e.g., videoData strings in the page's __NEXT_DATA__). The beacon.py extractor previously missed these, so `info['chapters']` was not populated

**Solution**
--------
- Recursively scan jwplayer_data, info['subtitles'], and content_data (including JSON-encoded videoData) for .vtt tracks
- Download and parse the first matching VTT (non-fatal)
- Populate `info['chapters']` with the parsed chapter list

**Notes**
-----
- Requires logged-in cookies from Beacon.tv membership
- Embed chapters using yt-dlp's postprocessors as usual (`--embed-metadata` or `--embed-chapters`)
- If no VTT is found or parsing fails, extraction proceeds normally

**How to test**
-----------
Run (Windows): `yt-dlp --cookies "~/cookies.txt" -J "https://beacon.tv/content/c4-e009-to-the-hounds" > out.json 2> ytlog.txt`

Expect a non-empty chapters array for the sample URL in out.json:
```
[...] "chapters": [{"start_time": 0.0, "end_time": 833.265, "title": "Cold Open"}, {"start_time": 833.266, "end_time": 1213.579, "title": "Announcement Playhouse"}, {"start_time": 1213.58, "end_time": 1559.391, "title": "Opening Title"}, {"start_time": 1559.392, "end_time": 4433.766, "title": "In the Kingdom of Timmony"}, {"start_time": 4433.767, "end_time": 5390.255, "title": "Miller's Road"}, {"start_time": 5390.256, "end_time": 6813.912, "title": "The Black Rabbits"}, {"start_time": 6813.913, "end_time": 9196.662, "title": "Candle Feast"}, {"start_time": 9196.663, "end_time": 9196.829, "title": "Break"}, {"start_time": 9196.83, "end_time": 11620.219, "title": "Tybry's Lea"}, {"start_time": 11620.22, "end_time": 11927.893, "title": "The Convert"}, {"start_time": 11927.894, "end_time": 13210.275, "title": "Infiltrating Castle Delawney"}, {"start_time": 13210.276, "end_time": 14709.041, "title": "Castle Delawney Cellar"}, {"start_time": 14709.042, "end_time": 14709.1, "title": "End of Show"}], "webpage_url": "https://beacon.tv/content/c4-e009-to-the-hounds", [...]
 ```