### PR TITLE
[utils] Fix `--match-filter` float comparison (e.g. `aspect_ratio`)

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1525,6 +1525,15 @@ ffmpeg version 2.4.4 Copyright (c) 2000-2014 the FFmpeg ...'''), '2.4.4')
         self.assertFalse(match_str('x>=1100 & x < 1200', {'x': 1200}))
         self.assertTrue(match_str('x > 1:0:0', {'x': 3700}))
 
+        # Float
+        self.assertTrue(match_str('x=1.78', {'x': 1.78}))
+        self.assertFalse(match_str('x=1.78', {'x': 1.79}))
+        self.assertTrue(match_str('x>1.0', {'x': 1.78}))
+        self.assertFalse(match_str('x>2.0', {'x': 1.78}))
+        self.assertTrue(match_str('x>=1.78', {'x': 1.78}))
+        self.assertTrue(match_str('x<2.0', {'x': 1.78}))
+        self.assertFalse(match_str('x<1.0', {'x': 1.78}))
+
         # String
         self.assertFalse(match_str('y=a212', {'y': 'foobar42'}))
         self.assertTrue(match_str('y=foobar42', {'y': 'foobar42'}))

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -3271,7 +3271,7 @@ def _match_one(filter_part, dct, incomplete):
             # and process comparison value as a string (see
             # https://github.com/ytdl-org/youtube-dl/issues/11082)
             try:
-                numeric_comparison = int(comparison_value)
+                numeric_comparison = float(comparison_value)
             except ValueError:
                 numeric_comparison = parse_filesize(comparison_value)
                 if numeric_comparison is None:


### PR DESCRIPTION
## Summary
- Fix `_match_one` in `utils/_utils.py` to use `float()` instead of `int()` when parsing numeric comparison values in `--match-filter`
- Previously, float values like `aspect_ratio=1.78` failed `int()` parsing and fell through to `parse_filesize`, which incorrectly rounded `1.78` to `2`, causing the filter to never match
- This aligns `_match_one` with the existing behavior in `_build_format_filter` (used by `-f` format filters), which already uses `float()`
- Added tests for float comparisons in `test_match_str`

Closes #16329

## Test plan
- [x] `python3 -m pytest test/test_utils.py::TestUtil::test_match_str -v` passes
- [x] Full `test/test_utils.py` suite passes (115 passed, 1 skipped)
- [x] Verified integer, filesize (`1K`), and duration (`1:0:0`) comparisons still work correctly
- [x] Verified `aspect_ratio=1.78` now correctly matches `{'aspect_ratio': 1.78}`