### PR TITLE
[ie/picarto] fix 'AttributeError' when stream has no 'title'

### DIFF
--- a/yt_dlp/extractor/picarto.py
+++ b/yt_dlp/extractor/picarto.py
@@ -159,7 +159,7 @@ class PicartoVodIE(InfoExtractor):
             'id': video_id,
             **traverse_obj(data, {
                 'id': ('id', {str_or_none}),
-                'title': ('title', {strip_or_none}),
+                'title': ('title', {str.strip}),
                 'thumbnail': 'video_recording_image_url',
                 'channel': ('channel', 'name', {str}),
                 'age_limit': ('adult', {lambda x: 18 if x else 0}),


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fixes #14540

The `picarto` IE raises an exception when a livestream has no `title`.
This change prevents this from happening.

``` python
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/yt_dlp/YoutubeDL.py", line 1645, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/lib/python3.13/site-packages/yt_dlp/YoutubeDL.py", line 1780, in __extract_info
    ie_result = ie.extract(url)
  File "/usr/lib/python3.13/site-packages/yt_dlp/extractor/common.py", line 762, in extract
    ie_result = self._real_extract(url)
  File "/usr/lib/python3.13/site-packages/yt_dlp/extractor/picarto.py", line 82, in _real_extract
    'title': title.strip(),
             ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
