### PR TITLE
[ie/googledrive] Fall back to source download when playback metadata fails

### DIFF
--- a/yt_dlp/extractor/googledrive.py
+++ b/yt_dlp/extractor/googledrive.py
@@ -141,7 +141,7 @@ class GoogleDriveIE(InfoExtractor):
         video_info = self._download_json(
             f'https://content-workspacevideo-pa.googleapis.com/v1/drive/media/{video_id}/playback',
             video_id, 'Downloading video webpage', query={'key': 'AIzaSyDVQw45DwoYh632gvsP5vPDqEKvb-Ywnb8'},
-            headers={'Referer': 'https://drive.google.com/'})
+            headers={'Referer': 'https://drive.google.com/'}, fatal=False) or {}
 
         formats = []
         for fmt in traverse_obj(video_info, (
@@ -230,7 +230,7 @@ class GoogleDriveIE(InfoExtractor):
                 }),
             }),
             'formats': formats,
-            'subtitles': self.extract_subtitles(video_id, video_info),
+            'subtitles': self.extract_subtitles(video_id, video_info) if video_info else {},
         }
 
 


### PR DESCRIPTION
### Description of your pull request and other information

GoogleDrive currently exits before reaching its existing source-file fallback when the playback metadata endpoint returns an HTTP error.

This makes playback metadata non-fatal so files with a working direct source download can still be extracted.

Tested with a Drive file where playback metadata returns HTTP 400 but the direct source download returns a valid attachment.

Commands run:

```shell
python3 -m yt_dlp --ignore-config --dump-single-json --skip-download --no-playlist --ignore-no-formats-error 'https://drive.google.com/file/d/13Ied4_fnmxib2zr_ICxhDGZAp43MtSY1/view?usp=drive_link'
hatch run python -m unittest test.test_download.TestDownload.test_GoogleDrive
hatch fmt --check
```

### Before submitting a pull request make sure you have:

- [x] At least skimmed through contributing guidelines including yt-dlp coding conventions
- [x] Searched the bugtracker for similar pull requests
- [x] Checked the code with ruff and ran relevant tests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under Unlicense. Check those that apply and remove the others:

- [x] I am the original author of the code in this PR, and I am willing to release it under Unlicense

### What is the purpose of your pull request?

- [x] Fix or improvement to an extractor