### PR TITLE
Fix match-filter comparison for float fields like aspect_ratio

### DIFF
--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -3273,11 +3273,14 @@ def _match_one(filter_part, dct, incomplete):
             try:
                 numeric_comparison = int(comparison_value)
             except ValueError:
-                numeric_comparison = parse_filesize(comparison_value)
-                if numeric_comparison is None:
-                    numeric_comparison = parse_filesize(f'{comparison_value}B')
-                if numeric_comparison is None:
-                    numeric_comparison = parse_duration(comparison_value)
+                try:
+                    numeric_comparison = float(comparison_value)
+                except ValueError:
+                    numeric_comparison = parse_filesize(comparison_value)
+                    if numeric_comparison is None:
+                        numeric_comparison = parse_filesize(f'{comparison_value}B')
+                    if numeric_comparison is None:
+                        numeric_comparison = parse_duration(comparison_value)
         if numeric_comparison is not None and m['op'] in STRING_OPERATORS:
             raise ValueError('Operator {} only supports string values!'.format(m['op']))
         if actual_value is None:


### PR DESCRIPTION
## Description

Fixes #16329

When using `--match-filter` with a float field like `aspect_ratio`, the filter never matches. For example, `--match-filter aspect_ratio=1.78` always skips all videos even when the aspect ratio is exactly 1.78.

## Root Cause

In `_match_one()` in `yt_dlp/utils/_utils.py`, when the actual field value is numeric (int or float), the comparison value string is parsed. The code only attempted `int(comparison_value)` -- which raises ValueError for float strings like 1.78. After the ValueError, it fell through to `parse_filesize()` and `parse_duration()`, neither of which handle plain float strings, resulting in `numeric_comparison = None`. This caused the comparison to be done as string comparison, where `1.78 == 1.78` is always False.

## Fix

Added a `float()` fallback after `int()` fails, so float field values (like `aspect_ratio`, `fps`, `tbr`, `abr`, `vbr`, etc.) are properly compared numerically.

Before:
```python
try:
    numeric_comparison = int(comparison_value)
except ValueError:
    numeric_comparison = parse_filesize(comparison_value)
    if numeric_comparison is None:
        numeric_comparison = parse_filesize(f'{comparison_value}B')
    if numeric_comparison is None:
        numeric_comparison = parse_duration(comparison_value)
```

After:
```python
try:
    numeric_comparison = int(comparison_value)
except ValueError:
    try:
        numeric_comparison = float(comparison_value)
    except ValueError:
        numeric_comparison = parse_filesize(comparison_value)
        if numeric_comparison is None:
            numeric_comparison = parse_filesize(f'{comparison_value}B')
        if numeric_comparison is None:
            numeric_comparison = parse_duration(comparison_value)
```

## Testing

- All existing `test_match_filter` tests pass
- This follows the same pattern as the format filter fix in #10115