### PR TITLE
[twitter] Set availability for Spaces extractor

### DIFF
--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -1717,6 +1717,7 @@ class TwitterSpacesIE(TwitterBaseIE):
             'formats': formats,
             'http_headers': headers,
             'live_status': live_status,
+            'availability': 'needs_auth',
             **traverse_obj(metadata, {
                 'title': ('title', {str}),
                 # started_at is None when stream is_upcoming so fallback to scheduled_start for --wait-for-video


### PR DESCRIPTION
### Description of your *pull request* and other information

This PR fixes an issue where Twitter Spaces were incorrectly skipped by
`--match-filter` conditions due to missing availability metadata.

The Twitter Spaces extractor now explicitly sets:

    availability = "needs_auth"

This makes availability-based match-filters deterministic and aligns
the extractor with other authenticated Twitter content.

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through contributing guidelines and yt-dlp coding conventions
- [x] Searched the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under Unlicense. Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under Unlicense
- [x] I have read the policy against AI/LLM contributions and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor

</details>