### PR TITLE
Set a timeout on generate third party licenses HTTP calls

### DIFF
--- a/devscripts/generate_third_party_licenses.py
+++ b/devscripts/generate_third_party_licenses.py
@@ -297,7 +297,7 @@ def fetch_text(dep: Dependency) -> str:
         return cache_file.read_text()
 
     # UA needed since some domains block requests default UA
-    req = requests.get(dep.license_url, headers={'User-Agent': 'yt-dlp license fetcher'})
+    req = requests.get(dep.license_url, headers={'User-Agent': 'yt-dlp license fetcher'}, timeout=10.0)
     req.raise_for_status()
     text = req.text
     cache_file.write_text(text)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1722,7 +1722,9 @@ class YoutubeDL:
                 break
         return wrapper
 
-    def _wait_for_video(self, ie_result={}):
+    def _wait_for_video(self, ie_result=None):
+        if ie_result is None:
+            ie_result = {}
         if (not self.params.get('wait_for_video')
                 or ie_result.get('_type', 'video') != 'video'
                 or ie_result.get('formats') or ie_result.get('url')):
@@ -3736,7 +3738,9 @@ class YoutubeDL:
         """ Alias of sanitize_info for backward compatibility """
         return YoutubeDL.sanitize_info(info_dict, actually_filter)
 
-    def _delete_downloaded_files(self, *files_to_delete, info={}, msg=None):
+    def _delete_downloaded_files(self, *files_to_delete, info=None, msg=None):
+        if info is None:
+            info = {}
         for filename in set(filter(None, files_to_delete)):
             if msg:
                 self.to_screen(msg % filename)

--- a/yt_dlp/downloader/__init__.py
+++ b/yt_dlp/downloader/__init__.py
@@ -1,7 +1,9 @@
 from ..utils import NO_DEFAULT, determine_protocol
 
 
-def get_suitable_downloader(info_dict, params={}, default=NO_DEFAULT, protocol=None, to_stdout=False):
+def get_suitable_downloader(info_dict, params=None, default=NO_DEFAULT, protocol=None, to_stdout=False):
+    if params is None:
+        params = {}
     info_dict['protocol'] = determine_protocol(info_dict)
     info_copy = info_dict.copy()
     info_copy['to_stdout'] = to_stdout

--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1411,7 +1411,9 @@ class AdobePassIE(InfoExtractor):  # XXX: Conventionally, base classes should en
             token_expires = unified_timestamp(re.sub(r'[_ ]GMT', '', xml_text(token, date_ele)))
             return token_expires and token_expires <= int(time.time())
 
-        def post_form(form_page_res, note, data={}, validate_url=False):
+        def post_form(form_page_res, note, data=None, validate_url=False):
+            if data is None:
+                data = {}
             form_page, urlh = form_page_res
             post_url = self._html_search_regex(r'<form[^>]+action=(["\'])(?P<url>.+?)\1', form_page, 'post url', group='url')
             if not re.match(r'https?://', post_url):

--- a/yt_dlp/extractor/brainpop.py
+++ b/yt_dlp/extractor/brainpop.py
@@ -33,7 +33,9 @@ class BrainPOPBaseIE(InfoExtractor):
         root = re.escape(cls._ORIGIN).replace(r'https:', r'https?:').replace(r'www\.', r'(?:www\.)?')
         return rf'{root}/(?P<slug>[^/]+/[^/]+/(?P<id>[^/?#&]+))'
 
-    def _assemble_formats(self, slug, format_id, display_id, token='', extra_fields={}):
+    def _assemble_formats(self, slug, format_id, display_id, token='', extra_fields=None):
+        if extra_fields is None:
+            extra_fields = {}
         formats = []
         formats = self._extract_m3u8_formats(
             f'{urljoin(self._HLS_URL, slug)}.m3u8?{token}',
@@ -46,7 +48,9 @@ class BrainPOPBaseIE(InfoExtractor):
             f.update(extra_fields)
         return formats
 
-    def _extract_adaptive_formats(self, data, token, display_id, key_format='%s', extra_fields={}):
+    def _extract_adaptive_formats(self, data, token, display_id, key_format='%s', extra_fields=None):
+        if extra_fields is None:
+            extra_fields = {}
         formats = []
         additional_key_formats = {
             '%s': {},

--- a/yt_dlp/extractor/brightcove.py
+++ b/yt_dlp/extractor/brightcove.py
@@ -494,7 +494,9 @@ class BrightcoveLegacyIE(InfoExtractor):
 
 
 class BrightcoveNewBaseIE(AdobePassIE):
-    def _parse_brightcove_metadata(self, json_data, video_id, headers={}):
+    def _parse_brightcove_metadata(self, json_data, video_id, headers=None):
+        if headers is None:
+            headers = {}
         formats, subtitles = [], {}
         sources = json_data.get('sources') or []
         for source in sources:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -928,7 +928,7 @@ class InfoExtractor:
                 return False
 
     def _download_webpage_handle(self, url_or_request, video_id, note=None, errnote=None, fatal=True,
-                                 encoding=None, data=None, headers={}, query={}, expected_status=None,
+                                 encoding=None, data=None, headers=None, query=None, expected_status=None,
                                  impersonate=None, require_impersonation=False):
         """
         Return a tuple (page content as string, URL handle).
@@ -968,6 +968,10 @@ class InfoExtractor:
         require_impersonation -- flag to toggle whether the request should raise an error
             if impersonation is not possible (bool, default: False)
         """
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
 
         # Strip hashes from the URL (#1038)
         if isinstance(url_or_request, str):
@@ -1106,8 +1110,12 @@ class InfoExtractor:
             return getattr(ie, parser)(content, *args, **kwargs)
 
         def download_handle(self, url_or_request, video_id, note=note, errnote=errnote, transform_source=None,
-                            fatal=True, encoding=None, data=None, headers={}, query={}, expected_status=None,
+                            fatal=True, encoding=None, data=None, headers=None, query=None, expected_status=None,
                             impersonate=None, require_impersonation=False):
+            if headers is None:
+                headers = {}
+            if query is None:
+                query = {}
             res = self._download_webpage_handle(
                 url_or_request, video_id, note=note, errnote=errnote, fatal=fatal, encoding=encoding,
                 data=data, headers=headers, query=query, expected_status=expected_status,
@@ -1118,8 +1126,12 @@ class InfoExtractor:
             return parse(self, content, video_id, transform_source=transform_source, fatal=fatal, errnote=errnote), urlh
 
         def download_content(self, url_or_request, video_id, note=note, errnote=errnote, transform_source=None,
-                             fatal=True, encoding=None, data=None, headers={}, query={}, expected_status=None,
+                             fatal=True, encoding=None, data=None, headers=None, query=None, expected_status=None,
                              impersonate=None, require_impersonation=False):
+            if headers is None:
+                headers = {}
+            if query is None:
+                query = {}
             if self.get_param('load_pages'):
                 url_or_request = self._create_request(url_or_request, data, headers, query)
                 filename = _request_dump_filename(
@@ -1951,7 +1963,9 @@ class InfoExtractor:
             'Use yt_dlp.utils.FormatSorter instead')
         return FormatSort
 
-    def _sort_formats(self, formats, field_preference=[]):
+    def _sort_formats(self, formats, field_preference=None):
+        if field_preference is None:
+            field_preference = []
         if not field_preference:
             self._downloader.deprecation_warning(
                 'yt_dlp.InfoExtractor._sort_formats is deprecated and is no longer required')
@@ -1994,7 +2008,9 @@ class InfoExtractor:
 
         formats[:] = unique_formats
 
-    def _is_valid_url(self, url, video_id, item='video', headers={}):
+    def _is_valid_url(self, url, video_id, item='video', headers=None):
+        if headers is None:
+            headers = {}
         url = self._proto_relative_url(url, scheme='http:')
         # For now assume non HTTP(S) URLs always valid
         if not url.startswith(('http://', 'https://')):
@@ -2028,7 +2044,11 @@ class InfoExtractor:
 
     def _extract_f4m_formats(self, manifest_url, video_id, preference=None, quality=None, f4m_id=None,
                              transform_source=lambda s: fix_xml_ampersands(s).strip(),
-                             fatal=True, m3u8_id=None, data=None, headers={}, query={}):
+                             fatal=True, m3u8_id=None, data=None, headers=None, query=None):
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         if self.get_param('ignore_no_formats_error'):
             fatal = False
 
@@ -2178,9 +2198,13 @@ class InfoExtractor:
     def _extract_m3u8_formats_and_subtitles(
             self, m3u8_url, video_id, ext=None, entry_protocol='m3u8_native',
             preference=None, quality=None, m3u8_id=None, note=None,
-            errnote=None, fatal=True, live=False, data=None, headers={},
-            query={}):
+            errnote=None, fatal=True, live=False, data=None, headers=None,
+            query=None):
 
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         if self.get_param('ignore_no_formats_error'):
             fatal = False
 
@@ -2225,8 +2249,12 @@ class InfoExtractor:
     def _parse_m3u8_formats_and_subtitles(
             self, m3u8_doc, m3u8_url=None, ext=None, entry_protocol='m3u8_native',
             preference=None, quality=None, m3u8_id=None, live=False, note=None,
-            errnote=None, fatal=True, data=None, headers={}, query={},
+            errnote=None, fatal=True, data=None, headers=None, query=None,
             video_id=None):
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         formats, subtitles = [], {}
         has_drm = HlsFD._has_drm(m3u8_doc)
 
@@ -2477,8 +2505,12 @@ class InfoExtractor:
         return formats, subtitles
 
     def _extract_m3u8_vod_duration(
-            self, m3u8_vod_url, video_id, note=None, errnote=None, data=None, headers={}, query={}):
+            self, m3u8_vod_url, video_id, note=None, errnote=None, data=None, headers=None, query=None):
 
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         m3u8_vod = self._download_webpage(
             m3u8_vod_url, video_id,
             note='Downloading m3u8 VOD manifest' if note is None else note,
@@ -2496,8 +2528,12 @@ class InfoExtractor:
             for line in m3u8_vod.splitlines() if line.startswith('#EXTINF:'))) or None
 
     def _extract_mpd_vod_duration(
-            self, mpd_url, video_id, note=None, errnote=None, data=None, headers={}, query={}):
+            self, mpd_url, video_id, note=None, errnote=None, data=None, headers=None, query=None):
 
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         mpd_doc = self._download_xml(
             mpd_url, video_id,
             note='Downloading MPD VOD manifest' if note is None else note,
@@ -2810,8 +2846,12 @@ class InfoExtractor:
 
     def _extract_mpd_periods(
             self, mpd_url, video_id, mpd_id=None, note=None, errnote=None,
-            fatal=True, data=None, headers={}, query={}):
+            fatal=True, data=None, headers=None, query=None):
 
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         if self.get_param('ignore_no_formats_error'):
             fatal = False
 
@@ -3214,7 +3254,11 @@ class InfoExtractor:
             self._report_ignoring_subs('ISM')
         return fmts
 
-    def _extract_ism_formats_and_subtitles(self, ism_url, video_id, ism_id=None, note=None, errnote=None, fatal=True, data=None, headers={}, query={}):
+    def _extract_ism_formats_and_subtitles(self, ism_url, video_id, ism_id=None, note=None, errnote=None, fatal=True, data=None, headers=None, query=None):
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         if self.get_param('ignore_no_formats_error'):
             fatal = False
 
@@ -3482,7 +3526,9 @@ class InfoExtractor:
             self._report_ignoring_subs('akamai')
         return fmts
 
-    def _extract_akamai_formats_and_subtitles(self, manifest_url, video_id, hosts={}):
+    def _extract_akamai_formats_and_subtitles(self, manifest_url, video_id, hosts=None):
+        if hosts is None:
+            hosts = {}
         signed = 'hdnea=' in manifest_url
         if not signed:
             # https://learn.akamai.com/en-us/webhelp/media-services-on-demand/stream-packaging-user-guide/GUID-BE6C0F73-1E06-483B-B0EA-57984B91B7F9.html
@@ -3540,7 +3586,9 @@ class InfoExtractor:
 
         return formats, subtitles
 
-    def _extract_wowza_formats(self, url, video_id, m3u8_entry_protocol='m3u8_native', skip_protocols=[]):
+    def _extract_wowza_formats(self, url, video_id, m3u8_entry_protocol='m3u8_native', skip_protocols=None):
+        if skip_protocols is None:
+            skip_protocols = []
         query = urllib.parse.urlparse(url).query
         url = re.sub(r'/(?:manifest|playlist|jwplayer)\.(?:m3u8|f4m|mpd|smil)', '', url)
         mobj = re.search(
@@ -3764,7 +3812,9 @@ class InfoExtractor:
         return res
 
     def _set_cookie(self, domain, name, value, expire_time=None, port=None,
-                    path='/', secure=False, discard=False, rest={}, **kwargs):
+                    path='/', secure=False, discard=False, rest=None, **kwargs):
+        if rest is None:
+            rest = {}
         cookie = http.cookiejar.Cookie(
             0, name, value, port, port is not None, domain, True,
             domain.startswith('.'), path, True, secure, expire_time,
@@ -4072,7 +4122,9 @@ class InfoExtractor:
     def RetryManager(self, **kwargs):
         return RetryManager(self.get_param('extractor_retries', 3), self._error_or_warning, **kwargs)
 
-    def _extract_generic_embeds(self, url, *args, info_dict={}, note='Extracting generic embeds', **kwargs):
+    def _extract_generic_embeds(self, url, *args, info_dict=None, note='Extracting generic embeds', **kwargs):
+        if info_dict is None:
+            info_dict = {}
         display_id = traverse_obj(info_dict, 'display_id', 'id')
         self.to_screen(f'{format_field(display_id, None, "%s: ")}{note}')
         return self._downloader.get_info_extractor('Generic')._extract_embeds(

--- a/yt_dlp/extractor/dangalplay.py
+++ b/yt_dlp/extractor/dangalplay.py
@@ -57,7 +57,9 @@ class DangalPlayBaseIE(InfoExtractor):
             }),
         }
 
-    def _call_api(self, path, display_id, note='Downloading JSON metadata', fatal=True, query={}):
+    def _call_api(self, path, display_id, note='Downloading JSON metadata', fatal=True, query=None):
+        if query is None:
+            query = {}
         return self._download_json(
             f'{self._API_BASE}/{path}', display_id, note, fatal=fatal,
             headers={'Accept': 'application/json'}, query={

--- a/yt_dlp/extractor/espn.py
+++ b/yt_dlp/extractor/espn.py
@@ -331,7 +331,9 @@ class WatchESPNIE(AdobePassIE):
     _API_KEY = 'ZXNwbiZicm93c2VyJjEuMC4w.ptUt7QxsteaRruuPmGZFaJByOoqKvDP2a5YkInHrc7c'
     _SOFTWARE_STATEMENT = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIyZGJmZWM4My03OWE1LTQyNzEtYTVmZC04NTZjYTMxMjRjNjMiLCJuYmYiOjE1NDAyMTI3NjEsImlzcyI6ImF1dGguYWRvYmUuY29tIiwiaWF0IjoxNTQwMjEyNzYxfQ.yaK3r4AI2uLVvsyN1GLzqzgzRlxMPtasSaiYYBV0wIstqih5tvjTmeoLmi8Xy9Kp_U7Md-bOffwiyK3srHkpUkhhwXLH2x6RPjmS1tPmhaG7-3LBcHTf2ySPvXhVf7cN4ngldawK4tdtLtsw6rF_JoZE2yaC6XbS2F51nXSFEDDnOQWIHEQRG3aYAj-38P2CLGf7g-Yfhbp5cKXeksHHQ90u3eOO4WH0EAjc9oO47h33U8KMEXxJbvjV5J8Va2G2fQSgLDZ013NBI3kQnE313qgqQh2feQILkyCENpB7g-TVBreAjOaH1fU471htSoGGYepcAXv-UDtpgitDiLy7CQ'
 
-    def _call_bamgrid_api(self, path, video_id, payload=None, headers={}):
+    def _call_bamgrid_api(self, path, video_id, payload=None, headers=None):
+        if headers is None:
+            headers = {}
         if 'Authorization' not in headers:
             headers['Authorization'] = f'Bearer {self._API_KEY}'
         parse = urllib.parse.urlencode if path == 'token' else json.dumps

--- a/yt_dlp/extractor/gamejolt.py
+++ b/yt_dlp/extractor/gamejolt.py
@@ -298,7 +298,9 @@ class GameJoltIE(GameJoltBaseIE):
 
 
 class GameJoltPostListBaseIE(GameJoltBaseIE):
-    def _entries(self, endpoint, list_id, note='Downloading post list', errnote='Unable to download post list', initial_items=[]):
+    def _entries(self, endpoint, list_id, note='Downloading post list', errnote='Unable to download post list', initial_items=None):
+        if initial_items is None:
+            initial_items = []
         page_num, scroll_id = 1, None
         items = initial_items or self._call_api(endpoint, list_id, note=note, errnote=errnote)['items']
         while items:

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -983,8 +983,10 @@ class GenericIE(InfoExtractor):
             return self.playlist_result(embeds, **info_dict)
         raise UnsupportedError(url)
 
-    def _extract_embeds(self, url, webpage, *, urlh=None, info_dict={}):
+    def _extract_embeds(self, url, webpage, *, urlh=None, info_dict=None):
         """Returns an iterator of video entries"""
+        if info_dict is None:
+            info_dict = {}
         info_dict = types.MappingProxyType(info_dict)  # Prevents accidental mutation
         video_id = traverse_obj(info_dict, 'display_id', 'id') or self._generic_id(url)
         url, smuggled_data = unsmuggle_url(url, {})

--- a/yt_dlp/extractor/hidive.py
+++ b/yt_dlp/extractor/hidive.py
@@ -60,7 +60,9 @@ class HiDiveIE(InfoExtractor):
                 'returnUrl': '/dashboard',
             }))
 
-    def _call_api(self, video_id, title, key, data={}, **kwargs):
+    def _call_api(self, video_id, title, key, data=None, **kwargs):
+        if data is None:
+            data = {}
         data = {
             **data,
             'Title': title,

--- a/yt_dlp/extractor/jiosaavn.py
+++ b/yt_dlp/extractor/jiosaavn.py
@@ -67,7 +67,9 @@ class JioSaavnBaseIE(InfoExtractor):
                 'vcodec': 'none',
             }
 
-    def _call_api(self, type_, token, note='API', params={}):
+    def _call_api(self, type_, token, note='API', params=None):
+        if params is None:
+            params = {}
         return self._download_json(
             self._API_URL, token, f'Downloading {note} JSON', f'Unable to download {note} JSON',
             query={

--- a/yt_dlp/extractor/kick.py
+++ b/yt_dlp/extractor/kick.py
@@ -23,7 +23,9 @@ class KickBaseIE(InfoExtractor):
             ('session_token', 'value', {urllib.parse.unquote}))
         return {'Authorization': f'Bearer {token}'} if token else {}
 
-    def _call_api(self, path, display_id, note='Downloading API JSON', headers={}, **kwargs):
+    def _call_api(self, path, display_id, note='Downloading API JSON', headers=None, **kwargs):
+        if headers is None:
+            headers = {}
         return self._download_json(
             f'https://kick.com/api/{path}', display_id, note=note,
             headers={**self._api_headers, **headers}, impersonate=True, **kwargs)

--- a/yt_dlp/extractor/naver.py
+++ b/yt_dlp/extractor/naver.py
@@ -54,7 +54,9 @@ class NaverBaseIE(InfoExtractor):
         formats = []
         get_list = lambda x: try_get(video_data, lambda y: y[x + 's']['list'], list) or []
 
-        def extract_formats(streams, stream_type, query={}):
+        def extract_formats(streams, stream_type, query=None):
+            if query is None:
+                query = {}
             for stream in streams:
                 stream_url = stream.get('source')
                 if not stream_url:

--- a/yt_dlp/extractor/neteasemusic.py
+++ b/yt_dlp/extractor/neteasemusic.py
@@ -46,7 +46,9 @@ class NetEaseMusicBaseIE(InfoExtractor):
         encrypted = bytes(aes_ecb_encrypt(data, list(b'e82ckenh8dichen8')))
         return f'params={encrypted.hex().upper()}'.encode()
 
-    def _download_eapi_json(self, path, video_id, query_body, headers={}, **kwargs):
+    def _download_eapi_json(self, path, video_id, query_body, headers=None, **kwargs):
+        if headers is None:
+            headers = {}
         cookies = {
             'osver': 'undefined',
             'deviceId': 'undefined',

--- a/yt_dlp/extractor/netverse.py
+++ b/yt_dlp/extractor/netverse.py
@@ -13,7 +13,9 @@ class NetverseBaseIE(InfoExtractor):
         'season': 'webseason_videos',
     }
 
-    def _call_api(self, slug, endpoint, query={}, season_id='', display_id=None):
+    def _call_api(self, slug, endpoint, query=None, season_id='', display_id=None):
+        if query is None:
+            query = {}
         return self._download_json(
             f'https://api.netverse.id/medias/api/v2/{self._ENDPOINTS[endpoint]}/{slug}/{season_id}',
             display_id or slug, query=query)

--- a/yt_dlp/extractor/nexx.py
+++ b/yt_dlp/extractor/nexx.py
@@ -144,7 +144,9 @@ class NexxIE(InfoExtractor):
             '{} said: {}'.format(self.IE_NAME, response['metadata']['errorhint']),
             expected=True)
 
-    def _call_api(self, domain_id, path, video_id, data=None, headers={}):
+    def _call_api(self, domain_id, path, video_id, data=None, headers=None):
+        if headers is None:
+            headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
         result = self._download_json(
             f'https://api.nexx.cloud/v3/{domain_id}/{path}', video_id,

--- a/yt_dlp/extractor/nuevo.py
+++ b/yt_dlp/extractor/nuevo.py
@@ -3,7 +3,9 @@ from ..utils import float_or_none, xpath_text
 
 
 class NuevoBaseIE(InfoExtractor):
-    def _extract_nuevo(self, config_url, video_id, headers={}):
+    def _extract_nuevo(self, config_url, video_id, headers=None):
+        if headers is None:
+            headers = {}
         config = self._download_xml(
             config_url, video_id, transform_source=lambda s: s.strip(),
             headers=headers)

--- a/yt_dlp/extractor/nuum.py
+++ b/yt_dlp/extractor/nuum.py
@@ -15,7 +15,9 @@ from ..utils.traversal import traverse_obj
 
 
 class NuumBaseIE(InfoExtractor):
-    def _call_api(self, path, video_id, description, query={}):
+    def _call_api(self, path, video_id, description, query=None):
+        if query is None:
+            query = {}
         response = self._download_json(
             f'https://nuum.ru/api/v2/{path}', video_id, query=query,
             note=f'Downloading {description} metadata',

--- a/yt_dlp/extractor/openload.py
+++ b/yt_dlp/extractor/openload.py
@@ -160,7 +160,7 @@ class PhantomJSwrapper:
                 cookie['expire_time'] = cookie['expiry']
             self.extractor._set_cookie(**cookie)
 
-    def get(self, url, html=None, video_id=None, note=None, note2='Executing JS on webpage', headers={}, jscode='saveAndExit();'):
+    def get(self, url, html=None, video_id=None, note=None, note2='Executing JS on webpage', headers=None, jscode='saveAndExit();'):
         """
         Downloads webpage (if needed) and executes JS
 
@@ -196,6 +196,8 @@ class PhantomJSwrapper:
             });
             check();
         """
+        if headers is None:
+            headers = {}
         if 'saveAndExit();' not in jscode:
             raise ExtractorError('`saveAndExit();` not found in `jscode`')
         if not html:

--- a/yt_dlp/extractor/pr0gramm.py
+++ b/yt_dlp/extractor/pr0gramm.py
@@ -120,7 +120,9 @@ class Pr0grammIE(InfoExtractor):
 
         return flags
 
-    def _call_api(self, endpoint, video_id, query={}, note='Downloading API json'):
+    def _call_api(self, endpoint, video_id, query=None, note='Downloading API json'):
+        if query is None:
+            query = {}
         data = self._download_json(
             f'https://pr0gramm.com/api/items/{endpoint}',
             video_id, note, query=query, expected_status=403)

--- a/yt_dlp/extractor/qqmusic.py
+++ b/yt_dlp/extractor/qqmusic.py
@@ -49,7 +49,9 @@ class QQMusicBaseIE(InfoExtractor):
         return self._search_json(r'window\.__INITIAL_DATA__\s*=', webpage,
                                  'init data', mid, transform_source=js_to_json, fatal=fatal)
 
-    def _make_fcu_req(self, req_dict, mid, headers={}, **kwargs):
+    def _make_fcu_req(self, req_dict, mid, headers=None, **kwargs):
+        if headers is None:
+            headers = {}
         return self._download_json(
             'https://u.y.qq.com/cgi-bin/musicu.fcg', mid, data=json.dumps({
                 'comm': {

--- a/yt_dlp/extractor/radiokapital.py
+++ b/yt_dlp/extractor/radiokapital.py
@@ -6,7 +6,9 @@ from ..utils import clean_html, traverse_obj, unescapeHTML
 
 
 class RadioKapitalBaseIE(InfoExtractor):
-    def _call_api(self, resource, video_id, note='Downloading JSON metadata', qs={}):
+    def _call_api(self, resource, video_id, note='Downloading JSON metadata', qs=None):
+        if qs is None:
+            qs = {}
         return self._download_json(
             f'https://www.radiokapital.pl/wp-json/kapital/v1/{resource}?{urllib.parse.urlencode(qs)}',
             video_id, note=note)

--- a/yt_dlp/extractor/rcti.py
+++ b/yt_dlp/extractor/rcti.py
@@ -257,7 +257,9 @@ class RCTIPlusSeriesIE(RCTIPlusBaseIE):
     def suitable(cls, url):
         return False if RCTIPlusIE.suitable(url) else super().suitable(url)
 
-    def _entries(self, url, display_id=None, note='Downloading entries JSON', metadata={}):
+    def _entries(self, url, display_id=None, note='Downloading entries JSON', metadata=None):
+        if metadata is None:
+            metadata = {}
         total_pages = 0
         try:
             total_pages = self._call_api(
@@ -291,7 +293,9 @@ class RCTIPlusSeriesIE(RCTIPlusBaseIE):
                     **metadata,
                 }
 
-    def _series_entries(self, series_id, display_id=None, video_type=None, metadata={}):
+    def _series_entries(self, series_id, display_id=None, video_type=None, metadata=None):
+        if metadata is None:
+            metadata = {}
         if not video_type or video_type in 'episodes':
             try:
                 seasons_list = self._call_api(

--- a/yt_dlp/extractor/rokfin.py
+++ b/yt_dlp/extractor/rokfin.py
@@ -257,7 +257,11 @@ class RokfinIE(InfoExtractor):
     def _get_auth_token(self):
         return try_get(self._access_mgmt_tokens, lambda x: ' '.join([x['token_type'], x['access_token']]))
 
-    def _download_json_using_access_token(self, url_or_request, video_id, headers={}, query={}):
+    def _download_json_using_access_token(self, url_or_request, video_id, headers=None, query=None):
+        if headers is None:
+            headers = {}
+        if query is None:
+            query = {}
         assert 'authorization' not in headers
         headers = headers.copy()
         auth_token = self._get_auth_token()

--- a/yt_dlp/extractor/theplatform.py
+++ b/yt_dlp/extractor/theplatform.py
@@ -340,7 +340,9 @@ class ThePlatformFeedIE(ThePlatformBaseIE):
         'only_matching': True,
     }]
 
-    def _extract_feed_info(self, provider_id, feed_id, filter_query, video_id, custom_fields=None, asset_types_query={}, account_id=None):
+    def _extract_feed_info(self, provider_id, feed_id, filter_query, video_id, custom_fields=None, asset_types_query=None, account_id=None):
+        if asset_types_query is None:
+            asset_types_query = {}
         real_url = self._URL_TEMPLATE % (self.http_scheme(), provider_id, feed_id, filter_query)
         entry = self._download_json(real_url, video_id)['entries'][0]
         main_smil_url = 'http://link.theplatform.com/s/%s/media/guid/%d/%s' % (provider_id, account_id, entry['guid']) if account_id else entry.get('plmedia$publicUrl')

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -414,7 +414,9 @@ class TikTokBaseIE(InfoExtractor):
                 'height': None,
             } if ext == 'mp3' or '-music-' in url else {}
 
-        def extract_addr(addr, add_meta={}):
+        def extract_addr(addr, add_meta=None):
+            if add_meta is None:
+                add_meta = {}
             parsed_meta, res = self._parse_url_key(addr.get('url_key', ''))
             is_bytevc2 = parsed_meta.get('vcodec') == 'bytevc2'
             if res:

--- a/yt_dlp/extractor/turner.py
+++ b/yt_dlp/extractor/turner.py
@@ -47,7 +47,11 @@ class TurnerBaseIE(AdobePassIE):
             self._AKAMAI_SPE_TOKEN_CACHE[secure_path] = token
         return video_url + '?hdnea=' + token
 
-    def _extract_cvp_info(self, data_src, video_id, software_statement, path_data={}, ap_data={}, fatal=False):
+    def _extract_cvp_info(self, data_src, video_id, software_statement, path_data=None, ap_data=None, fatal=False):
+        if path_data is None:
+            path_data = {}
+        if ap_data is None:
+            ap_data = {}
         video_data = self._download_xml(
             data_src, video_id,
             transform_source=lambda s: fix_xml_ampersands(s).strip(),

--- a/yt_dlp/extractor/tv4.py
+++ b/yt_dlp/extractor/tv4.py
@@ -79,7 +79,9 @@ class TV4IE(InfoExtractor):
         },
     ]
 
-    def _call_api(self, endpoint, video_id, headers=None, query={}):
+    def _call_api(self, endpoint, video_id, headers=None, query=None):
+        if query is None:
+            query = {}
         return self._download_json(
             f'https://playback2.a2d.tv/{endpoint}/{video_id}', video_id,
             f'Downloading {endpoint} API JSON', headers=headers, query={

--- a/yt_dlp/extractor/tvp.py
+++ b/yt_dlp/extractor/tvp.py
@@ -481,7 +481,9 @@ class TVPEmbedIE(InfoExtractor):
 class TVPVODBaseIE(InfoExtractor):
     _API_BASE_URL = 'https://vod.tvp.pl/api/products'
 
-    def _call_api(self, resource, video_id, query={}, **kwargs):
+    def _call_api(self, resource, video_id, query=None, **kwargs):
+        if query is None:
+            query = {}
         is_valid = lambda x: 200 <= x < 300
         document, urlh = self._download_json_handle(
             f'{self._API_BASE_URL}/{resource}', video_id,

--- a/yt_dlp/extractor/twitter.py
+++ b/yt_dlp/extractor/twitter.py
@@ -116,7 +116,9 @@ class TwitterBaseIE(InfoExtractor):
             'x-csrf-token': try_call(lambda: self._get_cookies(self._API_BASE)['ct0'].value),
         })
 
-    def _call_api(self, path, video_id, query={}, graphql=False):
+    def _call_api(self, path, video_id, query=None, graphql=False):
+        if query is None:
+            query = {}
         headers = self._set_base_headers(legacy=not graphql and self._selected_api == 'legacy')
         headers.update({
             'x-twitter-auth-type': 'OAuth2Session',

--- a/yt_dlp/extractor/viu.py
+++ b/yt_dlp/extractor/viu.py
@@ -20,7 +20,9 @@ from ..utils import (
 
 
 class ViuBaseIE(InfoExtractor):
-    def _call_api(self, path, *args, headers={}, **kwargs):
+    def _call_api(self, path, *args, headers=None, **kwargs):
+        if headers is None:
+            headers = {}
         response = self._download_json(
             f'https://www.viu.com/api/{path}', *args, **kwargs,
             headers={**self.geo_verification_headers(), **headers})['response']

--- a/yt_dlp/extractor/wrestleuniverse.py
+++ b/yt_dlp/extractor/wrestleuniverse.py
@@ -110,7 +110,9 @@ class WrestleUniverseBaseIE(InfoExtractor):
             raise ExtractorError('No auth token returned from refresh request')
         self._TOKEN = token
 
-    def _call_api(self, video_id, param='', msg='API', auth=True, data=None, query={}, fatal=True):
+    def _call_api(self, video_id, param='', msg='API', auth=True, data=None, query=None, fatal=True):
+        if query is None:
+            query = {}
         headers = {'CA-CID': ''}
         if data:
             headers['Content-Type'] = 'application/json;charset=utf-8'
@@ -122,7 +124,11 @@ class WrestleUniverseBaseIE(InfoExtractor):
             note=f'Downloading {msg} JSON', errnote=f'Failed to download {msg} JSON',
             data=data, headers=headers, query=query, fatal=fatal)
 
-    def _call_encrypted_api(self, video_id, param='', msg='API', data={}, query={}, fatal=True):
+    def _call_encrypted_api(self, video_id, param='', msg='API', data=None, query=None, fatal=True):
+        if data is None:
+            data = {}
+        if query is None:
+            query = {}
         if not Cryptodome.RSA:
             raise ExtractorError('pycryptodomex not found. Please install', expected=True)
         private_key = Cryptodome.RSA.generate(2048)

--- a/yt_dlp/extractor/wykop.py
+++ b/yt_dlp/extractor/wykop.py
@@ -28,7 +28,9 @@ class WykopBaseIE(InfoExtractor):
         self.cache.store('wykop', 'bearer', new_token)
         return new_token
 
-    def _do_call_api(self, path, video_id, note='Downloading JSON metadata', data=None, headers={}):
+    def _do_call_api(self, path, video_id, note='Downloading JSON metadata', data=None, headers=None):
+        if headers is None:
+            headers = {}
         if data:
             data = json.dumps({'data': data}).encode()
             headers['Content-Type'] = 'application/json'

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -961,7 +961,9 @@ class JSInterpreter:
         global_stack = list(global_stack) or [{}]
         argnames = tuple(argnames)
 
-        def resf(args, kwargs={}, allow_recursion=100):
+        def resf(args, kwargs=None, allow_recursion=100):
+            if kwargs is None:
+                kwargs = {}
             global_stack[0].update(itertools.zip_longest(argnames, args, fillvalue=None))
             global_stack[0].update(kwargs)
             var_stack = LocalNameSpace(*global_stack)

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -254,8 +254,10 @@ def create_parser():
             current + value if append is True else value + current)
 
     def _set_from_options_callback(
-            option, opt_str, value, parser, allowed_values, delim=',', aliases={},
+            option, opt_str, value, parser, allowed_values, delim=',', aliases=None,
             process=lambda x: x.lower().strip()):
+        if aliases is None:
+            aliases = {}
         values = [process(value)] if delim is None else map(process, value.split(delim))
         try:
             requested = orderedSet_from_options(values, collections.ChainMap(aliases, {'all': allowed_values}),

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -266,7 +266,9 @@ class FFmpegPostProcessor(PostProcessor):
                 return mobj.group(1)
         return None
 
-    def get_metadata_object(self, path, opts=[]):
+    def get_metadata_object(self, path, opts=None):
+        if opts is None:
+            opts = []
         if self.probe_basename != 'ffprobe':
             if self.probe_available:
                 self.report_warning('Only ffprobe is supported for metadata extraction')

--- a/yt_dlp/utils/_deprecated.py
+++ b/yt_dlp/utils/_deprecated.py
@@ -32,7 +32,9 @@ def intlist_to_bytes(xs):
     return struct.pack('%dB' % len(xs), *xs)
 
 
-def jwt_encode_hs256(payload_data, key, headers={}):
+def jwt_encode_hs256(payload_data, key, headers=None):
+    if headers is None:
+        headers = {}
     header_data = {
         'alg': 'HS256',
         'typ': 'JWT',

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -2151,9 +2151,11 @@ prepend_extension = functools.partial(_change_extension, True)
 replace_extension = functools.partial(_change_extension, False)
 
 
-def check_executable(exe, args=[]):
+def check_executable(exe, args=None):
     """ Checks if the given binary is installed somewhere in PATH, and returns its name.
     args can be a list of arguments for a short output (like -version) """
+    if args is None:
+        args = []
     try:
         Popen.run([exe, *args], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError:
@@ -2186,10 +2188,12 @@ def detect_exe_version(output, version_re=None, unrecognized='present'):
         return unrecognized
 
 
-def get_exe_version(exe, args=['--version'],
+def get_exe_version(exe, args=None,
                     version_re=None, unrecognized=('present', 'broken')):
     """ Returns the version of the specified executable,
     or False if the executable is not present """
+    if args is None:
+        args = []
     unrecognized = variadic(unrecognized)
     assert len(unrecognized) in (1, 2)
     out = _get_exe_version_output(exe, args)
@@ -2677,7 +2681,11 @@ def variadic(x, allowed_types=NO_DEFAULT):
     return x if is_iterable_like(x, blocked_types=allowed_types) else (x, )
 
 
-def try_call(*funcs, expected_type=None, args=[], kwargs={}):
+def try_call(*funcs, expected_type=None, args=None, kwargs=None):
+    if args is None:
+        args = []
+    if kwargs is None:
+        kwargs = {}
     for f in funcs:
         try:
             val = f(*args, **kwargs)
@@ -2757,8 +2765,10 @@ def strip_jsonp(code):
         r'\g<callback_data>', code)
 
 
-def js_to_json(code, vars={}, *, strict=False):
+def js_to_json(code, vars=None, *, strict=False):
     # vars is a dict of var, val pairs to substitute
+    if vars is None:
+        vars = {}
     STRING_QUOTES = '\'"`'
     STRING_RE = '|'.join(rf'{q}(?:\\.|[^\\{q}])*{q}' for q in STRING_QUOTES)
     COMMENT_RE = r'/\*(?:(?!\*/).)*?\*/|//[^\n]*\n'
@@ -3590,7 +3600,9 @@ def cli_valueless_option(params, command_option, param, expected_value=True):
     return [command_option] if params.get(param) == expected_value else []
 
 
-def cli_configuration_args(argdict, keys, default=[], use_compat=True):
+def cli_configuration_args(argdict, keys, default=None, use_compat=True):
+    if default is None:
+        default = []
     if isinstance(argdict, (list, tuple)):  # for backward compatibility
         if use_compat:
             return argdict
@@ -3610,7 +3622,9 @@ def cli_configuration_args(argdict, keys, default=[], use_compat=True):
     return default
 
 
-def _configuration_args(main_key, argdict, exe, keys=None, default=[], use_compat=True):
+def _configuration_args(main_key, argdict, exe, keys=None, default=None, use_compat=True):
+    if default is None:
+        default = []
     main_key, exe = main_key.lower(), exe.lower()
     root_key = exe if main_key == exe else f'{main_key}+{exe}'
     keys = [f'{root_key}{k}' for k in (keys or [''])]
@@ -4960,7 +4974,9 @@ class Config:
             delim='\n')
 
     @staticmethod
-    def read_file(filename, default=[]):
+    def read_file(filename, default=None):
+        if default is None:
+            default = []
         try:
             optionf = open(filename, 'rb')
         except OSError:


### PR DESCRIPTION
Upon reviewing devscripts/generate_third_party_licenses.py, I noticed an opportunity for improvement. Set a timeout on generate third party licenses HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.

Backward-compat note: This changes a public function signature by replacing mutable defaults with None guards. Call sites stay source-compatible, but callers introspecting defaults will see None now.