### PR TITLE
[build] Fix PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.10"  # Keep this in sync with test-workflows.yml
+          python-version: "3.13"  # Keep this in sync with test-workflows.yml
 
       - name: Process inputs
         id: process_inputs
@@ -180,7 +180,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.13"  # Keep this in sync with devscripts/update_bundle_requirements.py
 
       - name: Install Requirements
         run: |
@@ -250,7 +250,7 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Generate release notes
         env:

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.10"  # Keep this in sync with release.yml's prepare job
+          python-version: "3.13"  # Keep this in sync with release.yml's prepare job
       - name: Install requirements
         env:
           ACTIONLINT_TARBALL: ${{ format('actionlint_{0}_linux_amd64.tar.gz', env.ACTIONLINT_VERSION) }}


### PR DESCRIPTION
Fixes https://github.com/yt-dlp/yt-dlp/actions/runs/23696858290/job/69033604093

`requirements-pypi-build.txt` is being generated for Python 3.13, but the release workflow was using Python 3.10 to build the distribution files. Python 3.10 tries to install `tomli` with the build dependencies, but no hashes are found in the requirements file, so installation fails.

Need to keep the release workflow's Python version in sync with the Python version used by `devscripts/update_bundle_requirements.py` to generate the requirements files.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fixing my own stupid mistake

</details>
