### PR TITLE
Update nuvid extractor: add new URL pattern and acknowledge 80 kb/sec throttling.

### DIFF
--- a/yt_dlp/extractor/nuvid.py
+++ b/yt_dlp/extractor/nuvid.py
@@ -11,7 +11,7 @@ from ..utils import (
 
 
 class NuvidIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www|m)\.nuvid\.com/video/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www|m)\.nuvid\.com/(?:video|embed)/(?P<id>[0-9]+)'
     _TESTS = [{
         'url': 'https://www.nuvid.com/video/6513023/italian-babe',
         'md5': '772d2f8288f3d3c5c45f7a41761c7844',
@@ -46,6 +46,11 @@ class NuvidIE(InfoExtractor):
             'age_limit': 18,
             'thumbnail': r're:https?://.+\.jpg',
         },
+    }, {
+        # /embed/<id> path — same underlying player_config_json API as /video/,
+        # so the existing _real_extract handles it once _VALID_URL accepts it.
+        'url': 'https://www.nuvid.com/embed/3547026',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
@@ -77,6 +82,14 @@ class NuvidIE(InfoExtractor):
             'url': source,
             'format_id': qualities.get(quality),
             'height': int_or_none(qualities.get(quality)[:-1]),
+            # nuvid throttles each signed URL server-side (the `speed=NNk`
+            # query param — typically 50-100 KB/s). On long videos that means
+            # 15-30 minute downloads — use chunked HTTP so a connection blip
+            # mid-download only loses the current 10 MB chunk instead of
+            # restarting from zero.
+            'downloader_options': {
+                'http_chunk_size': 10485760,  # 10 MB
+            },
         } for quality, source in video_data.get('files').items() if source]
 
         self._check_formats(formats, video_id)


### PR DESCRIPTION
### Update nuvid extractor: add new URL pattern and acknowledge 80 kb/sec throttling.

Added new URL pattern used on the site.  Also, restrict chunk size to help with avoiding problems with downloads, given that the site throttles downloads to 80 kb/sec.

Fixes 1


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
There are two PRs currently open that reference "nuvid"; one is very old (from 2021) and the other does not update nuvid.py at all.  And, neither appear to address the two issues that this PR addresses.

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
</details>
