### PR TITLE
[ie/xhamster] Fix thumbnail extension extraction

### DIFF
--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -403,7 +403,7 @@ class XHamsterIE(InfoExtractor):
                     video, lambda x: x['author']['name'], str),
                 'uploader_url': uploader_url,
                 'uploader_id': uploader_url.split('/')[-1] if uploader_url else None,
-                'thumbnail': video.get('thumbURL'),
+                'thumbnail': url_or_none(re.sub(r'/v\d+$', '', video.get('thumbURL') or '')),
                 'duration': int_or_none(video.get('duration')),
                 'view_count': int_or_none(video.get('views')),
                 'like_count': int_or_none(try_get(
@@ -469,10 +469,11 @@ class XHamsterIE(InfoExtractor):
             r'<span[^>]+itemprop=["\']author[^>]+><a[^>]+><span[^>]+>([^<]+)',
             webpage, 'uploader', default='anonymous')
 
-        thumbnail = self._search_regex(
-            [r'''["']thumbUrl["']\s*:\s*(?P<q>["'])(?P<thumbnail>.+?)(?P=q)''',
-             r'''<video[^>]+"poster"=(?P<q>["'])(?P<thumbnail>.+?)(?P=q)[^>]*>'''],
-            webpage, 'thumbnail', fatal=False, group='thumbnail')
+        thumbnail = url_or_none(re.sub(
+            r'/v\d+$', '', self._search_regex(
+                [r'''["']thumbUrl["']\s*:\s*(?P<q>["'])(?P<thumbnail>.+?)(?P=q)''',
+                 r'''<video[^>]+"poster"=(?P<q>["'])(?P<thumbnail>.+?)(?P=q)[^>]*>'''],
+                webpage, 'thumbnail', fatal=False, group='thumbnail') or ''))
 
         duration = parse_duration(self._search_regex(
             [r'<[^<]+\bitemprop=["\']duration["\'][^<]+\bcontent=["\'](.+?)["\']',


### PR DESCRIPTION
Fixes #16073

### Description of your *pull request* and other information

The xHamster extractor was failing with the error "The extracted extension ('v1663824436') is unusual and will be skipped for safety reasons" when trying to write thumbnails.

The issue was caused by CDN version parameters (e.g., `/v1663824436`) being appended to thumbnail URLs after the actual image extension. The `determine_ext` function was incorrectly extracting these version parameters as file extensions instead of the actual `.jpg` extension.

This PR strips trailing path segments matching the pattern `/v\d+$` (a common CDN version parameter format used by services like Cloudinary) from thumbnail URLs before returning them.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

## Changes
- Strip CDN version parameters (`/v\d+`) from thumbnail URLs in both modern and old layout extraction paths
- Use `url_or_none` wrapper to ensure valid URL output

## Testing
Verified that:
- URLs with version parameters (e.g., `.../image.jpg/v1663824436`) are correctly cleaned to `.../image.jpg`
- URLs without version parameters remain unchanged
- Empty/None values are handled correctly

```
 yt_dlp/extractor/xhamster.py | 11 ++++++-----
 1 file changed, 6 insertions(+), 5 deletions(-)
```