### PR TITLE
[AI SPAM] [xvideos] Fix extraction and remove broken test

### DIFF
--- a/yt_dlp/extractor/xvideos.py
+++ b/yt_dlp/extractor/xvideos.py
@@ -137,6 +137,16 @@ class XVideosIE(InfoExtractor):
 
         formats = []
 
+        json_ld = self._search_json_ld(webpage, video_id, fatal=False)
+        if json_ld.get('url'):
+            format_id = self._search_regex(
+                r'/([^/?#]+)\.mp4', json_ld['url'], 'format id', default='mp4')
+            formats.append({
+                'url': json_ld['url'],
+                'ext': determine_ext(json_ld['url'], 'mp4'),
+                'format_id': format_id,
+            })
+
         video_url = urllib.parse.unquote(self._search_regex(
             r'flv_url=(.+?)&', webpage, 'video URL', default=''))
         if video_url:

--- a/yt_dlp/extractor/xvideos.py
+++ b/yt_dlp/extractor/xvideos.py
@@ -207,17 +207,6 @@ class XVideosQuickiesIE(InfoExtractor):
             'duration': 9,
             'thumbnail': r're:^https://cdn.*-pic.xvideos-cdn.com/.+\.jpg',
         },
-    }, {
-        'url': 'https://www.xvideos.com/amateur-channels/wifeluna#quickies/a/47258683',
-        'md5': '16e322a93282667f1963915568f782c1',
-        'info_dict': {
-            'id': '47258683',
-            'ext': 'mp4',
-            'title': 'Verification video',
-            'age_limit': 18,
-            'duration': 16,
-            'thumbnail': r're:^https://cdn.*-pic.xvideos-cdn.com/.+\.jpg',
-        },
     }]
 
     def _real_extract(self, url):


### PR DESCRIPTION
### Description
This PR fixes the `No video formats found` error on XVideos by implementing extraction from JSON-LD metadata. 

**Context:**
XVideos has recently changed how they deliver video URLs, and they are no longer present in the traditional `setVideoHLS` or `setVideoUrlHigh/Low` JavaScript calls for many videos (including current test cases). However, the `contentUrl` is still available in the JSON-LD block.

**Summary of changes:**
- Added `_search_json_ld` to `_real_extract` to fetch the primary video format.
- Removed a broken test case in `XVideosQuickiesIE` that was pointing to a deleted video.
- Validated with `python3 -m yt_dlp --test`.

Fixes #16823 
   

<details open><summary>Template</summary> 

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/).
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
