### PR TITLE
[ie/franceinfo:la1ere:audio] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -659,6 +659,7 @@ from .franceinter import FranceInterIE
 from .francetv import (
     FranceTVIE,
     FranceTVInfoIE,
+    FranceTVInfoLa1ereAudioIE,
     FranceTVSiteIE,
 )
 from .freesound import FreesoundIE

--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -1,3 +1,4 @@
+import functools
 import re
 import urllib.parse
 
@@ -6,6 +7,7 @@ from .dailymotion import DailymotionIE
 from ..networking import HEADRequest
 from ..utils import (
     ExtractorError,
+    OnDemandPagedList,
     clean_html,
     determine_ext,
     extract_attributes,
@@ -487,3 +489,54 @@ class FranceTVInfoIE(FranceTVBaseInfoExtractor):
         )
 
         return self._make_url_result(video_id, url=url)
+
+
+class FranceTVInfoLa1ereAudioIE(InfoExtractor):
+    IE_NAME = 'franceinfo:la1ere:audio'
+    IE_DESC = 'la1ere.franceinfo.fr audio podcast series'
+    _VALID_URL = r'https?://la1ere\.franceinfo\.fr/[^/?#]+/programme-audio/(?P<display_id>[^/?#]+-(?P<id>\d+))/?'
+
+    _TESTS = [{
+        'url': 'https://la1ere.franceinfo.fr/nouvellecaledonie/programme-audio/le-journal-de-06h30-nouvelle-caledonie-14634/',
+        'info_dict': {
+            'id': '14634',
+            'title': 'Le journal de 06h30- Nouvelle-Calédonie',
+        },
+        'playlist_mincount': 50,
+    }]
+
+    def _fetch_page(self, series_id, page):
+        episodes = self._download_json(
+            f'https://la1ere.franceinfo.fr/api/audio/podcasts/{series_id}/episodes',
+            series_id, f'Downloading episodes page {page + 1}',
+            query={'page': page + 1}, fatal=False) or []
+        for episode in episodes:
+            feed_url = traverse_obj(episode, ('feed', {url_or_none}))
+            episode_id = episode.get('id')
+            if not feed_url or not episode_id:
+                continue
+            yield {
+                'id': str(episode_id),
+                'url': feed_url,
+                'ext': 'mp3',
+                'vcodec': 'none',
+                'title': episode.get('title'),
+                'description': episode.get('description'),
+                'duration': int_or_none(episode.get('duration')),
+                'timestamp': parse_iso8601(episode.get('broadcastDate')),
+                'thumbnail': traverse_obj(episode, ('thumbnail', 'src', {url_or_none})),
+            }
+
+    def _real_extract(self, url):
+        display_id, series_id = self._match_valid_url(url).group('display_id', 'id')
+
+        webpage = self._download_webpage(url, display_id, fatal=False) or ''
+        title = (
+            self._html_search_meta(['og:title', 'twitter:title'], webpage, default=None)
+            or self._html_extract_title(webpage, default=None))
+        if title:
+            title = re.sub(r'\s+à\s+\(ré\)écouter\s+sur.*$', '', title).strip(' .') or None
+
+        entries = OnDemandPagedList(functools.partial(self._fetch_page, series_id), 8)
+
+        return self.playlist_result(entries, playlist_id=series_id, playlist_title=title)


### PR DESCRIPTION
### Description of your *pull request* and other information

Adds `FranceTVInfoLa1ereAudioIE` for la1ere podcast series pages
(`/programme-audio/<slug>-<id>/`). Episodes paginated via
`/api/audio/podcasts/<id>/episodes`, served as direct MP3s by Saooti.

Pagination follows the `agora.py` pattern. Not a Python dev (PHP/JS),
this took some trial and error.

Companion PR #16646 adds la1ere subdomain support to `FranceTVInfoIE` and
excludes `/programme-audio/` so the two don't collide.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
</details>
