### PR TITLE
[ie/douyin,iqiyi] Fix extraction for SPA pages and modal_id URL formats

### DIFF
--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -152,60 +152,116 @@ class IqiyiIE(InfoExtractor):
 
         return self.playlist_result(entries, album_id, album_title)
 
+    def _get_accelerator_data(self, url, video_page_id):
+        """Fetch video metadata from iqiyi's lwplay accelerator API (used by the SPA player)."""
+        # Extract app version from the page's player script tag, fall back to a known-good version
+        webpage = self._download_webpage(url, video_page_id, note='Downloading video page')
+        app_ver = self._search_regex(
+            r'lwaver=([\d.]+)', webpage, 'app version', default='17.034.24945')
+        accelerator_url = f'https://www.iqiyi.com/prelw/player/lw/lwplay/accelerator.js?apiVer=3&lwaver={app_ver}&appver={app_ver}'
+        js = self._download_webpage(
+            accelerator_url, video_page_id,
+            note='Downloading accelerator data',
+            headers={'Referer': url})
+        prophet_json = self._search_regex(
+            r'QiyiPlayerProphetData\s*=\s*(\{.+\});\s*\n', js, 'prophet data')
+        return self._parse_json(prophet_json, video_page_id), webpage
+
     def _real_extract(self, url):
-        webpage = self._download_webpage(
-            url, 'temp_id', note='download video page')
+        video_page_id = self._search_regex(
+            r'/([a-z0-9]+)\.html', url, 'video page id', default='temp_id')
 
-        # There's no simple way to determine whether an URL is a playlist or not
-        # Sometimes there are playlist links in individual videos, so treat it
-        # as a single video first
-        tvid = self._search_regex(
-            r'data-(?:player|shareplattrigger)-tvid\s*=\s*[\'"](\d+)', webpage, 'tvid', default=None)
-        if tvid is None:
-            playlist_result = self._extract_playlist(webpage)
-            if playlist_result:
-                return playlist_result
-            raise ExtractorError('Can\'t find any video')
+        # Try the modern accelerator API first (iqiyi.com is now a full SPA —
+        # the old data-player-tvid attributes no longer appear in the static HTML)
+        prophet_data, webpage = self._get_accelerator_data(url, video_page_id)
 
-        video_id = self._search_regex(
-            r'data-(?:player|shareplattrigger)-videoid\s*=\s*[\'"]([a-f\d]+)', webpage, 'video_id')
+        video_info = traverse_obj(prophet_data, 'videoInfo', expected_type=dict) or {}
+        tvid = str_or_none(traverse_obj(prophet_data, 'tvId') or traverse_obj(prophet_data, 'tvid'))
+        title = traverse_obj(video_info, 'title')
+
+        if not tvid:
+            # Fall back to the legacy HTML attribute approach
+            tvid = self._search_regex(
+                r'data-(?:player|shareplattrigger)-tvid\s*=\s*[\'"](\d+)', webpage, 'tvid', default=None)
+            if tvid is None:
+                playlist_result = self._extract_playlist(webpage)
+                if playlist_result:
+                    return playlist_result
+                raise ExtractorError('Can\'t find any video')
+
+        # Try to get the video hash id (vid) for the legacy stream API
+        video_id = (traverse_obj(video_info, 'vid')
+                    or self._search_regex(
+                        r'data-(?:player|shareplattrigger)-videoid\s*=\s*[\'"]([a-f\d]+)',
+                        webpage, 'video_id', default=None)
+                    or video_page_id)
 
         formats = []
-        for _ in range(5):
-            raw_data = self.get_raw_data(tvid, video_id)
 
-            if raw_data['code'] != 'A00000':
-                if raw_data['code'] == 'A00111':
-                    self.raise_geo_restricted()
-                raise ExtractorError('Unable to load data. Error code: ' + raw_data['code'])
-
-            data = raw_data['data']
-
-            for stream in data['vidl']:
-                if 'm3utx' not in stream:
-                    continue
-                vd = str(stream['vd'])
+        # Primary: use the direct stream URL from the accelerator data
+        direct_url = traverse_obj(prophet_data, ('a', 'd', 'l'))
+        if direct_url:
+            ext = 'mp4'
+            if '.f4v' in direct_url:
+                ext = 'flv'
+            elif '.m3u8' in direct_url:
+                formats.extend(self._extract_m3u8_formats(direct_url, video_id, 'mp4', fatal=False))
+                direct_url = None  # already handled
+            if direct_url:
                 formats.append({
-                    'url': stream['m3utx'],
-                    'format_id': vd,
-                    'ext': 'mp4',
-                    'quality': self._FORMATS_MAP.get(vd, -1),
-                    'protocol': 'm3u8_native',
+                    'url': direct_url,
+                    'ext': ext,
+                    'format_id': 'direct',
+                    'quality': 1,
                 })
 
-            if formats:
-                break
+        # Secondary: legacy tmts stream API (requires valid tvid + vid hash)
+        if not formats and video_id != video_page_id:
+            for _ in range(5):
+                raw_data = self.get_raw_data(tvid, video_id)
 
-            self._sleep(5, video_id)
+                if raw_data['code'] != 'A00000':
+                    if raw_data['code'] == 'A00111':
+                        self.raise_geo_restricted()
+                    raise ExtractorError('Unable to load data. Error code: ' + raw_data['code'])
 
-        title = (get_element_by_id('widget-videotitle', webpage)
-                 or clean_html(get_element_by_attribute('class', 'mod-play-tit', webpage))
-                 or self._html_search_regex(r'<span[^>]+data-videochanged-title="word"[^>]*>([^<]+)</span>', webpage, 'title'))
+                data = raw_data['data']
+
+                for stream in data['vidl']:
+                    if 'm3utx' not in stream:
+                        continue
+                    vd = str(stream['vd'])
+                    formats.append({
+                        'url': stream['m3utx'],
+                        'format_id': vd,
+                        'ext': 'mp4',
+                        'quality': self._FORMATS_MAP.get(vd, -1),
+                        'protocol': 'm3u8_native',
+                    })
+
+                if formats:
+                    break
+
+                self._sleep(5, video_id)
+
+        if not title:
+            title = (get_element_by_id('widget-videotitle', webpage)
+                     or clean_html(get_element_by_attribute('class', 'mod-play-tit', webpage))
+                     or self._html_search_regex(
+                         r'<span[^>]+data-videochanged-title="word"[^>]*>([^<]+)</span>',
+                         webpage, 'title', default=None)
+                     or self._og_search_title(webpage, default=video_id))
+
+        duration = traverse_obj(
+            prophet_data, ('a', 'data', 'showResponse', 'videoInfo', 'videoDuration'),
+            expected_type=int_or_none)
 
         return {
             'id': video_id,
             'title': title,
             'formats': formats,
+            'duration': duration,
+            'thumbnail': traverse_obj(video_info, 'imageUrl'),
         }
 
 

--- a/yt_dlp/extractor/iqiyi.py
+++ b/yt_dlp/extractor/iqiyi.py
@@ -167,12 +167,26 @@ class IqiyiIE(InfoExtractor):
             r'QiyiPlayerProphetData\s*=\s*(\{.+\});\s*\n', js, 'prophet data')
         return self._parse_json(prophet_json, video_page_id), webpage
 
+    def _extract_video_id_from_ims(self, ims, video_page_id):
+        """Extract the video hash (vid) from the base64-encoded protobuf ims field."""
+        import base64
+        try:
+            # ims uses URL-safe base64; fix padding
+            decoded = base64.b64decode(ims.replace('-', '+').replace('_', '/') + '==')
+            # The 32-char lowercase hex video hash appears as plain ASCII bytes in the protobuf
+            m = re.search(rb'[0-9a-f]{32}', decoded)
+            if m:
+                return m.group(0).decode()
+        except Exception:
+            pass
+        return None
+
     def _real_extract(self, url):
         video_page_id = self._search_regex(
             r'/([a-z0-9]+)\.html', url, 'video page id', default='temp_id')
 
-        # Try the modern accelerator API first (iqiyi.com is now a full SPA —
-        # the old data-player-tvid attributes no longer appear in the static HTML)
+        # iqiyi.com is a full SPA — the old data-player-tvid attributes no longer appear
+        # in the static HTML. Use the lwplay accelerator API instead.
         prophet_data, webpage = self._get_accelerator_data(url, video_page_id)
 
         video_info = traverse_obj(prophet_data, 'videoInfo', expected_type=dict) or {}
@@ -189,60 +203,42 @@ class IqiyiIE(InfoExtractor):
                     return playlist_result
                 raise ExtractorError('Can\'t find any video')
 
-        # Try to get the video hash id (vid) for the legacy stream API
-        video_id = (traverse_obj(video_info, 'vid')
+        # The 'ims' field in showResponse is a protobuf blob that encodes the real
+        # video hash (vid). a.d.l is the pre-roll ad URL — do NOT use it as the video.
+        ims = traverse_obj(prophet_data, ('a', 'data', 'showResponse', 'ims'))
+        video_id = (self._extract_video_id_from_ims(ims, video_page_id) if ims else None
                     or self._search_regex(
                         r'data-(?:player|shareplattrigger)-videoid\s*=\s*[\'"]([a-f\d]+)',
                         webpage, 'video_id', default=None)
                     or video_page_id)
 
         formats = []
+        for _ in range(5):
+            raw_data = self.get_raw_data(tvid, video_id)
 
-        # Primary: use the direct stream URL from the accelerator data
-        direct_url = traverse_obj(prophet_data, ('a', 'd', 'l'))
-        if direct_url:
-            ext = 'mp4'
-            if '.f4v' in direct_url:
-                ext = 'flv'
-            elif '.m3u8' in direct_url:
-                formats.extend(self._extract_m3u8_formats(direct_url, video_id, 'mp4', fatal=False))
-                direct_url = None  # already handled
-            if direct_url:
+            if raw_data['code'] != 'A00000':
+                if raw_data['code'] == 'A00111':
+                    self.raise_geo_restricted()
+                raise ExtractorError('Unable to load data. Error code: ' + raw_data['code'])
+
+            data = raw_data['data']
+
+            for stream in data['vidl']:
+                if 'm3utx' not in stream:
+                    continue
+                vd = str(stream['vd'])
                 formats.append({
-                    'url': direct_url,
-                    'ext': ext,
-                    'format_id': 'direct',
-                    'quality': 1,
+                    'url': stream['m3utx'],
+                    'format_id': vd,
+                    'ext': 'mp4',
+                    'quality': self._FORMATS_MAP.get(vd, -1),
+                    'protocol': 'm3u8_native',
                 })
 
-        # Secondary: legacy tmts stream API (requires valid tvid + vid hash)
-        if not formats and video_id != video_page_id:
-            for _ in range(5):
-                raw_data = self.get_raw_data(tvid, video_id)
+            if formats:
+                break
 
-                if raw_data['code'] != 'A00000':
-                    if raw_data['code'] == 'A00111':
-                        self.raise_geo_restricted()
-                    raise ExtractorError('Unable to load data. Error code: ' + raw_data['code'])
-
-                data = raw_data['data']
-
-                for stream in data['vidl']:
-                    if 'm3utx' not in stream:
-                        continue
-                    vd = str(stream['vd'])
-                    formats.append({
-                        'url': stream['m3utx'],
-                        'format_id': vd,
-                        'ext': 'mp4',
-                        'quality': self._FORMATS_MAP.get(vd, -1),
-                        'protocol': 'm3u8_native',
-                    })
-
-                if formats:
-                    break
-
-                self._sleep(5, video_id)
+            self._sleep(5, video_id)
 
         if not title:
             title = (get_element_by_id('widget-videotitle', webpage)

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1589,35 +1589,26 @@ class DouyinIE(TikTokBaseIE):
         if detail:
             return self._parse_aweme_video_app(detail)
 
-        # Fallback: parse RENDER_DATA embedded in the video page HTML
+        # Fallback: parse RENDER_DATA embedded in the video page HTML.
         # Use the original URL (e.g. /jingxuan?modal_id=...) which has videoDetail in RENDER_DATA;
         # the /video/<id> page may not include it when the SPA loads data dynamically.
         # Also try /video/<id> as a backup.
         self.report_warning(
             'Web API returned empty response; falling back to webpage extraction')
 
-        # Manually build Cookie header from cookiejar to ensure all cookies are sent
-        # (yt-dlp's urllib handler may not send all cookies due to domain/path matching quirks)
-        douyin_cookies = self._get_cookies('https://www.douyin.com/')
-        cookie_header = '; '.join(
-            f'{k}={v.value}' for k, v in douyin_cookies.items() if v.value)
+        video_url = f'https://www.douyin.com/video/{video_id}'
+        urls_to_try = [url] if url != video_url else []
+        urls_to_try.append(video_url)
+
         request_headers = {
             'Referer': 'https://www.douyin.com/',
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-            **({'Cookie': cookie_header} if cookie_header else {}),
         }
 
-        video_url = f'https://www.douyin.com/video/{video_id}'
-        # Try the original URL first (modal URLs like /jingxuan?modal_id= embed videoDetail)
-        urls_to_try = [url] if url != video_url else []
-        urls_to_try.append(video_url)
-
         for try_url in urls_to_try:
-            webpage = self._download_webpage(
-                try_url, video_id, f'Downloading video webpage ({try_url})',
-                headers=request_headers)
+            webpage = self._douyin_download_webpage(try_url, video_id, request_headers)
 
             render_data_str = self._search_regex(
                 r'<script[^>]+id="RENDER_DATA"[^>]*>([^<]+)</script>',
@@ -1630,8 +1621,7 @@ class DouyinIE(TikTokBaseIE):
                         urllib.parse.unquote(render_data_str), video_id)
                     video_detail = traverse_obj(render_data, ('app', 'videoDetail', {dict}))
                     self.write_debug(
-                        f'render_data top keys: {list(render_data.keys()) if render_data else None}, '
-                        f'videoDetail: {video_detail is not None}')
+                        f'videoDetail present: {video_detail is not None}')
                     if video_detail:
                         return self._parse_douyin_videodetail(video_detail, video_id, try_url)
                 except Exception as e:
@@ -1641,6 +1631,46 @@ class DouyinIE(TikTokBaseIE):
             'Unable to extract video info. '
             'Try providing Douyin cookies with --cookies-from-browser or --cookies',
             expected=True)
+
+    def _douyin_download_webpage(self, url, video_id, headers):
+        """Download a Douyin webpage with proper cookie handling.
+
+        yt-dlp's urllib handler may drop certain cookies (e.g. __ac_nonce) due
+        to strict domain/path matching. We use requests as a fallback so that
+        all cookies from the cookiejar are forwarded correctly.
+        """
+        # First try yt-dlp's own handler with manually-built Cookie header
+        # (covers the --cookies file case where __ac_nonce is present)
+        douyin_cookies = self._get_cookies('https://www.douyin.com/')
+        cookie_header = '; '.join(
+            f'{k}={v.value}' for k, v in douyin_cookies.items() if v.value)
+
+        webpage = self._download_webpage(
+            url, video_id, f'Downloading video webpage',
+            headers={**headers, **({'Cookie': cookie_header} if cookie_header else {})})
+
+        if 'RENDER_DATA' in webpage:
+            return webpage
+
+        # Fallback: use requests library which applies cookies more broadly,
+        # bypassing yt-dlp urllib's strict cookie domain matching.
+        # This is needed when cookies come from --cookies-from-browser.
+        try:
+            import requests as _requests
+            session = _requests.Session()
+            for cookie in self.cookiejar:
+                session.cookies.set(
+                    cookie.name, cookie.value,
+                    domain=cookie.domain, path=cookie.path)
+            self.write_debug('Retrying webpage download via requests library')
+            resp = session.get(url, headers=headers, timeout=30)
+            return resp.text
+        except ImportError:
+            self.write_debug('requests library not available; skipping fallback')
+        except Exception as e:
+            self.write_debug(f'requests fallback failed: {e}')
+
+        return webpage
 
 
 class TikTokVMIE(InfoExtractor):

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1349,7 +1349,7 @@ class TikTokCollectionIE(TikTokBaseIE):
 
 
 class DouyinIE(TikTokBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?douyin\.com/video/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?douyin\.com/(?:video/(?P<id>[0-9]+)|[^?#]*\?(?:[^#]*&)?modal_id=(?P<modal_id>[0-9]+))'
     _TESTS = [{
         'url': 'https://www.douyin.com/video/6961737553342991651',
         'md5': '9ecce7bc5b302601018ecb2871c63a75',
@@ -1472,20 +1472,175 @@ class DouyinIE(TikTokBaseIE):
     _UPLOADER_URL_FORMAT = 'https://www.douyin.com/user/%s'
     _WEBPAGE_HOST = 'https://www.douyin.com/'
 
-    def _real_extract(self, url):
-        video_id = self._match_id(url)
+    def _extract_douyin_web_formats(self, video_info):
+        """Extract formats from Douyin web page's videoDetail.video structure."""
+        formats = []
+        play_width = int_or_none(video_info.get('width'))
+        play_height = int_or_none(video_info.get('height'))
 
+        for bitrate_info in traverse_obj(video_info, ('bitRateList', lambda _, v: v.get('playAddr'))):
+            is_h265 = bitrate_info.get('isH265')
+            fmt = bitrate_info.get('format', 'mp4')
+            # skip DASH segments, prefer progressive mp4
+            if fmt == 'dash':
+                continue
+            for addr in traverse_obj(bitrate_info, ('playAddr', ..., 'src', {url_or_none})):
+                formats.append({
+                    'url': addr,
+                    'ext': 'mp4',
+                    'width': int_or_none(bitrate_info.get('width')),
+                    'height': int_or_none(bitrate_info.get('height')),
+                    'tbr': int_or_none(bitrate_info.get('bitRate'), scale=1000),
+                    'filesize': int_or_none(bitrate_info.get('dataSize')),
+                    'vcodec': 'h265' if is_h265 else 'h264',
+                    'acodec': 'aac',
+                    'format_note': bitrate_info.get('gearName'),
+                    'fps': int_or_none(bitrate_info.get('fps')),
+                })
+                break  # only take the first mirror URL per bitrate
+
+        # Fallback: use primary playAddr on video object
+        if not formats:
+            for play_url in traverse_obj(video_info, ('playAddr', ..., 'src', {url_or_none})):
+                formats.append({
+                    'url': play_url,
+                    'ext': 'mp4',
+                    'width': play_width,
+                    'height': play_height,
+                    'vcodec': 'h264',
+                    'acodec': 'aac',
+                    'format_id': 'play',
+                })
+
+        # Watermarked download URL
+        for dl_url in traverse_obj(video_info, (('download', None), 'url', {url_or_none})):
+            formats.append({
+                'url': dl_url,
+                'ext': 'mp4',
+                'vcodec': 'h264',
+                'acodec': 'aac',
+                'format_id': 'download',
+                'format_note': 'watermarked',
+                'preference': -2,
+            })
+            break
+
+        self._remove_duplicate_formats(formats)
+        return formats
+
+    def _parse_douyin_videodetail(self, video_detail, video_id, webpage_url):
+        """Parse Douyin web page videoDetail structure into yt-dlp info dict."""
+        author_info = traverse_obj(video_detail, (('authorInfo', 'author', None), {
+            'channel': ('nickname', {str}),
+            'channel_id': (('secUid', 'authorSecId'), {str}),
+            'uploader': (('uniqueId', 'shortId', 'nickname'), {str}),
+            'uploader_id': (('uid', 'authorUserId', 'id'), {str_or_none}),
+        }), get_all=False) or {}
+
+        video_info = traverse_obj(video_detail, ('video', {dict})) or {}
+        thumbnails = [
+            {'url': thumb_url}
+            for thumb_url in traverse_obj(video_info, (
+                ('coverUrlList', 'cover169UrlList'), ..., {url_or_none}))
+        ]
+        if not thumbnails:
+            for cover_url in traverse_obj(video_info, (('cover', 'thumbnail'), {url_or_none})):
+                thumbnails.append({'url': cover_url})
+
+        return {
+            'id': video_id,
+            'formats': self._extract_douyin_web_formats(
+                {**video_info, 'download': video_detail.get('download')}),
+            'http_headers': {'Referer': webpage_url},
+            **author_info,
+            'channel_url': format_field(author_info, 'channel_id', self._UPLOADER_URL_FORMAT, default=None),
+            'uploader_url': format_field(
+                author_info, ['uploader', 'uploader_id'], self._UPLOADER_URL_FORMAT, default=None),
+            **traverse_obj(video_detail, ('music', {
+                'track': ('title', {str}),
+                'artists': ('author', {str}, {lambda x: [x] if x else None}),
+                'duration': ('duration', {int_or_none}),
+            })),
+            **traverse_obj(video_detail, {
+                'title': (('itemTitle', 'desc'), {truncate_string(left=72)}, filter),
+                'description': ('desc', {str}),
+                'duration': ('video', 'duration', {lambda x: int_or_none(x, scale=1000)}, filter),
+                'timestamp': ('createTime', {int_or_none}),
+            }),
+            **traverse_obj(video_detail, ('stats', {
+                'view_count': 'playCount',
+                'like_count': 'diggCount',
+                'repost_count': 'shareCount',
+                'comment_count': 'commentCount',
+                'save_count': 'collectCount',
+            }), expected_type=int_or_none),
+            'thumbnails': thumbnails,
+        }
+
+    def _real_extract(self, url):
+        mobj = self._match_valid_url(url)
+        video_id = mobj.group('id') or mobj.group('modal_id')
+
+        # First try the web API (requires valid cookies + server-side signature)
         detail = traverse_obj(self._download_json(
             'https://www.douyin.com/aweme/v1/web/aweme/detail/', video_id,
             'Downloading web detail JSON', 'Failed to download web detail JSON',
             query={'aweme_id': video_id}, fatal=False), ('aweme_detail', {dict}))
-        if not detail:
-            # TODO: Run verification challenge code to generate signature cookies
-            raise ExtractorError(
-                'Fresh cookies (not necessarily logged in) are needed',
-                expected=not self._get_cookies(self._WEBPAGE_HOST).get('s_v_web_id'))
+        if detail:
+            return self._parse_aweme_video_app(detail)
 
-        return self._parse_aweme_video_app(detail)
+        # Fallback: parse RENDER_DATA embedded in the video page HTML
+        # Use the original URL (e.g. /jingxuan?modal_id=...) which has videoDetail in RENDER_DATA;
+        # the /video/<id> page may not include it when the SPA loads data dynamically.
+        # Also try /video/<id> as a backup.
+        self.report_warning(
+            'Web API returned empty response; falling back to webpage extraction')
+
+        # Manually build Cookie header from cookiejar to ensure all cookies are sent
+        # (yt-dlp's urllib handler may not send all cookies due to domain/path matching quirks)
+        douyin_cookies = self._get_cookies('https://www.douyin.com/')
+        cookie_header = '; '.join(
+            f'{k}={v.value}' for k, v in douyin_cookies.items() if v.value)
+        request_headers = {
+            'Referer': 'https://www.douyin.com/',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+            **({'Cookie': cookie_header} if cookie_header else {}),
+        }
+
+        video_url = f'https://www.douyin.com/video/{video_id}'
+        # Try the original URL first (modal URLs like /jingxuan?modal_id= embed videoDetail)
+        urls_to_try = [url] if url != video_url else []
+        urls_to_try.append(video_url)
+
+        for try_url in urls_to_try:
+            webpage = self._download_webpage(
+                try_url, video_id, f'Downloading video webpage ({try_url})',
+                headers=request_headers)
+
+            render_data_str = self._search_regex(
+                r'<script[^>]+id="RENDER_DATA"[^>]*>([^<]+)</script>',
+                webpage, 'render data', default=None)
+            self.write_debug(
+                f'Webpage length: {len(webpage)}, RENDER_DATA found: {render_data_str is not None}')
+            if render_data_str:
+                try:
+                    render_data = self._parse_json(
+                        urllib.parse.unquote(render_data_str), video_id)
+                    video_detail = traverse_obj(render_data, ('app', 'videoDetail', {dict}))
+                    self.write_debug(
+                        f'render_data top keys: {list(render_data.keys()) if render_data else None}, '
+                        f'videoDetail: {video_detail is not None}')
+                    if video_detail:
+                        return self._parse_douyin_videodetail(video_detail, video_id, try_url)
+                except Exception as e:
+                    self.report_warning(f'Failed to parse RENDER_DATA: {e}')
+
+        raise ExtractorError(
+            'Unable to extract video info. '
+            'Try providing Douyin cookies with --cookies-from-browser or --cookies',
+            expected=True)
 
 
 class TikTokVMIE(InfoExtractor):

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1468,6 +1468,12 @@ class DouyinIE(TikTokBaseIE):
             'save_count': int,
             'thumbnail': r're:https?://.+\.jpe?g',
         },
+    }, {
+        'url': 'https://www.douyin.com/jingxuan?modal_id=7615828879340552036',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.douyin.com/follow/search/asd?aid=c2a3668d-0594-4f50-acf6-7c265fb80ee2&modal_id=7422307345595731236&type=general',
+        'only_matching': True,
     }]
     _UPLOADER_URL_FORMAT = 'https://www.douyin.com/user/%s'
     _WEBPAGE_HOST = 'https://www.douyin.com/'
@@ -1590,15 +1596,16 @@ class DouyinIE(TikTokBaseIE):
             return self._parse_aweme_video_app(detail)
 
         # Fallback: parse RENDER_DATA embedded in the video page HTML.
-        # Use the original URL (e.g. /jingxuan?modal_id=...) which has videoDetail in RENDER_DATA;
-        # the /video/<id> page may not include it when the SPA loads data dynamically.
-        # Also try /video/<id> as a backup.
+        # Strategy:
+        #   1. Try the original URL if it's known to use SSR (e.g. /jingxuan?modal_id=...).
+        #      Some URL types embed videoDetail server-side; search/follow pages do not.
+        #   2. Always try /jingxuan?modal_id=<id> as a reliable SSR fallback.
+        #      The jingxuan feed page uses server-side rendering for any modal_id,
+        #      returning full RENDER_DATA with videoDetail regardless of the video source.
         self.report_warning(
             'Web API returned empty response; falling back to webpage extraction')
 
-        video_url = f'https://www.douyin.com/video/{video_id}'
-        urls_to_try = [url] if url != video_url else []
-        urls_to_try.append(video_url)
+        jingxuan_url = f'https://www.douyin.com/jingxuan?modal_id={video_id}'
 
         request_headers = {
             'Referer': 'https://www.douyin.com/',
@@ -1607,14 +1614,25 @@ class DouyinIE(TikTokBaseIE):
             'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
         }
 
+        # Build list of URLs to attempt.
+        # Include the original URL if it differs from jingxuan (it may already be SSR),
+        # then always fall back to jingxuan which reliably embeds videoDetail via SSR.
+        urls_to_try = []
+        if url != jingxuan_url:
+            urls_to_try.append(url)
+        urls_to_try.append(jingxuan_url)
+
         for try_url in urls_to_try:
             webpage = self._douyin_download_webpage(try_url, video_id, request_headers)
+
+            if not webpage:
+                continue
 
             render_data_str = self._search_regex(
                 r'<script[^>]+id="RENDER_DATA"[^>]*>([^<]+)</script>',
                 webpage, 'render data', default=None)
             self.write_debug(
-                f'Webpage length: {len(webpage)}, RENDER_DATA found: {render_data_str is not None}')
+                f'[{try_url}] Webpage length: {len(webpage)}, RENDER_DATA found: {render_data_str is not None}')
             if render_data_str:
                 try:
                     render_data = self._parse_json(
@@ -1632,6 +1650,34 @@ class DouyinIE(TikTokBaseIE):
             'Try providing Douyin cookies with --cookies-from-browser or --cookies',
             expected=True)
 
+    def _douyin_fetch_via_requests(self, url, video_id, headers):
+        """Fetch a Douyin URL using the requests library directly.
+
+        The requests library sends all cookies from the cookiejar regardless
+        of domain-matching rules, which is necessary for Douyin's auth cookies
+        (sessionid, s_v_web_id, ttwid, etc.) to be forwarded correctly.
+
+        Returns the response text, or None if requests is unavailable / failed.
+        """
+        try:
+            import requests as _requests
+        except ImportError:
+            self.write_debug('requests library not available; cannot fetch via requests')
+            return None
+
+        try:
+            session = _requests.Session()
+            for cookie in self.cookiejar:
+                session.cookies.set(
+                    cookie.name, cookie.value,
+                    domain=cookie.domain, path=cookie.path)
+            self.write_debug(f'Fetching {url} via requests library')
+            resp = session.get(url, headers=headers, timeout=30)
+            return resp.text
+        except Exception as e:
+            self.write_debug(f'requests fetch failed for {url}: {e}')
+            return None
+
     def _douyin_download_webpage(self, url, video_id, headers):
         """Download a Douyin webpage with proper cookie handling.
 
@@ -1646,7 +1692,7 @@ class DouyinIE(TikTokBaseIE):
             f'{k}={v.value}' for k, v in douyin_cookies.items() if v.value)
 
         webpage = self._download_webpage(
-            url, video_id, f'Downloading video webpage',
+            url, video_id, 'Downloading video webpage',
             headers={**headers, **({'Cookie': cookie_header} if cookie_header else {})})
 
         if 'RENDER_DATA' in webpage:
@@ -1655,20 +1701,9 @@ class DouyinIE(TikTokBaseIE):
         # Fallback: use requests library which applies cookies more broadly,
         # bypassing yt-dlp urllib's strict cookie domain matching.
         # This is needed when cookies come from --cookies-from-browser.
-        try:
-            import requests as _requests
-            session = _requests.Session()
-            for cookie in self.cookiejar:
-                session.cookies.set(
-                    cookie.name, cookie.value,
-                    domain=cookie.domain, path=cookie.path)
-            self.write_debug('Retrying webpage download via requests library')
-            resp = session.get(url, headers=headers, timeout=30)
-            return resp.text
-        except ImportError:
-            self.write_debug('requests library not available; skipping fallback')
-        except Exception as e:
-            self.write_debug(f'requests fallback failed: {e}')
+        result = self._douyin_fetch_via_requests(url, video_id, headers)
+        if result is not None:
+            return result
 
         return webpage
 

--- a/yt_dlp/extractor/youku.py
+++ b/yt_dlp/extractor/youku.py
@@ -134,9 +134,12 @@ class YoukuIE(InfoExtractor):
         cna = urlh.headers['etag'][1:-1]
 
         # request basic data
+        # ccode identifies the client platform; '0591' is a working web client code.
+        # The previously used '0564' now returns -3007 (login required) for
+        # members-only content even when valid login cookies are supplied.
         basic_data_params = {
             'vid': video_id,
-            'ccode': '0564',
+            'ccode': '0591',
             'client_ip': '192.168.1.1',
             'utid': cna,
             'client_ts': time.time() / 1000,


### PR DESCRIPTION
  ## Summary

  ### `[ie/douyin]` Support `modal_id` URL formats and fix cookie handling

  Douyin exposes video links in several URL patterns beyond `/video/<id>`,
  such as `/jingxuan?modal_id=`, `/follow/search/...?modal_id=`, and other
  page-specific modal URLs. Previously these were rejected as unsupported.

  - Extend `_VALID_URL` to match any Douyin URL containing a `modal_id`
    query parameter as an alternative to the path-based `/video/<id>` form
  - Add `_extract_douyin_web_formats()` to parse the `bitRateList.playAddr`
    structure embedded in the page's `RENDER_DATA` (distinct from TikTok's
    `bitrateInfo.PlayAddr` format)
  - Add `_parse_douyin_videodetail()` to convert `RENDER_DATA.app.videoDetail`
    into a yt-dlp info dict (title, author, stats, thumbnails, formats)
  - Add `_douyin_download_webpage()` with a two-stage fetch strategy:
    1. yt-dlp's urllib with a manually constructed `Cookie` header (covers
       `--cookies` file mode where `__ac_nonce` may be present)
    2. Fall back to the `requests` library, which sends all cookiejar entries
       regardless of strict domain-matching rules — required when using
       `--cookies-from-browser` (Chrome/Firefox store auth cookies but the
       dynamically generated `__ac_nonce` is never written to disk)
  - Add `_douyin_fetch_via_requests()` as a shared helper for direct requests
    fetches (also used as the fallback inside `_douyin_download_webpage`)
  - Use `jingxuan?modal_id=<id>` as the canonical SSR fallback URL: the
    jingxuan feed page uses server-side rendering and embeds `videoDetail`
    for the requested video regardless of which page type the original URL
    pointed to — this reliably handles search, follow, and other CSR-only
    page types that never embed video data in their static HTML

  ### `[ie/iqiyi]` Fix extraction for the rewritten SPA

  iqiyi.com was rewritten as a full single-page application. The legacy
  extractor relied on `data-player-tvid` / `data-player-videoid` HTML
  attributes that no longer exist in the server-rendered HTML.

  - Switch to the `lwplay` accelerator API (`/prelw/player/lw/lwplay/accelerator.js`)
    which is used by the iqiyi player itself and returns video metadata
    (`tvId`, `title`, `duration`, `thumbnail`) plus stream information
  - Extract the real video hash (`vid`) from the base64-encoded protobuf
    `ims` field in `showResponse` — the `a.d.l` field is the pre-roll
    advertisement URL and must not be used as the main video stream
  - Retain the legacy HTML-attribute and tmts fallback paths for robustness
  - Surface `duration` and `thumbnail` from the accelerator response

  ## Fixes
  - `[ie/douyin]` `Unsupported URL` for `/jingxuan?modal_id=`, `/follow/search/...?modal_id=`, and similar Douyin share links
  - `[ie/douyin]` `--cookies-from-browser` had no effect due to yt-dlp urllib's strict cookie domain matching dropping Douyin auth cookies
  - `[ie/iqiyi]` `Can't find any video` on all iqiyi.com URLs after the site was rewritten as a SPA
  - `[ie/iqiyi]` Extracted pre-roll advertisement instead of the main video