### PR TITLE
[ie/rutube] Fix crash on unavailable/upcoming videos

### DIFF
--- a/yt_dlp/extractor/rutube.py
+++ b/yt_dlp/extractor/rutube.py
@@ -2,6 +2,7 @@ import itertools
 
 from .common import InfoExtractor
 from ..utils import (
+    ExtractorError,
     UnsupportedError,
     bool_or_none,
     determine_ext,
@@ -73,9 +74,11 @@ class RutubeBaseIE(InfoExtractor):
             headers=self.geo_verification_headers(), query=query)
 
     def _extract_formats_and_subtitles(self, options, video_id):
+        if error := options.get('detail'):
+            raise ExtractorError(error, expected=True)
         formats = []
         subtitles = {}
-        for format_id, format_url in options['video_balancer'].items():
+        for format_id, format_url in (options.get('video_balancer') or {}).items():
             ext = determine_ext(format_url)
             if ext == 'm3u8':
                 fmts, subs = self._extract_m3u8_formats_and_subtitles(


### PR DESCRIPTION
### Description of your *pull request* and other information

When a video is unavailable or upcoming, the Rutube play options API returns
`video_balancer: null`. This caused an `AttributeError` crash because `.items()`
was called directly on `None`.

- Check for a `detail` error field in the API response and raise `ExtractorError` with it
- Use `options.get('video_balancer') or {}` to handle null/missing `video_balancer` without crashing

Fixes #16417