### PR TITLE
fix: prevent erroneous Klingon language code assignment

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -134,7 +134,7 @@ from yt_dlp.utils import (
     xpath_text,
     xpath_with_ns,
 )
-from yt_dlp.utils._utils import _UnsafeExtensionError
+from yt_dlp.utils._utils import ISO639Utils, _UnsafeExtensionError
 from yt_dlp.utils.networking import (
     HTTPHeaderDict,
     escape_rfc3986,
@@ -2242,6 +2242,46 @@ Line 1
         test(self._JWT_WITH_REORDERED_HEADERS)
         test(self._JWT_WITH_REORDERED_HEADERS_AND_RS256_ALG)
         test(self._JWT_WITH_EXTRA_HEADERS_AND_ES256_ALG)
+
+    def test_iso639_utils(self):
+        # Test short2long: valid 2-char codes (ISO 639-1 -> ISO 639-2/T)
+        self.assertEqual(ISO639Utils.short2long('en'), 'eng')
+        self.assertEqual(ISO639Utils.short2long('de'), 'deu')
+        self.assertEqual(ISO639Utils.short2long('fr'), 'fra')
+        self.assertEqual(ISO639Utils.short2long('es'), 'spa')
+        self.assertEqual(ISO639Utils.short2long('zh'), 'zho')
+        self.assertEqual(ISO639Utils.short2long('ja'), 'jpn')
+
+        # Test short2long: invalid 2-char codes should return None
+        self.assertIsNone(ISO639Utils.short2long('zz'))
+        self.assertIsNone(ISO639Utils.short2long(''))
+
+        # Test short2long: 3-char codes (ISO 639-3 like 'tlh' for Klingon) should NOT be converted
+        # Previously this would truncate 'tlh' to 'tl' and return 'tgl' (Tagalog) - GH#16045
+        self.assertIsNone(ISO639Utils.short2long('tlh'))  # Klingon
+        self.assertIsNone(ISO639Utils.short2long('eng'))  # Already 3-char
+        self.assertIsNone(ISO639Utils.short2long('tgl'))  # Already 3-char
+
+        # Test long2short: valid 3-char codes (ISO 639-2/T -> ISO 639-1)
+        self.assertEqual(ISO639Utils.long2short('eng'), 'en')
+        self.assertEqual(ISO639Utils.long2short('deu'), 'de')
+        self.assertEqual(ISO639Utils.long2short('fra'), 'fr')
+        self.assertEqual(ISO639Utils.long2short('spa'), 'es')
+        self.assertEqual(ISO639Utils.long2short('zho'), 'zh')
+        self.assertEqual(ISO639Utils.long2short('jpn'), 'ja')
+
+        # Test long2short: invalid 3-char codes should return None
+        self.assertIsNone(ISO639Utils.long2short('zzz'))
+        self.assertIsNone(ISO639Utils.long2short(''))
+
+        # Test long2short: 2-char codes should NOT be converted (they're already short)
+        self.assertIsNone(ISO639Utils.long2short('en'))
+        self.assertIsNone(ISO639Utils.long2short('de'))
+
+        # Test deprecated/alternative codes
+        self.assertEqual(ISO639Utils.short2long('iw'), 'heb')  # Hebrew (old code)
+        self.assertEqual(ISO639Utils.short2long('he'), 'heb')  # Hebrew (new code)
+        self.assertEqual(ISO639Utils.long2short('heb'), 'he')  # Should return new code
 
 
 if __name__ == '__main__':

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -3819,14 +3819,17 @@ class ISO639Utils:
     @classmethod
     def short2long(cls, code):
         """Convert language code from ISO 639-1 to ISO 639-2/T"""
-        return cls._lang_map.get(code[:2])
+        # Only convert 2-character ISO 639-1 codes; leave 3-character codes (e.g., 'tlh' for Klingon) unchanged
+        if len(code) == 2:
+            return cls._lang_map.get(code)
 
     @classmethod
     def long2short(cls, code):
         """Convert language code from ISO 639-2/T to ISO 639-1"""
-        for short_name, long_name in cls._lang_map.items():
-            if long_name == code:
-                return short_name
+        if len(code) == 3:
+            for short_name, long_name in cls._lang_map.items():
+                if long_name == code:
+                    return short_name
 
 
 class ISO3166Utils:


### PR DESCRIPTION
## Summary

Fixes #16045

YouTube audio tracks labeled as "Klingon" were getting mislabeled after yt-dlp writes the file. This was caused by erroneous ISO 639 language code conversions.

## Changes

- Fixed language code detection logic in `_utils.py`
- Added proper handling for edge cases in language code mapping
- Added tests to verify correct behavior

## Testing

Added test case in `test/test_utils.py` to prevent regression.