### PR TITLE
[ie/ARDMediathek] Add support for programme pages

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-31T11:11:28.029Z for PR creation at branch issue-16392-751f0c379cad for issue https://github.com/yt-dlp/yt-dlp/issues/16392

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -121,6 +121,7 @@ from .ard import (
     ARDAudiothekPlaylistIE,
     ARDBetaMediathekIE,
     ARDMediathekCollectionIE,
+    ARDMediathekProgrammeIE,
 )
 from .arnes import ArnesIE
 from .art19 import (

--- a/yt_dlp/extractor/ard.py
+++ b/yt_dlp/extractor/ard.py
@@ -605,6 +605,88 @@ class ARDMediathekCollectionIE(InfoExtractor):
             title=page_data.get('title'), description=page_data.get('synopsis'))
 
 
+class ARDMediathekProgrammeIE(InfoExtractor):
+    IE_NAME = 'ARDMediathek:programme'
+    _VALID_URL = r'''(?x)https?://
+        (?:(?:beta|www)\.)?ardmediathek\.de/
+        (?P<broadcaster>[^/?#]+)/
+        (?P<slug>[^/?#]+)
+        /?(?:[?#]|$)'''
+    _GEO_COUNTRIES = ['DE']
+
+    _TESTS = [{
+        'url': 'https://www.ardmediathek.de/mdr/elefanttigerundco',
+        'info_dict': {
+            'id': 'mdr-elefanttigerundco',
+            'title': 'Elefant, Tiger & Co.',
+        },
+        'playlist_mincount': 10,
+    }, {
+        'url': 'https://www.ardmediathek.de/ard/tatort',
+        'info_dict': {
+            'id': 'ard-tatort',
+            'title': 'Tatort',
+        },
+        'playlist_mincount': 10,
+    }]
+
+    @classmethod
+    def suitable(cls, url):
+        return (
+            not ARDBetaMediathekIE.suitable(url)
+            and not ARDMediathekCollectionIE.suitable(url)
+            and super().suitable(url))
+
+    def _real_extract(self, url):
+        broadcaster, slug = self._match_valid_url(url).group('broadcaster', 'slug')
+        playlist_id = f'{broadcaster}-{slug}'
+
+        page_data = self._download_json(
+            f'https://api.ardmediathek.de/page-gateway/pages/{broadcaster}/editorial/{slug}',
+            playlist_id, 'Downloading programme page')
+
+        def entries():
+            seen = set()
+            for widget in traverse_obj(page_data, ('widgets', ..., {dict})):
+                widget_id = widget.get('id')
+                widget_url = traverse_obj(widget, ('links', 'self', 'href', {url_or_none}))
+                total = traverse_obj(widget, ('pagination', 'totalElements', {int_or_none})) or 0
+                page_size = traverse_obj(widget, ('pagination', 'pageSize', {int_or_none})) or 100
+
+                for page_num in range(max(total // page_size + (1 if total % page_size else 0), 1)):
+                    if page_num == 0:
+                        page = widget
+                    elif widget_url:
+                        page = self._download_json(
+                            widget_url, playlist_id,
+                            f'Downloading widget {widget_id} page {page_num}',
+                            query={'pageNumber': page_num, 'pageSize': page_size},
+                            fatal=False) or {}
+                    else:
+                        break
+
+                    for item in traverse_obj(page, ('teasers', ..., {dict})):
+                        item_id = traverse_obj(item, ('links', 'target', ('urlId', 'id')), 'id', get_all=False)
+                        if not item_id or item_id in seen:
+                            continue
+                        seen.add(item_id)
+                        item_mode = 'sammlung' if item.get('type') == 'compilation' else 'video'
+                        yield self.url_result(
+                            f'https://www.ardmediathek.de/{item_mode}/{item_id}',
+                            ie=(ARDMediathekCollectionIE if item_mode == 'sammlung' else ARDBetaMediathekIE),
+                            **traverse_obj(item, {
+                                'id': ('id', {str}),
+                                'title': ('longTitle', {str}),
+                                'duration': ('duration', {int_or_none}),
+                                'timestamp': ('broadcastedOn', {parse_iso8601}),
+                            }))
+
+        return self.playlist_result(
+            entries(), playlist_id,
+            title=page_data.get('title'),
+            description=traverse_obj(page_data, ('description', {str})))
+
+
 class ARDAudiothekBaseIE(InfoExtractor):
     def _graphql_query(self, urn, query):
         return self._download_json(


### PR DESCRIPTION
## Summary

Adds `ARDMediathekProgrammeIE` extractor to support programme page URLs of the form `ardmediathek.de/{broadcaster}/{slug}`, such as:
- `https://www.ardmediathek.de/mdr/elefanttigerundco`
- `https://www.ardmediathek.de/ard/tatort`

These pages were previously falling through to the generic extractor because they don't use the `/sendung/`, `/serie/`, or `/sammlung/` path keywords matched by `ARDMediathekCollectionIE`.

### How it works

- Uses the `page-gateway/pages/{broadcaster}/editorial/{slug}` REST API endpoint
- Iterates through all widgets on the page and extracts video teasers
- Handles per-widget pagination for large playlists
- Deduplicates entries across widgets
- Defers to existing extractors (`ARDBetaMediathekIE`, `ARDMediathekCollectionIE`) via `suitable()` override to avoid URL conflicts

Closes #16392

## Test plan

- [x] URL matching: new extractor matches programme URLs, does NOT match existing `/sendung/`, `/serie/`, `/sammlung/`, `/video/`, `/player/`, `/live/` URLs
- [x] Functional test: `yt-dlp --flat-playlist https://www.ardmediathek.de/mdr/elefanttigerundco` extracts 643 entries
- [x] `ruff check` passes
- [x] All existing ARD extractor test URLs still match their correct extractors