### PR TITLE
[ie/franceinfo] Add la1ere subdomain support

### DIFF
--- a/yt_dlp/extractor/francetv.py
+++ b/yt_dlp/extractor/francetv.py
@@ -13,6 +13,7 @@ from ..utils import (
     format_field,
     int_or_none,
     join_nonempty,
+    orderedSet,
     parse_iso8601,
     smuggle_url,
     unsmuggle_url,
@@ -373,7 +374,7 @@ class FranceTVSiteIE(FranceTVBaseInfoExtractor):
 class FranceTVInfoIE(FranceTVBaseInfoExtractor):
     IE_NAME = 'franceinfo'
     IE_DESC = 'franceinfo.fr (formerly francetvinfo.fr)'
-    _VALID_URL = r'https?://(?:www|mobile|france3-regions)\.france(?:tv)?info.fr/(?:[^/?#]+/)*(?P<id>[^/?#&.]+)'
+    _VALID_URL = r'https?://(?:www|mobile|france3-regions|la1ere)\.france(?:tv)?info\.fr/(?!(?:[^/?#]+/)*programme-audio/)(?:[^/?#]+/)*(?P<id>[^/?#&.]+)'
 
     _TESTS = [{
         'url': 'https://www.francetvinfo.fr/replay-jt/france-3/soir-3/jt-grand-soir-3-jeudi-22-aout-2019_3561461.html',
@@ -461,6 +462,27 @@ class FranceTVInfoIE(FranceTVBaseInfoExtractor):
     }, {
         'url': 'https://www.franceinfo.fr/replay-jt/france-2/20-heures/robert-de-niro-portrait-d-un-monument-du-cinema_7245456.html',
         'only_matching': True,
+    }, {
+        # la1ere article page with several embedded videos
+        'url': 'https://la1ere.franceinfo.fr/nouvellecaledonie/l-hopital-de-poindimie-commence-a-rouvrir-quatorze-lits-pour-les-patients-de-la-cote-est-1698130.html',
+        'info_dict': {
+            'id': 'l-hopital-de-poindimie-commence-a-rouvrir-quatorze-lits-pour-les-patients-de-la-cote-est-1698130',
+        },
+        'playlist_mincount': 2,
+    }, {
+        # la1ere single episode page
+        'url': 'https://la1ere.franceinfo.fr/nouvellecaledonie/programme-video/la1ere_nouvelle-caledonie_journal-de-19h30-de-nouvelle-caledonie/diffusion/8412318-edition-du-mardi-05-mai-2026.html',
+        'info_dict': {
+            'id': 'bab33e2a-829f-4fda-9bde-b071ac808cde',
+            'ext': 'mp4',
+            'title': 'Journal de 19h30 de Nouvelle-Calédonie - Édition du mardi 05 mai 2026',
+            'duration': 1620,
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'timestamp': 1777969766,
+            'upload_date': '20260505',
+        },
+        'params': {'skip_download': True},
+        'add_ie': [FranceTVIE.ie_key()],
     }]
 
     def _real_extract(self, url):
@@ -483,7 +505,25 @@ class FranceTVInfoIE(FranceTVBaseInfoExtractor):
                  r'id-video=([^@]+@[^"]+)',
                  r'<a[^>]+href="(?:https?:)?//videos\.francetv\.fr/video/([^@]+@[^"]+)"',
                  r'(?:data-id|<figure[^<]+\bid)=["\']([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})'),
-                webpage, 'video id')
+                webpage, 'video id', default=None)
         )
 
-        return self._make_url_result(video_id, url=url)
+        if video_id:
+            return self._make_url_result(video_id, url=url)
+
+        # la1ere falls back to inline JS data: a 'diffusion:{...}' block on
+        # single-episode pages, or one or more bare videoId fields on articles
+        diffusion_id = self._search_regex(
+            r'\bdiffusion:\{[^{}]*videoId:"([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})"',
+            webpage, 'diffusion video id', default=None)
+        if diffusion_id:
+            return self._make_url_result(diffusion_id, url=url)
+        video_ids = orderedSet(re.findall(
+            r'videoId:"([\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12})"', webpage))
+        if not video_ids:
+            raise ExtractorError('Unable to extract video id', expected=True)
+        if len(video_ids) == 1:
+            return self._make_url_result(video_ids[0], url=url)
+        return self.playlist_result(
+            [self._make_url_result(vid, url=url) for vid in video_ids],
+            playlist_id=display_id)


### PR DESCRIPTION
### Description of your *pull request* and other information

Picks up where #15669 left off:  *"I did not include the la1ere part because it is not working"*. 

`la1ere` pages reference videos via inline JS data instead of the standard player markup, this adds a fallback for that. Handles both single-episode `/diffusion/` pages and multi-video article pages.

Excludes `/programme-audio/` paths — those are audio podcasts handle by a companion PR: #16645.

I am NOT a Python dev (PHP/JS), reuses the existing `FranceTVInfoIE` style.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
