### PR TITLE
[build] Fix manually triggered nightly releases

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   check_nightly:
     name: Check for new commits
-    if: github.event_name != 'workflow_dispatch' || vars.BUILD_NIGHTLY
+    if: github.event_name == 'workflow_dispatch' || vars.BUILD_NIGHTLY
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
Manually triggering the nightly release workflow doesn't do anything if `BUILD_NIGHTLY` isn't set

Fix 3763d0d4ab8bdbe433ce08e45e21f36ebdeb5db3

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix an oopsie

</details>
