### PR TITLE
[ie/vk] Add view_count field to video metadata extraction

### DIFF
--- a/yt_dlp/extractor/vk.py
+++ b/yt_dlp/extractor/vk.py
@@ -147,6 +147,7 @@ class VKIE(VKBaseIE):
                 'upload_date': '20120212',
                 'comment_count': int,
                 'like_count': int,
+                'view_count': int,
                 'thumbnail': r're:https?://.+(?:\.jpg|getVideoPreview.*)$',
             },
             'params': {'skip_download': 'm3u8'},
@@ -164,6 +165,7 @@ class VKIE(VKBaseIE):
                 'upload_date': '20130720',
                 'comment_count': int,
                 'like_count': int,
+                'view_count': int,
                 'thumbnail': r're:https?://.+(?:\.jpg|getVideoPreview.*)$',
             },
         },
@@ -194,6 +196,7 @@ class VKIE(VKBaseIE):
                 'comment_count': int,
                 'uploader': 'Dizi2021',
                 'like_count': int,
+                'view_count': int,
                 'timestamp': 1640162189,
                 'upload_date': '20211222',
                 'uploader_id': '-93049196',
@@ -259,6 +262,7 @@ class VKIE(VKBaseIE):
                 'comment_count': int,
                 'duration': 9,
                 'like_count': int,
+                'view_count': int,
                 'thumbnail': r're:https?://.+(?:\.jpg|getVideoPreview.*)$',
                 'timestamp': 1664995597,
                 'title': 'Clip by @madempress',
@@ -316,6 +320,7 @@ class VKIE(VKBaseIE):
                 'uploader_id': '-18403220',
                 'comment_count': int,
                 'like_count': int,
+                'view_count': int,
                 'duration': 1983,
                 'thumbnail': r're:https?://.+\.jpg',
                 'chapters': 'count:21',
@@ -334,6 +339,7 @@ class VKIE(VKBaseIE):
                 'uploader_id': '-50883936',
                 'comment_count': int,
                 'like_count': int,
+                'view_count': int,
                 'duration': 4651,
                 'thumbnail': r're:https?://.+\.jpg',
                 'chapters': 'count:59',
@@ -394,6 +400,7 @@ class VKIE(VKBaseIE):
         video_id = mobj.group('videoid')
 
         mv_data = {}
+        modal_info = {}
         if video_id:
             data = {
                 'act': 'show',
@@ -408,6 +415,7 @@ class VKIE(VKBaseIE):
             info_page = payload[1]
             opts = payload[-1]
             mv_data = opts.get('mvData') or {}
+            modal_info = opts.get('videoModalInfoData') or {}
             player = opts.get('player') or {}
         else:
             video_id = '{}_{}'.format(mobj.group('oid'), mobj.group('id'))
@@ -565,12 +573,16 @@ class VKIE(VKBaseIE):
             'id': video_id,
             'formats': formats,
             'subtitles': subtitles,
+            'view_count': view_count,
             **traverse_obj(mv_data, {
                 'title': ('title', {str}, {unescapeHTML}),
                 'description': ('desc', {clean_html}, filter),
                 'duration': ('duration', {int_or_none}),
                 'like_count': ('likes', {int_or_none}),
                 'comment_count': ('commcount', {int_or_none}),
+            }),
+            **traverse_obj(modal_info, {
+                'view_count': ('views', {int_or_none}),
             }),
             **traverse_obj(data, {
                 'title': ('md_title', {str}, {unescapeHTML}),
@@ -585,7 +597,6 @@ class VKIE(VKBaseIE):
                 }),
             }),
             'timestamp': timestamp,
-            'view_count': view_count,
             'is_live': is_live,
             '_format_sort_fields': ('res', 'source'),
         }


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Pulls view count from `videoModalInfoData` JSON data structure. I also moved the HTML regex extraction (which I think might still be broken) to before the dict-merge, so that the JSON information (if present) takes precedence 

Fixes #16175


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>

Output of the same URL from linked issue:

```
[debug] Command-line config: ['-v', '--skip-download', '--print', 'view_count', 'https://vk.com/video-209702645_456242873']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8 
[debug] yt-dlp version stable@2026.03.17 from yt-dlp/yt-dlp [04d6974f5] (source) 
[debug] Lazy loading extractors is disabled 
[debug] Git HEAD: bd0a80c5c 
[debug] Python 3.14.2 (CPython AMD64 64bit) - Windows-11-10.0.26200-SP0 (OpenSSL 3.0.18 30 Sep 2025) 
[debug] exe versions: ffmpeg 8.1-full_build-www.gyan.dev (setts), ffprobe 8.1-full_build-www.gyan.dev 
[debug] Optional libraries: certifi-2026.02.25, curl_cffi-0.14.0, sqlite3-3.50.4, urllib3-2.6.3 
[debug] JS runtimes: deno-2.7.5 
[debug] Proxy map: {} 
[debug] Request Handlers: urllib, curl_cffi 
[debug] Plugin directories: none 
[debug] Loaded 1864 extractors 
[vk] Extracting URL: https://vk.com/video-209702645_456242873 
[vk] -209702645_456242873: Downloading JSON metadata 
[vk] -209702645_456242873: Downloading MPD manifest 
[vk] -209702645_456242873: Downloading m3u8 information 
[vk] -209702645_456242873: Downloading m3u8 information 
[debug] Sort order given by extractor: res, source 
[debug] Formats sorted by: hasvid, ie_pref, res, source, lang, quality, fps, hdr:12(7), vcodec, channels, acodec, size, br, asr, proto, vext, aext, hasaud, id
[debug] Default format spec: bestvideo*+bestaudio/best
[info] -209702645_456242873: Downloading 1 format(s): url360
14755
```
