### PR TITLE
[ie/youtube] Fix outdated quickjs-ng warning

### DIFF
--- a/yt_dlp/extractor/youtube/jsc/_builtin/quickjs.py
+++ b/yt_dlp/extractor/youtube/jsc/_builtin/quickjs.py
@@ -30,10 +30,11 @@ class QuickJSJCP(EJSBaseJCP, BuiltinIEContentProvider):
         'and will solve the JS challenges very slowly. Consider upgrading.')
 
     def _run_js_runtime(self, stdin: str, /) -> str:
-        if self.runtime_info.version_tuple < self._QJS_MIN_RECOMMENDED[self.runtime_info.name]:
+        min_recommended_version = self._QJS_MIN_RECOMMENDED[self.runtime_info.name]
+        if self.runtime_info.version_tuple < min_recommended_version:
             self.logger.warning(self._QJS_WARNING_TMPL.format(
                 name=self.runtime_info.name,
-                version='.'.join(map(str, self.runtime_info.version_tuple))))
+                version='.'.join(map(str, min_recommended_version))))
 
         # QuickJS does not support reading from stdin, so we have to use a temp file
         temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False, encoding='utf-8')


### PR DESCRIPTION
Ref: https://github.com/quickjs-ng/quickjs/commit/e85ae372edf32882c8b877cd770fe485f2b05147

Closes #16403


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] Core bug fix/improvement

</details>
