### PR TITLE
[ie/newgrounds] Fix login `ERROR: url must be a string` (#16636)

### DIFF
--- a/yt_dlp/extractor/newgrounds.py
+++ b/yt_dlp/extractor/newgrounds.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import re
 
 from .common import InfoExtractor
@@ -128,18 +129,23 @@ class NewgroundsIE(InfoExtractor):
     def _perform_login(self, username, password):
         login_webpage = self._download_webpage(self._LOGIN_URL, None, 'Downloading login page')
         login_url = urljoin(self._LOGIN_URL, self._search_regex(
-            r'<form action="([^"]+)"', login_webpage, 'login endpoint', default=None))
+            r"loginUrl: '([^']+)'", login_webpage, 'login endpoint'))
+        csrf_token = self._search_regex(
+            r"csrfToken: '([^']+)'", login_webpage, 'CSRF token')
         result = self._download_json(login_url, None, 'Logging in', headers={
             'Accept': 'application/json',
+            'Content-Type': 'application/json',
             'Referer': self._LOGIN_URL,
-            'X-Requested-With': 'XMLHttpRequest',
-        }, data=urlencode_postdata({
-            **self._hidden_inputs(login_webpage),
-            'username': username,
+            'X-CSRF-TOKEN': csrf_token,
+        }, data=json.dumps({
+            'identity': username,
             'password': password,
-        }))
+            'remember': 0
+        }).encode())
         if errors := traverse_obj(result, ('errors', ..., {str})):
             raise ExtractorError(', '.join(errors) or 'Unknown Error', expected=True)
+        if result.get('two_factor'):
+            raise ExtractorError('2FA Not Supported', expected=True)
 
     def _real_extract(self, url):
         media_id = self._match_id(url)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

The newgrounds.com login page no longer contains a `<form action=`.  Instead, it contains markup with JavaScript attributes:

```html
                <div class="pod-body text-center" x-data="loginForm({
        loginUrl: 'https://www.newgrounds.com/passport',
        codeUrl: 'https://www.newgrounds.com/passport/two-factor',
        csrfToken: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
        old: JSON.parse('{\u0022identity\u0022:\u0022\u0022,\u0022remember\u0022:1}')
    })">
```

When the form is submitted, it sends a POST request with the following JSON content to `loginUrl`:

```
{
  "identity": $username,
  "password": $password,
  "remember": 0 (or 1 if "Remember Me" is checked)
}
```

On error, the JSON response contains:

```json
{
  "message": "These credentials do not match our records.",
  "errors": {
    "identity": [
      "These credentials do not match our records."
    ]
  }
}
```

On success, the JSON response contains:

```json
{
  "two_factor": false
}
```

Presumably `two_factor` would be `true` for accounts with two-factor authentication, but I have not tested it.

This PR adds support for logging in to an account without 2FA.

Fixes #16636


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>