### PR TITLE
Adjust QQMusic extractor to support `/ryqq_v2/` URLs.

### DIFF
--- a/yt_dlp/extractor/qqmusic.py
+++ b/yt_dlp/extractor/qqmusic.py
@@ -65,7 +65,7 @@ class QQMusicBaseIE(InfoExtractor):
 class QQMusicIE(QQMusicBaseIE):
     IE_NAME = 'qqmusic'
     IE_DESC = 'QQ音乐'
-    _VALID_URL = r'https?://y\.qq\.com/n/ryqq/songDetail/(?P<id>[0-9A-Za-z]+)'
+    _VALID_URL = r'https?://y\.qq\.com/n/ryqq(?:_v2)?/songDetail/(?P<id>[0-9A-Za-z]+)'
     _TESTS = [{
         'url': 'https://y.qq.com/n/ryqq/songDetail/004Ti8rT003TaZ',
         'md5': 'd7adc5c438d12e2cb648cca81593fd47',
@@ -231,7 +231,7 @@ class QQMusicIE(QQMusicBaseIE):
 class QQMusicSingerIE(QQMusicBaseIE):
     IE_NAME = 'qqmusic:singer'
     IE_DESC = 'QQ音乐 - 歌手'
-    _VALID_URL = r'https?://y\.qq\.com/n/ryqq/singer/(?P<id>[0-9A-Za-z]+)'
+    _VALID_URL = r'https?://y\.qq\.com/n/ryqq(?:_v2)?/singer/(?P<id>[0-9A-Za-z]+)'
     _TESTS = [{
         'url': 'https://y.qq.com/n/ryqq/singer/001BLpXF2DyJe2',
         'info_dict': {
@@ -309,7 +309,7 @@ class QQPlaylistBaseIE(InfoExtractor):
 class QQMusicAlbumIE(QQPlaylistBaseIE):
     IE_NAME = 'qqmusic:album'
     IE_DESC = 'QQ音乐 - 专辑'
-    _VALID_URL = r'https?://y\.qq\.com/n/ryqq/albumDetail/(?P<id>[0-9A-Za-z]+)'
+    _VALID_URL = r'https?://y\.qq\.com/n/ryqq(?:_v2)?/albumDetail/(?P<id>[0-9A-Za-z]+)'
 
     _TESTS = [{
         'url': 'https://y.qq.com/n/ryqq/albumDetail/000gXCTb2AhRR1',
@@ -348,7 +348,7 @@ class QQMusicAlbumIE(QQPlaylistBaseIE):
 class QQMusicToplistIE(QQPlaylistBaseIE):
     IE_NAME = 'qqmusic:toplist'
     IE_DESC = 'QQ音乐 - 排行榜'
-    _VALID_URL = r'https?://y\.qq\.com/n/ryqq/toplist/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://y\.qq\.com/n/ryqq(?:_v2)?/toplist/(?P<id>[0-9]+)'
 
     _TESTS = [{
         'url': 'https://y.qq.com/n/ryqq/toplist/123',
@@ -394,7 +394,7 @@ class QQMusicToplistIE(QQPlaylistBaseIE):
 class QQMusicPlaylistIE(QQPlaylistBaseIE):
     IE_NAME = 'qqmusic:playlist'
     IE_DESC = 'QQ音乐 - 歌单'
-    _VALID_URL = r'https?://y\.qq\.com/n/ryqq/playlist/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://y\.qq\.com/n/ryqq(?:_v2)?/playlist/(?P<id>[0-9]+)'
 
     _TESTS = [{
         'url': 'https://y.qq.com/n/ryqq/playlist/1374105607',
@@ -431,7 +431,7 @@ class QQMusicPlaylistIE(QQPlaylistBaseIE):
 class QQMusicVideoIE(QQMusicBaseIE):
     IE_NAME = 'qqmusic:mv'
     IE_DESC = 'QQ音乐 - MV'
-    _VALID_URL = r'https?://y\.qq\.com/n/ryqq/mv/(?P<id>[0-9A-Za-z]+)'
+    _VALID_URL = r'https?://y\.qq\.com/n/ryqq(?:_v2)?/mv/(?P<id>[0-9A-Za-z]+)'
 
     _TESTS = [{
         'url': 'https://y.qq.com/n/ryqq/mv/002Vsarh3SVU8K',


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Looking for supported extractors with names having the word "music", I discovered QQMuic, which I never used before.

So I navigated to a random song page and passed that into `yt-dlp -F` to extract the available streams.  However, the URL that my browser was sent to `https://y.qq.com/n/ryqq_v2/songDetail/002QE4o71oJARc` didn't trigger `qqmusic.py` and instead went to the generic extractor.

I soon discovered that whilst the `/ryqq/` segment does get regex matches, the (probably) newer `/ryqq_v2/` did not get matched, so I got that fixed.

**This is a minor edit and not a definitive fix for other limitation of the QQMusic extractor.**


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
