### PR TITLE
[ie/arte] Fix ArteTV format_note for audio tracks (fixes #11501)

### DIFF
--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -183,7 +183,7 @@ class ArteTVIE(ArteTVBaseIE):
                     stream['url'], video_id=video_id, ext='mp4', m3u8_id=stream_version_code, fatal=False)
                 for fmt in fmts:
                     fmt.update({
-                        'format_note': f'{stream_version.get("label", "unknown")} [{short_label}]',
+                        'format_note': fmt.get('format_note', f'{stream_version.get("label", "unknown")} [{short_label}]'),
                         'language_preference': lang_pref,
                     })
                 if any(map(short_label.startswith, ('cc', 'OGsub'))):

--- a/yt_dlp/extractor/arte.py
+++ b/yt_dlp/extractor/arte.py
@@ -88,9 +88,7 @@ class ArteTVIE(ArteTVBaseIE):
         'es': 'E[ESP]',
         'it': 'E[ITA]',
         'pl': 'E[POL]',
-        # XXX: probably means mixed; <https://www.arte.tv/en/videos/107710-029-A/dispatches-from-ukraine-local-journalists-report/>
-        # uses this code for audio that happens to be in Ukrainian, but the manifest uses the ISO code 'mul' (mixed)
-        'mul': 'EU',
+        'mul': 'EU',  # multilingual OR language not matching Arte's official languages
     }
 
     _VERSION_CODE_RE = re.compile(r'''(?x)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

In the `ArteTV` extractor, fix the ` format_note`  for audio tracks:
- in the current version, `format_note` was always overwritten and set to e.g. "[mul] Deutsch [DE]"
- now it keeps the description of the audio track if already available.

Fixes #11501:

Results of `yt-dlp -F "https://www.arte.tv/de/videos/117217-024-A/tracks-east/"`:
#### Before
```shell
[info] Available formats for 117217-024-A:
ID                                         EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC     MORE INFO
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
VA-STA-audio_0-Deutsch                     mp4 audio only     │                  m3u8  │ audio only        unknown    [de] Deutsch [DE]
VA-STA-audio_0-Deutsch__Klare_Sprache_     mp4 audio only     │                  m3u8  │ audio only        unknown    [de] Deutsch [DE]
VA-STA-audio_0-Französisch                 mp4 audio only     │                  m3u8  │ audio only        unknown    [fr] Deutsch [DE]
VA-STA-audio_0-Französisch__Klare_Sprache_ mp4 audio only     │                  m3u8  │ audio only        unknown    [fr] Deutsch [DE]
VA-STA-audio_0-Mehrsprachig                mp4 audio only     │                  m3u8  │ audio only        unknown    [mul] Deutsch [DE]
VA-STA-427                                 mp4 384x216     25 │ ~ 92.58MiB  428k m3u8  │ avc1.42e00d  428k video only Deutsch [DE]
VA-STA-827                                 mp4 640x360     25 │ ~178.98MiB  827k m3u8  │ avc1.4d401e  827k video only Deutsch [DE]
VA-STA-1503                                mp4 768x432     25 │ ~325.21MiB 1503k m3u8  │ avc1.4d401e 1503k video only Deutsch [DE]
VA-STA-2294                                mp4 1280x720    25 │ ~496.53MiB 2295k m3u8  │ avc1.4d401f 2295k video only Deutsch [DE]
VA-STA-2688                                mp4 1920x1080   25 │ ~581.79MiB 2689k m3u8  │ avc1.4d0028 2689k video only Deutsch [DE]
```

#### After
```shell
[info] Available formats for 117217-024-A:
ID                                         EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC     MORE INFO
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
VA-STA-audio_0-Deutsch__Klare_Sprache_     mp4 audio only     │                  m3u8  │ audio only        unknown    [de] Deutsch (Klare Sprache)
VA-STA-audio_0-Französisch                 mp4 audio only     │                  m3u8  │ audio only        unknown    [fr] Französisch
VA-STA-audio_0-Französisch__Klare_Sprache_ mp4 audio only     │                  m3u8  │ audio only        unknown    [fr] Französisch (Klare Sprache)
VA-STA-audio_0-Mehrsprachig                mp4 audio only     │                  m3u8  │ audio only        unknown    [mul] Mehrsprachig
VA-STA-audio_0-Deutsch                     mp4 audio only     │                  m3u8  │ audio only        unknown    [de] Deutsch
VA-STA-427                                 mp4 384x216     25 │ ~ 92.58MiB  428k m3u8  │ avc1.42e00d  428k video only Deutsch [DE]
VA-STA-827                                 mp4 640x360     25 │ ~178.98MiB  827k m3u8  │ avc1.4d401e  827k video only Deutsch [DE]
VA-STA-1503                                mp4 768x432     25 │ ~325.21MiB 1503k m3u8  │ avc1.4d401e 1503k video only Deutsch [DE]
VA-STA-2294                                mp4 1280x720    25 │ ~496.53MiB 2295k m3u8  │ avc1.4d401f 2295k video only Deutsch [DE]
VA-STA-2688                                mp4 1920x1080   25 │ ~581.79MiB 2689k m3u8  │ avc1.4d0028 2689k video only Deutsch [DE]

```


Notes: 
- I also improved slightly a comment on "multilingual" audio tracks, based on my experience of Arte, 
- I didn't add tests because this attribute was not tested before; it's more of a cosmetic/UI fix.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [X] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [X] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
