### PR TITLE
[ie/mir24tv] Match non-news paths

### DIFF
--- a/yt_dlp/extractor/mir24tv.py
+++ b/yt_dlp/extractor/mir24tv.py
@@ -9,7 +9,7 @@ class Mir24TvIE(InfoExtractor):
     _TESTS = [{
         'url': 'https://mir24.tv/news/16635210/dni-kultury-rossii-otkrylis-v-uzbekistane.-na-prazdnichnom-koncerte-vystupili-zvezdy-rossijskoj-estrada',
         'info_dict': {
-            'id': '16635210',
+            'id': '68394c39b199e60001702be0',
             'title': 'Дни культуры России открылись в Узбекистане.  На праздничном концерте выступили звезды российской эстрады',
             'ext': 'mp4',
             'thumbnail': r're:https://images\.mir24\.tv/.+\.jpg',
@@ -17,7 +17,7 @@ class Mir24TvIE(InfoExtractor):
     }, {
         'url': 'https://mir24.tv/tv-shows/rozdennye-v-sssr/260',
         'info_dict': {
-            'id': 'rozdennye-v-sssr',
+            'id': '698199dd0b17790001fc2c29',
             'ext': 'mp4',
             'title': 'Рожденные в СССР смотреть онлайн. ',
             'thumbnail': 'https://mir24.tv/og_image_1200x630.png',
@@ -34,6 +34,7 @@ class Mir24TvIE(InfoExtractor):
 
         m3u8_url = traverse_obj(iframe_url, (
             {parse_qs}, 'source', -1, {self._proto_relative_url}, {url_or_none}, {require('m3u8 URL')}))
+        video_id = self._search_regex(r'/([^/]+)/[^./]+\.m3u8', m3u8_url, 'video id')
         formats, subtitles = self._extract_m3u8_formats_and_subtitles(m3u8_url, video_id, 'mp4', m3u8_id='hls')
 
         return {


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Match other Mir24.tv URLs than /news.
The `_VALID_URL` regex has been modified replacing `/news` with `/[^/]+`, and the ID group to match non-numeric IDs too.
A test was added with the URL posted as example in the linked issue.

Fixes #15832


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
