### PR TITLE
Fix duplicate subtitle tracks for same language (issue 16475)

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -568,6 +568,19 @@ class TestYoutubeDL(unittest.TestCase):
         subs = result['requested_subtitles']
         self.assertEqual(subs['en']['ext'], 'srt')
 
+        subtitles_with_duplicate_formats = {'en': [
+            {'ext': 'vtt', 'url': 'http://localhost/video.en.primary.vtt'},
+            {'ext': 'vtt', 'url': 'http://localhost/video.en.sdh.vtt'},
+        ]}
+        duplicate_info_dict = {**info_dict, 'subtitles': subtitles_with_duplicate_formats}
+        ydl = YDL({'simulate': True, 'writesubtitles': True})
+        ydl.report_warning = lambda *args, **kargs: None
+        result = ydl.process_video_result(duplicate_info_dict, download=False)
+        subs = result['requested_subtitles']
+        self.assertEqual(set(subs.keys()), {'en', 'en-1'})
+        self.assertEqual(subs['en']['url'], 'http://localhost/video.en.primary.vtt')
+        self.assertEqual(subs['en-1']['url'], 'http://localhost/video.en.sdh.vtt')
+
         result = get_info({'writesubtitles': True, 'subtitleslangs': ['es', 'fr', 'it']})
         subs = result['requested_subtitles']
         self.assertTrue(subs)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3157,25 +3157,41 @@ class YoutubeDL:
         formats_query = self.params.get('subtitlesformat', 'best')
         formats_preference = formats_query.split('/') if formats_query else []
         subs = {}
+        reserved_langs = set(available_subs)
+
+        def _next_sub_lang(base_lang):
+            idx = 1
+            while True:
+                candidate = f'{base_lang}-{idx}'
+                if candidate not in reserved_langs and candidate not in subs:
+                    return candidate
+                idx += 1
         for lang in requested_langs:
             formats = available_subs.get(lang)
             if formats is None:
                 self.report_warning(f'{lang} subtitles not available for {video_id}')
                 continue
+            selected_formats = None
             for ext in formats_preference:
                 if ext == 'best':
-                    f = formats[-1]
+                    selected_formats = [f for f in formats if f['ext'] == formats[-1]['ext']] or [formats[-1]]
                     break
                 matches = list(filter(lambda f: f['ext'] == ext, formats))
                 if matches:
-                    f = matches[-1]
+                    selected_formats = matches
                     break
             else:
-                f = formats[-1]
+                selected_formats = [f for f in formats if f['ext'] == formats[-1]['ext']] or [formats[-1]]
+                f = selected_formats[-1]
                 self.report_warning(
                     'No subtitle format found matching "{}" for language {}, '
                     'using {}. Use --list-subs for a list of available subtitles'.format(formats_query, lang, f['ext']))
-            subs[lang] = f
+
+            first_sub_lang = True
+            for f in selected_formats:
+                sub_lang = lang if first_sub_lang else _next_sub_lang(lang)
+                first_sub_lang = False
+                subs[sub_lang] = f
         return subs
 
     def _forceprint(self, key, info_dict):


### PR DESCRIPTION

### Description of your *pull request* and other information

Fixes #16475 (https://github.com/yt-dlp/yt-dlp/issues/16475)

This PR fixes a bug where only one subtitle track was kept when multiple tracks shared the same language code.  
Previously, the code effectively picked only the last selected format for a language.  
Now it keeps all matching subtitle formats and uses '_next_sub_lang' to assign unique keys (for example: 'en', 'en-1', 'en-2'), so all tracks are preserved.

I also added a regression test in `TestYoutubeDL.test_subtitles` to cover this case.

For reproduction, the URL from the issue produced SSL certificate errors in my environment, so I used a local HTTPS server with this test manifest ('demo.m3u8'):
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs0",NAME="English",LANGUAGE="en",AUTOSELECT=YES,DEFAULT=YES,URI="subs-en.vtt"
#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs0",NAME="English SDH",LANGUAGE="en",AUTOSELECT=YES,DEFAULT=NO,CHARACTERISTICS="public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound",URI="subs-en-sdh.vtt"
#EXTINF:10.0,
fake-segment.ts

The new regression check is intentionally done with a custom info_dict instead of reusing the common helper "get_info", to keep the test scope minimal and avoid changing shared test setup for unrelated cases.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x ] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x ] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x ] Core bug fix/improvement

</details>
