### PR TITLE
Clarify failure when video streams are gated

### DIFF
--- a/yt_dlp/extractor/xiaohongshu.py
+++ b/yt_dlp/extractor/xiaohongshu.py
@@ -1,6 +1,6 @@
-
 from .common import InfoExtractor
 from ..utils import (
+    ExtractorError,
     float_or_none,
     int_or_none,
     js_to_json,
@@ -13,94 +13,103 @@ from ..utils.traversal import traverse_obj
 class XiaoHongShuIE(InfoExtractor):
     _VALID_URL = r'https?://www\.xiaohongshu\.com/(?:explore|discovery/item)/(?P<id>[\da-f]+)'
     IE_DESC = '小红书'
-    _TESTS = [{
-        'url': 'https://www.xiaohongshu.com/explore/6411cf99000000001300b6d9',
-        'md5': '2a87a77ddbedcaeeda8d7eae61b61228',
-        'info_dict': {
-            'id': '6411cf99000000001300b6d9',
-            'ext': 'mp4',
-            'uploader_id': '5c31698d0000000007018a31',
-            'description': '#今日快乐今日发[话题]# #吃货薯看这里[话题]# #香妃蛋糕[话题]# #小五卷蛋糕[话题]# #新手蛋糕卷[话题]#',
-            'title': '香妃蛋糕也太香了吧🔥不需要卷❗️绝对的友好',
-            'tags': ['今日快乐今日发', '吃货薯看这里', '香妃蛋糕', '小五卷蛋糕', '新手蛋糕卷'],
-            'duration': 101.726,
-            'thumbnail': r're:https?://sns-webpic-qc\.xhscdn\.com/\d+/[a-z0-9]+/[\w]+',
-        },
-    }, {
-        'url': 'https://www.xiaohongshu.com/discovery/item/674051740000000007027a15?xsec_token=CBgeL8Dxd1ZWBhwqRd568gAZ_iwG-9JIf9tnApNmteU2E=',
-        'info_dict': {
-            'id': '674051740000000007027a15',
-            'ext': 'mp4',
-            'title': '相互喜欢就可以了',
-            'uploader_id': '63439913000000001901f49a',
-            'duration': 28.073,
-            'description': '#广州[话题]# #深圳[话题]# #香港[话题]# #街头采访[话题]# #是你喜欢的类型[话题]#',
-            'thumbnail': r're:https?://sns-webpic-qc\.xhscdn\.com/\d+/[\da-f]+/[^/]+',
-            'tags': ['广州', '深圳', '香港', '街头采访', '是你喜欢的类型'],
-        },
-    }]
+    _LOGIN_HINT = 'Use --cookies-from-browser or --cookies with a logged-in browser session'
 
     def _real_extract(self, url):
-        display_id = self._match_id(url)
-        webpage = self._download_webpage(url, display_id)
-        initial_state = self._search_json(
-            r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state', display_id, transform_source=js_to_json)
+        video_id = self._match_id(url)
 
-        note_info = traverse_obj(initial_state, ('note', 'noteDetailMap', display_id, 'note'))
-        video_info = traverse_obj(note_info, ('video', 'media', 'stream', ..., ...))
+        webpage = self._download_webpage(url, video_id)
+        initial_state = self._search_json(
+            r'window\.__INITIAL_STATE__\s*=',
+            webpage,
+            'initial state',
+            video_id,
+            transform_source=js_to_json,
+        )
+
+        note = traverse_obj(
+            initial_state,
+            ('note', 'noteDetailMap', video_id, 'note'),
+            expected_type=dict,
+        )
+
+        if not note:
+            raise ExtractorError('Unable to locate note data')
+
+        streams = traverse_obj(
+            note,
+            ('video', 'media', 'stream', ..., ...),
+            expected_type=dict,
+        ) or []
 
         formats = []
-        for info in video_info:
-            format_info = traverse_obj(info, {
-                'fps': ('fps', {int_or_none}),
-                'width': ('width', {int_or_none}),
-                'height': ('height', {int_or_none}),
-                'vcodec': ('videoCodec', {str}),
-                'acodec': ('audioCodec', {str}),
-                'abr': ('audioBitrate', {int_or_none(scale=1000)}),
-                'vbr': ('videoBitrate', {int_or_none(scale=1000)}),
-                'audio_channels': ('audioChannels', {int_or_none}),
-                'tbr': ('avgBitrate', {int_or_none(scale=1000)}),
-                'format': ('qualityType', {str}),
-                'filesize': ('size', {int_or_none}),
-                'duration': ('duration', {float_or_none(scale=1000)}),
-            })
+        for stream in streams:
+            base = {
+                'fps': int_or_none(stream.get('fps')),
+                'width': int_or_none(stream.get('width')),
+                'height': int_or_none(stream.get('height')),
+                'vcodec': stream.get('videoCodec'),
+                'acodec': stream.get('audioCodec'),
+                'vbr': int_or_none(stream.get('videoBitrate'), scale=1000),
+                'abr': int_or_none(stream.get('audioBitrate'), scale=1000),
+                'tbr': int_or_none(stream.get('avgBitrate'), scale=1000),
+                'filesize': int_or_none(stream.get('size')),
+                'duration': float_or_none(stream.get('duration'), scale=1000),
+                'format': stream.get('qualityType'),
+            }
 
-            formats.extend(traverse_obj(info, (('masterUrl', ('backupUrls', ...)), {
-                lambda u: url_or_none(u) and {'url': u, **format_info}})))
+            for media_url in traverse_obj(
+                stream,
+                ('masterUrl', ('backupUrls', ...)),
+                expected_type=url_or_none,
+            ):
+                formats.append({
+                    'url': media_url,
+                    **base,
+                })
 
-        if origin_key := traverse_obj(note_info, ('video', 'consumer', 'originVideoKey', {str})):
-            # Not using a head request because of false negatives
+        # Original video (only available when authenticated)
+        origin_key = traverse_obj(note, ('video', 'consumer', 'originVideoKey'), expected_type=str)
+        if origin_key:
             urlh = self._request_webpage(
-                f'https://sns-video-bd.xhscdn.com/{origin_key}', display_id,
-                'Checking original video availability', 'Original video is not available', fatal=False)
+                f'https://sns-video-bd.xhscdn.com/{origin_key}',
+                video_id,
+                note='Checking original video availability',
+                fatal=False,
+            )
             if urlh:
                 formats.append({
                     'format_id': 'direct',
+                    'url': urlh.url,
                     'ext': urlhandle_detect_ext(urlh, default='mp4'),
                     'filesize': int_or_none(urlh.get_header('Content-Length')),
-                    'url': urlh.url,
                     'quality': 1,
                 })
 
+        # Explicit stream gating detection
+        if not formats:
+            if traverse_obj(note, ('video', 'media')):
+                self.raise_login_required(
+                    'Xiaohongshu now requires a web_session cookie to access video streams',
+                    metadata_available=True,
+                )
+            raise ExtractorError('No video formats found')
+
         thumbnails = []
-        for image_info in traverse_obj(note_info, ('imageList', ...)):
-            thumbnail_info = traverse_obj(image_info, {
-                'height': ('height', {int_or_none}),
-                'width': ('width', {int_or_none}),
-            })
-            for thumb_url in traverse_obj(image_info, (('urlDefault', 'urlPre'), {url_or_none})):
+        for img in traverse_obj(note, ('imageList', ...), expected_type=dict):
+            for thumb_url in traverse_obj(img, ('urlDefault', 'urlPre'), expected_type=url_or_none):
                 thumbnails.append({
                     'url': thumb_url,
-                    **thumbnail_info,
+                    'width': int_or_none(img.get('width')),
+                    'height': int_or_none(img.get('height')),
                 })
 
         return {
-            'id': display_id,
+            'id': video_id,
             'formats': formats,
             'thumbnails': thumbnails,
-            'title': self._html_search_meta(['og:title'], webpage, default=None),
-            **traverse_obj(note_info, {
+            'title': self._html_search_meta('og:title', webpage, default=None),
+            **traverse_obj(note, {
                 'title': ('title', {str}),
                 'description': ('desc', {str}),
                 'tags': ('tagList', ..., 'name', {str}),

--- a/yt_dlp/extractor/xiaohongshu.py
+++ b/yt_dlp/extractor/xiaohongshu.py
@@ -13,103 +13,123 @@ from ..utils.traversal import traverse_obj
 class XiaoHongShuIE(InfoExtractor):
     _VALID_URL = r'https?://www\.xiaohongshu\.com/(?:explore|discovery/item)/(?P<id>[\da-f]+)'
     IE_DESC = '小红书'
-    _LOGIN_HINT = 'Use --cookies-from-browser or --cookies with a logged-in browser session'
+
+    _TESTS = [{
+        'url': 'https://www.xiaohongshu.com/explore/6411cf99000000001300b6d9',
+        'md5': '2a87a77ddbedcaeeda8d7eae61b61228',
+        'info_dict': {
+            'id': '6411cf99000000001300b6d9',
+            'ext': 'mp4',
+            'uploader_id': '5c31698d0000000007018a31',
+            'description': '#今日快乐今日发[话题]# #吃货薯看这里[话题]# #香妃蛋糕[话题]# #小五卷蛋糕[话题]# #新手蛋糕卷[话题]#',
+            'title': '香妃蛋糕也太香了吧🔥不需要卷❗️绝对的友好',
+            'tags': ['今日快乐今日发', '吃货薯看这里', '香妃蛋糕', '小五卷蛋糕', '新手蛋糕卷'],
+            'duration': 101.726,
+            'thumbnail': r're:https?://sns-webpic-qc\.xhscdn\.com/\d+/[a-z0-9]+/[\w]+',
+        },
+    }, {
+        'url': 'https://www.xiaohongshu.com/discovery/item/674051740000000007027a15?xsec_token=CBgeL8Dxd1ZWBhwqRd568gAZ_iwG-9JIf9tnApNmteU2E=',
+        'info_dict': {
+            'id': '674051740000000007027a15',
+            'ext': 'mp4',
+            'title': '相互喜欢就可以了',
+            'uploader_id': '63439913000000001901f49a',
+            'duration': 28.073,
+            'description': '#广州[话题]# #深圳[话题]# #香港[话题]# #街头采访[话题]# #是你喜欢的类型[话题]#',
+            'thumbnail': r're:https?://sns-webpic-qc\.xhscdn\.com/\d+/[\da-f]+/[^/]+',
+            'tags': ['广州', '深圳', '香港', '街头采访', '是你喜欢的类型'],
+        },
+    }]
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
+        display_id = self._match_id(url)
 
-        webpage = self._download_webpage(url, video_id)
+        webpage = self._download_webpage(url, display_id)
         initial_state = self._search_json(
-            r'window\.__INITIAL_STATE__\s*=',
-            webpage,
-            'initial state',
-            video_id,
-            transform_source=js_to_json,
-        )
+            r'window\.__INITIAL_STATE__\s*=', webpage, 'initial state',
+            display_id, transform_source=js_to_json)
 
-        note = traverse_obj(
+        note_info = traverse_obj(
             initial_state,
-            ('note', 'noteDetailMap', video_id, 'note'),
-            expected_type=dict,
+            ('note', 'noteDetailMap', display_id, 'note'),
         )
 
-        if not note:
-            raise ExtractorError('Unable to locate note data')
-
-        streams = traverse_obj(
-            note,
+        video_info = traverse_obj(
+            note_info,
             ('video', 'media', 'stream', ..., ...),
-            expected_type=dict,
-        ) or []
+        )
 
         formats = []
-        for stream in streams:
-            base = {
-                'fps': int_or_none(stream.get('fps')),
-                'width': int_or_none(stream.get('width')),
-                'height': int_or_none(stream.get('height')),
-                'vcodec': stream.get('videoCodec'),
-                'acodec': stream.get('audioCodec'),
-                'vbr': int_or_none(stream.get('videoBitrate'), scale=1000),
-                'abr': int_or_none(stream.get('audioBitrate'), scale=1000),
-                'tbr': int_or_none(stream.get('avgBitrate'), scale=1000),
-                'filesize': int_or_none(stream.get('size')),
-                'duration': float_or_none(stream.get('duration'), scale=1000),
-                'format': stream.get('qualityType'),
-            }
+        for info in video_info or []:
+            format_info = traverse_obj(info, {
+                'fps': ('fps', {int_or_none}),
+                'width': ('width', {int_or_none}),
+                'height': ('height', {int_or_none}),
+                'vcodec': ('videoCodec', {str}),
+                'acodec': ('audioCodec', {str}),
+                'abr': ('audioBitrate', {int_or_none(scale=1000)}),
+                'vbr': ('videoBitrate', {int_or_none(scale=1000)}),
+                'audio_channels': ('audioChannels', {int_or_none}),
+                'tbr': ('avgBitrate', {int_or_none(scale=1000)}),
+                'format': ('qualityType', {str}),
+                'filesize': ('size', {int_or_none}),
+                'duration': ('duration', {float_or_none(scale=1000)}),
+            })
 
-            for media_url in traverse_obj(
-                stream,
-                ('masterUrl', ('backupUrls', ...)),
-                expected_type=url_or_none,
-            ):
-                formats.append({
-                    'url': media_url,
-                    **base,
-                })
+            formats.extend(traverse_obj(
+                info,
+                (('masterUrl', ('backupUrls', ...)), {
+                    lambda u: url_or_none(u) and {'url': u, **format_info}
+                }),
+            ))
 
-        # Original video (only available when authenticated)
-        origin_key = traverse_obj(note, ('video', 'consumer', 'originVideoKey'), expected_type=str)
-        if origin_key:
+        # original video (unchanged)
+        if origin_key := traverse_obj(
+            note_info, ('video', 'consumer', 'originVideoKey', {str})
+        ):
             urlh = self._request_webpage(
                 f'https://sns-video-bd.xhscdn.com/{origin_key}',
-                video_id,
-                note='Checking original video availability',
+                display_id,
+                'Checking original video availability',
+                'Original video is not available',
                 fatal=False,
             )
             if urlh:
                 formats.append({
                     'format_id': 'direct',
-                    'url': urlh.url,
                     'ext': urlhandle_detect_ext(urlh, default='mp4'),
                     'filesize': int_or_none(urlh.get_header('Content-Length')),
+                    'url': urlh.url,
                     'quality': 1,
                 })
 
-        # Explicit stream gating detection
-        if not formats:
-            if traverse_obj(note, ('video', 'media')):
-                self.raise_login_required(
-                    'Xiaohongshu now requires a web_session cookie to access video streams',
-                    metadata_available=True,
-                )
-            raise ExtractorError('No video formats found')
+        # 🔧 ADDITIVE FIX: explicit login gating detection
+        if not formats and traverse_obj(note_info, ('video', 'media')):
+            self.raise_login_required(
+                'Xiaohongshu now requires a web_session cookie to access video streams',
+                metadata_available=True,
+            )
 
         thumbnails = []
-        for img in traverse_obj(note, ('imageList', ...), expected_type=dict):
-            for thumb_url in traverse_obj(img, ('urlDefault', 'urlPre'), expected_type=url_or_none):
+        for image_info in traverse_obj(note_info, ('imageList', ...)):
+            thumbnail_info = traverse_obj(image_info, {
+                'height': ('height', {int_or_none}),
+                'width': ('width', {int_or_none}),
+            })
+            for thumb_url in traverse_obj(
+                image_info, (('urlDefault', 'urlPre'), {url_or_none})
+            ):
                 thumbnails.append({
                     'url': thumb_url,
-                    'width': int_or_none(img.get('width')),
-                    'height': int_or_none(img.get('height')),
+                    **thumbnail_info,
                 })
 
         return {
-            'id': video_id,
+            'id': display_id,
             'formats': formats,
             'thumbnails': thumbnails,
-            'title': self._html_search_meta('og:title', webpage, default=None),
-            **traverse_obj(note, {
+            'title': self._html_search_meta(['og:title'], webpage, default=None),
+            **traverse_obj(note_info, {
                 'title': ('title', {str}),
                 'description': ('desc', {str}),
                 'tags': ('tagList', ..., 'name', {str}),


### PR DESCRIPTION
## Fixes issue #15467 by Improving handling of login-required content
The issue is not a functional bug just a bug in error handling this fixes 
The code currently omits video stream information from __INITIAL_STATE__ unless a valid web_session cookie is present. In this case, metadata is still available, but video.media.stream is empty, causing the extractor to fail with a misleading No video formats found error.

This change adds detection for this condition and raises a login_required error when stream data is missing but video metadata exists. Extraction behavior is unchanged when streams are available. 

Fixes #15467 