### PR TITLE
[ie/tldv] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2039,6 +2039,7 @@ from .telequebec import (
 )
 from .teletask import TeleTaskIE
 from .telewebion import TelewebionIE
+from .tldv import TldvIE
 from .tempo import (
     IVXPlayerIE,
     TempoIE,

--- a/yt_dlp/extractor/tldv.py
+++ b/yt_dlp/extractor/tldv.py
@@ -1,0 +1,154 @@
+import json
+import re
+
+from .common import InfoExtractor
+from ..utils import (
+    ExtractorError,
+    int_or_none,
+    str_or_none,
+    url_or_none,
+)
+from ..utils.traversal import traverse_obj
+
+
+def _caesar_decode(text, shift):
+    """Decode Caesar cipher by shifting each letter forward by ``shift`` positions."""
+    result = []
+    for ch in text:
+        if 'a' <= ch <= 'z':
+            result.append(chr((ord(ch) - ord('a') + shift) % 26 + ord('a')))
+        elif 'A' <= ch <= 'Z':
+            result.append(chr((ord(ch) - ord('A') + shift) % 26 + ord('A')))
+        else:
+            result.append(ch)
+    return ''.join(result)
+
+
+class TldvIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?tldv\.io/app/meetings/(?P<id>[a-f0-9]+)'
+    _NETRC_MACHINE = 'tldv'
+    IE_NAME = 'tldv'
+
+    _API_BASE = 'https://gaia.tldv.io/v1'
+
+    _TESTS = [{
+        'url': 'https://tldv.io/app/meetings/6979fa3e5095a7001341ea2c',
+        'only_matching': True,
+    }]
+
+    def _get_auth_token(self, video_id):
+        token = self._configuration_arg('token', [None], casesense=True)[0]
+        if token:
+            return token
+
+        username, password = self._get_login_info()
+        if username and password:
+            return self._login(username, password, video_id)
+
+        token = self._get_token_from_cookies()
+        if token:
+            return token
+
+        raise ExtractorError(
+            'No authentication token found. Use one of:\n'
+            '  --extractor-args "tldv:token=YOUR_JWT_TOKEN"\n'
+            '  --username EMAIL --password PASSWORD\n'
+            '\n'
+            'To get your token from the browser:\n'
+            '  1. Open tldv.io and log in\n'
+            '  2. Press F12 and open the Console tab\n'
+            '  3. Run: JSON.parse(localStorage.getItem("_cap_jwt")).token\n'
+            '  4. Copy the output',
+            expected=True)
+
+    def _login(self, username, password, video_id):
+        response = self._download_json(
+            f'{self._API_BASE}/auth/login', video_id,
+            note='Logging in to tldv',
+            errnote='Login failed',
+            data=json.dumps({
+                'email': username,
+                'password': password,
+            }).encode(),
+            headers={'Content-Type': 'application/json'},
+            expected_status=(401, 403))
+
+        token = traverse_obj(response, (
+            ('token', 'accessToken', 'access_token'), {str}, any))
+        if not token:
+            token = traverse_obj(response, ('data', 'token', {str}))
+
+        if not token:
+            raise ExtractorError(
+                'Login failed. Check your credentials or provide the token directly:\n'
+                '  --extractor-args "tldv:token=YOUR_JWT_TOKEN"',
+                expected=True)
+
+        return token
+
+    def _get_token_from_cookies(self):
+        cookies = self._get_cookies('https://tldv.io')
+        for name in ('token', 'jwt', 'access_token', 'auth_token', 'session', 'tldv_token'):
+            cookie = cookies.get(name)
+            if cookie:
+                return cookie.value
+        return None
+
+    def _decode_playlist(self, raw_m3u8, shift, base_url):
+        """Decode an obfuscated tldv m3u8 playlist.
+
+        Segment URL lines are Caesar-cipher decoded and prepended with
+        ``base_url`` to form absolute S3 pre-signed URLs. HLS tags,
+        comments, and blank lines are kept as-is.
+        """
+        decoded_lines = []
+        for line in raw_m3u8.splitlines():
+            if line.startswith('#TLDVCONF'):
+                continue
+            if line.startswith('#') or not line.strip():
+                decoded_lines.append(line)
+                continue
+            decoded_lines.append(base_url + _caesar_decode(line.strip(), shift))
+
+        return '\n'.join(decoded_lines)
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        token = self._get_auth_token(video_id)
+        headers = {'Authorization': f'Bearer {token}'}
+
+        metadata = self._download_json(
+            f'{self._API_BASE}/meetings/{video_id}',
+            video_id, note='Downloading meeting metadata',
+            headers=headers, fatal=False) or {}
+
+        raw_m3u8 = self._download_webpage(
+            f'{self._API_BASE}/meetings/{video_id}/playlist.m3u8',
+            video_id, note='Downloading obfuscated playlist',
+            headers=headers)
+
+        tldvconf_match = re.search(r'#TLDVCONF:(\d+),(\d+),(.+)', raw_m3u8)
+        if not tldvconf_match:
+            raise ExtractorError(
+                'Could not find TLDVCONF header in playlist. '
+                'The format may have changed.', expected=True)
+
+        shift = int(tldvconf_match.group(2))
+        base_url = tldvconf_match.group(3).strip()
+
+        self.to_screen(f'Decoding playlist (Caesar shift={shift})')
+        decoded_m3u8 = self._decode_playlist(raw_m3u8, shift, base_url)
+
+        formats, subtitles = self._parse_m3u8_formats_and_subtitles(
+            decoded_m3u8, m3u8_url=None, ext='mp4',
+            m3u8_id='hls', video_id=video_id)
+
+        return {
+            'id': video_id,
+            'title': traverse_obj(metadata, (
+                ('name', 'title', 'meetingName'), {str_or_none}, any)) or video_id,
+            'formats': formats,
+            'subtitles': subtitles,
+            'duration': traverse_obj(metadata, ('duration', {int_or_none})),
+            'thumbnail': traverse_obj(metadata, ('thumbnail', {url_or_none})),
+        }

--- a/yt_dlp/extractor/tldv.py
+++ b/yt_dlp/extractor/tldv.py
@@ -1,27 +1,16 @@
 import json
 import re
+import string
 
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    caesar,
     int_or_none,
     str_or_none,
     url_or_none,
 )
 from ..utils.traversal import traverse_obj
-
-
-def _caesar_decode(text, shift):
-    """Decode Caesar cipher by shifting each letter forward by ``shift`` positions."""
-    result = []
-    for ch in text:
-        if 'a' <= ch <= 'z':
-            result.append(chr((ord(ch) - ord('a') + shift) % 26 + ord('a')))
-        elif 'A' <= ch <= 'Z':
-            result.append(chr((ord(ch) - ord('A') + shift) % 26 + ord('A')))
-        else:
-            result.append(ch)
-    return ''.join(result)
 
 
 class TldvIE(InfoExtractor):
@@ -36,14 +25,36 @@ class TldvIE(InfoExtractor):
         'only_matching': True,
     }]
 
+    def _perform_login(self, username, password):
+        response = self._download_json(
+            f'{self._API_BASE}/auth/login', None,
+            note='Logging in to tldv',
+            errnote='Login failed',
+            data=json.dumps({
+                'email': username,
+                'password': password,
+            }).encode(),
+            headers={'Content-Type': 'application/json'},
+            expected_status=(401, 403))
+
+        self._token = traverse_obj(response, (
+            ('token', 'accessToken', 'access_token'), {str}, any))
+        if not self._token:
+            self._token = traverse_obj(response, ('data', 'token', {str}))
+
+        if not self._token:
+            raise ExtractorError(
+                'Login failed. Check your credentials or provide the token directly:\n'
+                '  --extractor-args "tldv:token=YOUR_JWT_TOKEN"',
+                expected=True)
+
     def _get_auth_token(self, video_id):
         token = self._configuration_arg('token', [None], casesense=True)[0]
         if token:
             return token
 
-        username, password = self._get_login_info()
-        if username and password:
-            return self._login(username, password, video_id)
+        if getattr(self, '_token', None):
+            return self._token
 
         token = self._get_token_from_cookies()
         if token:
@@ -60,31 +71,6 @@ class TldvIE(InfoExtractor):
             '  3. Run: JSON.parse(localStorage.getItem("_cap_jwt")).token\n'
             '  4. Copy the output',
             expected=True)
-
-    def _login(self, username, password, video_id):
-        response = self._download_json(
-            f'{self._API_BASE}/auth/login', video_id,
-            note='Logging in to tldv',
-            errnote='Login failed',
-            data=json.dumps({
-                'email': username,
-                'password': password,
-            }).encode(),
-            headers={'Content-Type': 'application/json'},
-            expected_status=(401, 403))
-
-        token = traverse_obj(response, (
-            ('token', 'accessToken', 'access_token'), {str}, any))
-        if not token:
-            token = traverse_obj(response, ('data', 'token', {str}))
-
-        if not token:
-            raise ExtractorError(
-                'Login failed. Check your credentials or provide the token directly:\n'
-                '  --extractor-args "tldv:token=YOUR_JWT_TOKEN"',
-                expected=True)
-
-        return token
 
     def _get_token_from_cookies(self):
         cookies = self._get_cookies('https://tldv.io')
@@ -108,7 +94,9 @@ class TldvIE(InfoExtractor):
             if line.startswith('#') or not line.strip():
                 decoded_lines.append(line)
                 continue
-            decoded_lines.append(base_url + _caesar_decode(line.strip(), shift))
+            decoded_url = caesar(line.strip(), string.ascii_lowercase, shift)
+            decoded_url = caesar(decoded_url, string.ascii_uppercase, shift)
+            decoded_lines.append(base_url + decoded_url)
 
         return '\n'.join(decoded_lines)
 


### PR DESCRIPTION
### Description of your *pull request* and other information

Adds support for downloading meeting recordings from [tldv.io](https://tldv.io).

tldv.io serves recordings as HLS streams with a custom obfuscation layer: segment URLs in the m3u8 playlist are encoded with a Caesar cipher. The shift value and S3 base URL are provided in a custom `#TLDVCONF` header line in the playlist.

**Authentication** requires a JWT token, obtainable from the browser console:
```js
JSON.parse(localStorage.getItem("_cap_jwt")).token
```

Supports three auth methods:
- `--extractor-args "tldv:token=JWT"` (recommended)
- `--username EMAIL --password PASSWORD`
- `--cookies-from-browser` (checks common cookie names)

**How the obfuscation works:**
1. Fetch `GET /v1/meetings/{id}/playlist.m3u8` with Bearer token
2. Parse `#TLDVCONF:expiry,shift,base_url` header
3. Caesar-decode each segment URL line (shift letters forward by `shift`, mod 26)
4. Prepend `base_url` to get absolute pre-signed S3 URLs
5. Pass decoded m3u8 to yt-dlp's native HLS downloader

**Example usage:**
```bash
yt-dlp --extractor-args "tldv:token=YOUR_TOKEN" "https://tldv.io/app/meetings/MEETING_ID"
```

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))

</details>