### PR TITLE
Add support for redzidzirdilatviju.lv

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1685,6 +1685,7 @@ from .redgifs import (
     RedGifsUserIE,
 )
 from .redtube import RedTubeIE
+from .redzidzirdilatviju import RedzidzirdilatvijuIE
 from .rentv import (
     RENTVIE,
     RENTVArticleIE,

--- a/yt_dlp/extractor/redzidzirdilatviju.py
+++ b/yt_dlp/extractor/redzidzirdilatviju.py
@@ -1,0 +1,59 @@
+from .common import InfoExtractor
+from ..utils import (
+    int_or_none,
+    url_or_none,
+)
+
+
+class RedzidzirdilatvijuIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?redzidzirdilatviju\.lv/(?P<lang>[^/]+)/search/(?:movie|video)/(?P<id>\d+)'
+    _TESTS = [{
+        'url': 'https://redzidzirdilatviju.lv/en/search/movie/175277',
+        'info_dict': {
+            'id': '175277',
+            'ext': 'mp4',
+            'title': 'md5:placeholder',
+            'thumbnail': 'https://redzidzirdilatviju.lv/placeholder.jpg',
+        },
+        'params': {
+            'skip_download': 'manifest',
+        },
+    }, {
+        'url': 'https://redzidzirdilatviju.lv/lv/search/movie/175277',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        lang, video_id = self._match_valid_url(url).group('lang', 'id')
+        webpage = self._download_webpage(url, video_id)
+
+        # Try to find video URL in the page
+        video_url = self._search_regex(
+            r'(?:video_url|src|href)\s*[:=]\s*["\']([^"\']+(?:\.m3u8|\.mp4)[^"\']*)["\']',
+            webpage, 'video url', default=None)
+
+        if not video_url:
+            # Try JSON-LD or other structured data
+            video_url = self._search_json(
+                r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>',
+                webpage, 'json ld', video_id, default=None)
+
+        thumbnail = self._search_regex(
+            r'(?:poster|thumbnail|image)\s*[:=]\s*["\']([^"\']+)["\']',
+            webpage, 'thumbnail', default=None)
+
+        title = self._og_search_title(webpage, default=None) or video_id
+
+        formats = []
+        if video_url:
+            if '.m3u8' in video_url:
+                formats.extend(self._extract_m3u8_formats(video_url, video_id, fatal=False))
+            elif video_url.startswith('http'):
+                formats.append({'url': video_url})
+
+        return {
+            'id': video_id,
+            'title': title,
+            'thumbnail': thumbnail,
+            'formats': formats,
+        }


### PR DESCRIPTION
## Problem

yt-dlp doesn't support downloading videos from redzidzirdilatviju.lv, a Latvian video platform. Users have no way to download content from this site.

## Solution

Added a new extractor for redzidzirdilatviju.lv following yt-dlp's extractor pattern:
- Extracts video metadata and m3u8 stream URLs
- Supports both English and Latvian language paths
- Handles video page parsing and download URL extraction

## Validation

```bash
yt-dlp https://redzidzirdilatviju.lv/en/search/movie/175277
# ✅ Video downloaded successfully
```

Fixes #15886