### PR TITLE
[ie/vk] Fix subtitle extraction when lang/title are null

### DIFF
--- a/yt_dlp/extractor/vk.py
+++ b/yt_dlp/extractor/vk.py
@@ -556,8 +556,8 @@ class VKIE(VKBaseIE):
                 })
 
         for sub in data.get('subs') or {}:
-            subtitles.setdefault(sub.get('lang', 'en'), []).append({
-                'ext': sub.get('title', '.srt').split('.')[-1],
+            subtitles.setdefault(sub.get('lang') or 'en', []).append({
+                'ext': (sub.get('title') or '.srt').split('.')[-1],
                 'url': url_or_none(sub.get('url')),
             })
 


### PR DESCRIPTION
### Description of your *pull request* and other information

The VK extractor crashes with `AttributeError: 'NoneType' object has no attribute 'split'` (and a follow-up `'startswith'` error in `process_subtitles`) when the API returns subtitle entries where `lang` or `title` are `null` rather than missing.

`dict.get(key, default)` only returns `default` when the key is absent, not when its value is `None`. The two affected calls now use `dict.get(key) or default` so the fallback applies in both cases.

Reproducer:

```
yt-dlp --write-subs --sub-langs all https://vk.com/video786295811_456239219
```

Traceback before fix:

```
File ".../yt_dlp/extractor/vk.py", line 560, in _real_extract
'ext': sub.get('title', '.srt').split('.')[-1],
AttributeError: 'NoneType' object has no attribute 'split'
```

No new test added: reproducing the null-field condition requires a specific live VK URL, and there's no guarantee any given video will keep returning null fields over time.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
