### PR TITLE
Improve FFmpeg missing dependency error messages with install guidance

### DIFF
--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -33,6 +33,8 @@ from ..utils import (
     write_json_file,
 )
 
+from ..utils._utils import get_ffmpeg_install_instructions
+
 EXT_TO_OUT_FORMATS = {
     'aac': 'adts',
     'flac': 'flac',
@@ -222,7 +224,11 @@ class FFmpegPostProcessor(PostProcessor):
 
     def check_version(self):
         if not self.available:
-            raise FFmpegPostProcessorError('ffmpeg not found. Please install or provide the path using --ffmpeg-location')
+            raise FFmpegPostProcessorError(
+                'ffmpeg not found.\n\n'
+                + get_ffmpeg_install_instructions()
+                + '\n\nYou can also specify the path using --ffmpeg-location'
+            )
 
         required_version = '1.0'
         if is_outdated_version(self._version, required_version):
@@ -231,7 +237,12 @@ class FFmpegPostProcessor(PostProcessor):
 
     def get_audio_codec(self, path):
         if not self.probe_available and not self.available:
-            raise PostProcessingError('ffprobe and ffmpeg not found. Please install or provide the path using --ffmpeg-location')
+            raise PostProcessingError(
+                'ffprobe and ffmpeg not found.\n\n'
+                + get_ffmpeg_install_instructions()
+                + '\n\nYou can also specify the path using --ffmpeg-location'
+            )
+
         try:
             if self.probe_available:
                 cmd = [

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -414,8 +414,10 @@ def get_ffmpeg_install_instructions():
     # Windows users need either static builds or a package manager
     elif sys.platform.startswith('win'):
         return (
-            "Download FFmpeg static builds from:\n"
-            "  https://ffmpeg.org/download.html\n"
+            "Install FFmpeg on Windows:\n"
+            "  Using winget: winget install ffmpeg\n"
+            "  Or download static builds from:\n"
+            "    https://ffmpeg.org/download.html\n"
             "Then add ffmpeg/bin to your PATH"
         )
 

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -384,6 +384,45 @@ def get_elements_text_and_html_by_attribute(attribute, value, html, *, tag=r'[\w
         )
 
 
+def get_ffmpeg_install_instructions():
+    """
+    Return OS-specific guidance for installing FFmpeg.
+
+    This is used only when ffmpeg/ffprobe binaries are missing,
+    to provide actionable next steps without auto-downloading
+    external dependencies.
+    """
+    # Import locally to avoid adding overhead at module import time
+    import sys
+
+    # Linux distributions rely on system package managers
+    if sys.platform.startswith('linux'):
+        return (
+            "Install FFmpeg using your package manager:\n"
+            "  Debian/Ubuntu: sudo apt install ffmpeg\n"
+            "  Arch Linux: sudo pacman -S ffmpeg\n"
+            "  Fedora: sudo dnf install ffmpeg"
+        )
+
+    # macOS users typically install FFmpeg via Homebrew
+    elif sys.platform == 'darwin':
+        return (
+            "Install FFmpeg using Homebrew:\n"
+            "  brew install ffmpeg"
+        )
+
+    # Windows users need either static builds or a package manager
+    elif sys.platform.startswith('win'):
+        return (
+            "Download FFmpeg static builds from:\n"
+            "  https://ffmpeg.org/download.html\n"
+            "Then add ffmpeg/bin to your PATH"
+        )
+
+    # Fallback for unknown platforms
+    return "Please install FFmpeg from https://ffmpeg.org/"
+
+
 class HTMLBreakOnClosingTagParser(html.parser.HTMLParser):
     """
     HTML parser which raises HTMLBreakOnClosingTagException upon reaching the


### PR DESCRIPTION
### Summary
Improve the error messages shown when ffmpeg/ffprobe are missing by
providing clear, OS-specific installation guidance.

### Motivation
Users frequently encounter unclear errors when FFmpeg is not installed.
This change improves usability without changing behavior or bundling
external dependencies.

### Changes
- Add reusable helper for OS-specific FFmpeg install guidance
- Improve FFmpeg postprocessor error messages to include install hints
- Mention winget as an optional installation method on Windows

### Notes
- No automatic downloads
- No behavior changes when FFmpeg is available
