### PR TITLE
[ie/secondtry] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -1808,6 +1808,10 @@ from .scrippsnetworks import (
     ScrippsNetworksWatchIE,
 )
 from .scrolller import ScrolllerIE
+from .secondtry import (
+    SecondTryIE,
+    SecondTrySeasonIE,
+)
 from .sejmpl import SejmIE
 from .sen import SenIE
 from .senalcolombia import SenalColombiaLiveIE

--- a/yt_dlp/extractor/secondtry.py
+++ b/yt_dlp/extractor/secondtry.py
@@ -1,0 +1,150 @@
+import functools
+
+from .common import InfoExtractor
+from .vimeo import VHXEmbedIE
+from ..utils import (
+    ExtractorError,
+    OnDemandPagedList,
+    clean_html,
+    extract_attributes,
+    get_element_by_class,
+    get_element_by_id,
+    get_elements_html_by_class,
+    int_or_none,
+    traverse_obj,
+    unified_strdate,
+    urlencode_postdata,
+)
+
+
+class SecondTryIE(InfoExtractor):
+    _LOGIN_URL = 'https://watch.2ndtry.tv/login'
+    _NETRC_MACHINE = 'secondtry'
+
+    _VALID_URL = r'https?://(?:watch\.)?2ndtry\.tv/(?:[^/?#]+/)*videos/(?P<id>[^/?#]+)/?(?:[?#]|$)'
+    _TESTS = [
+        {
+            'url': 'https://watch.2ndtry.tv/trolley-problems/season:1/videos/trolley-problems-101',
+            'note': 'Episode in a series (subscriber-only)',
+            'info_dict': {
+                'id': '3240323',
+                'display_id': 'trolley-problems-101',
+                'ext': 'mp4',
+                'title': 'Show Me Them Piggies • Trolley Problems',
+                'series': 'Trolley Problems',
+                'season_number': 1,
+                'season': 'Season 1',
+                'episode_number': 2,
+                'episode': 'Show Me Them Piggies • Trolley Problems',
+                'release_date': '20240601',
+            },
+            'params': {'skip_download': True},
+            'skip': 'Requires a 2nd try subscription',
+            'expected_warnings': ['Ignoring subtitle tracks found in the HLS manifest', 'Failed to parse XML: not well-formed'],
+        },
+    ]
+
+    def _get_authenticity_token(self, display_id):
+        signin_page = self._download_webpage(
+            self._LOGIN_URL, display_id, note='Getting authenticity token')
+        return self._html_search_regex(
+            r'name=["\']authenticity_token["\'] value=["\'](.+?)["\']',
+            signin_page, 'authenticity_token')
+
+    def _login(self, display_id):
+        username, password = self._get_login_info()
+        if not username:
+            return True
+
+        response = self._download_webpage(
+            self._LOGIN_URL, display_id, note='Logging in', fatal=False,
+            data=urlencode_postdata({
+                'email': username,
+                'password': password,
+                'authenticity_token': self._get_authenticity_token(display_id),
+                'utf8': True,
+            }))
+
+        user_has_subscription = self._search_regex(
+            r'user_has_subscription:\s*["\'](.+?)["\']', response, 'subscription status', default='none')
+        if user_has_subscription.lower() == 'true':
+            return
+        elif user_has_subscription.lower() == 'false':
+            return 'Account is not subscribed'
+        else:
+            return 'Incorrect username/password'
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+
+        webpage = None
+        if self._get_cookies('https://watch.2ndtry.tv').get('_session'):
+            webpage = self._download_webpage(url, display_id)
+        if not webpage or '<div id="watch-unauthorized"' in webpage:
+            login_err = self._login(display_id)
+            webpage = self._download_webpage(url, display_id)
+            if login_err and '<div id="watch-unauthorized"' in webpage:
+                if login_err is True:
+                    self.raise_login_required(method='any')
+                raise ExtractorError(login_err, expected=True)
+
+        embed_url = self._html_search_regex(r'embed_url:\s*["\'](.+?)["\']', webpage, 'embed url')
+        thumbnail = self._og_search_thumbnail(webpage)
+        watch_info = get_element_by_id('watch-info', webpage) or ''
+
+        title = clean_html(get_element_by_class('video-title', watch_info))
+        season_episode = get_element_by_class(
+            'site-font-secondary-color', get_element_by_class('text', watch_info))
+        episode_number = int_or_none(self._search_regex(
+            r'Episode (\d+)', season_episode or '', 'episode', default=None))
+
+        return {
+            '_type': 'url_transparent',
+            'ie_key': VHXEmbedIE.ie_key(),
+            'url': VHXEmbedIE._smuggle_referrer(embed_url, 'https://watch.2ndtry.tv'),
+            'id': self._search_regex(r'embed\.vhx\.tv/videos/(.+?)\?', embed_url, 'id'),
+            'display_id': display_id,
+            'title': title,
+            'description': self._html_search_meta('description', webpage, fatal=False),
+            'thumbnail': thumbnail.split('?')[0] if thumbnail else None,
+            'series': clean_html(get_element_by_class('series-title', watch_info)),
+            'episode_number': episode_number,
+            'episode': title if episode_number else None,
+            'season_number': int_or_none(self._search_regex(
+                r'Season (\d+),', season_episode or '', 'season', default=None)),
+            'release_date': unified_strdate(self._search_regex(
+                r'data-meta-field-name=["\']release_dates["\'] data-meta-field-value=["\'](.+?)["\']',
+                watch_info, 'release date', default=None)),
+        }
+
+
+class SecondTrySeasonIE(InfoExtractor):
+    _PAGE_SIZE = 24
+    _VALID_URL = r'https?://(?:watch\.)?2ndtry\.tv/(?P<id>[^\/$&?#]+)(?:/?$|/season:(?P<season>[0-9]+)/?$)'
+    _TESTS = [
+        {
+            'url': 'https://watch.2ndtry.tv/trolley-problems/season:1',
+            'note': 'Series season',
+            'playlist_mincount': 6,
+            'info_dict': {
+                'id': 'trolley-problems-season-1',
+                'title': 'Trolley Problems - Season 1',
+            },
+        },
+    ]
+
+    def _fetch_page(self, url, season_id, page):
+        page += 1
+        webpage = self._download_webpage(
+            f'{url}?page={page}', season_id, note=f'Downloading page {page}', expected_status={400})
+        yield from [self.url_result(item_url, SecondTryIE) for item_url in traverse_obj(
+            get_elements_html_by_class('browse-item-link', webpage), (..., {extract_attributes}, 'href'))]
+
+    def _real_extract(self, url):
+        season_id = self._match_id(url)
+        season_num = self._match_valid_url(url).group('season') or 1
+        season_title = season_id.replace('-', ' ').title()
+
+        return self.playlist_result(
+            OnDemandPagedList(functools.partial(self._fetch_page, url, season_id), self._PAGE_SIZE),
+            f'{season_id}-season-{season_num}', f'{season_title} - Season {season_num}')


### PR DESCRIPTION
### Description of your *pull request* and other information

Adds support for [2nd Try TV](https://watch.2ndtry.tv) — a subscriber-based video platform that uses VHX (Vimeo OTT) for embeds.

Two extractors:
- `SecondTryIE` — single videos (handles login flow with authenticity token + subscription check, falls back to existing cookies if available, then delegates playback to `VHXEmbedIE`).
- `SecondTrySeasonIE` — season/series pages, returns a paged playlist of episode URLs.

Fixes #

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))

</details>