### PR TITLE
Extract chapter data from jw player

### DIFF
--- a/test/test_InfoExtractor.py
+++ b/test/test_InfoExtractor.py
@@ -656,6 +656,34 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
                 }],
             })
 
+        # from https://jwplayer-chapters-example.vercel.app/
+        expect_dict(
+            self,
+            self.ie._extract_jwplayer_data(r'''
+<script>
+    const player = jwplayer('player').setup({
+        file: 'https://jwplayer-chapters-example.vercel.app/willie.webm',
+        tracks: [{
+            file: 'https://jwplayer-chapters-example.vercel.app/chapters.vtt',
+            kind: 'chapters'
+        }]
+    });
+</script>
+            ''', 'dummy', require_title=False),
+            {
+                'chapters': [{
+                    'start_time': 0,
+                    'end_time': 15,
+                    'title': 'The First Half',
+                },
+                    {
+                    'start_time': 15,
+                    'end_time': 30,
+                    'title': 'The Second Half',
+                }],
+            },
+        )
+
     def test_parse_m3u8_formats(self):
         _TEST_CASES = [
             (

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -102,10 +102,7 @@ from ..utils import (
 )
 from ..utils._utils import _request_dump_filename
 from ..utils.jslib import devalue
-from ..webvtt import (
-    parse_fragment,
-    CueBlock
-)
+from ..webvtt import CueBlock, parse_fragment
 
 
 class InfoExtractor:
@@ -3650,7 +3647,7 @@ class InfoExtractor:
                 subtitles.setdefault(track.get('label') or 'en', []).append({
                     'url': self._proto_relative_url(track_url),
                 })
-            
+
             chapters = []
             for track in traverse_obj(video_data, (
                     'tracks', lambda _, v: v['kind'].lower() == 'chapters')):
@@ -3667,7 +3664,7 @@ class InfoExtractor:
                             # Convert timestamps from MPEG PES into seconds
                             'start_time': block.start / 90000,
                             'end_time': block.end / 90000,
-                            'title': block.text.strip()
+                            'title': block.text.strip(),
                         })
                 break
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

Modifies the `_parse_jwplayer_data` method in `yt_dlp/extractor/common.py` to parse chapter infomation [as documented here](https://docs.jwplayer.com/players/docs/jw8-add-chapter-markers).

To this end, I've also added `_download_webvtt` to `yt_dlp/extractor/common.py` which calls `_parse_vtt`, itself a wrapper around the `parse_fragment` function from `yt_dlp/webvtt.py`.

Fixes #15773 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
