### PR TITLE
[postprocessor/sponsorblock] Discard segments beyond video duration

### DIFF
--- a/yt_dlp/postprocessor/sponsorblock.py
+++ b/yt_dlp/postprocessor/sponsorblock.py
@@ -60,6 +60,9 @@ class SponsorBlockPP(FFmpegPostProcessor):
             # Make POI chapters 1 sec so that we can properly mark them
             if s['category'] in self.POI_CATEGORIES:
                 start_end[1] += 1
+            # Discard segments that start at or beyond the video duration.
+            if duration and start_end[0] >= duration:
+                return False
             # Ignore milliseconds difference at the end.
             # Never allow the segment to exceed the video.
             if duration and duration - start_end[1] <= 1:


### PR DESCRIPTION
## Summary

Fixes #15716

When a SponsorBlock segment has a start time at or beyond the actual video duration (e.g. a segment starting at 592s for a 209s video), the segment should be discarded entirely. Previously, the `duration_filter` only clamped the segment's `end_time` to the video duration but did not check whether the `start_time` itself was already beyond the video. This produced a segment with `start_time > end_time`, which caused `_make_concat_opts` to generate a nonsensical ffmpeg concat spec that extended the output file well beyond the actual video content with freeze frames.

The fix adds an early return in `duration_filter` to discard any segment whose start time is at or beyond the video duration, since such segments cannot refer to any real content in the video.

## Test plan

- [x] All 56 existing postprocessor tests pass (`python3 -m pytest test/test_postprocessors.py`)
- [x] Passes `ruff check`
- [ ] Manual test: download a video with an out-of-range SponsorBlock segment (e.g. https://www.youtube.com/watch?v=jBrcBPXUBFw if the erroneous segment is still present) and verify the output file duration matches the actual video content