### PR TITLE
Add support for chapter and episode metadata in Laracasts extractor and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
-dependencies = []
+dependencies = [
+    "beautifulsoup4",
+    "lxml"
+]
 
 [project.optional-dependencies]
 default = [

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1277,6 +1277,9 @@ class YoutubeDL:
             'playlist_index': number_of_digits(info_dict.get('__last_playlist_index') or 0),
             'playlist_autonumber': number_of_digits(info_dict.get('n_entries') or 0),
             'autonumber': self.params.get('autonumber_size') or 5,
+            'chapter_number': number_of_digits(info_dict.get('chapters_count') or 0),
+            'episode_number': number_of_digits(info_dict.get('n_entries') or 0),
+            'relative_episode_number': number_of_digits(info_dict.get('chapter_episodes_count') or 0)
         }
 
         TMPL_DICT = {}

--- a/yt_dlp/extractor/laracasts.py
+++ b/yt_dlp/extractor/laracasts.py
@@ -1,11 +1,9 @@
 import json
 
 from .common import InfoExtractor
-from .vimeo import VimeoIE
+from .mux import MuxIE
 from ..utils import (
     clean_html,
-    extract_attributes,
-    get_element_html_by_id,
     int_or_none,
     parse_duration,
     str_or_none,
@@ -14,28 +12,71 @@ from ..utils import (
     urljoin,
 )
 from ..utils.traversal import traverse_obj
+from bs4 import BeautifulSoup
+
+chapter_names = []
+
+chapter_episodes_counts = []
+
+chapters_count = 0
+
+def set_episode_chapter_info(episode):
+    global chapter_names
+    global chapters_count
+    global chapter_episodes_counts
+    index = int(episode['chapter']) - 1
+    episode['chapterName'] = chapter_names[index]
+    episode['chaptersCount'] = chapters_count
+    episode['chapterEpisodesCount'] = chapter_episodes_counts[index]
+    return episode
+
+def get_chapter_info(chapter):
+    global chapter_names
+    global chapter_episodes_counts
+    index = int(chapter['number']) - 1
+    chapter_names[index] = chapter['heading']
+    chapter_episodes_counts[index] = chapter['count']
+    return chapter
+
+def get_relative_episode_number(episode_number):
+    global chapter_episodes_counts
+    relative_episode_number = episode_number
+    increment = 0
+    for episodes_count in chapter_episodes_counts:
+        if increment + episodes_count >= episode_number:
+            relative_episode_number = episode_number - increment
+            break
+        increment = increment + episodes_count
+    return relative_episode_number
+
 
 
 class LaracastsBaseIE(InfoExtractor):
     def _get_prop_data(self, url, display_id):
         webpage = self._download_webpage(url, display_id)
+        soup = BeautifulSoup(webpage, 'lxml')
         return traverse_obj(
-            get_element_html_by_id('app', webpage),
-            ({extract_attributes}, 'data-page', {json.loads}, 'props'))
+            soup.find('script', {'data-page': 'app'}).text,
+            ({json.loads}, 'props'))
 
     def _parse_episode(self, episode):
-        if not traverse_obj(episode, 'vimeoId'):
+        with open(r'C:\Users\Osema\Music\test\laracasts\test.json', 'w') as f:
+            f.write(json.dumps(episode))
+        if not traverse_obj(episode, 'muxPlaybackId'):
             self.raise_login_required('This video is only available for subscribers.')
         return self.url_result(
-            VimeoIE._smuggle_referrer(
-                f'https://player.vimeo.com/video/{episode["vimeoId"]}', 'https://laracasts.com/'),
-            VimeoIE, url_transparent=True,
+            f'https://player.mux.com/{episode["muxPlaybackId"]}?playback-token={episode['muxTokens']['playback']}',
+            MuxIE, url_transparent=True,
             **traverse_obj(episode, {
                 'id': ('id', {int}, {str_or_none}),
                 'webpage_url': ('path', {urljoin('https://laracasts.com')}),
                 'title': ('title', {clean_html}),
-                'season_number': ('chapter', {int_or_none}),
+                'chapter_number': ('chapter', {int_or_none}),
+                'chapter_name': ('chapterName', {str_or_none}),
+                'chapters_count': ('chaptersCount', {int_or_none}),
+                'chapter_episodes_count': ('chapterEpisodesCount', {int_or_none}),
                 'episode_number': ('position', {int_or_none}),
+                'relative_episode_number': ('position', {get_relative_episode_number}),
                 'description': ('body', {clean_html}),
                 'thumbnail': ('largeThumbnail', {url_or_none}),
                 'duration': ('length', {int_or_none}),
@@ -70,7 +111,16 @@ class LaracastsIE(LaracastsBaseIE):
 
     def _real_extract(self, url):
         display_id = self._match_id(url)
-        return self._parse_episode(self._get_prop_data(url, display_id)['lesson'])
+        props = self._get_prop_data(url, display_id)
+        lesson = props['lesson']
+        chapters = props['series']['chapters']
+        index = int(lesson['chapter']) - 1
+        lesson['chapterName'] = chapters[index]['heading']
+        lesson['chaptersCount'] = len(chapters)
+        global chapter_episodes_counts
+        chapter_episodes_counts = [int(c['count']) for c in chapters]
+        lesson['chapterEpisodesCount'] = chapter_episodes_counts[index]
+        return self._parse_episode(lesson)
 
 
 class LaracastsPlaylistIE(LaracastsBaseIE):
@@ -96,6 +146,17 @@ class LaracastsPlaylistIE(LaracastsBaseIE):
         display_id = self._match_id(url)
         series = self._get_prop_data(url, display_id)['series']
 
+        global chapter_names
+
+        global chapters_count
+
+        global chapter_episodes_counts
+
+        chapters_count = len(series['chapters'])
+
+        chapter_names = ['' for i in range(chapters_count)]
+        chapter_episodes_counts = [0 for i in range(chapters_count)]
+
         metadata = {
             'display_id': display_id,
             **traverse_obj(series, {
@@ -111,4 +172,5 @@ class LaracastsPlaylistIE(LaracastsBaseIE):
         }
 
         return self.playlist_result(traverse_obj(
-            series, ('chapters', ..., 'episodes', lambda _, v: v['vimeoId'], {self._parse_episode})), **metadata)
+            series, ('chapters', lambda _,v: get_chapter_info(v) , 'episodes', lambda _, v: set_episode_chapter_info(v), {self._parse_episode})), **metadata)
+


### PR DESCRIPTION
Enhance the Laracasts extractor by adding support for chapter and episode metadata and updating dependencies. Change the video extraction method from Vimeo to Mux to align with platform requirements.