### PR TITLE
docs: fix incorrect parameter description in aes_ecb_decrypt

### DIFF
--- a/yt_dlp/aes.py
+++ b/yt_dlp/aes.py
@@ -97,7 +97,7 @@ def aes_ecb_decrypt(data, key, iv=None):
     """
     Decrypt with aes in ECB mode
 
-    @param {int[]} data        cleartext
+    @param {int[]} data        ciphertext
     @param {int[]} key         16/24/32-Byte cipher key
     @param {int[]} iv          Unused for this mode
     @returns {int[]}           decrypted data


### PR DESCRIPTION
This PR corrects an inaccurate parameter description in the aes_ecb_decrypt function docstring.

Changes:
- Updated docstring in yt_dlp/aes.py line 100
- Changed 'cleartext' to 'ciphertext' for the data parameter

Rationale:
The aes_ecb_decrypt function is a decryption function, which means it takes encrypted data (ciphertext) as input and returns decrypted data (cleartext) as output. The current docstring incorrectly labels the input parameter as 'cleartext', which is misleading.

Impact:
This is a documentation-only change that improves code clarity and helps developers understand the function's purpose correctly.