### PR TITLE
[ie/pornhub] Add Referer header for media downloads (#15827)

### DIFF
--- a/yt_dlp/extractor/pornhub.py
+++ b/yt_dlp/extractor/pornhub.py
@@ -506,6 +506,7 @@ class PornHubIE(PornHubBaseIE):
                 'cast': ({find_elements(attr='data-label', value='pornstar')}, ..., {clean_html}),
             }),
             'subtitles': subtitles,
+            'http_headers': {'Referer': f'https://www.{host}/'},
         }, info)
 
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Set the `Referer` header for media downloads in the Pornhub extractor to avoid 404/403 when fetching video data.

This adds a single line to the `pornhub` extractor so returned format/info dictionaries include `http_headers: {'Referer': 'https://www.<host>/'}`. Some Pornhub endpoints require a proper Referer when downloading the media; without it yt-dlp can receive 404/403 for the actual video data.

Fixes #15827.

Credit: this change implements the suggestion from the issue comment linked here (author of that comment): [https://github.com/yt-dlp/yt-dlp/issues/15827#issuecomment-3854445803](https://github.com/yt-dlp/yt-dlp/issues/15827#issuecomment-3854445803)

**Code change (already in this PR):**

```diff
diff --git a/yt_dlp/extractor/pornhub.py b/yt_dlp/extractor/pornhub.py
index cdfa3f1b0..5144f1409 100644
--- a/yt_dlp/extractor/pornhub.py
+++ b/yt_dlp/extractor/pornhub.py
@@ -506,6 +506,7 @@ def extract_vote_count(kind, name):
                 'cast': ({find_elements(attr='data-label', value='pornstar')}, ..., {clean_html}),
             }),
             'subtitles': subtitles,
+            'http_headers': {'Referer': f'https://www.{host}/'},
         }, info)
```

**How to test / reproduce**

1. Before the change: running `yt-dlp -v 'https://www.pornhub.com/view_video.php?viewkey=68a742d160ee9'` produced a 404/472/472-like error (see #15827).
2. After this change: run the same command; the formats should download normally and you should not see the 404/472 error when fetching the media.
3. Example verify command:

```bash
yt-dlp -v 'https://www.pornhub.com/view_video.php?viewkey=68a742d160ee9'
```

---

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:

* [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
* [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:

* [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (see evidence: linked issue comment).
  Evidence / attribution: [https://github.com/yt-dlp/yt-dlp/issues/15827#issuecomment-3854445803](https://github.com/yt-dlp/yt-dlp/issues/15827#issuecomment-3854445803)
* [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:

* [x] Fix or improvement to an extractor (Make sure to add/update tests)
* [ ] New extractor
* [ ] Core bug fix/improvement
* [ ] New feature

</details>