### PR TITLE
[ie/descript] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -461,6 +461,7 @@ from .daystar import DaystarClipIE
 from .dbtv import DBTVIE
 from .dctp import DctpTvIE
 from .democracynow import DemocracynowIE
+from .descript import DescriptIE
 from .detik import DetikEmbedIE
 from .deuxm import (
     DeuxMIE,

--- a/yt_dlp/extractor/descript.py
+++ b/yt_dlp/extractor/descript.py
@@ -1,0 +1,88 @@
+from .common import InfoExtractor
+from ..utils import (
+    float_or_none,
+    int_or_none,
+    parse_iso8601,
+    url_or_none,
+)
+from ..utils.traversal import traverse_obj
+
+
+class DescriptIE(InfoExtractor):
+    _VALID_URL = r'https?://share\.descript\.com/(?:view|embed)/(?P<id>[^/?#]+)'
+    _EMBED_REGEX = [rf'<iframe[^>]+\bsrc=["\'](?P<url>{_VALID_URL})']
+    _TESTS = [{
+        'url': 'https://share.descript.com/view/3nvfjWuet4r',
+        'md5': '637286c7ad0cecda6529f41acfb20db0',
+        'info_dict': {
+            'id': '3nvfjWuet4r',
+            'ext': 'mp4',
+            'title': 'clip1_doac',
+            'uploader': 'Siddharth Rodrigues',
+            'timestamp': 1770805377,
+            'upload_date': '20260211',
+            'duration': 15.0,
+            'thumbnail': r're:^https?://.+\.jpg',
+        },
+    }, {
+        'url': 'https://share.descript.com/view/ZS2zF6ZONam',
+        'only_matching': True,
+    }, {
+        'url': 'https://share.descript.com/embed/3nvfjWuet4r',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(
+            f'https://share.descript.com/view/{video_id}', video_id)
+
+        metadata = self._search_json(
+            r'<script[^>]+\bid=["\']metadata["\'][^>]*>',
+            webpage, 'metadata', video_id, end_pattern=r'</script>')
+
+        formats = []
+
+        original_url = traverse_obj(
+            metadata, ('contents', 'media', 'original', 'cdn_url', {url_or_none}))
+        if original_url:
+            formats.append({
+                'url': original_url,
+                'format_id': 'original',
+                'quality': 1,
+                **traverse_obj(metadata, ('contents', 'media', 'original', 'video', {
+                    'width': ('width', {int_or_none}),
+                    'height': ('height', {int_or_none}),
+                })),
+            })
+
+        stream_url = traverse_obj(
+            metadata, ('contents', 'media', 'stream', 'cdn_url', {url_or_none}))
+        if stream_url:
+            formats.extend(self._extract_m3u8_formats(
+                stream_url, video_id, 'mp4', m3u8_id='hls', fatal=False))
+
+        # Duration is in the document script (transcript data), not in the metadata script
+        duration = float_or_none(self._search_regex(
+            r'"duration"\s*:\s*([\d.]+)', webpage, 'duration', fatal=False))
+
+        return {
+            'id': video_id,
+            'formats': formats,
+            'subtitles': self.extract_subtitles(video_id, metadata),
+            'duration': duration,
+            'uploader': ' '.join(traverse_obj(
+                metadata, ('published_by', ('first_name', 'last_name'), {str}))).strip() or None,
+            **traverse_obj(metadata, {
+                'title': ('name', {str}),
+                'timestamp': ('created_at', {parse_iso8601}),
+                'thumbnail': ('contents', 'media', 'thumbnail', 'cdn_url', {url_or_none}),
+            }),
+        }
+
+    def _get_subtitles(self, video_id, metadata):
+        subtitles = {}
+        for sub_key, ext in [('subtitles', 'vtt'), ('transcript', 'json')]:
+            if sub_url := traverse_obj(metadata, ('contents', sub_key, 'cdn_url', {url_or_none})):
+                subtitles.setdefault('en', []).append({'url': sub_url, 'ext': ext})
+        return subtitles


### PR DESCRIPTION
### Description of your *pull request* and other information

Adds support for downloading videos from [Descript](https://www.descript.com/) share links (`share.descript.com`).

Descript is a collaborative video/audio editing platform. Users can publish content via share links. This extractor handles both `/view/` and `/embed/` URLs.

**Extracted data:**
- Formats: Original MP4 (direct download) + HLS adaptive stream
- Subtitles: WebVTT captions + JSON transcript (word-level timestamps with speaker attribution)
- Metadata: Title, uploader, upload timestamp, duration, thumbnail

**Implementation:** Parses the embedded `<script id="metadata">` JSON on the share page for media URLs and author info. Duration is extracted via regex from a separate document script (avoids parsing a potentially large transcript JSON blob). No authentication required for published content.

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))

</details>