### PR TITLE
[Boxcast] Fix BoxCast extractor false negatives when playlist is present

### DIFF
--- a/yt_dlp/extractor/boxcast.py
+++ b/yt_dlp/extractor/boxcast.py
@@ -45,6 +45,19 @@ class BoxCastVideoIE(InfoExtractor):
             'description': 'md5:ac23e3d01b0b0be592e8f7fe0ec3a340',
             'title': 'New Year\'s Eve CROSSOVER Service at LHMI | December 31, 2022',
         },
+    }, {
+        # Test case for playlist-based extraction
+        'url': 'https://boxcast.tv/channel/thzz3mve4hxxwwce9csj?b=k1rlqzhv9jk5of1vujzs',
+        'info_dict': {
+            'id': 'k1rlqzhv9jk5of1vujzs',
+            'ext': 'mp4',
+            'thumbnail': r're:https?://uploads\.boxcast\.com/(?:[\w-]+/){3}.+\.jpg$',
+            'release_date': '20260107',
+            'uploader_id': 'qwdn19qiip1t4hbenfuw',
+            'release_timestamp': 1767829804,
+            'uploader': 'City of Louisburg KS - Louisburg, KS',
+            'title': 'Special meeting of the Fox Hall/Cemetery Board',
+        },
     }]
     _WEBPAGE_TESTS = [{
         'url': 'https://childrenshealthdefense.eu/live-stream/',
@@ -77,9 +90,11 @@ class BoxCastVideoIE(InfoExtractor):
                                    display_id, fatal=False) or {})
 
         formats, subtitles = [], {}
-        if view_json_data.get('status') == 'recorded':
+        playlist = view_json_data.get('playlist')
+        if playlist:
             formats, subtitles = self._extract_m3u8_formats_and_subtitles(
-                view_json_data['playlist'], display_id)
+                playlist, display_id)
+
 
         return {
             'id': str(broadcast_json_data['id']),


### PR DESCRIPTION
[extractor/boxcast] Fix false negatives when playlist is present
### Description of your *fix-boxcast-playlist-status* and other information

This PR fixes a false-negative in the BoxCast extractor where video formats are not extracted even when a valid HLS playlist is available.

The extractor previously only extracted formats when `view_json_data["status"] == "recorded"`. BoxCast now serves playable HLS playlists for some broadcasts whose status is not `"recorded"` (e.g. ended or archived streams), causing yt-dlp to incorrectly report that no video formats are found.

This change extracts formats whenever a `playlist` URL is present in the view API response, avoiding reliance on status values and preventing incorrect failures.

A new test case has been added to cover playlist-based extraction from channel URLs.

Example URL affected by this issue:
https://boxcast.tv/channel/thzz3mve4hxxwwce9csj?b=k1rlqzhv9jk5of1vujzs


<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
