### PR TITLE
[ie/whyp] Add extra fields to infojson

### DIFF
--- a/yt_dlp/extractor/whyp.py
+++ b/yt_dlp/extractor/whyp.py
@@ -17,9 +17,12 @@ class WhypIE(InfoExtractor):
         'info_dict': {
             'id': '18337',
             'title': 'Example Track',
+            'display_id': 'example-track',
             'description': 'md5:e0b1bcf1d267dc1a0f15efff09c8f297',
             'ext': 'flac',
             'duration': 135.63,
+            'timestamp': 1643216583,
+            'upload_date': '20220126',
             'uploader': 'Brad',
             'uploader_id': '1',
             'thumbnail': 'https://cdn.whyp.it/6ad0bbd9-577d-42bb-9b61-2a4f57f647eb.jpg',


### PR DESCRIPTION
The whyp data contains both `slug` and `created_at` fields, which are now added to the infojson as `display_id` and `timestamp` respectively.

### Description of your *pull request* and other information

Rebased work originally done for #15719 [(comment)](https://github.com/yt-dlp/yt-dlp/issues/15719#issuecomment-3814364096).

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
 
</details>
