### PR TITLE
[ie/audius] Fix extractor

### DIFF
--- a/yt_dlp/extractor/audius.py
+++ b/yt_dlp/extractor/audius.py
@@ -104,7 +104,29 @@ class AudiusIE(AudiusBaseIE):
                 'duration': 318,
                 'track': 'RADAR',
                 'artist': 'voltra',
+                'artists': ['voltra'],
                 'genre': 'Trance',
+                'genres': ['Trance'],
+                'thumbnail': r're:https?://.*\.jpg',
+                'view_count': int,
+                'like_count': int,
+                'repost_count': int,
+            },
+        },
+        {
+            # `artwork` dict contains a non-string `mirrors` list; see
+            # https://github.com/yt-dlp/yt-dlp/issues/16854
+            'url': 'https://audius.co/middled/desert-sand-323283',
+            'info_dict': {
+                'id': 'ogxJd',
+                'title': 'Desert Sand',
+                'ext': 'mp3',
+                'duration': 309,
+                'track': 'Desert Sand',
+                'artist': 'Middle-D',
+                'artists': ['Middle-D'],
+                'genre': 'Trance',
+                'genres': ['Trance'],
                 'thumbnail': r're:https?://.*\.jpg',
                 'view_count': int,
                 'like_count': int,
@@ -143,6 +165,10 @@ class AudiusIE(AudiusBaseIE):
         thumbnails = []
         if isinstance(artworks_data, dict):
             for quality_key, thumbnail_url in artworks_data.items():
+                if not isinstance(thumbnail_url, str):
+                    # The `artwork` dict may contain non-URL entries, e.g.
+                    # `mirrors` which is a list of content-node hosts
+                    continue
                 thumbnail = {
                     'url': thumbnail_url,
                 }


### PR DESCRIPTION
### Description of your *pull request* and other information

Fixes the Audius extractor, which currently crashes on **every** track with:

```
ERROR: 'list' object has no attribute 'startswith'
```

The discovery-node API now includes a `mirrors` key inside the track's `artwork` object, whose value is a **list** of content-node hosts rather than an image URL:

```json
"artwork": {
  "150x150":   "https://.../150x150.jpg",
  "480x480":   "https://.../480x480.jpg",
  "1000x1000": "https://.../1000x1000.jpg",
  "mirrors": ["https://creatornode2.audius.co", "https://audius-creator-17.theblueprint.xyz", "..."]
}
```

The thumbnail loop in `AudiusBaseIE._real_extract` iterated every key/value pair and assumed each value was a string URL, so the `mirrors` list propagated into a thumbnail `url` and later crashed in `YoutubeDL._sanitize_thumbnails` → `sanitize_url()`. This skips non-string values, consistent with the `isinstance` guards already used elsewhere in this file.

**Tests:**
- Added a regression test (`AudiusIE`) for `https://audius.co/middled/desert-sand-323283`, whose `artwork` contains the `mirrors` list. `python -m pytest test/test_download.py -k Audius_2` passes.
- The existing `radar` test now also declares the `artists`/`genres` fields the extractor emits — without the crash fix it never reached that assertion. It passes again (`-k Audius_1`).
- Note: the unrelated `test_acc` test track (`tеееest-1…`) now returns **HTTP 404** (deleted upstream), a pre-existing failure independent of this change — left untouched here.

`ruff check yt_dlp/extractor/audius.py` passes.

Fixes #16854

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](https://unlicense.org/). Check those that apply and remove the others:
- [x] I am the author of all changes in this pull request and I am willing to release these changes under [Unlicense](https://unlicense.org/)
- [x] I have read the [development and maintenance guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
