### PR TITLE
[build] Upgrade all Linux binaries to Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
         id: linux_matrix
         env:
           INPUTS: ${{ toJSON(inputs) }}
-          PYTHON_VERSION: '3.13'
+          PYTHON_VERSION: '3.14'
           UPDATE_TO: yt-dlp/yt-dlp@2025.09.05
         shell: python
         run: |
@@ -152,12 +152,10 @@ jobs:
                   'os': 'musllinux',
                   'arch': 'x86_64',
                   'runner': 'ubuntu-24.04',
-                  'python_version': '3.14',
               }, {
                   'os': 'musllinux',
                   'arch': 'aarch64',
                   'runner': 'ubuntu-24.04-arm',
-                  'python_version': '3.14',
               }],
           }
           INPUTS = json.loads(os.environ['INPUTS'])

--- a/bundle/docker/linux/build.sh
+++ b/bundle/docker/linux/build.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 if [[ -z "${PYTHON_VERSION:-}" ]]; then
-    PYTHON_VERSION="3.13"
+    PYTHON_VERSION="3.14"
     echo "Defaulting to using Python ${PYTHON_VERSION}"
 fi
 


### PR DESCRIPTION
Per https://www.python.org/downloads/release/python-3145/ :

> Notably, the garbage collector (GC) has changed in Python 3.14.5.
> 
> The incremental garbage collector shipped in Python 3.14.0-3.14.4 has been reverted back to the generational garbage collector from 3.13, due to a number of [reports](https://github.com/python/cpython/issues/142516) of significant memory pressure in production environments.

The above-referenced GC issue is why I had been hesitant to move most of our binaries to Python 3.14.x. Now that the problem has been solved (by reverting to the generational GC), I feel confident in bumping all of the `_linux*` binaries.

Ref:

- https://github.com/yt-dlp/manylinux-shared/commit/a42da7942908877b8ca7579c020e6d6aba7d18c6


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Build maintenance

</details>
