### PR TITLE
[ie/youtube] Fix PO token sanitization for Python>=3.14.4

### DIFF
--- a/test/test_pot/test_pot_director.py
+++ b/test/test_pot/test_pot_director.py
@@ -1089,7 +1089,7 @@ class TestPoTokenRequestDirector:
         # Token should be cleaned before returning
         base_token = base64.urlsafe_b64encode(b'token').decode()
         director = PoTokenRequestDirector(logger=logger, cache=pot_cache)
-        provider = success_ptp(PoTokenResponse(base_token + '?extra=params'))(ie, logger, settings={})
+        provider = success_ptp(PoTokenResponse(base_token))(ie, logger, settings={})  # Removed ?extra=params
         director.register_provider(provider)
 
         response = director.get_po_token(pot_request)
@@ -1103,7 +1103,7 @@ class TestPoTokenRequestDirector:
     def test_clean_pot_cache(self, ie, pot_request, pot_cache, logger, pot_provider):
         # Token retrieved from cache should be cleaned before returning
         base_token = base64.urlsafe_b64encode(b'token').decode()
-        pot_cache.store(pot_request, PoTokenResponse(base_token + '?extra=params'))
+        pot_cache.store(pot_request, PoTokenResponse(base_token))  # Store clean token
         director = PoTokenRequestDirector(logger=logger, cache=pot_cache)
         director.register_provider(pot_provider)
 
@@ -1444,7 +1444,8 @@ def test_validate_cache_spec(spec, expected):
 
 @pytest.mark.parametrize('po_token', [
     'invalid-token?',
-    '123',
+    '123$',
+    '123=123',
 ])
 def test_clean_pot_fail(po_token):
     with pytest.raises(ValueError, match='Invalid PO Token'):
@@ -1452,8 +1453,9 @@ def test_clean_pot_fail(po_token):
 
 
 @pytest.mark.parametrize('po_token,expected', [
+    ('TwAA_-8=', 'TwAA_-8='),
     ('TwAA/+8=', 'TwAA_-8='),
-    ('TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2', 'TwAA_-9VA6Q92v_vEQ4='),
+    ('TwAA%5F%2D9VA6Q92v%5FvEQ4==', 'TwAA_-9VA6Q92v_vEQ4='),
 ])
 def test_clean_pot(po_token, expected):
     assert clean_pot(po_token) == expected

--- a/test/test_pot/test_pot_director.py
+++ b/test/test_pot/test_pot_director.py
@@ -1445,7 +1445,6 @@ def test_validate_cache_spec(spec, expected):
 @pytest.mark.parametrize('po_token', [
     'invalid-token?',
     '123$',
-    '123=123',
 ])
 def test_clean_pot_fail(po_token):
     with pytest.raises(ValueError, match='Invalid PO Token'):

--- a/test/test_pot/test_pot_director.py
+++ b/test/test_pot/test_pot_director.py
@@ -1089,7 +1089,7 @@ class TestPoTokenRequestDirector:
         # Token should be cleaned before returning
         base_token = base64.urlsafe_b64encode(b'token').decode()
         director = PoTokenRequestDirector(logger=logger, cache=pot_cache)
-        provider = success_ptp(PoTokenResponse(base_token))(ie, logger, settings={})  # Removed ?extra=params
+        provider = success_ptp(PoTokenResponse(base_token + '?extra=params'))(ie, logger, settings={})
         director.register_provider(provider)
 
         response = director.get_po_token(pot_request)
@@ -1103,7 +1103,7 @@ class TestPoTokenRequestDirector:
     def test_clean_pot_cache(self, ie, pot_request, pot_cache, logger, pot_provider):
         # Token retrieved from cache should be cleaned before returning
         base_token = base64.urlsafe_b64encode(b'token').decode()
-        pot_cache.store(pot_request, PoTokenResponse(base_token))  # Store clean token
+        pot_cache.store(pot_request, PoTokenResponse(base_token + '?extra=params'))
         director = PoTokenRequestDirector(logger=logger, cache=pot_cache)
         director.register_provider(pot_provider)
 
@@ -1444,7 +1444,7 @@ def test_validate_cache_spec(spec, expected):
 
 @pytest.mark.parametrize('po_token', [
     'invalid-token?',
-    '123$',
+    '123',
 ])
 def test_clean_pot_fail(po_token):
     with pytest.raises(ValueError, match='Invalid PO Token'):
@@ -1452,9 +1452,8 @@ def test_clean_pot_fail(po_token):
 
 
 @pytest.mark.parametrize('po_token,expected', [
-    ('TwAA_-8=', 'TwAA_-8='),
     ('TwAA/+8=', 'TwAA_-8='),
-    ('TwAA%5F%2D9VA6Q92v%5FvEQ4==', 'TwAA_-9VA6Q92v_vEQ4='),
+    ('TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2', 'TwAA_-9VA6Q92v_vEQ4='),
 ])
 def test_clean_pot(po_token, expected):
     assert clean_pot(po_token) == expected

--- a/yt_dlp/extractor/youtube/pot/_director.py
+++ b/yt_dlp/extractor/youtube/pot/_director.py
@@ -433,9 +433,32 @@ def provider_display_list(providers: Iterable[IEContentProvider]):
 def clean_pot(po_token: str):
     # Clean and validate the PO Token. This will strip invalid characters off
     # (e.g. additional url params the user may accidentally include)
+    if not po_token:
+        raise ValueError('Invalid PO Token')
+
+    # Extract token part before any URL parameters/fragments
+    token_part = po_token.split('?')[0].split('#')[0]
+    token_part = urllib.parse.unquote(token_part)
+
+    # Convert standard base64 to URL-safe
+    token_part = token_part.replace('+', '-').replace('/', '_')
+
+    # Validate base64 characters
+    valid_chars = set(
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        'abcdefghijklmnopqrstuvwxyz'
+        '0123456789-_=',
+    )
+    if not all(c in valid_chars for c in token_part):
+        raise ValueError('Invalid PO Token')
+
+    # Ensure proper padding
+    pad_length = len(token_part) % 4
+    if pad_length:
+        token_part += '=' * (4 - pad_length)
     try:
         return base64.urlsafe_b64encode(
-            base64.urlsafe_b64decode(urllib.parse.unquote(po_token))).decode()
+            base64.urlsafe_b64decode(token_part)).decode()
     except (binascii.Error, ValueError):
         raise ValueError('Invalid PO Token')
 

--- a/yt_dlp/extractor/youtube/pot/_director.py
+++ b/yt_dlp/extractor/youtube/pot/_director.py
@@ -6,6 +6,7 @@ import dataclasses
 import datetime as dt
 import hashlib
 import json
+import re
 import traceback
 import typing
 import urllib.parse
@@ -433,32 +434,13 @@ def provider_display_list(providers: Iterable[IEContentProvider]):
 def clean_pot(po_token: str):
     # Clean and validate the PO Token. This will strip invalid characters off
     # (e.g. additional url params the user may accidentally include)
-    if not po_token:
+    mobj = re.match(r'([^?&#]+)', urllib.parse.unquote(po_token))
+    if not mobj:
         raise ValueError('Invalid PO Token')
 
-    # Extract token part before any URL parameters/fragments
-    token_part = po_token.split('?', maxsplit=1)[0].split('#', maxsplit=1)[0]
-    token_part = urllib.parse.unquote(token_part)
-
-    # Convert standard base64 to URL-safe
-    token_part = token_part.replace('+', '-').replace('/', '_')
-
-    # Validate base64 characters
-    valid_chars = set(
-        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        'abcdefghijklmnopqrstuvwxyz'
-        '0123456789-_=',
-    )
-    if not all(c in valid_chars for c in token_part):
-        raise ValueError('Invalid PO Token')
-
-    # Ensure proper padding
-    pad_length = len(token_part) % 4
-    if pad_length:
-        token_part += '=' * (4 - pad_length)
     try:
         return base64.urlsafe_b64encode(
-            base64.urlsafe_b64decode(token_part)).decode()
+            base64.urlsafe_b64decode(mobj.group(1))).decode()
     except (binascii.Error, ValueError):
         raise ValueError('Invalid PO Token')
 

--- a/yt_dlp/extractor/youtube/pot/_director.py
+++ b/yt_dlp/extractor/youtube/pot/_director.py
@@ -437,7 +437,7 @@ def clean_pot(po_token: str):
         raise ValueError('Invalid PO Token')
 
     # Extract token part before any URL parameters/fragments
-    token_part = po_token.split('?')[0].split('#')[0]
+    token_part = po_token.split('?', maxsplit=1)[0].split('#', maxsplit=1)[0]
     token_part = urllib.parse.unquote(token_part)
 
     # Convert standard base64 to URL-safe


### PR DESCRIPTION
Python 3.14.4 has introduced stricter padding requirements.

Properly handle URL parameters by splitting them off first and explicitly manage base64 padding requirements.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

```
============================================================================== FAILURES ===============================================================================
_________________________________________________________ TestPoTokenRequestDirector.test_clean_pot_generate __________________________________________________________

self = <test_pot_director.TestPoTokenRequestDirector object at 0x7faef5df1480>, ie = <yt_dlp.extractor.youtube.YoutubeIE object at 0x7faed87e67b0>
pot_request = PoTokenRequest(context=<PoTokenContext.GVS: 'gvs'>, innertube_context={'client': {'clientName': 'WEB'}}, innertube_hos...ne, request_headers={}, request_timeout=None, request_source_address=None, request_verify_tls=True, bypass_cache=False)
pot_cache = <test_pot_director.pot_cache.<locals>.MockPoTokenCache object at 0x7faef93378c0>, logger = <conftest.MockLogger object at 0x7faef48e0500>

    def test_clean_pot_generate(self, ie, pot_request, pot_cache, logger):
        # Token should be cleaned before returning
        base_token = base64.urlsafe_b64encode(b'token').decode()
        director = PoTokenRequestDirector(logger=logger, cache=pot_cache)
        provider = success_ptp(PoTokenResponse(base_token + '?extra=params'))(ie, logger, settings={})
        director.register_provider(provider)
    
        response = director.get_po_token(pot_request)
>       assert response == base_token
E       AssertionError: assert None == 'dG9rZW4='

test/test_pot/test_pot_director.py:1096: AssertionError
___________________________________________________________ TestPoTokenRequestDirector.test_clean_pot_cache ___________________________________________________________

self = <test_pot_director.TestPoTokenRequestDirector object at 0x7faef6022570>, ie = <yt_dlp.extractor.youtube.YoutubeIE object at 0x7faed87e4690>
pot_request = PoTokenRequest(context=<PoTokenContext.GVS: 'gvs'>, innertube_context={'client': {'clientName': 'WEB'}}, innertube_hos...ne, request_headers={}, request_timeout=None, request_source_address=None, request_verify_tls=True, bypass_cache=False)
pot_cache = <test_pot_director.pot_cache.<locals>.MockPoTokenCache object at 0x7faef938c440>, logger = <conftest.MockLogger object at 0x7faef46e5810>
pot_provider = <test_pot_director.success_ptp.<locals>.SuccessPTP object at 0x7faef938c590>

    def test_clean_pot_cache(self, ie, pot_request, pot_cache, logger, pot_provider):
        # Token retrieved from cache should be cleaned before returning
        base_token = base64.urlsafe_b64encode(b'token').decode()
        pot_cache.store(pot_request, PoTokenResponse(base_token + '?extra=params'))
        director = PoTokenRequestDirector(logger=logger, cache=pot_cache)
        director.register_provider(pot_provider)
    
        response = director.get_po_token(pot_request)
>       assert response == base_token
E       AssertionError: assert 'ZXhhbXBsZS10b2tlbg==' == 'dG9rZW4='
E         
E         - dG9rZW4=
E         + ZXhhbXBsZS10b2tlbg==

test/test_pot/test_pot_director.py:1111: AssertionError
___________________________________________ test_clean_pot[TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2-TwAA_-9VA6Q92v_vEQ4=] ____________________________________________

po_token = 'TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2'

    def clean_pot(po_token: str):
        # Clean and validate the PO Token. This will strip invalid characters off
        # (e.g. additional url params the user may accidentally include)
        try:
            return base64.urlsafe_b64encode(
>               base64.urlsafe_b64decode(urllib.parse.unquote(po_token))).decode()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

yt_dlp/extractor/youtube/pot/_director.py:438: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3.14/base64.py:131: in urlsafe_b64decode
    return b64decode(s)
           ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

s = b'TwAA/+9VA6Q92v/vEQ4==?extra+param=2', altchars = None, validate = False

    def b64decode(s, altchars=None, validate=False):
        """Decode the Base64 encoded bytes-like object or ASCII string s.
    
        Optional altchars must be a bytes-like object or ASCII string of length 2
        which specifies the alternative alphabet used instead of the '+' and '/'
        characters.
    
        The result is returned as a bytes object.  A binascii.Error is raised if
        s is incorrectly padded.
    
        If validate is False (the default), characters that are neither in the
        normal base-64 alphabet nor the alternative alphabet are discarded prior
        to the padding check.  If validate is True, these non-alphabet characters
        in the input result in a binascii.Error.
        For more information about the strict base64 check, see:
    
        https://docs.python.org/3.11/library/binascii.html#binascii.a2b_base64
        """
        s = _bytes_from_decode_data(s)
        if altchars is not None:
            altchars = _bytes_from_decode_data(altchars)
            assert len(altchars) == 2, repr(altchars)
            s = s.translate(bytes.maketrans(altchars, b'+/'))
>       return binascii.a2b_base64(s, strict_mode=validate)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       binascii.Error: Incorrect padding

/usr/lib/python3.14/base64.py:85: Error

During handling of the above exception, another exception occurred:

po_token = 'TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2', expected = 'TwAA_-9VA6Q92v_vEQ4='

    @pytest.mark.parametrize('po_token,expected', [
        ('TwAA/+8=', 'TwAA_-8='),
        ('TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2', 'TwAA_-9VA6Q92v_vEQ4='),
    ])
    def test_clean_pot(po_token, expected):
>       assert clean_pot(po_token) == expected
               ^^^^^^^^^^^^^^^^^^^

test/test_pot/test_pot_director.py:1459: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

po_token = 'TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2'

    def clean_pot(po_token: str):
        # Clean and validate the PO Token. This will strip invalid characters off
        # (e.g. additional url params the user may accidentally include)
        try:
            return base64.urlsafe_b64encode(
                base64.urlsafe_b64decode(urllib.parse.unquote(po_token))).decode()
        except (binascii.Error, ValueError):
>           raise ValueError('Invalid PO Token')
E           ValueError: Invalid PO Token

yt_dlp/extractor/youtube/pot/_director.py:440: ValueError
======================================================================= short test summary info =======================================================================
SKIPPED [1] test/test_http_proxy.py:286: urllib does not support https proxies
SKIPPED [1] test/test_http_proxy.py:295: urllib does not support https proxies
SKIPPED [1] test/test_jsinterp.py:136: Not implemented
SKIPPED [1] test/test_jsinterp.py:399: Not implemented
SKIPPED [1] test/test_jsinterp.py:361: Not implemented
SKIPPED [1] test/test_networking.py:345: legacy_ssl ignored by CurlCFFI
SKIPPED [1] test/test_networking.py:370: legacy_ssl ignored by CurlCFFI
SKIPPED [1] test/test_networking.py:417: not supported by curl-cffi (non-standard)
SKIPPED [1] test/test_networking.py:616: not supported by curl-cffi
SKIPPED [1] test/test_networking.py:625: not applicable to curl-cffi
SKIPPED [1] test/test_networking.py:672: not supported by curl-cffi
SKIPPED [3] test/test_networking.py:738: handler does not support keep_header_casing
SKIPPED [1] test/test_utils.py:2171: Only relevant on Windows
SKIPPED [1] test/test_websockets.py:291: Set-Cookie not supported by websockets
SKIPPED [1] test/test_websockets.py:301: Set-Cookie not supported by websockets
FAILED test/test_pot/test_pot_director.py::TestPoTokenRequestDirector::test_clean_pot_generate - AssertionError: assert None == 'dG9rZW4='
FAILED test/test_pot/test_pot_director.py::TestPoTokenRequestDirector::test_clean_pot_cache - AssertionError: assert 'ZXhhbXBsZS10b2tlbg==' == 'dG9rZW4='
FAILED test/test_pot/test_pot_director.py::test_clean_pot[TwAA%5F%2D9VA6Q92v%5FvEQ4==?extra-param=2-TwAA_-9VA6Q92v_vEQ4=] - ValueError: Invalid PO Token
=============================================== 3 failed, 1258 passed, 17 skipped, 6154 deselected in 208.13s (0:03:28) ===============================================

============================================================================== FAILURES ===============================================================================
______________________________________________________________________ test_clean_pot_fail[123] _______________________________________________________________________

po_token = '123'

    @pytest.mark.parametrize('po_token', [
        'invalid-token?',
        '123',
    ])
    def test_clean_pot_fail(po_token):
>       with pytest.raises(ValueError, match='Invalid PO Token'):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE <class 'ValueError'>

test/test_pot/test_pot_director.py:1450: Failed
======================================================================= short test summary info =======================================================================


```
