### PR TITLE
[pornhub] Fix segment downloads (404/410 errors) by enforcing strict headers

### DIFF
--- a/yt_dlp/extractor/pornhub.py
+++ b/yt_dlp/extractor/pornhub.py
@@ -277,6 +277,12 @@ class PornHubIE(PornHubBaseIE):
         self._login(host)
         self._set_age_cookies(host)
 
+        # Define strict headers to prevent 404/410 errors on segments
+        http_headers = {
+            'Referer': url,
+            'Origin': f'https://www.{host}',
+        }
+
         def dl_webpage(platform):
             self._set_cookie(host, 'platform', platform)
             return self._download_webpage(
@@ -425,13 +431,19 @@ class PornHubIE(PornHubBaseIE):
         def add_format(format_url, height=None):
             ext = determine_ext(format_url)
             if ext == 'mpd':
-                formats.extend(self._extract_mpd_formats(
-                    format_url, video_id, mpd_id='dash', fatal=False))
+                mpd_formats = self._extract_mpd_formats(
+                    format_url, video_id, mpd_id='dash', fatal=False, mpd_headers=http_headers)
+                for f in mpd_formats:
+                    f.setdefault('http_headers', {}).update(http_headers)
+                formats.extend(mpd_formats)
                 return
             if ext == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(
+                m3u8_formats = self._extract_m3u8_formats(
                     format_url, video_id, 'mp4', entry_protocol='m3u8_native',
-                    m3u8_id='hls', fatal=False))
+                    m3u8_id='hls', fatal=False, m3u8_headers=http_headers)
+                for f in m3u8_formats:
+                    f.setdefault('http_headers', {}).update(http_headers)
+                formats.extend(m3u8_formats)
                 return
             if not height:
                 height = int_or_none(self._search_regex(
@@ -441,6 +453,7 @@ class PornHubIE(PornHubBaseIE):
                 'url': format_url,
                 'format_id': format_field(height, None, '%dp'),
                 'height': height,
+                'http_headers': http_headers,
             })
 
         for video_url, height in video_urls:
@@ -506,7 +519,7 @@ class PornHubIE(PornHubBaseIE):
                 'cast': ({find_elements(attr='data-label', value='pornstar')}, ..., {clean_html}),
             }),
             'subtitles': subtitles,
-            'http_headers': {'Referer': f'https://www.{host}/'},
+            'http_headers': http_headers,
         }, info)
 
 


### PR DESCRIPTION
PornHub has seemingly updated their protection/CDN configuration. HLS (`.m3u8`) and DASH (`.mpd`) segments now return **HTTP 404 Not Found** or **410 Gone** if the request does not include strict `Referer` and `Origin` headers matching the video page.

This PR:
1. Defines `http_headers` containing the correct `Referer` and `Origin` in `_real_extract`.
2. Passes these headers to `_extract_mpd_formats` (via `mpd_headers`) and `_extract_m3u8_formats` (via `m3u8_headers`).
3. Iterates through the extracted formats and injects these `http_headers` into every format dictionary. This ensures that the downloader (native or ffmpeg) sends the correct headers when requesting individual video segments, fixing the download failure.

Tested with URL: `https://www.pornhub.com/view_video.php?viewkey=68c16aeb671f1`

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>