### PR TITLE
fix: use www.bilibili.com as Referer instead of raw URL

### DIFF
--- a/yt_dlp/extractor/bilibili.py
+++ b/yt_dlp/extractor/bilibili.py
@@ -748,7 +748,7 @@ class BiliBiliIE(BilibiliBaseIE):
             'id': f'{video_id}{format_field(part_id, None, "_p%d")}',
             '_old_archive_ids': [make_archive_id(self, old_video_id)] if old_video_id else None,
             'title': title,
-            'http_headers': {'Referer': url},
+            'http_headers': self._HEADERS,
         }
 
         is_interactive = traverse_obj(video_data, ('rights', 'is_stein_gate'))


### PR DESCRIPTION
Fixes https://github.com/yt-dlp/yt-dlp/issues/16597

**What was wrong:**
When using Bilibili URLs that don't start with `www.` (e.g., `https://bilibili.com/video/...`) together with `--write-info-json` or `--write-subs`, the request fails with HTTP 403. The root cause is that the code used the input URL as the Referer header, but Bilibili's API requires the Referer to always be `https://www.bilibili.com`.

**How I fixed it:**
Changed line 751 in `yt_dlp/extractor/bilibili.py` from:
```python
'http_headers': {'Referer': url},
```
to:
```python
'http_headers': self._HEADERS,
```

This ensures the correct Referer header (`https://www.bilibili.com`) is used regardless of whether the user provided a URL with or without `www.`.