### PR TITLE
bugfix: Wrap format selection exception

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -809,10 +809,14 @@ class YoutubeDL:
         self._parse_outtmpl()
 
         # Creating format selector here allows us to catch syntax errors before the extraction
-        self.format_selector = (
-            self.params.get('format') if self.params.get('format') in (None, '-')
-            else self.params['format'] if callable(self.params['format'])
-            else self.build_format_selector(self.params['format']))
+        try:
+            self.format_selector = (
+                self.params.get('format') if self.params.get('format') in (None, '-')
+                else self.params['format'] if callable(self.params['format'])
+                else self.build_format_selector(self.params['format']))
+        except SyntaxError as err:
+            self.report_error(err, tb=False)
+            raise DownloadError(str(err)) from err
 
         hooks = {
             'post_hooks': self.add_post_hook,


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Wraps the construction of `format_selector` and on exception reports via `report_error` and raises `DownloadError` which is what `main()` catches. 

Fixes #16312 

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Core bug fix/improvement

</details>
