### PR TITLE
[ie/laracasts] Fix prop data extraction after page restructure #16654

### DIFF
--- a/yt_dlp/extractor/laracasts.py
+++ b/yt_dlp/extractor/laracasts.py
@@ -1,11 +1,7 @@
-import json
-
 from .common import InfoExtractor
 from .vimeo import VimeoIE
 from ..utils import (
     clean_html,
-    extract_attributes,
-    get_element_html_by_id,
     int_or_none,
     parse_duration,
     str_or_none,
@@ -19,9 +15,10 @@ from ..utils.traversal import traverse_obj
 class LaracastsBaseIE(InfoExtractor):
     def _get_prop_data(self, url, display_id):
         webpage = self._download_webpage(url, display_id)
-        return traverse_obj(
-            get_element_html_by_id('app', webpage),
-            ({extract_attributes}, 'data-page', {json.loads}, 'props'))
+        return self._search_json(
+            r'<script[^>]*\bdata-page="app"[^>]*>',
+            webpage, 'inertia data',
+            display_id, end_pattern=r'</script>').get('props')
 
     def _parse_episode(self, episode):
         if not traverse_obj(episode, 'vimeoId'):


### PR DESCRIPTION
* Bump build 1.4.2 => 1.4.4
* Bump certifi 2026.2.25 => 2026.4.22
* Bump charset-normalizer 3.4.6 => 3.4.7
* Bump cryptography 46.0.6 => 47.0.0
* Bump deno 2.7.8 => 2.7.14
* Bump filelock 3.25.2 => 3.29.0
* Bump identify 2.6.18 => 2.6.19
* Bump idna 3.11 => 3.13
* Bump packaging 26.0 => 26.2
* Bump pathspec 1.0.4 => 1.1.1
* Bump pip 26.0.1 => 26.1
* Bump platformdirs 4.9.4 => 4.9.6
* Bump pre-commit 4.5.1 => 4.6.0
* Bump pygments 2.19.2 => 2.20.0
* Bump pyinstaller 6.19.0 => 6.20.0
* Bump pyinstaller-hooks-contrib 2026.3 => 2026.4
* Bump pyinstaller[win32] 6.19.0 => 6.20.0
* Bump pyinstaller[win_amd64] 6.19.0 => 6.20.0
* Bump pyinstaller[win_arm64] 6.19.0 => 6.20.0
* Bump pytest 9.0.2 => 9.0.3
* Bump python-discovery 1.2.0 => 1.2.2
* Bump requests 2.33.0 => 2.33.1
* Bump rich 14.3.3 => 15.0.0
* Bump ruff 0.15.8 => 0.15.12
* Bump trove-classifiers 2026.1.14.14 => 2026.4.28.13
* Bump uv 0.11.1 => 0.11.8
* Bump virtualenv 21.2.0 => 21.3.0
* Bump zipp 3.23.0 => 3.23.1

Authored by: bashonly

<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information
[ie/laracasts] Fix prop data extraction after page restructure #16654

ADD DETAILED DESCRIPTION HERE
Laracasts now ships its Inertia.js page payload inside a
<script data-page="app" type="application/json">...</script> tag,
instead of as a data-page attribute on a <div id="app">. The previous
helper returns None, causing both LaracastsIE and LaracastsPlaylistIE to
crash with TypeError: 'NoneType' object is not subscriptable.

Fixes #
Used regex to extract the JSON cleanly and parse successfully (_search_json).

class LaracastsBaseIE(InfoExtractor):
def _get_prop_data(self, url, display_id):
webpage = self._download_webpage(url, display_id)
return self._search_json(
r'<script[^>]\bdata-page="app"[^>]>',
webpage, 'inertia data',
display_id, end_pattern=r'</script>').get('props')

TEST
PS C:\Users\ishol\OneDrive\Desktop\CES\yt_dlp> python -m yt_dlp -v "https://laracasts.com/series/laravel-from-scratch-2026/"
[debug] Command-line config: ['-v', 'https://laracasts.com/series/laravel-from-scratch-2026/']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8 
[debug] yt-dlp version stable@2026.03.17 from yt-dlp/yt-dlp [04d6974f5] (source) 
[debug] Lazy loading extractors is disabled 
[debug] Git HEAD: c8695f52a 
[debug] Python 3.14.0 (CPython AMD64 64bit) - Windows-11-10.0.26200-SP0 (OpenSSL 3.0.18 30 Sep 2025) 
[debug] exe versions: none 
[debug] Optional libraries: certifi-2026.04.22, requests-2.33.1, sqlite3-3.50.4, urllib3-2.6.3 
[debug] JS runtimes: none 
[debug] Proxy map: {} 
[debug] Request Handlers: urllib, requests 
[debug] Plugin directories: none 
[debug] Loaded 1864 extractors 
[laracasts:series] Extracting URL: https://laracasts.com/series/laravel-from-scratch-2026/ 
[laracasts:series] laravel-from-scratch-2026: Downloading webpage 
[download] Downloading playlist: Laravel From Scratch (2026 Edition) 
[laracasts:series] Playlist Laravel From Scratch (2026 Edition): Downloading 0 items 
[download] Finished downloading playlist: Laravel From Scratch (2026 Edition)

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x ] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
