### PR TITLE
YouTube thumbnail extension selector (extractor argument), and changes default to prioritize .jpg

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -4010,6 +4010,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                             if f.get('vcodec') != 'none':
                                 f['stretched_ratio'] = ratio
                         break
+        thumbnail_exts = ('jpg', 'webp')
+        thumbnail_ext_pref = self._configuration_arg('thumbnail_ext', [''], ie_key=YoutubeIE)[0]
+        if thumbnail_ext_pref not in thumbnail_exts:
+            thumbnail_ext_pref = thumbnail_exts[0]
         thumbnails = self._extract_thumbnails((video_details, microformats), (..., ..., 'thumbnail'))
         thumbnail_url = search_meta(['og:image', 'twitter:image'])
         if thumbnail_url:
@@ -4032,10 +4036,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'url': 'https://i.ytimg.com/vi{webp}/{video_id}/{name}{live}.{ext}'.format(
                 video_id=video_id, name=name, ext=ext,
                 webp='_webp' if ext == 'webp' else '', live='_live' if live_status == 'is_live' else ''),
-        } for name in thumbnail_names for ext in ('webp', 'jpg'))
+        } for name in thumbnail_names for ext in thumbnail_exts)
         for thumb in thumbnails:
             i = next((i for i, t in enumerate(thumbnail_names) if f'/{video_id}/{t}' in thumb['url']), n_thumbnail_names)
-            thumb['preference'] = (0 if '.jpg' in thumb['url'] else -1) - (2 * i)
+            thumb['preference'] = (0 if f'.{thumbnail_ext_pref}' in thumb['url'] else -1) - (2 * i)
         self._remove_duplicate_formats(thumbnails)
         self._downloader._sort_thumbnails(original_thumbnails)
 

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -4035,7 +4035,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         } for name in thumbnail_names for ext in ('webp', 'jpg'))
         for thumb in thumbnails:
             i = next((i for i, t in enumerate(thumbnail_names) if f'/{video_id}/{t}' in thumb['url']), n_thumbnail_names)
-            thumb['preference'] = (0 if '.webp' in thumb['url'] else -1) - (2 * i)
+            thumb['preference'] = (0 if '.jpg' in thumb['url'] else -1) - (2 * i)
         self._remove_duplicate_formats(thumbnails)
         self._downloader._sort_thumbnails(original_thumbnails)
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

* Changes the default YouTube thumbnail download to prioritize .jpg instead .webp.
* Adds extractor argument for YouTube to select preferred thumbnail extension with `--extractor-arg "youtube:thumbnail_ext=<jpg,webp>"`

Fixes #11242

"Why isn't `--convert-thumbnails jpg` good enough?"
While this is a good feature, there are two things that make this a less-than-ideal solution. 

1. `--convert-thumbnails` is implemented is a generationally lossy way, meaning that the quality of the JPEG will be significantly lower than the WEBP that was used for conversion. I would honestly consider this an issue, and might open an issue about it, if it doesn't already exist. Below is a link to a page where you can compare the original WEBP thumbnail vs the JPEG after `--convert-thumbnails jpg` was used to convert it.
https://slow.pics/c/aQnmLXRO
A lot of the grain and fine detail has been reduced. From https://youtu.be/Rkbb-llcLrQ

2. YouTube's own JPEG's are higher quality than their WEBP's. Although the difference is not as drastic as when using `--convert-thumbnails jpg`, it can still be noticed if you look closely.
https://slow.pics/c/lKJZTO6z
In the thumbnail with a car, the reflections around the rear tire are more clear, and the overall texture on the tires (especially the front) is clearer. In the thumbnail about action movies, even more grain and fine detail is retained.
From https://youtu.be/Rkbb-llcLrQ and https://youtu.be/tMn5vpZofUE

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [ ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
