### PR TITLE
Handle abrupt TLS connection close as EOF for live streams (FLV downloads)

### DIFF
--- a/yt_dlp/downloader/http.py
+++ b/yt_dlp/downloader/http.py
@@ -251,6 +251,19 @@ class HttpFD(FileDownloader):
                     data_block = ctx.data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
                 except TransportError as err:
                     retry(err)
+                except OSError as err:
+                    # Some live streams may abruptly close the connection (e.g. TLS shutdown)
+                    # when the stream ends. If we already received data, treat this as EOF.
+                    if (
+                        info_dict.get('is_live')
+                        and byte_counter > 0
+                        and ctx.data.headers.get('Content-length') is None
+                    ):
+                        self.report_warning(
+                            f'Connection closed unexpectedly (treated as EOF): {err}')
+                        break
+
+                    retry(err)
 
                 byte_counter += len(data_block)
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

ADD DETAILED DESCRIPTION HERE

This PR fixes unexpected download failure when live FLV streams (notably TikTok live). This occurs when the server closes the TLS connection without sending a proper close_notify, causing Python to raise an OSError/SSLError during read.


Since live streams often terminate this way, I treat it as EOF when:

- The stream is live

- data has already been received

- No Content-Length is provided


This allows proper finalization of the file instead of leaving a .part file.

Fixes #16570


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [ x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [ x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
