### PR TITLE
[rh:curl_cffi] Fix supported impersonate targets

### DIFF
--- a/yt_dlp/networking/_curlcffi.py
+++ b/yt_dlp/networking/_curlcffi.py
@@ -123,31 +123,31 @@ BROWSER_TARGETS: dict[tuple[int, ...], dict[str, ImpersonateTarget]] = {
         'chrome110': ImpersonateTarget('chrome', '110', 'windows', '10'),
         'edge99': ImpersonateTarget('edge', '99', 'windows', '10'),
         'edge101': ImpersonateTarget('edge', '101', 'windows', '10'),
+    },
+    (0, 6): {
+        'chrome116': ImpersonateTarget('chrome', '116', 'windows', '10'),
+        'chrome119': ImpersonateTarget('chrome', '119', 'macos', '14'),
+        'chrome120': ImpersonateTarget('chrome', '120', 'macos', '14'),
+        'safari170': ImpersonateTarget('safari', '17.0', 'macos', '14'),
+        'safari172_ios': ImpersonateTarget('safari', '17.2', 'ios', '17.2'),
+        # safari153 and safari155 were available in 0.5.10, but fingerprints were wrong until 0.6.0
+        # Ref: https://github.com/lwthiker/curl-impersonate/issues/215
         'safari153': ImpersonateTarget('safari', '15.3', 'macos', '11'),
         'safari155': ImpersonateTarget('safari', '15.5', 'macos', '12'),
     },
     (0, 7): {
-        'chrome116': ImpersonateTarget('chrome', '116', 'windows', '10'),
-        'chrome119': ImpersonateTarget('chrome', '119', 'macos', '14'),
-        'chrome120': ImpersonateTarget('chrome', '120', 'macos', '14'),
         'chrome123': ImpersonateTarget('chrome', '123', 'macos', '14'),
         'chrome124': ImpersonateTarget('chrome', '124', 'macos', '14'),
-        'safari170': ImpersonateTarget('safari', '17.0', 'macos', '14'),
-        'safari172_ios': ImpersonateTarget('safari', '17.2', 'ios', '17.2'),
+    },
+    (0, 8): {
+        'safari180': ImpersonateTarget('safari', '18.0', 'macos', '15'),
+        'safari180_ios': ImpersonateTarget('safari', '18.0', 'ios', '18.0'),
     },
     (0, 9): {
-        'safari153': ImpersonateTarget('safari', '15.3', 'macos', '14'),
-        'safari155': ImpersonateTarget('safari', '15.5', 'macos', '14'),
-        'chrome119': ImpersonateTarget('chrome', '119', 'macos', '14'),
-        'chrome120': ImpersonateTarget('chrome', '120', 'macos', '14'),
-        'chrome123': ImpersonateTarget('chrome', '123', 'macos', '14'),
-        'chrome124': ImpersonateTarget('chrome', '124', 'macos', '14'),
         'chrome131': ImpersonateTarget('chrome', '131', 'macos', '14'),
         'chrome131_android': ImpersonateTarget('chrome', '131', 'android', '14'),
         'chrome133a': ImpersonateTarget('chrome', '133', 'macos', '15'),
         'firefox133': ImpersonateTarget('firefox', '133', 'macos', '14'),
-        'safari180': ImpersonateTarget('safari', '18.0', 'macos', '15'),
-        'safari180_ios': ImpersonateTarget('safari', '18.0', 'ios', '18.0'),
     },
     (0, 10): {
         'firefox135': ImpersonateTarget('firefox', '135', 'macos', '14'),
@@ -169,7 +169,7 @@ BROWSER_TARGETS: dict[tuple[int, ...], dict[str, ImpersonateTarget]] = {
     (0, 15): {
         'chrome145': ImpersonateTarget('chrome', '145', 'macos', '26'),
         'chrome146': ImpersonateTarget('chrome', '146', 'macos', '26'),
-        # firefox144 was added in 0.14.0, but its UA had a typo in 0.14.0
+        # firefox144 was added in 0.14.0, but its UA was wrong until 0.15.0
         # Ref: https://github.com/lexiforest/curl-impersonate/issues/234
         'firefox144': ImpersonateTarget('firefox', '144', 'macos', '26'),
         'firefox147': ImpersonateTarget('firefox', '147', 'macos', '26'),


### PR DESCRIPTION
Some corrections and deduplication for the `curl_cffi` browser targets mapping.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
