### PR TITLE
[ie/xhamster] Set age_verified cookie to bypass age verification

### DIFF
--- a/yt_dlp/extractor/xhamster.py
+++ b/yt_dlp/extractor/xhamster.py
@@ -268,6 +268,7 @@ class XHamsterIE(InfoExtractor):
         display_id = mobj.group('display_id') or mobj.group('display_id_2')
 
         desktop_url = re.sub(r'^(https?://(?:.+?\.)?)m\.', r'\1', url)
+        self._set_cookie(urllib.parse.urlparse(desktop_url).hostname, 'age_verified', '1')
         webpage, urlh = self._download_webpage_handle(desktop_url, video_id, impersonate=True)
 
         error = self._html_search_regex(


### PR DESCRIPTION
Fixes #15497

### Description of your *pull request* and other information

The xHamster extractor was failing with "No video formats found" error because the site was showing an age verification page instead of the video content. This fix adds an `age_verified=1` cookie before downloading the webpage, similar to how other adult site extractors (YouPorn, Tube8, PornHub) handle age verification.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

## Changes
- Added `age_verified=1` cookie before downloading the webpage to bypass age verification screen

## Testing
The fix follows the same pattern used by other adult site extractors (YouPorn, Tube8, PornHub) which set similar age verification cookies.

```
 yt_dlp/extractor/xhamster.py | 1 +
 1 file changed, 1 insertion(+)
```