### PR TITLE
[ie/toutiao] Support DASH video and audio formats

### DIFF
--- a/yt_dlp/extractor/toutiao.py
+++ b/yt_dlp/extractor/toutiao.py
@@ -49,6 +49,22 @@ class ToutiaoIE(InfoExtractor):
             'uploader_id': 'MS4wLjABAAAA4f7d4mwtApALtHIiq-QM20dwXqe32NUz0DeWF7wbHKw',
             'view_count': int,
         },
+    }, {
+        'url': 'https://www.toutiao.com/video/6863662555659764228/',
+        'info_dict': {
+            'id': '6863662555659764228',
+            'ext': 'mp4',
+            'title': '机器学习，梯度下降算法，问题引入',
+            'comment_count': int,
+            'duration': 512.132,
+            'like_count': int,
+            'release_date': '20200822',
+            'release_timestamp': 1598070970,
+            'thumbnail': r're:https?://p\d+-sign\.toutiaoimg\.com/.+$',
+            'uploader': '动画讲编程',
+            'uploader_id': 'MS4wLjABAAAAUbAv6lV7flBtQQ985gWufzkO45WqoJdVL6KGJi--Mtg',
+            'view_count': int,
+        },
     }]
 
     def _real_initialize(self):
@@ -83,24 +99,46 @@ class ToutiaoIE(InfoExtractor):
         ))
 
         formats = []
-        for video in traverse_obj(video_data, (
-            'videoPlayInfo', 'video_list', lambda _, v: v['main_url'],
+        for path, override in (
+            (('video_list',), {}),
+            (('dynamic_video', 'dynamic_video_list'), {'acodec': 'none', 'ext': 'mp4'}),
+        ):
+            for video in traverse_obj(video_data, (
+                'videoPlayInfo', *path, lambda _, v: v['main_url'],
+            )):
+                formats.append({
+                    'url': video['main_url'],
+                    **traverse_obj(video, ('video_meta', {
+                        'acodec': ('audio_profile', {str}),
+                        'asr': ('audio_sample_rate', {int_or_none}),
+                        'audio_channels': ('audio_channels', {float_or_none}, {int_or_none}),
+                        'ext': ('vtype', {str}),
+                        'filesize': ('size', {int_or_none}),
+                        'format_id': ('definition', {str}),
+                        'fps': ('fps', {int_or_none}),
+                        'height': ('vheight', {int_or_none}),
+                        'tbr': ('real_bitrate', {float_or_none(scale=1000)}),
+                        'vcodec': ('codec_type', {str}),
+                        'width': ('vwidth', {int_or_none}),
+                    })),
+                    **override,
+                })
+
+        for audio in traverse_obj(video_data, (
+            'videoPlayInfo', 'dynamic_video', 'dynamic_audio_list',
+            lambda _, v: v['main_url'],
         )):
             formats.append({
-                'url': video['main_url'],
-                **traverse_obj(video, ('video_meta', {
-                    'acodec': ('audio_profile', {str}),
+                'url': audio['main_url'],
+                **traverse_obj(audio, ('audio_meta', {
+                    'abr': ('bitrate', {float_or_none(scale=1000)}),
                     'asr': ('audio_sample_rate', {int_or_none}),
-                    'audio_channels': ('audio_channels', {float_or_none}, {int_or_none}),
-                    'ext': ('vtype', {str}),
                     'filesize': ('size', {int_or_none}),
-                    'format_id': ('definition', {str}),
-                    'fps': ('fps', {int_or_none}),
-                    'height': ('vheight', {int_or_none}),
-                    'tbr': ('real_bitrate', {float_or_none(scale=1000)}),
-                    'vcodec': ('codec_type', {str}),
-                    'width': ('vwidth', {int_or_none}),
+                    'format_id': ('quality', {str}),
                 })),
+                'vcodec': 'none',
+                'ext': 'm4a',
+                'acodec': 'aac',  # 'codec_type' from JSON is h264, which is wrong
             })
 
         return {


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR adds DASH extraction support for toutiao extractor.

Previously, toutiao extractor only parsed and returned direct link for `.mp4` URLs, which is used for short-videos. For long videos, toutiao only provides DASH stream, by extracting DASH manifest, `yt-dlp` is able to download long video on toutiao properly.

**Key Changes**
 - Extract `dynamic_video` from manifest for DASH stream while keeping `video_list` for legacy videos
 - Update test cases in `extractor/toutiao.py`

**Example Output**

```
python3 -m yt_dlp -F https://www.toutiao.com/video/6863662555659764228/
[toutiao] Fetching ttwid
[toutiao] Extracting URL: https://www.toutiao.com/video/6863662555659764228/
[toutiao] 6863662555659764228: Downloading webpage
[info] Available formats for 6863662555659764228:
ID     EXT RESOLUTION FPS │  FILESIZE  TBR PROTO │ VCODEC      VBR ACODEC     ABR ASR
─────────────────────────────────────────────────────────────────────────────────────
normal m4a audio only     │ ≈ 4.06MiB  67k https │ audio only      aac        67k 44k
360p   mp4 640x360     25 │   8.56MiB 140k https │ h264       140k video only
480p   mp4 854x480     25 │  11.06MiB 181k https │ h264       181k video only
720p   mp4 1280x720    25 │  23.16MiB 379k https │ h264       379k video only
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
