### PR TITLE
[ie/nrl] Fix extractor

### DIFF
--- a/yt_dlp/extractor/nrl.py
+++ b/yt_dlp/extractor/nrl.py
@@ -1,27 +1,93 @@
+
 from .common import InfoExtractor
+from ..utils import (
+    float_or_none,
+    get_element_by_class,
+    traverse_obj,
+    unified_timestamp,
+)
 
 
 class NRLTVIE(InfoExtractor):
-    _WORKING = False
-    _VALID_URL = r'https?://(?:www\.)?nrl\.com/tv(/[^/]+)*/(?P<id>[^/?&#]+)'
-    _TEST = {
-        'url': 'https://www.nrl.com/tv/news/match-highlights-titans-v-knights-862805/',
+    IE_NAME = 'nrlwatch'
+    IE_DESC = 'NRL.com Watch'
+    _VALID_URL = r'https?://(?:www\.)?nrl\.com/watch(?:/[^/?#]+)*/(?P<id>[^/?#]+)'
+    _GEO_COUNTRIES = ['AU']
+    _TESTS = [{
+        # Globally available video
+        'url': 'https://www.nrl.com/watch/news/match-highlights-titans-v-knights-862805/',
         'info_dict': {
-            'id': 'YyNnFuaDE6kPJqlDhG4CGQ_w89mKTau4',
+            'id': 'match-highlights-titans-v-knights-862805',
             'ext': 'mp4',
             'title': 'Match Highlights: Titans v Knights',
+            'description': 'The Gold Coast host Newcastle in round 6 of the 2019 NRL Telstra Premiership',
+            'duration': 270.0,
+            'thumbnail': 'https://www.nrl.com/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/28839369/keyframes/273128/image?center=0.427%2C0.513&preset=seo-card-large',
+            'season': '2019',
+            'season_id': '2019',
+            'timestamp': 1555894764,
+            'upload_date': '20190422',
+            'modified_timestamp': 1724762491,
+            'modified_date': '20240827',
         },
         'params': {
-            # m3u8 download
-            'skip_download': True,
+            'skip_download': 'm3u8',
         },
-    }
+    }, {
+        # Geo-restricted video (bypassable via X-Forwarded-For)
+        # Also: Video with broken 1080p format
+        'url': 'https://www.nrl.com/watch/matches/telstra-premiership/2025/grand-final/full-match-replay-storm-v-broncos---grand-final-2025/',
+        'info_dict': {
+            'id': 'full-match-replay-storm-v-broncos---grand-final-2025',
+            'ext': 'mp4',
+            'title': 'Full Match Replay: Storm v Broncos - Grand Final 2025',
+            'description': 'The Melbourne Storm and Brisbane Broncos face off in the 2025 NRL Telstra Premiership Grand Final',
+            'duration': 6666.0,
+            'thumbnail': 'https://www.nrl.com/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/79824761/keyframes/554177/image?center=0.5%2C0.5&preset=seo-card-large',
+            'season': '2025',
+            'season_id': '2025',
+            'timestamp': 1759707882,
+            'upload_date': '20251005',
+            'modified_timestamp': 1759919888,
+            'modified_date': '20251008',
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }, {
+        # Video requiring login
+        'url': 'https://www.nrl.com/watch/matches/telstra-premiership/2019/round-6/full-match-replay-titans-v-knights---round-6-2019/',
+        'only_matching': True,
+    }]
 
     def _real_extract(self, url):
-        display_id = self._match_id(url)
-        webpage = self._download_webpage(url, display_id)
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        if get_element_by_class('locked-content-video-wrapper', webpage):
+            self.raise_login_required(method='cookies')
+
         q_data = self._parse_json(self._html_search_regex(
-            r'(?s)q-data="({.+?})"', webpage, 'player data'), display_id)
-        ooyala_id = q_data['videoId']
-        return self.url_result(
-            'ooyala:' + ooyala_id, 'Ooyala', ooyala_id, q_data.get('title'))
+            r'(?s)q-data="({.+?})"', webpage, 'player data'), video_id)
+
+        formats = self._extract_m3u8_formats(q_data['streams']['hls'], video_id, 'mp4')
+        # The 1080p formats for full matches are just broken (failing to play in a browser as well).
+        # We don't have a reliable condition to detect these up front,
+        # so mark all formats as __needs_testing to be safe.
+        for fmt in formats:
+            fmt['__needs_testing'] = True
+
+        return {
+            **self._search_json_ld(webpage, video_id, fatal=False),
+            **traverse_obj(q_data, {
+                'title': ('name', {str}),
+                'description': ('summary', {str}),
+                'duration': ('duration', {float_or_none}),
+                'timestamp': ('published', {unified_timestamp}),
+                'modified_timestamp': ('lastModified', {unified_timestamp}),
+                'season_id': ('tags', 'season', 'id', {str}),
+                'season': ('tags', 'season', 'name', {str}),
+            }),
+            'formats': formats,
+            'id': video_id,
+        }

--- a/yt_dlp/extractor/nrl.py
+++ b/yt_dlp/extractor/nrl.py
@@ -1,10 +1,13 @@
+import re
 
 from .common import InfoExtractor
 from ..utils import (
+    find_element,
     float_or_none,
     get_element_by_class,
     traverse_obj,
     unified_timestamp,
+    urlencode_postdata,
 )
 
 
@@ -13,6 +16,7 @@ class NRLTVIE(InfoExtractor):
     IE_DESC = 'NRL.com Watch'
     _VALID_URL = r'https?://(?:www\.)?nrl\.com/watch(?:/[^/?#]+)*/(?P<id>[^/?#]+)'
     _GEO_COUNTRIES = ['AU']
+    _SIGNIN_URL = 'https://www.nrl.com/account/signin-nrl'
     _TESTS = [{
         # Globally available video
         'url': 'https://www.nrl.com/watch/news/match-highlights-titans-v-knights-862805/',
@@ -63,6 +67,18 @@ class NRLTVIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
+
+        anon_login_form = traverse_obj(webpage, ({find_element(
+            tag='form', attr='action', value=self._SIGNIN_URL, html=True)}))
+        if anon_login_form:
+            matches = re.finditer(r'''(?x)<input
+                (?=[^>]*\sname\s*=\s*(?P<_q1>['"])(?P<name>(?:(?!(?P=_q1)).)+)(?P=_q1))
+                (?=[^>]*\svalue\s*=\s*(?P<_q2>['"])(?P<value>(?:(?!(?P=_q2)).)+)(?P=_q2))
+                [^>]*>''', anon_login_form)
+            webpage = self._download_webpage(
+                self._SIGNIN_URL, video_id,
+                data=urlencode_postdata({m.group('name'): m.group('value') for m in matches}),
+                note='Performing anonymous login', errnote='Failed to perform anonymous login')
 
         if get_element_by_class('locked-content-video-wrapper', webpage):
             self.raise_login_required(method='cookies')


### PR DESCRIPTION
### Description of your *pull request* and other information

Fixes the long-broken extractor. Unfortunately the old IDs cannot be preserved. The site changed its streaming backend and the old IDs were specific to the previous backend implementation and are no longer available.

Fixes #15801 and probably also #7080 (where OP never provided needed information)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
