### PR TITLE
[utils] `get_element(s)_*`, `find_element(s)`: Improve element matching more comprehensively

### DIFF
--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -577,7 +577,6 @@ class TestTraversalHelpers:
 
     def test_find_element(self):
         for improper_kwargs in [
-            dict(attr='data-id'),
             dict(value='y'),
             dict(attr='data-id', value='y', cls='a'),
             dict(attr='data-id', value='y', id='x'),
@@ -608,7 +607,6 @@ class TestTraversalHelpers:
     def test_find_elements(self):
         for improper_kwargs in [
             dict(tag='p'),
-            dict(attr='data-id'),
             dict(value='y'),
             dict(attr='data-id', value='y', cls='a'),
             dict(cls='a', tag='div'),

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -45,6 +45,11 @@ _TEST_HTML = '''<html><body>
     <div class="b" data-id="y" custom="z">3</div>
     <p class="a">4</p>
     <p id="d" custom="e">5</p>
+    <p class=foo>bar</p>
+    <p class="">123</p>
+    <TIME id="t">12</TIME>
+    <link rel="canonical" href="url">
+    <input type="checkbox" checked />
 </body></html>'''
 
 
@@ -578,13 +583,13 @@ class TestTraversalHelpers:
             dict(attr='data-id', value='y', id='x'),
             dict(cls='a', id='x'),
             dict(cls='a', tag='p'),
-            dict(cls='[ab]', regex=True),
         ]:
             with pytest.raises(AssertionError):
                 find_element(**improper_kwargs)(_TEST_HTML)
 
         assert find_element(cls='a')(_TEST_HTML) == '1'
         assert find_element(cls='a', html=True)(_TEST_HTML) == '<div class="a">1</div>'
+        assert find_element(cls='[ab]', regex=True)(_TEST_HTML) == '1'
         assert find_element(id='x')(_TEST_HTML) == '2'
         assert find_element(id='[ex]')(_TEST_HTML) is None
         assert find_element(id='[ex]', regex=True)(_TEST_HTML) == '2'
@@ -594,6 +599,11 @@ class TestTraversalHelpers:
         assert find_element(attr='data-id', value='y(?:es)?', regex=True)(_TEST_HTML) == '3'
         assert find_element(
             attr='data-id', value='y', html=True)(_TEST_HTML) == '<div class="b" data-id="y" custom="z">3</div>'
+        assert find_element(cls='foo', quoted=False)(_TEST_HTML) == 'bar'
+        assert find_element(cls='')(_TEST_HTML) == '123'
+        assert find_element(tag='time')(_TEST_HTML) == '12'
+        assert find_element(attr='rel', value='canonical', html=True)(_TEST_HTML) == '<link rel="canonical" href="url">'
+        assert find_element(attr='checked', value=None, require_value=False, html=True)(_TEST_HTML) == '<input type="checkbox" checked />'
 
     def test_find_elements(self):
         for improper_kwargs in [
@@ -602,7 +612,6 @@ class TestTraversalHelpers:
             dict(value='y'),
             dict(attr='data-id', value='y', cls='a'),
             dict(cls='a', tag='div'),
-            dict(cls='[ab]', regex=True),
         ]:
             with pytest.raises(AssertionError):
                 find_elements(**improper_kwargs)(_TEST_HTML)
@@ -610,6 +619,7 @@ class TestTraversalHelpers:
         assert find_elements(cls='a')(_TEST_HTML) == ['1', '2', '4']
         assert find_elements(cls='a', html=True)(_TEST_HTML) == [
             '<div class="a">1</div>', '<div class="a" id="x" custom="z">2</div>', '<p class="a">4</p>']
+        assert find_elements(cls='[ab]', regex=True)(_TEST_HTML) == ['1', '2', '3', '4']
         assert find_elements(attr='custom', value='z')(_TEST_HTML) == ['2', '3']
         assert find_elements(attr='custom', value='[ez]')(_TEST_HTML) == []
         assert find_elements(attr='custom', value='[ez]', regex=True)(_TEST_HTML) == ['2', '3', '5']

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -46,7 +46,9 @@ _TEST_HTML = '''<html><body>
     <p class="a">4</p>
     <p id="d" custom="e">5</p>
     <p class=foo>bar</p>
+    <p class="a b">c</p>
     <p class="">123</p>
+    <p class=" ">456</p>
     <TIME id="t">12</TIME>
     <link rel="canonical" href="url">
     <input type="checkbox" checked />
@@ -614,13 +616,14 @@ class TestTraversalHelpers:
             with pytest.raises(AssertionError):
                 find_elements(**improper_kwargs)(_TEST_HTML)
 
-        assert find_elements(cls='a')(_TEST_HTML) == ['1', '2', '4']
+        assert find_elements(cls='a')(_TEST_HTML) == ['1', '2', '4', 'c']
         assert find_elements(cls='a', html=True)(_TEST_HTML) == [
-            '<div class="a">1</div>', '<div class="a" id="x" custom="z">2</div>', '<p class="a">4</p>']
-        assert find_elements(cls='[ab]', regex=True)(_TEST_HTML) == ['1', '2', '3', '4']
+            '<div class="a">1</div>', '<div class="a" id="x" custom="z">2</div>', '<p class="a">4</p>', '<p class="a b">c</p>']
+        assert find_elements(cls='[ab]', regex=True)(_TEST_HTML) == ['1', '2', '3', '4', 'c']
         assert find_elements(attr='custom', value='z')(_TEST_HTML) == ['2', '3']
         assert find_elements(attr='custom', value='[ez]')(_TEST_HTML) == []
         assert find_elements(attr='custom', value='[ez]', regex=True)(_TEST_HTML) == ['2', '3', '5']
+        assert find_elements(cls='')(_TEST_HTML) == ['123', '456']
 
 
 class TestDictGet:

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -345,6 +345,9 @@ def get_element_html_by_attribute(attribute, value, html, **kwargs):
 def get_elements_by_class(class_name, html, *, escape_value=True, quoted=True, **kwargs):
     """Return the content of all tags with the specified class in the passed HTML document as a list"""
     if quoted:
+        if class_name == '':
+            return get_elements_by_attribute(
+                'class', r'\s*', html, escape_value=False, quoted=True, **kwargs)
         class_name = re.escape(class_name) if escape_value else class_name
         return get_elements_by_attribute(
             'class', rf'[^\'"]*(?<=[\'"\s]){class_name}(?=[\'"\s])[^\'"]*',
@@ -356,6 +359,9 @@ def get_elements_by_class(class_name, html, *, escape_value=True, quoted=True, *
 def get_elements_html_by_class(class_name, html, *, escape_value=True, quoted=True, **kwargs):
     """Return the html of all tags with the specified class in the passed HTML document as a list"""
     if quoted:
+        if class_name == '':
+            return get_elements_html_by_attribute(
+                'class', r'\s*', html, escape_value=False, quoted=True, **kwargs)
         class_name = re.escape(class_name) if escape_value else class_name
         return get_elements_html_by_attribute(
             'class', rf'[^\'"]*(?<=[\'"\s]){class_name}(?=[\'"\s])[^\'"]*',

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -171,6 +171,12 @@ JSON_LD_RE = r'(?is)<script[^>]+type=(["\']?)application/ld\+json\1[^>]*>\s*(?P<
 
 NUMBER_RE = r'\d+(?:\.\d+)?'
 
+VOID_ELEMENTS = [
+    'area', 'base', 'br', 'col', 'embed',
+    'hr', 'img', 'input', 'link', 'meta',
+    'param', 'source', 'track', 'wbr',
+]
+
 
 @functools.cache
 def preferredencoding():
@@ -314,15 +320,15 @@ def get_element_html_by_id(id, html, **kwargs):
     return get_element_html_by_attribute('id', id, html, **kwargs)
 
 
-def get_element_by_class(class_name, html):
+def get_element_by_class(class_name, html, **kwargs):
     """Return the content of the first tag with the specified class in the passed HTML document"""
-    retval = get_elements_by_class(class_name, html)
+    retval = get_elements_by_class(class_name, html, **kwargs)
     return retval[0] if retval else None
 
 
-def get_element_html_by_class(class_name, html):
+def get_element_html_by_class(class_name, html, **kwargs):
     """Return the html of the first tag with the specified class in the passed HTML document"""
-    retval = get_elements_html_by_class(class_name, html)
+    retval = get_elements_html_by_class(class_name, html, **kwargs)
     return retval[0] if retval else None
 
 
@@ -331,23 +337,31 @@ def get_element_by_attribute(attribute, value, html, **kwargs):
     return retval[0] if retval else None
 
 
-def get_element_html_by_attribute(attribute, value, html, **kargs):
-    retval = get_elements_html_by_attribute(attribute, value, html, **kargs)
+def get_element_html_by_attribute(attribute, value, html, **kwargs):
+    retval = get_elements_html_by_attribute(attribute, value, html, **kwargs)
     return retval[0] if retval else None
 
 
-def get_elements_by_class(class_name, html, **kargs):
+def get_elements_by_class(class_name, html, *, escape_value=True, quoted=True, **kwargs):
     """Return the content of all tags with the specified class in the passed HTML document as a list"""
+    if quoted:
+        class_name = re.escape(class_name) if escape_value else class_name
+        return get_elements_by_attribute(
+            'class', rf'[^\'"]*(?<=[\'"\s]){class_name}(?=[\'"\s])[^\'"]*',
+            html, escape_value=False, quoted=True, **kwargs)
     return get_elements_by_attribute(
-        'class', rf'[^\'"]*(?<=[\'"\s]){re.escape(class_name)}(?=[\'"\s])[^\'"]*',
-        html, escape_value=False)
+        'class', class_name, html, escape_value=escape_value, quoted=False, **kwargs)
 
 
-def get_elements_html_by_class(class_name, html):
+def get_elements_html_by_class(class_name, html, *, escape_value=True, quoted=True, **kwargs):
     """Return the html of all tags with the specified class in the passed HTML document as a list"""
+    if quoted:
+        class_name = re.escape(class_name) if escape_value else class_name
+        return get_elements_html_by_attribute(
+            'class', rf'[^\'"]*(?<=[\'"\s]){class_name}(?=[\'"\s])[^\'"]*',
+            html, escape_value=False, quoted=True, **kwargs)
     return get_elements_html_by_attribute(
-        'class', rf'[^\'"]*(?<=[\'"\s]){re.escape(class_name)}(?=[\'"\s])[^\'"]*',
-        html, escape_value=False)
+        'class', class_name, html, escape_value=escape_value, quoted=False, **kwargs)
 
 
 def get_elements_by_attribute(*args, **kwargs):
@@ -360,22 +374,30 @@ def get_elements_html_by_attribute(*args, **kwargs):
     return [whole for _, whole in get_elements_text_and_html_by_attribute(*args, **kwargs)]
 
 
-def get_elements_text_and_html_by_attribute(attribute, value, html, *, tag=r'[\w:.-]+', escape_value=True):
+def get_elements_text_and_html_by_attribute(attribute, value, html, *, tag=r'[\w:.-]+', escape_attr=True, escape_value=True, require_value=True, quoted=True):
     """
     Return the text (content) and the html (whole) of the tag with the specified
     attribute in the passed HTML document
     """
-    if not value:
-        return
+    if require_value:
+        if value is None or (value == '' and not quoted):
+            return
 
-    quote = '' if re.match(r'''[\s"'`=<>]''', value) else '?'
+        value = re.escape(value) if escape_value else value
+        if quoted:
+            value_re = rf'(?P<_q>["\'])(?-x:{value})(?P=_q)'
+        else:
+            value_re = rf'(?-x:{value})(?=[\s/>]|$)'
+        value_part = rf'\s*=\s*{value_re}'
+    else:
+        assert value is None, 'value must be None when require_value=False'
+        value_part = r'(?=[\s/>]|$)(?!\s*=)'
 
-    value = re.escape(value) if escape_value else value
-
+    attribute = re.escape(attribute) if escape_attr else attribute
     partial_element_re = rf'''(?x)
-        <(?P<tag>{tag})
+        <(?P<tag>(?i:{tag}))
          (?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?
-         \s{re.escape(attribute)}\s*=\s*(?P<_q>['"]{quote})(?-x:{value})(?P=_q)
+         \s(?i:(?:{attribute})){value_part}
         '''
 
     for m in re.finditer(partial_element_re, html):
@@ -435,33 +457,34 @@ def get_element_text_and_html_by_tag(tag, html):
     For the first element with the specified tag in the passed HTML document
     return its' content (text) and the whole element (html)
     """
-    def find_or_raise(haystack, needle, exc):
-        try:
-            return haystack.index(needle)
-        except ValueError:
-            raise exc
-    closing_tag = f'</{tag}>'
-    whole_start = find_or_raise(
-        html, f'<{tag}', compat_HTMLParseError(f'opening {tag} tag not found'))
-    content_start = find_or_raise(
-        html[whole_start:], '>', compat_HTMLParseError(f'malformed opening {tag} tag'))
-    content_start += whole_start + 1
+    opening_match = re.search(rf'<{re.escape(tag)}\b', html, flags=re.IGNORECASE)
+    if not opening_match:
+        raise compat_HTMLParseError(f'opening {tag} tag not found')
+    whole_start = opening_match.start()
+    content_start = html.find('>', whole_start)
+    if content_start < 0:
+        raise compat_HTMLParseError(f'malformed opening {tag} tag')
+    content_start += 1
+
+    if tag.lower() in VOID_ELEMENTS:
+        return '', html[whole_start:content_start]
+
     with HTMLBreakOnClosingTagParser() as parser:
         parser.feed(html[whole_start:content_start])
-        if not parser.tagstack or parser.tagstack[0] != tag:
+        if not parser.tagstack or parser.tagstack[0] != tag.lower():
             raise compat_HTMLParseError(f'parser did not match opening {tag} tag')
         offset = content_start
+        closing_re = re.compile(rf'</{re.escape(tag)}\s*>', flags=re.IGNORECASE)
         while offset < len(html):
-            next_closing_tag_start = find_or_raise(
-                html[offset:], closing_tag,
-                compat_HTMLParseError(f'closing {tag} tag not found'))
-            next_closing_tag_end = next_closing_tag_start + len(closing_tag)
+            closing_match = closing_re.search(html, offset)
+            if not closing_match:
+                raise compat_HTMLParseError(f'closing {tag} tag not found')
+            closing_start, closing_end = closing_match.start(), closing_match.end()
             try:
-                parser.feed(html[offset:offset + next_closing_tag_end])
-                offset += next_closing_tag_end
+                parser.feed(html[offset:closing_end])
+                offset = closing_end
             except HTMLBreakOnClosingTagParser.HTMLBreakOnClosingTagException:
-                return html[content_start:offset + next_closing_tag_start], \
-                    html[whole_start:offset + next_closing_tag_end]
+                return html[content_start:closing_start], html[whole_start:closing_end]
         raise compat_HTMLParseError('unexpected end of html')
 
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

- improve boundary checks to avoid false positives

- make tag/attr names case-insensitive
	`<TIME></TIME>`, `<Div></dIV>`
	Closes https://github.com/yt-dlp/yt-dlp/issues/8915
	Related https://github.com/yt-dlp/yt-dlp/issues/11557
	Supersedes https://github.com/yt-dlp/yt-dlp/pull/11736

- add support for void/self-contained elements
	`<img />`, `<link />`, `<source />`
	Related https://github.com/yt-dlp/yt-dlp/blob/81bdea03f3414dd4d086610c970ec14e15bd3d36/yt_dlp/extractor/generic.py#L729
	Supersedes https://github.com/yt-dlp/yt-dlp/pull/13138

- add support for unquoted attribute values via `quoted=False`
	`class=foo`, `data-id=bar`
	Related [Видео](https://video.sibnet.ru/)

- add support for empty attribute values
	`class=""`
	Related https://github.com/yt-dlp/yt-dlp/blob/81bdea03f3414dd4d086610c970ec14e15bd3d36/yt_dlp/extractor/tvnoe.py#L70
	Supersedes https://github.com/yt-dlp/yt-dlp/pull/14068

- add support for valueless boolean attributes via `require_value=False` (with `value=None`)
	`disabled`, `selected`, `crossorigin`
	Related https://github.com/yt-dlp/yt-dlp/blob/81bdea03f3414dd4d086610c970ec14e15bd3d36/yt_dlp/extractor/appleconnect.py#L73

- enable optional regex matching for `class`/`attr`
	`class`: `escape_value=False`, `attr`: `escape_attr=False`

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
