### PR TITLE
[ie/youtube] Fix live manifest lookback window

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -3157,7 +3157,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
     def _needs_live_processing(self, live_status, duration):
         if ((live_status == 'is_live' and self.get_param('live_from_start'))
-                or (live_status == 'post_live' and (duration or 0) > 2 * 3600)):
+                or (live_status == 'post_live' and (duration or 0) > 4 * 3600)):
             return live_status
 
     def _report_pot_format_skipped(self, video_id, client_name, proto):
@@ -4080,7 +4080,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         needs_live_processing = self._needs_live_processing(live_status, duration)
 
-        def adjust_incomplete_format(fmt, note_suffix='(Last 2 hours)', pref_adjustment=-10):
+        def adjust_incomplete_format(fmt, note_suffix='(last ~4 hours)', pref_adjustment=-10):
             fmt['preference'] = (fmt.get('preference') or -1) + pref_adjustment
             fmt['format_note'] = join_nonempty(fmt.get('format_note'), note_suffix, delim=' ')
 
@@ -4095,10 +4095,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     # These formats are *only* useful to external applications, so we can hide them
                     # Set their preference <= -1000 so that FormatSorter flags them as 'hidden'
                     adjust_incomplete_format(fmt, note_suffix='(ended)', pref_adjustment=-5000)
-                # Is it live with --live-from-start? Or is it post-live and its duration is >2hrs?
+                # Is it live with --live-from-start? Or is it post-live and its duration is >4hrs?
                 elif needs_live_processing:
                     if not fmt.get('is_from_start'):
-                        # Post-live m3u8 formats for >2hr streams
+                        # Post-live m3u8 formats for >4hr streams
                         adjust_incomplete_format(fmt)
                 elif live_status == 'is_live':
                     if protocol == 'http_dash_segments':


### PR DESCRIPTION
<details><summary>outdated original description</summary>
Live and post-live manifest formats include the past 4 hours, while the extractor had their lookback window hardcoded as 2 hours.
</details>

Our "needs live processing" condition is incorrect for some livestreams.

Thanks @absidue and @coletdjnz for the following info:

- normal latency streams: 4 hours (each segment is 5 seconds long, i.e. `targetDurationSec` == `5`)
- low latency streams: 2 hours (each segment is 2 seconds long, i.e. `targetDurationSec` == `2`)
- ultra low latency streams: 1??? hour (each segment is 1 second long, i.e. `targetDurationSec` == `1`)

TODO:
- find a way to pass `targetDurationSec` to `YoutubeIE._needs_live_processing` and to the nested `adjust_incomplete_formats` function in `YoutubeIE._real_extract` so that the correct duration can be calculated

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
