### PR TITLE
[postprocessor/sponsorblock] Gracefully handle API errors

### DIFF
--- a/yt_dlp/postprocessor/sponsorblock.py
+++ b/yt_dlp/postprocessor/sponsorblock.py
@@ -3,6 +3,7 @@ import json
 import re
 import urllib.parse
 
+from .common import PostProcessingError
 from .ffmpeg import FFmpegPostProcessor
 
 
@@ -99,7 +100,11 @@ class SponsorBlockPP(FFmpegPostProcessor):
             'categories': json.dumps(self._categories),
             'actionTypes': json.dumps(['skip', 'poi', 'chapter']),
         })
-        for d in self._download_json(url) or []:
-            if d['videoID'] == video_id:
-                return d['segments']
+        try:
+            for d in self._download_json(url) or []:
+                if d['videoID'] == video_id:
+                    return d['segments']
+        except PostProcessingError as e:
+            self.report_warning(f'Unable to fetch SponsorBlock segments: {e}')
+            return []
         return []


### PR DESCRIPTION
Closes #16234

<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

When the SponsorBlock API is inaccessible, `_download_json()` raises `PostProcessingError` after retries are exhausted. This propagates to `pre_process()` →
 `__pending_error` → `_raise_pending_errors()` → `report_error()`, which aborts the entire download.

SponsorBlock is an optional enhancement — its unavailability should not prevent downloading. This PR catches `PostProcessingError` in `_get_sponsor_segments()` and calls
 `report_warning()` instead, returning empty segments so the download proceeds normally.

Fixes #16234


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
