### PR TITLE
[ie/yandexmusic] Force HTTPS for API-provided URLs

### DIFF
--- a/yt_dlp/extractor/yandexmusic.py
+++ b/yt_dlp/extractor/yandexmusic.py
@@ -14,14 +14,6 @@ class YandexMusicBaseIE(InfoExtractor):
     _VALID_URL_BASE = r'https?://music\.yandex\.(?P<tld>ru|kz|ua|by|com)'
 
     @staticmethod
-    def _ensure_secure_url(url):
-        if url and url.startswith('//'):
-            return f'https:{url}'
-        if url and url.startswith('http://'):
-            return f'https://{url[7:]}'
-        return url
-
-    @staticmethod
     def _handle_error(response):
         if isinstance(response, dict):
             error = response.get('error')
@@ -125,19 +117,19 @@ class YandexMusicTrackIE(YandexMusicBaseIE):
             track_id, 'Downloading track location url JSON', query={'hq': 1}, headers={'X-Retpath-Y': url})
 
         fd_data = self._download_json(
-            self._ensure_secure_url(download_data['src']), track_id,
+            self._proto_relative_url(download_data['src'], scheme='https:'), track_id,
             'Downloading track location JSON',
             query={'format': 'json'})
         key = hashlib.md5(('XGRlBW9FXlekgbPrRHuSiA' + fd_data['path'][1:] + fd_data['s']).encode()).hexdigest()
-        f_url = self._ensure_secure_url(
-            'http://{}/get-mp3/{}/{}?track-id={} '.format(fd_data['host'], key, fd_data['ts'] + fd_data['path'], track['id']))
+        f_url = 'https://{}/get-mp3/{}/{}?track-id={} '.format(fd_data['host'], key, fd_data['ts'] + fd_data['path'], track['id'])
 
         thumbnail = None
         cover_uri = track.get('albums', [{}])[0].get('coverUri')
         if cover_uri:
             thumbnail = cover_uri.replace('%%', 'orig')
-            if not thumbnail.startswith('http'):
-                thumbnail = f'https://{thumbnail}'
+            if not thumbnail.startswith(('http', '//')):
+                thumbnail = f'//{thumbnail}'
+            thumbnail = self._proto_relative_url(thumbnail, scheme='https:')
 
         track_info = {
             'id': track_id,

--- a/yt_dlp/extractor/yandexmusic.py
+++ b/yt_dlp/extractor/yandexmusic.py
@@ -14,6 +14,14 @@ class YandexMusicBaseIE(InfoExtractor):
     _VALID_URL_BASE = r'https?://music\.yandex\.(?P<tld>ru|kz|ua|by|com)'
 
     @staticmethod
+    def _ensure_secure_url(url):
+        if url and url.startswith('//'):
+            return f'https:{url}'
+        if url and url.startswith('http://'):
+            return f'https://{url[7:]}'
+        return url
+
+    @staticmethod
     def _handle_error(response):
         if isinstance(response, dict):
             error = response.get('error')
@@ -117,18 +125,19 @@ class YandexMusicTrackIE(YandexMusicBaseIE):
             track_id, 'Downloading track location url JSON', query={'hq': 1}, headers={'X-Retpath-Y': url})
 
         fd_data = self._download_json(
-            download_data['src'], track_id,
+            self._ensure_secure_url(download_data['src']), track_id,
             'Downloading track location JSON',
             query={'format': 'json'})
         key = hashlib.md5(('XGRlBW9FXlekgbPrRHuSiA' + fd_data['path'][1:] + fd_data['s']).encode()).hexdigest()
-        f_url = 'http://{}/get-mp3/{}/{}?track-id={} '.format(fd_data['host'], key, fd_data['ts'] + fd_data['path'], track['id'])
+        f_url = self._ensure_secure_url(
+            'http://{}/get-mp3/{}/{}?track-id={} '.format(fd_data['host'], key, fd_data['ts'] + fd_data['path'], track['id']))
 
         thumbnail = None
         cover_uri = track.get('albums', [{}])[0].get('coverUri')
         if cover_uri:
             thumbnail = cover_uri.replace('%%', 'orig')
             if not thumbnail.startswith('http'):
-                thumbnail = 'http://' + thumbnail
+                thumbnail = f'https://{thumbnail}'
 
         track_info = {
             'id': track_id,
@@ -244,7 +253,7 @@ class YandexMusicPlaylistBaseIE(YandexMusicBaseIE):
             if not album_id:
                 continue
             entries.append(self.url_result(
-                f'http://music.yandex.ru/album/{album_id}/track/{track_id}',
+                f'https://music.yandex.ru/album/{album_id}/track/{track_id}',
                 ie=YandexMusicTrackIE.ie_key(), video_id=track_id))
         return entries
 
@@ -446,7 +455,7 @@ class YandexMusicArtistAlbumsIE(YandexMusicArtistBaseIE):
             if not album_id:
                 continue
             entries.append(self.url_result(
-                f'http://music.yandex.ru/album/{album_id}',
+                f'https://music.yandex.ru/album/{album_id}',
                 ie=YandexMusicAlbumIE.ie_key(), video_id=album_id))
         artist = try_get(data, lambda x: x['artist']['name'], str)
         title = '{} - {}'.format(artist or artist_id, 'Альбомы')


### PR DESCRIPTION
## Summary
- normalize Yandex Music API and generated resource URLs to HTTPS
- handle protocol-relative API responses such as `//api.music.yandex.net/...`
- avoid timeouts in environments where plain HTTP access is blocked

## Details
Yandex Music returns a protocol-relative `src` URL for the second metadata request. The extractor previously used that value as-is and also constructed several Yandex URLs with `http://`. In environments where HTTP traffic is blocked, that follow-up request times out even when the main site is accessed over HTTPS.

This change adds a small URL normalizer in the extractor and uses it for the API-provided `src`, generated MP3 URL, thumbnail URL, and internal Yandex result URLs.
