### PR TITLE
[ie/rinsefm] Fix release_timestamp extraction

### DIFF
--- a/yt_dlp/extractor/rinsefm.py
+++ b/yt_dlp/extractor/rinsefm.py
@@ -1,8 +1,9 @@
+import datetime as dt
+
 from .common import InfoExtractor
 from ..utils import (
     MEDIA_EXTENSIONS,
     determine_ext,
-    parse_iso8601,
     url_or_none,
 )
 from ..utils.traversal import traverse_obj
@@ -11,14 +12,19 @@ from ..utils.traversal import traverse_obj
 class RinseFMBaseIE(InfoExtractor):
     _API_BASE = 'https://rinse.fm/api/query/v1'
 
-    @staticmethod
-    def _parse_entry(entry):
+    # Offsets from UTC in hours, no DST
+    _TZ_OFFSETS = {
+        'Europe/London': 0,
+        'Europe/Paris': 1,
+    }
+
+    def _parse_entry(self, entry):
         return {
             **traverse_obj(entry, {
                 'id': ('id', {str}),
                 'title': ('title', {str}),
                 'url': ('fileUrl', {url_or_none}),
-                'release_timestamp': ('episodeDate', {parse_iso8601}),
+                'release_timestamp': {self._extract_episode_timestamp},
                 'thumbnail': ('featuredImage', 0, 'filename', {str},
                               {lambda x: x and f'https://rinse.imgix.net/media/{x}'}),
                 'webpage_url': ('slug', {str},
@@ -28,6 +34,37 @@ class RinseFMBaseIE(InfoExtractor):
             'extractor_key': RinseFMIE.ie_key(),
             'extractor': RinseFMIE.IE_NAME,
         }
+
+    def _extract_episode_timestamp(self, entry):
+        # episodeDate contains the local date of the episode with the time set to 00:00:00
+        # _or_ the date of the previous day with the time set to 23:00:00 if DST was in effect
+        # at the time of the episode; the TZ offset is always set to +00:00 and should be ignored
+        episode_date = traverse_obj(entry, ('episodeDate', {dt.datetime.fromisoformat}))
+        if episode_date is None:
+            return None
+        if episode_date.hour not in [23, 0] or episode_date.minute != 0 or episode_date.second != 0:
+            self.report_warning(f'Unexpected episodeDate time: {episode_date}', entry.get('slug'))
+            return None
+        if episode_date.tzinfo not in [dt.timezone.utc, None]:
+            self.report_warning(
+                f'Unexpected episodeDate time zone: {episode_date.tzinfo}', entry.get('slug'))
+            return None
+        # episodeTime contains some random date (usually the current date) with the local time
+        # of the episode; both the date and the TZ offset should be ignored
+        episode_time = traverse_obj(entry, ('episodeTime', {dt.datetime.fromisoformat}))
+        if episode_time is None:
+            return None
+        tz_name = traverse_obj(entry, ('channel', 0, 'defaultTimezoneOffset'))
+        if not tz_name:
+            return None
+        # As episodeDate is already adjusted for DST, we should always use a "winter" time zone
+        tz_offset = self._TZ_OFFSETS.get(tz_name)
+        if tz_offset is None:
+            self.report_warning(f'Unknown channel time zone: {tz_name}', entry.get('slug'))
+            return None
+        episode_time_as_delta = dt.timedelta(
+            hours=episode_time.hour, minutes=episode_time.minute, seconds=episode_time.second)
+        return (episode_date + episode_time_as_delta - dt.timedelta(hours=tz_offset)).timestamp()
 
 
 class RinseFMIE(RinseFMBaseIE):
@@ -40,7 +77,7 @@ class RinseFMIE(RinseFMBaseIE):
             'ext': 'mp3',
             'title': 'Club Glow - 15/12/2023 - 20:00',
             'thumbnail': r're:^https://.+\.(?:jpg|JPG)$',
-            'release_timestamp': 1702598400,
+            'release_timestamp': 1702670400.0,
             'release_date': '20231215',
         },
     }]


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

The actual episode datetime is split into two fields – episodeDate and episodeTime – with the following quirks:

1. It's _local_ (UTC offset is present but is always set to +00:00 and should be ignored).
2. episodeDate is set to midnight of the episode date, unless DST was in effect at that moment, in which case one hour is subtracted, that is, episodeDate is set to 23:00 of the day _before_ the actual episode date.
3. the date part of episodeTime is garbage and should be ignored.

The one-hour-subtracted-in-case-of-DST quirk is actually a silver lining: as we don't have TZ database on Windows (stdlib's zoneinfo won't work unless tzdata is installed), we have to bring our own TZ offsets info, and, since episodeDate is already adjusted for DST, we only need regular ("winter") offsets, which, in case of both Europe/London (Rinse UK, Kool FM, SWU FM) and Europe/Paris (Rinse France) are established a long time ago (in the 19th and 20th century, respectively) and stay stable in the 21st century, therefore, it's relatively safe to simply hard code them into the extractor.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
