### PR TITLE
feat(extractor): Add youtubeeducation.com to supported domains

### DIFF
--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -87,6 +87,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                      (
                          (?:https?://|//)                                    # http(s):// or protocol-independent URL
                          (?:(?:(?:(?:\w+\.)?[yY][oO][uU][tT][uU][bB][eE](?:-nocookie|kids)?\.com|
+                             (?:www\.)?youtubeeducation\.com|
                             (?:www\.)?deturl\.com/www\.youtube\.com|
                             (?:www\.)?pwnyoutube\.com|
                             (?:www\.)?hooktube\.com|


### PR DESCRIPTION
This adds support for youtubeeducation.com URLs, as requested in #16363.