### PR TITLE
Fix `default` extra for `ios` platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ dependencies = []
 
 [project.optional-dependencies]
 default = [
-    "brotli; implementation_name=='cpython'",
-    "brotlicffi; implementation_name!='cpython'",
+    "brotli; implementation_name=='cpython' and sys_platform!='ios'",
+    "brotlicffi; implementation_name!='cpython' and sys_platform!='ios'",
     "certifi",
     "mutagen",
     "pycryptodomex",


### PR DESCRIPTION
The `default` extra fails to install on a-shell (iOS) because **1)** `brotli` doesn't provide `ios` wheels and **2)** the package cannot be built from source in the a-shell environment. The a-shell maintainer said that **2** is unlikely to change anytime soon, and `ios` wheels seem a long ways off for brotli/PyPI, so yt-dlp should prevent `brotli` from being installed with the `default` extra on `ios` platforms.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Maintenance

</details>
