### PR TITLE
[ie/genericembeds] Fix duplicate downloads in Erome

### DIFF
--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -258,6 +258,18 @@ class GenericIE(InfoExtractor):
         },
         'playlist_count': 2,
     }, {
+        # Duplicate HTML5 videos
+        'url': 'https://www.erome.com/a/XxDBEBL0',
+        'info_dict': {
+            'id': 'XxDBEBL0',
+            'title': 'emo girl dancing teaser',
+            'ext': 'mp4',
+            'age_limit': 18,
+            'thumbnail': 'https://s16.erome.com/8022/XxDBEBL0/ECWftvK8.jpg',
+            'description': 'Visit the page to see this album : emo girl dancing teaser',
+            '_old_archive_ids': ['XxDBEBL0'],
+        },
+    }, {
         # Cinerama Player
         # https://github.com/ytdl-org/youtube-dl/commit/501f13fbf3d1f7225f91e3e0ad008df2cd3219f1
         'url': 'https://www.abc.net.au/res/libraries/cinerama2/examples/single_clip.htm',

--- a/yt_dlp/extractor/genericembeds.py
+++ b/yt_dlp/extractor/genericembeds.py
@@ -2,7 +2,7 @@ import re
 import urllib.parse
 
 from .common import InfoExtractor
-from ..utils import make_archive_id, unescapeHTML
+from ..utils import make_archive_id, orderedSet, unescapeHTML
 
 
 class HTML5MediaEmbedIE(InfoExtractor):
@@ -21,16 +21,27 @@ class HTML5MediaEmbedIE(InfoExtractor):
 
     def _extract_from_webpage(self, url, webpage):
         video_id, title = self._generic_id(url), self._generic_title(url, webpage)
-        entries = self._parse_html5_media_entries(url, webpage, video_id, m3u8_id='hls') or []
-        for num, entry in enumerate(entries, start=1):
+        entries = orderedSet(self._parse_html5_media_entries(url, webpage, video_id, m3u8_id='hls')) or []
+        if len(entries) == 1:
+            entry = entries[0]
             entry.update({
-                'id': f'{video_id}-{num}',
-                'title': f'{title} ({num})',
+                'id': video_id,
+                'title': title,
                 '_old_archive_ids': [
-                    make_archive_id('generic', f'{video_id}-{num}' if len(entries) > 1 else video_id),
+                    video_id,
                 ],
             })
             yield entry
+        else:
+            for num, entry in enumerate(entries, start=1):
+                entry.update({
+                    'id': f'{video_id}-{num}',
+                    'title': f'{title} ({num})',
+                    '_old_archive_ids': [
+                        make_archive_id('generic', f'{video_id}-{num}'),
+                    ],
+                })
+                yield entry
 
 
 class QuotedHTMLIE(InfoExtractor):


### PR DESCRIPTION
### Description of your *pull request* and other information

This fixes a bug with Erome and potentially other websites that use the same `HTML5MediaEmbedIE` extractor.

As discussed in #256, the problem is that each video appears twice in the embedded HTML. So, if there's 3 videos in a page, `yt-dlp` will save 6 videos in total (2 copies for each video).

In that thread it was claimed that this is the expected behaviour. However, I noticed that the video URL is literally identical in both HTML elements, therefore we're making the exact same request twice in a row for each video.

I also noticed that in other extractors we already use the `orderedSet` utility to solve this very issue, so I believe that it makes sense to do the same in the `HTML5MediaEmbedIE` where it's missing.

Despite being a change in a generic extractor, I believe that this should not introduce any regression because it only merges entries that are completely identical.

I also changed the title generation to only include the number suffix if there's more than 1 file, which is also consistent with how the other extractors behave.

I hope that my PR is complete but if not, I'm open to any feedback.

Fixes #256


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
