### PR TITLE
[fd/websocket] Migrate to new websockets asyncio connect

### DIFF
--- a/yt_dlp/downloader/websocket.py
+++ b/yt_dlp/downloader/websocket.py
@@ -6,7 +6,7 @@ import threading
 
 from .common import FileDownloader
 from .external import FFmpegFD
-from ..dependencies import websockets
+from ..dependencies import websockets  # noqa: F401
 
 
 class FFmpegSinkFD(FileDownloader):
@@ -45,7 +45,8 @@ class FFmpegSinkFD(FileDownloader):
 
 class WebSocketFragmentFD(FFmpegSinkFD):
     async def real_connection(self, sink, info_dict):
-        async with websockets.connect(info_dict['url'], extra_headers=info_dict.get('http_headers', {})) as ws:
+        from websockets.asyncio.client import connect
+        async with connect(info_dict['url'], additional_headers=info_dict.get('http_headers', {})) as ws:
             while True:
                 recv = await ws.recv()
                 if isinstance(recv, str):


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

Client APIs
`websockets.connect()` → `websockets.asyncio.client.connect()`
https://websockets.readthedocs.io/en/latest/howto/upgrade.html#client-apis

HTTP headers
`extra_headers` → `additional_headers`
https://websockets.readthedocs.io/en/latest/howto/upgrade.html#arguments-of-connect
https://websockets.readthedocs.io/en/latest/faq/client.html#how-do-i-set-http-headers


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
