### PR TITLE
[core] Fix `--force-write-archive` with `--list-subs`, `--list-formats`, `--list-thumbnails`

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3023,6 +3023,8 @@ class YoutubeDL:
         if list_only:
             # Without this printing, -F --print-json will not work
             self.__forced_printings(info_dict)
+            if self.params.get('force_write_download_archive', False):
+                self.record_download_archive(info_dict)
             return info_dict
 
         format_selector = self.format_selector


### PR DESCRIPTION
## Description

Fixes #15902

When using list options (`--list-subs`, `--list-formats`, `--list-thumbnails`), the code enters the `list_only` path in `process_video_result` and returns early — before ever reaching the `force_write_download_archive` check. This means `--force-write-archive` has no effect when combined with these options.

## Changes

Added a `force_write_download_archive` check before the early return in the `list_only` code path (`YoutubeDL.py` line ~3026), consistent with how it's handled in the playlist processing path (line ~1907) and the `process_info` method.

## How to test

```sh
# Before fix: test.txt remains empty
yt-dlp --list-subs --download-archive test.txt --force-write-archive 'https://www.youtube.com/watch?v=HfHgUu_8KgA'
cat test.txt

# After fix: test.txt contains 'youtube HfHgUu_8KgA'
```

Same applies for `--list-formats` and `--list-thumbnails`.