### PR TITLE
[youtube] Add support for youtubeeducation.com domain

### DIFF
--- a/yt_dlp/extractor/youtube/_mistakes.py
+++ b/yt_dlp/extractor/youtube/_mistakes.py
@@ -8,7 +8,7 @@ class YoutubeTruncatedURLIE(YoutubeBaseInfoExtractor):
     IE_DESC = False  # Do not list
     _VALID_URL = r'''(?x)
         (?:https?://)?
-        (?:\w+\.)?[yY][oO][uU][tT][uU][bB][eE](?:-nocookie)?\.com/
+        (?:\w+\.)?[yY][oO][uU][tT][uU][bB][eE](?:-nocookie|kids|education)?\.com/
         (?:watch\?(?:
             feature=[a-z_]+|
             annotation_id=annotation_[^&]+|

--- a/yt_dlp/extractor/youtube/_tab.py
+++ b/yt_dlp/extractor/youtube/_tab.py
@@ -1008,7 +1008,7 @@ class YoutubeTabIE(YoutubeTabBaseInfoExtractor):
         https?://
             (?!consent\.)(?:\w+\.)?
             (?:
-                youtube(?:kids)?\.com|
+                youtube(?:kids|education)?\.com|
                 {invidious}
             )/
             (?:
@@ -2298,7 +2298,7 @@ class YoutubePlaylistIE(YoutubeBaseInfoExtractor):
                         (?:\w+\.)?
                         (?:
                             (?:
-                                youtube(?:kids)?\.com|
+                                youtube(?:kids|education)?\.com|
                                 {invidious}
                             )
                             /.*?\?.*?\blist=

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -86,7 +86,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     _VALID_URL = r'''(?x)^
                      (
                          (?:https?://|//)                                    # http(s):// or protocol-independent URL
-                         (?:(?:(?:(?:\w+\.)?[yY][oO][uU][tT][uU][bB][eE](?:-nocookie|kids)?\.com|
+                         (?:(?:(?:(?:\w+\.)?[yY][oO][uU][tT][uU][bB][eE](?:-nocookie|kids|education)?\.com|
                             (?:www\.)?deturl\.com/www\.youtube\.com|
                             (?:www\.)?pwnyoutube\.com|
                             (?:www\.)?hooktube\.com|
@@ -129,7 +129,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 new\s+SWFObject\(
             )
             (["\'])
-                (?P<url>(?:https?:)?//(?:www\.)?youtube(?:-nocookie)?\.com/
+                (?P<url>(?:https?:)?//(?:www\.)?youtube(?:-nocookie|kids|education)?\.com/
                 (?:embed|v|p)/[0-9A-Za-z_-]{11}.*?)
             \1''',
         # https://wordpress.org/plugins/lazy-load-for-videos/
@@ -880,6 +880,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'view_count': int,
         },
         'params': {'skip_download': True},
+    }, {
+        'url': 'https://www.youtubeeducation.com/watch?v=n_lqtqsXzkM',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.youtubeeducation.com/embed/n_lqtqsXzkM',
+        'only_matching': True,
     }, {
         'url': 'https://www.youtubekids.com/watch?v=3b8nCWDgZ6Q',
         'only_matching': True,


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR adds support for the `youtubeeducation.com` domain, which is used by Google Workspace for Education to embed YouTube content. 

Previously, these URLs were being intercepted by the `generic` extractor, which resulted in a `404 Not Found` error because the domain does not serve a standard webpage for direct GET requests. By adding `education` to the supported domain patterns in the YouTube extractors, `yt-dlp` now correctly identifies these URLs and uses the YouTube API to fetch video metadata and formats.

**Changes made:**
- Updated `_VALID_URL` and `_EMBED_REGEX` in [yt_dlp/extractor/youtube/_video.py](cci:7://file:///Users/swipemac/yt-dlp/yt_dlp/extractor/youtube/_video.py:0:0-0:0) to include the `education` variant.
- Updated `_VALID_URL` in [yt_dlp/extractor/youtube/_tab.py](cci:7://file:///Users/swipemac/yt-dlp/yt_dlp/extractor/youtube/_tab.py:0:0-0:0) for both [YoutubeTabIE](cci:2://file:///Users/swipemac/yt-dlp/yt_dlp/extractor/youtube/_tab.py:1004:0-2289:60) and [YoutubePlaylistIE](cci:2://file:///Users/swipemac/yt-dlp/yt_dlp/extractor/youtube/_tab.py:2293:0-2407:83).
- Updated `_VALID_URL` in [yt_dlp/extractor/youtube/_mistakes.py](cci:7://file:///Users/swipemac/yt-dlp/yt_dlp/extractor/youtube/_mistakes.py:0:0-0:0) for consistent truncated URL handling.
- Added `youtubeeducation.com` test cases to `YoutubeIE._TESTS`.

Fixes #16363


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>

Screenshot: 
<img width="1292" height="455" alt="image" src="https://github.com/user-attachments/assets/6149eb0e-6ced-4589-a034-8291c4a316e3" />


