### PR TITLE
[murrtube] Fix video ID extraction after May 2026 migration

### DIFF
--- a/yt_dlp/extractor/murrtube.py
+++ b/yt_dlp/extractor/murrtube.py
@@ -74,7 +74,7 @@ class MurrtubeIE(InfoExtractor):
         video_page = self._download_webpage(url, video_id)
         video_attrs = extract_attributes(get_element_html_by_id('video', video_page))
         playlist = update_url(video_attrs['data-url'], query=None)
-        video_id = self._search_regex(r'/([\da-f]+)/index.m3u8', playlist, 'video id')
+        video_id = self._search_regex(r'/([\da-f]+)/index\w*\.m3u8', playlist, 'video id')
 
         return {
             'id': video_id,


### PR DESCRIPTION
Fixes #16676

After Murrtube's May 8 2026 server migration, the m3u8 filename changed from \`index.m3u8\` to \`index_cmaf_cmaf{timestamp}.m3u8\`. The regex \`/([\da-f]+)/index.m3u8\` no longer matches.

Fix: change \`index.m3u8\` to \`index\w*\.m3u8\` to match the new filename format.