### PR TITLE
[radiko] Add support for timefree 30

### DIFF
--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -102,7 +102,7 @@ class RadikoBaseIE(InfoExtractor):
         self._FULL_KEY = full_key
         return full_key
 
-    def _find_program(self, cursor: float | int | None, station_program: ElementTree) -> tuple[Element | None, int| None, Any, Any]:
+    def _find_program(self, cursor: float | int | None, station_program: ElementTree) -> tuple[Element | None, int | None, Any, Any]:
         prog = None
         for p in station_program.findall('.//prog'):
             ft_str, to_str = p.attrib['ft'], p.attrib['to']


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR fixes the radiko extractor to properly support timefree downloads beyond the standard 7-day window by implementing support for radiko's "timefree 30" feature (premium service allowing 30-day playback).

**Changes made:**

1. **Fixed program lookup API endpoint**: Changed from the weekly program endpoint (`/v3/program/station/weekly/`) to the date-specific endpoint (`/program/v3/date/{broadcast_day}/station/`). This allows accurate program information retrieval for older broadcasts within the 30-day window.

2. **Added broadcast day calculation**: Implemented `_get_broadcast_day()` method that properly handles Radiko's broadcast day convention (broadcasts before 5:00 AM are considered part of the previous day).

3. **Updated `_find_program()` signature**: Changed parameter from `cursor` (integer timestamp) to `timestring` (string format `YYYYMMDDHHmmss`) to properly calculate the broadcast day and convert to timestamp internally.

4. **Fixed stream type parameter**: Changed playlist query parameter from `type=b` to `type=c`, which is required for timefree 30 playback.

cf:

- https://github.com/yt-dlp/yt-dlp/issues/11422#issuecomment-2452166625
- https://github.com/yt-dlp/yt-dlp/pull/11498#issuecomment-2493782013

These changes enable users with Radiko premium accounts (via cookies) to download archived programs from up to 30 days ago, not just the standard 7-day window.

I tested:

- pytest -Werror -m "not download"
- Can download timefree 7-day
- Can download timefree 30-day
- Unfortunately, yt-dlp can't download radiko live with FFmpeg regardless whether this pull request was applied or not

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
