### PR TITLE
Add optional PyPI Deno support and prefer Python-installed runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ default = [
     "websockets>=13.0",
     "yt-dlp-ejs==0.3.2",
 ]
+deno=[
+    "deno",
+]
 curl-cffi = [
     "curl-cffi>=0.5.10,!=0.6.*,!=0.7.*,!=0.8.*,!=0.9.*,<0.14; implementation_name=='cpython'",
 ]


### PR DESCRIPTION
Fixes #15530

### Summary
Add an optional `deno` extra to install Deno from PyPI and update Deno runtime detection to prefer a Python-installed Deno before falling back to a system-installed Deno.

### Changes
- Add `deno` optional dependency in `pyproject.toml`
- Prefer `deno.find_deno_exe()` in Deno JS runtime resolution

### Testing
- `pip install -e .[deno]`
- `yt-dlp --verbose` shows `JS runtimes: deno-<version>`
- `pip uninstall deno` falls back to system Deno or reports none
