### PR TITLE
[tv5unis] Support tv5plus.ca URLs

### DIFF
--- a/yt_dlp/extractor/murrtube.py
+++ b/yt_dlp/extractor/murrtube.py
@@ -74,7 +74,7 @@ class MurrtubeIE(InfoExtractor):
         video_page = self._download_webpage(url, video_id)
         video_attrs = extract_attributes(get_element_html_by_id('video', video_page))
         playlist = update_url(video_attrs['data-url'], query=None)
-        video_id = self._search_regex(r'/([\da-f]+)/index.m3u8', playlist, 'video id')
+        video_id = self._search_regex(r'/([\da-f]+)/index\w*\.m3u8', playlist, 'video id')
 
         return {
             'id': video_id,

--- a/yt_dlp/extractor/tv5unis.py
+++ b/yt_dlp/extractor/tv5unis.py
@@ -90,7 +90,7 @@ class TV5UnisBaseIE(InfoExtractor):
 
 class TV5UnisVideoIE(TV5UnisBaseIE):
     IE_NAME = 'tv5unis:video'
-    _VALID_URL = r'https?://(?:www\.)?tv5unis\.ca/videos/[^/?#]+/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?(?:tv5unis|tv5plus)\.ca/videos/[^/?#]+/(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.tv5unis.ca/videos/bande-annonces/144041',
         'md5': '24a247c96119d77fe1bae8b440457dfa',
@@ -102,6 +102,9 @@ class TV5UnisVideoIE(TV5UnisBaseIE):
             'description': r"re:En aidant son frère .+ dicté par l'amour et la solidarité.",
             'duration': 61,
         },
+    }, {
+        'url': 'https://www.tv5plus.ca/videos/bande-annonces/151265',
+        'only_matching': True,
     }]
     _GQL_QUERY_NAME = 'productById'
 
@@ -112,7 +115,7 @@ class TV5UnisVideoIE(TV5UnisBaseIE):
 
 class TV5UnisIE(TV5UnisBaseIE):
     IE_NAME = 'tv5unis'
-    _VALID_URL = r'https?://(?:www\.)?tv5unis\.ca/videos/(?P<id>[^/?#]+)(?:/saisons/(?P<season_number>\d+)/episodes/(?P<episode_number>\d+))?/?(?:[?#&]|$)'
+    _VALID_URL = r'https?://(?:www\.)?(?:tv5unis|tv5plus)\.ca/videos/(?P<id>[^/?#]+)(?:/saisons/(?P<season_number>\d+)/episodes/(?P<episode_number>\d+))?/?(?:[?#&]|$)'
     _TESTS = [{
         # geo-restricted to Canada; xff is ineffective
         'url': 'https://www.tv5unis.ca/videos/watatatow/saisons/11/episodes/1',
@@ -151,6 +154,9 @@ class TV5UnisIE(TV5UnisBaseIE):
             'duration': 1200,
             'tags': 'count:5',
         },
+    }, {
+        'url': 'https://www.tv5plus.ca/videos/boite-a-savon',
+        'only_matching': True,
     }]
     _GQL_QUERY_NAME = 'productByRootProductSlug'
 


### PR DESCRIPTION
Fixes #16664

tv5unis.ca has rebranded to tv5plus.ca. The frontend now redirects to tv5plus.ca but the backend API (api.tv5unis.ca) is unchanged. Added tv5plus.ca to _VALID_URL in both TV5UnisVideoIE and TV5UnisIE, with only_matching tests for each.