### PR TITLE
[ie/senategov] Fix extractor to handle JS generated embeds

### DIFF
--- a/yt_dlp/extractor/senategov.py
+++ b/yt_dlp/extractor/senategov.py
@@ -61,8 +61,6 @@ class SenateISVPIE(InfoExtractor):
         'url': 'http://www.senate.gov/isvp?type=live&comm=banking&filename=banking012715',
         'only_matching': True,
     }]
-    _WEBPAGE_TESTS = []
-
     _COMMITTEES = {
         'ag': ('76440', 'https://ag-f.akamaihd.net', '2036803', 'agriculture'),
         'aging': ('76442', 'https://aging-f.akamaihd.net', '2036801', 'aging'),
@@ -185,6 +183,7 @@ class SenateGovIE(InfoExtractor):
             'ext': 'mp4',
             'title': r're:.+',
             'thumbnail': r're:https?://.+\.(?:jpe?g|png)',
+            'age_limit': 0,
             '_old_archive_ids': ['senategov govtaff061025'],
         },
         'params': {'skip_download': 'm3u8'},
@@ -232,7 +231,7 @@ class SenateGovIE(InfoExtractor):
         url_info = next(SenateISVPIE.extract_from_webpage(self._downloader, url, webpage), None)
 
         if not url_info:
-            url_info = self._create_isvp_from_webpage(webpage, display_id)
+            url_info = self._extract_js_isvp_url(webpage, display_id)
         if not url_info:
             raise UnsupportedError(url)
 
@@ -246,21 +245,10 @@ class SenateGovIE(InfoExtractor):
             'title': re.sub(r'\s+', ' ', title.split('|')[0]).strip(),
             'description': self._og_search_description(webpage, default=None),
             'thumbnail': self._og_search_thumbnail(webpage, default=None),
-            'age_limit': self._rta_search(webpage),
+            'age_limit': self._rta_search(webpage) or 0,
         }
 
-    #
-    # Values are located in multiple separate script tags
-    # but generally follow basic layout:
-    # let archive_stream = null;
-    # archive_stream = "govtaff061025";
-    # ..
-    # archive_offset = "890";
-    # ..
-    # const comm_code = 'govtaff';
-    # ..
-    def _create_isvp_from_webpage(self, webpage, video_id):
-        # Cribbed from xhamster regex extraction
+    def _extract_js_isvp_url(self, webpage, video_id):
         comm = self._search_regex(
             r"const\s+comm_code\s*=\s*'([^']+)'", webpage, 'committee code', default=None)
         filename = self._search_regex(
@@ -271,12 +259,9 @@ class SenateGovIE(InfoExtractor):
         poster = self._search_regex(
             r"const\s+posterframe\s*=\s*'([^']+)'", webpage, 'poster', default=None)
 
-        # SenateISVPIE only uses comm, filename, and poster from the query params
         qs = urllib.parse.urlencode({
             'comm': comm,
             'filename': filename,
             **({'poster': poster} if poster else {}),
         })
-        # Passing to real IE similar to StarTrek/Parler/UN
-        return self.url_result(
-            f'https://www.senate.gov/isvp/?{qs}', SenateISVPIE)
+        return self.url_result(f'https://www.senate.gov/isvp/?{qs}', SenateISVPIE)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Creates an ISVP url from the JS variables present in the page per commentary on issue. Cribbed regex extraction from xhamster IE and chaining `url_result` back to the ISVPIE

Fixes #14295 

Also fixed failing tests by having age_limit return 0 if restriction markers were not found rather than None. 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
