### PR TITLE
[update] Bump GitHub REST API version to `2026-03-10`

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -316,7 +316,7 @@ class Updater:
         return json.loads(self.ydl.urlopen(Request(url, headers={
             'Accept': 'application/vnd.github+json',
             'User-Agent': 'yt-dlp',
-            'X-GitHub-Api-Version': '2022-11-28',
+            'X-GitHub-Api-Version': '2026-03-10',
         })).read().decode())
 
     def _get_version_info(self, tag: str) -> tuple[str | None, str | None]:


### PR DESCRIPTION
Ref: https://github.blog/changelog/2026-03-12-rest-api-version-2026-03-10-is-now-available/

Of interest:

> Version `2022-11-28` will continue to be fully supported for at least **24 months from today**, and requests that don’t include the `X-GitHub-Api-Version` header will continue to default to `2022-11-28`.

GitHub implies that version `2022-11-28` may not be supported anymore in ~2 years. Version `2022-11-28` is the first version of the GitHub REST API, so it's unclear what deprecation or dropped support will look like.

The changes in version `2026-03-10` do not affect the updater (as far as I can tell), so IMO it would be best to get out ahead of this. Upgrading the REST API version now means that yt-dlp would have at least ~2 years' worth of releases with a working updater by the time that GitHub drops support for the old API version.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
