### PR TITLE
[pp/exec] Restrict `--exec` template usage to safe conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2338,7 +2338,6 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * The sub-modules `swfinterp`, `casefold` are removed.
 * Passing `--simulate` (or calling `extract_info` with `download=False`) no longer alters the default format selection. See [#9843](https://github.com/yt-dlp/yt-dlp/issues/9843) for details.
 * yt-dlp no longer applies the server modified time to downloaded files by default. Use `--mtime` or `--compat-options mtime-by-default` to revert this.
-* The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opt allow-unsafe-exec-expansion` to revert this restriction
 
 For convenience, there are some compat option aliases available to use:
 
@@ -2360,6 +2359,11 @@ The following compat options restore vulnerable behavior from before security pa
     > :warning: Only use if a valid file download is rejected because its extension is detected as uncommon
     >
     > **This option can enable remote code execution! Consider [opening an issue](<https://github.com/yt-dlp/yt-dlp/issues/new/choose>) instead!**
+
+* `--compat-options allow-unsafe-exec-expansion`: The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. This option reverts this restriction
+
+    > :warning: **This option can enable remote code execution! Consider using `%()q` conversions in your exec command templates for any string values**
+
 
 ### Deprecated options
 

--- a/README.md
+++ b/README.md
@@ -2338,18 +2338,18 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * The sub-modules `swfinterp`, `casefold` are removed.
 * Passing `--simulate` (or calling `extract_info` with `download=False`) no longer alters the default format selection. See [#9843](https://github.com/yt-dlp/yt-dlp/issues/9843) for details.
 * yt-dlp no longer applies the server modified time to downloaded files by default. Use `--mtime` or `--compat-options mtime-by-default` to revert this.
-* The `--exec` option allows output template syntax to be used in its commands, but for security reasons the conversions that can be used are restricted to `d` (digit) and `q` (shell-quote). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-commands` to revert this restriction
+* The `--exec` option allows output template syntax to be used in its commands, but for security reasons the conversions that can be used are restricted to `d` (digit) and `q` (shell-quote). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-expansion` to revert this restriction
 
 For convenience, there are some compat option aliases available to use:
 
 * `--compat-options all`: Use all compat options (**Do NOT use this!**)
-* `--compat-options youtube-dl`: Same as `--compat-options all,-multistreams,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort,-allow-unsafe-exec-commands`
-* `--compat-options youtube-dlc`: Same as `--compat-options all,-no-live-chat,-no-youtube-channel-redirect,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort,-allow-unsafe-exec-commands`
+* `--compat-options youtube-dl`: Same as `--compat-options all,-multistreams,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort,-allow-unsafe-exec-expansion`
+* `--compat-options youtube-dlc`: Same as `--compat-options all,-no-live-chat,-no-youtube-channel-redirect,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort,-allow-unsafe-exec-expansion`
 * `--compat-options 2021`: Same as `--compat-options 2022,no-certifi,filename-sanitization`
 * `--compat-options 2022`: Same as `--compat-options 2023,playlist-match-filter,no-external-downloader-progress,prefer-legacy-http-handler,manifest-filesize-approx`
 * `--compat-options 2023`: Same as `--compat-options 2024,prefer-vp9-sort`
 * `--compat-options 2024`: Same as `--compat-options 2025,mtime-by-default`
-* `--compat-options 2025`: Same as `--compat-options allow-unsafe-exec-commands`
+* `--compat-options 2025`: Currently does nothing. Use this to enable all future compat options
 
 Using one of the yearly compat option aliases will pin yt-dlp's default behavior to what it was at the *end* of that calendar year.
 

--- a/README.md
+++ b/README.md
@@ -2332,23 +2332,24 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * `certifi` will be used for SSL root certificates, if installed. If you want to use system certificates (e.g. self-signed), use `--compat-options no-certifi`
 * yt-dlp's sanitization of invalid characters in filenames is different/smarter than in youtube-dl. You can use `--compat-options filename-sanitization` to revert to youtube-dl's behavior
 * ~~yt-dlp tries to parse the external downloader outputs into the standard progress output if possible (Currently implemented: [aria2c](https://github.com/yt-dlp/yt-dlp/issues/5931)). You can use `--compat-options no-external-downloader-progress` to get the downloader output as-is~~
-* yt-dlp versions between 2021.09.01 and 2023.01.02 applies `--match-filters` to nested playlists. This was an unintentional side-effect of [8f18ac](https://github.com/yt-dlp/yt-dlp/commit/8f18aca8717bb0dd49054555af8d386e5eda3a88) and is fixed in [d7b460](https://github.com/yt-dlp/yt-dlp/commit/d7b460d0e5fc710950582baed2e3fc616ed98a80). Use `--compat-options playlist-match-filter` to revert this
-* yt-dlp versions between 2021.11.10 and 2023.06.21 estimated `filesize_approx` values for fragmented/manifest formats. This was added for convenience in [f2fe69](https://github.com/yt-dlp/yt-dlp/commit/f2fe69c7b0d208bdb1f6292b4ae92bc1e1a7444a), but was reverted in [0dff8e](https://github.com/yt-dlp/yt-dlp/commit/0dff8e4d1e6e9fb938f4256ea9af7d81f42fd54f) due to the potentially extreme inaccuracy of the estimated values. Use `--compat-options manifest-filesize-approx` to keep extracting the estimated values
+* yt-dlp versions from 2021.09.01 to 2022.11.11 (inclusive) applied `--match-filters` to nested playlists. This was an unintentional side-effect of [8f18ac](https://github.com/yt-dlp/yt-dlp/commit/8f18aca8717bb0dd49054555af8d386e5eda3a88) and is fixed in [d7b460](https://github.com/yt-dlp/yt-dlp/commit/d7b460d0e5fc710950582baed2e3fc616ed98a80). Use `--compat-options playlist-match-filter` to revert this
+* yt-dlp versions from 2021.11.10 to 2023.06.21 (inclusive) estimated `filesize_approx` values for fragmented/manifest formats. This was added for convenience in [f2fe69](https://github.com/yt-dlp/yt-dlp/commit/f2fe69c7b0d208bdb1f6292b4ae92bc1e1a7444a), but was reverted in [0dff8e](https://github.com/yt-dlp/yt-dlp/commit/0dff8e4d1e6e9fb938f4256ea9af7d81f42fd54f) due to the potentially extreme inaccuracy of the estimated values. Use `--compat-options manifest-filesize-approx` to keep extracting the estimated values
 * yt-dlp uses modern http client backends such as `requests`. Use `--compat-options prefer-legacy-http-handler` to prefer the legacy http handler (`urllib`) to be used for standard http requests.
 * The sub-modules `swfinterp`, `casefold` are removed.
 * Passing `--simulate` (or calling `extract_info` with `download=False`) no longer alters the default format selection. See [#9843](https://github.com/yt-dlp/yt-dlp/issues/9843) for details.
 * yt-dlp no longer applies the server modified time to downloaded files by default. Use `--mtime` or `--compat-options mtime-by-default` to revert this.
+* The `--exec` option allows output template syntax to be used in its commands, but for security reasons the conversions that can be used are restricted to `d` (digit) and `q` (shell-quote). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-commands` to revert this
 
 For convenience, there are some compat option aliases available to use:
 
 * `--compat-options all`: Use all compat options (**Do NOT use this!**)
-* `--compat-options youtube-dl`: Same as `--compat-options all,-multistreams,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort`
-* `--compat-options youtube-dlc`: Same as `--compat-options all,-no-live-chat,-no-youtube-channel-redirect,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort`
+* `--compat-options youtube-dl`: Same as `--compat-options all,-multistreams,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort,-allow-unsafe-exec-commands`
+* `--compat-options youtube-dlc`: Same as `--compat-options all,-no-live-chat,-no-youtube-channel-redirect,-playlist-match-filter,-manifest-filesize-approx,-allow-unsafe-ext,-prefer-vp9-sort,-allow-unsafe-exec-commands`
 * `--compat-options 2021`: Same as `--compat-options 2022,no-certifi,filename-sanitization`
 * `--compat-options 2022`: Same as `--compat-options 2023,playlist-match-filter,no-external-downloader-progress,prefer-legacy-http-handler,manifest-filesize-approx`
 * `--compat-options 2023`: Same as `--compat-options 2024,prefer-vp9-sort`
 * `--compat-options 2024`: Same as `--compat-options 2025,mtime-by-default`
-* `--compat-options 2025`: Currently does nothing. Use this to enable all future compat options
+* `--compat-options 2025`: Same as `--compat-options allow-unsafe-exec-commands`
 
 Using one of the yearly compat option aliases will pin yt-dlp's default behavior to what it was at the *end* of that calendar year.
 

--- a/README.md
+++ b/README.md
@@ -2338,7 +2338,7 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * The sub-modules `swfinterp`, `casefold` are removed.
 * Passing `--simulate` (or calling `extract_info` with `download=False`) no longer alters the default format selection. See [#9843](https://github.com/yt-dlp/yt-dlp/issues/9843) for details.
 * yt-dlp no longer applies the server modified time to downloaded files by default. Use `--mtime` or `--compat-options mtime-by-default` to revert this.
-* The `--exec` option allows output template syntax to be used in its commands, but for security reasons the conversions that can be used are restricted to `d` (digit) and `q` (shell-quote). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-commands` to revert this
+* The `--exec` option allows output template syntax to be used in its commands, but for security reasons the conversions that can be used are restricted to `d` (digit) and `q` (shell-quote). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-commands` to revert this restriction
 
 For convenience, there are some compat option aliases available to use:
 

--- a/README.md
+++ b/README.md
@@ -2338,7 +2338,7 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * The sub-modules `swfinterp`, `casefold` are removed.
 * Passing `--simulate` (or calling `extract_info` with `download=False`) no longer alters the default format selection. See [#9843](https://github.com/yt-dlp/yt-dlp/issues/9843) for details.
 * yt-dlp no longer applies the server modified time to downloaded files by default. Use `--mtime` or `--compat-options mtime-by-default` to revert this.
-* The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-expansion` to revert this restriction
+* The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opt allow-unsafe-exec-expansion` to revert this restriction
 
 For convenience, there are some compat option aliases available to use:
 

--- a/README.md
+++ b/README.md
@@ -2362,7 +2362,7 @@ The following compat options restore vulnerable behavior from before security pa
 
 * `--compat-options allow-unsafe-exec-expansion`: The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. This option reverts this restriction
 
-    > :warning: **This option can enable remote code execution! Consider using `%()q` conversions in your exec command templates for any string values**
+    > :warning: **This option can enable remote code execution!** Consider using `%()q` conversions in your exec command templates for any string values.
 
 
 ### Deprecated options

--- a/README.md
+++ b/README.md
@@ -2338,7 +2338,7 @@ Some of yt-dlp's default options are different from that of youtube-dl and youtu
 * The sub-modules `swfinterp`, `casefold` are removed.
 * Passing `--simulate` (or calling `extract_info` with `download=False`) no longer alters the default format selection. See [#9843](https://github.com/yt-dlp/yt-dlp/issues/9843) for details.
 * yt-dlp no longer applies the server modified time to downloaded files by default. Use `--mtime` or `--compat-options mtime-by-default` to revert this.
-* The `--exec` option allows output template syntax to be used in its commands, but for security reasons the conversions that can be used are restricted to `d` (digit) and `q` (shell-quote). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-expansion` to revert this restriction
+* The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. Use `--compat-opts allow-unsafe-exec-expansion` to revert this restriction
 
 For convenience, there are some compat option aliases available to use:
 

--- a/README.md
+++ b/README.md
@@ -2358,7 +2358,7 @@ The following compat options restore vulnerable behavior from before security pa
 
     > :warning: Only use if a valid file download is rejected because its extension is detected as uncommon
     >
-    > **This option can enable remote code execution! Consider [opening an issue](<https://github.com/yt-dlp/yt-dlp/issues/new/choose>) instead!**
+    > **This option can enable remote code execution!** Consider [opening an issue](<https://github.com/yt-dlp/yt-dlp/issues/new/choose>) instead!
 
 * `--compat-options allow-unsafe-exec-expansion`: The `--exec` option allows output template syntax to be used in its commands; however, for security reasons the conversions that can be used are restricted to `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). yt-dlp versions from 2021.04.11 to 2026.03.17 (inclusive) did not apply this restriction. This option reverts this restriction
 

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -876,7 +876,7 @@ class TestYoutubeDL(unittest.TestCase):
                     'key': 'Exec',
                     'exec_cmd': [exec_cmd],
                     'when': 'after_move',
-                }] if exec_cmd else [],
+                }],
                 **(params or {}),
             })
 
@@ -895,7 +895,6 @@ class TestYoutubeDL(unittest.TestCase):
         self.assertIsInstance(test('echo {}', {'outtmpl_na_placeholder': ';'}), YoutubeDL)
         self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
         self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
-        self.assertIsInstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL)
 
     def test_postprocessors(self):
         filename = 'post-processor-testfile.mp4'

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -891,9 +891,9 @@ class TestYoutubeDL(unittest.TestCase):
             UnsafeExecExpansionError, r'Unsafe placeholder',
             test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
 
-        self.assertTrue(isinstance(test('echo %(title)q'), YoutubeDL))
-        self.assertTrue(isinstance(test('echo %(view_count).02d'), YoutubeDL))
-        self.assertTrue(isinstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL))
+        self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
+        self.assertIsInstance(test('echo %(view_count).02d'), YoutubeDL)
+        self.assertIsInstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL)
 
     def test_postprocessors(self):
         filename = 'post-processor-testfile.mp4'

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -892,7 +892,7 @@ class TestYoutubeDL(unittest.TestCase):
             test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
 
         self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
-        self.assertIsInstance(test('echo %(view_count).02d'), YoutubeDL)
+        self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
         self.assertIsInstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL)
 
     def test_postprocessors(self):

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -6,10 +6,10 @@ import sys
 import unittest
 from unittest.mock import patch
 
+from yt_dlp.globals import all_plugins_loaded
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
-from yt_dlp.globals import all_plugins_loaded
 
 import contextlib
 import copy

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -894,7 +894,11 @@ class TestYoutubeDL(unittest.TestCase):
         self.assertIsInstance(test('echo'), YoutubeDL)
         self.assertIsInstance(test('echo {}', {'outtmpl_na_placeholder': ';'}), YoutubeDL)
         self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
+        self.assertIsInstance(test('echo %(title)#q'), YoutubeDL)
+        self.assertIsInstance(test('echo %(view_count)i'), YoutubeDL)
         self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
+        self.assertIsInstance(test('echo %(aspect_ratio)f'), YoutubeDL)
+        self.assertIsInstance(test('echo %(aspect_ratio).2f'), YoutubeDL)
         self.assertIsInstance(
             test('echo "%(title)s"', {'compat_opts': {'allow-unsafe-exec-expansion'}}),
             YoutubeDL)

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -23,7 +23,6 @@ from yt_dlp.utils import (
     ExtractorError,
     LazyList,
     OnDemandPagedList,
-    UnsafeExecExpansionError,
     int_or_none,
     match_filter_func,
 )
@@ -867,55 +866,6 @@ class TestYoutubeDL(unittest.TestCase):
         assertRegexpMatches(self, ydl._format_note({
             'fps': 30,
         }), r'^30fps$')
-
-    def test_unsafe_exec_expansion(self):
-        def test(exec_cmd, params=None):
-            return YoutubeDL({
-                'ignoreerrors': True,
-                'postprocessors': [{
-                    'key': 'Exec',
-                    'exec_cmd': exec_cmd,
-                    'when': 'after_move',
-                }],
-                **(params or {}),
-            })
-
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)s"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title).100B"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)S"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#j"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe default', test, 'echo %(title|;)q')
-        self.assertRaisesRegex(
-            UnsafeExecExpansionError, r'Unsafe placeholder',
-            test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
-
-        self.assertIsInstance(
-            test([
-                'echo',
-                'echo {}',
-                'echo %(title)q',
-                'echo %(title)#q',
-                'echo %(view_count)i',
-                'echo %(view_count)02d',
-                'echo %(aspect_ratio)f',
-                'echo %(aspect_ratio).2f',
-            ]),
-            YoutubeDL)
-        self.assertIsInstance(
-            test([
-                'echo "%(title)s"',
-                'echo %(title)q',
-                'echo "%(title).100B"',
-                'echo "%(title)S"',
-                'echo "%(title)#S"',
-                'echo "%(title)j"',
-                'echo "%(title)#j"',
-                'echo %(title|;)q',
-            ], {
-                'outtmpl_na_placeholder': ';',
-                'compat_opts': {'allow-unsafe-exec-expansion'},
-            }),
-            YoutubeDL)
 
     def test_postprocessors(self):
         filename = 'post-processor-testfile.mp4'

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -891,6 +891,8 @@ class TestYoutubeDL(unittest.TestCase):
             UnsafeExecExpansionError, r'Unsafe placeholder',
             test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
 
+        self.assertIsInstance(test('echo'), YoutubeDL)
+        self.assertIsInstance(test('echo {}', {'outtmpl_na_placeholder': ';'}), YoutubeDL)
         self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
         self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
         self.assertIsInstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL)

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -874,7 +874,7 @@ class TestYoutubeDL(unittest.TestCase):
                 'ignoreerrors': True,
                 'postprocessors': [{
                     'key': 'Exec',
-                    'exec_cmd': [exec_cmd],
+                    'exec_cmd': exec_cmd,
                     'when': 'after_move',
                 }],
                 **(params or {}),
@@ -883,27 +883,38 @@ class TestYoutubeDL(unittest.TestCase):
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)s"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title).100B"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)S"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#S"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)j"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#j"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe default', test, 'echo %(title|;)q')
         self.assertRaisesRegex(
             UnsafeExecExpansionError, r'Unsafe placeholder',
             test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
 
-        self.assertIsInstance(test('echo'), YoutubeDL)
-        self.assertIsInstance(test('echo {}', {'outtmpl_na_placeholder': ';'}), YoutubeDL)
-        self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
-        self.assertIsInstance(test('echo %(title)#q'), YoutubeDL)
-        self.assertIsInstance(test('echo %(view_count)i'), YoutubeDL)
-        self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
-        self.assertIsInstance(test('echo %(aspect_ratio)f'), YoutubeDL)
-        self.assertIsInstance(test('echo %(aspect_ratio).2f'), YoutubeDL)
         self.assertIsInstance(
-            test('echo "%(title)s"', {'compat_opts': {'allow-unsafe-exec-expansion'}}),
+            test([
+                'echo',
+                'echo {}',
+                'echo %(title)q',
+                'echo %(title)#q',
+                'echo %(view_count)i',
+                'echo %(view_count)02d',
+                'echo %(aspect_ratio)f',
+                'echo %(aspect_ratio).2f',
+            ]),
             YoutubeDL)
         self.assertIsInstance(
-            test('echo %(title)q', {'outtmpl_na_placeholder': ';', 'compat_opts': {'allow-unsafe-exec-expansion'}}),
+            test([
+                'echo "%(title)s"',
+                'echo %(title)q',
+                'echo "%(title).100B"',
+                'echo "%(title)S"',
+                'echo "%(title)#S"',
+                'echo "%(title)j"',
+                'echo "%(title)#j"',
+                'echo %(title|;)q',
+            ], {
+                'outtmpl_na_placeholder': ';',
+                'compat_opts': {'allow-unsafe-exec-expansion'},
+            }),
             YoutubeDL)
 
     def test_postprocessors(self):

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -896,10 +896,10 @@ class TestYoutubeDL(unittest.TestCase):
         self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
         self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
         self.assertIsInstance(
-            test('echo "%(title)s"', {'compat_opts': {'allow-unsafe-exec-commands'}}),
+            test('echo "%(title)s"', {'compat_opts': {'allow-unsafe-exec-expansion'}}),
             YoutubeDL)
         self.assertIsInstance(
-            test('echo %(title)q', {'outtmpl_na_placeholder': ';', 'compat_opts': {'allow-unsafe-exec-commands'}}),
+            test('echo %(title)q', {'outtmpl_na_placeholder': ';', 'compat_opts': {'allow-unsafe-exec-expansion'}}),
             YoutubeDL)
 
     def test_postprocessors(self):

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -6,10 +6,10 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from yt_dlp.globals import all_plugins_loaded
-
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+
+from yt_dlp.globals import all_plugins_loaded
 
 import contextlib
 import copy
@@ -23,6 +23,7 @@ from yt_dlp.utils import (
     ExtractorError,
     LazyList,
     OnDemandPagedList,
+    UnsafeExecExpansionError,
     int_or_none,
     match_filter_func,
 )
@@ -866,6 +867,31 @@ class TestYoutubeDL(unittest.TestCase):
         assertRegexpMatches(self, ydl._format_note({
             'fps': 30,
         }), r'^30fps$')
+
+    def test_unsafe_exec_expansion(self):
+        def test(exec_cmd, params=None):
+            return YoutubeDL({
+                'ignoreerrors': 'only_download',
+                'postprocessors': [{
+                    'key': 'Exec',
+                    'exec_cmd': [exec_cmd],
+                    'when': 'after_move',
+                }] if exec_cmd else [],
+                **(params or {}),
+            })
+
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)s"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)S"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#S"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)j"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#j"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe default', test, 'echo %(title|;)q')
+        self.assertRaisesRegex(
+            UnsafeExecExpansionError, r'Unsafe placeholder',
+            test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
+
+        self.assertTrue(isinstance(test('echo %(title)q'), YoutubeDL))
+        self.assertTrue(isinstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL))
 
     def test_postprocessors(self):
         filename = 'post-processor-testfile.mp4'

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -871,7 +871,7 @@ class TestYoutubeDL(unittest.TestCase):
     def test_unsafe_exec_expansion(self):
         def test(exec_cmd, params=None):
             return YoutubeDL({
-                'ignoreerrors': 'only_download',
+                'ignoreerrors': True,
                 'postprocessors': [{
                     'key': 'Exec',
                     'exec_cmd': [exec_cmd],

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -895,6 +895,12 @@ class TestYoutubeDL(unittest.TestCase):
         self.assertIsInstance(test('echo {}', {'outtmpl_na_placeholder': ';'}), YoutubeDL)
         self.assertIsInstance(test('echo %(title)q'), YoutubeDL)
         self.assertIsInstance(test('echo %(view_count)02d'), YoutubeDL)
+        self.assertIsInstance(
+            test('echo "%(title)s"', {'compat_opts': {'allow-unsafe-exec-commands'}}),
+            YoutubeDL)
+        self.assertIsInstance(
+            test('echo %(title)q', {'outtmpl_na_placeholder': ';', 'compat_opts': {'allow-unsafe-exec-commands'}}),
+            YoutubeDL)
 
     def test_postprocessors(self):
         filename = 'post-processor-testfile.mp4'

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -881,6 +881,7 @@ class TestYoutubeDL(unittest.TestCase):
             })
 
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)s"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title).100B"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)S"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#S"')
         self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)j"')
@@ -891,6 +892,7 @@ class TestYoutubeDL(unittest.TestCase):
             test, 'echo %(title)q', {'outtmpl_na_placeholder': ';'})
 
         self.assertTrue(isinstance(test('echo %(title)q'), YoutubeDL))
+        self.assertTrue(isinstance(test('echo %(view_count).02d'), YoutubeDL))
         self.assertTrue(isinstance(test(None, {'outtmpl_na_placeholder': ';'}), YoutubeDL))
 
     def test_postprocessors(self):

--- a/test/test_postprocessors.py
+++ b/test/test_postprocessors.py
@@ -11,7 +11,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import subprocess
 
 from yt_dlp import YoutubeDL
-from yt_dlp.utils import shell_quote
+from yt_dlp.utils import (
+    UnsafeExecExpansionError,
+    shell_quote,
+)
 from yt_dlp.postprocessor import (
     ExecPP,
     FFmpegThumbnailsConvertorPP,
@@ -90,6 +93,54 @@ class TestExec(unittest.TestCase):
         self.assertEqual(pp.parse_cmd('echo', info), cmd)
         self.assertEqual(pp.parse_cmd('echo {}', info), cmd)
         self.assertEqual(pp.parse_cmd('echo %(filepath)q', info), cmd)
+
+    def test_unsafe_exec_expansion(self):
+        def test(exec_cmd):
+            return ExecPP(ydl, exec_cmd)
+
+        # Test unsafe placeholder
+        ydl = YoutubeDL({'outtmpl_na_placeholder': ';'})
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe placeholder', test, 'echo %(title)q')
+
+        ydl = YoutubeDL()
+        # Test unsafe commands
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)s"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title).100B"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)S"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#j"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe default', test, 'echo %(title|;)q')
+        # Test safe commands
+        self.assertIsInstance(
+            test([
+                'echo',
+                'echo {}',
+                'echo %(title)q',
+                'echo %(title|NA)q',
+                'echo %(title)#q',
+                'echo %(view_count)i',
+                'echo %(view_count)02d',
+                'echo %(aspect_ratio)f',
+                'echo %(aspect_ratio).2f',
+            ]),
+            ExecPP)
+
+        # Test compat opt
+        ydl = YoutubeDL({
+            'outtmpl_na_placeholder': ';',
+            'compat_opts': {'allow-unsafe-exec-expansion'},
+        })
+        self.assertIsInstance(
+            test([
+                'echo "%(title)s"',
+                'echo %(title)q',
+                'echo "%(title).100B"',
+                'echo "%(title)S"',
+                'echo "%(title)#S"',
+                'echo "%(title)j"',
+                'echo "%(title)#j"',
+                'echo %(title|;)q',
+            ]),
+            ExecPP)
 
 
 class TestModifyChaptersPP(unittest.TestCase):

--- a/test/test_postprocessors.py
+++ b/test/test_postprocessors.py
@@ -95,23 +95,20 @@ class TestExec(unittest.TestCase):
         self.assertEqual(pp.parse_cmd('echo %(filepath)q', info), cmd)
 
     def test_unsafe_exec_expansion(self):
-        def test(exec_cmd):
-            return ExecPP(ydl, exec_cmd)
-
         # Test unsafe placeholder
         ydl = YoutubeDL({'outtmpl_na_placeholder': ';'})
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe placeholder', test, 'echo %(title)q')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe placeholder', ExecPP, ydl, 'echo %(title)q')
 
         ydl = YoutubeDL()
         # Test unsafe commands
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)s"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title).100B"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)S"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', test, 'echo "%(title)#j"')
-        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe default', test, 'echo %(title|;)q')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', ExecPP, ydl, 'echo "%(title)s"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', ExecPP, ydl, 'echo "%(title).100B"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', ExecPP, ydl, 'echo "%(title)S"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe conversion', ExecPP, ydl, 'echo "%(title)#j"')
+        self.assertRaisesRegex(UnsafeExecExpansionError, r'Unsafe default', ExecPP, ydl, 'echo %(title|;)q')
         # Test safe commands
         self.assertIsInstance(
-            test([
+            ExecPP(ydl, [
                 'echo',
                 'echo {}',
                 'echo %(title)q',
@@ -130,7 +127,7 @@ class TestExec(unittest.TestCase):
             'compat_opts': {'allow-unsafe-exec-expansion'},
         })
         self.assertIsInstance(
-            test([
+            ExecPP(ydl, [
                 'echo "%(title)s"',
                 'echo %(title)q',
                 'echo "%(title).100B"',

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -830,16 +830,12 @@ class YoutubeDL:
 
             # Validate safety of exec commands immediately
             if pp_key == 'Exec':
-                exec_cmds = pp_def.pop('exec_cmd', [])
-                for exec_cmd in exec_cmds:
+                for exec_cmd in pp_def.get('exec_cmd', []):
                     try:
                         _ = self.prepare_outtmpl(exec_cmd, {}, _exec=True)
                     except UnsafeExecExpansionError as e:
                         self.report_error(e)
                         raise
-                    pp_def.setdefault('exec_cmd', []).append(exec_cmd)
-                if not pp_def.get('exec_cmd'):
-                    continue
 
             when = pp_def.pop('when', 'post_process')
             self.add_post_processor(

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -825,9 +825,24 @@ class YoutubeDL:
 
         for pp_def_raw in self.params.get('postprocessors', []):
             pp_def = dict(pp_def_raw)
+            pp_key = pp_def.pop('key')
+
+            # Validate safety of exec commands immediately
+            if pp_key == 'Exec':
+                exec_cmds = pp_def.pop('exec_cmd', [])
+                for exec_cmd in exec_cmds:
+                    try:
+                        _ = self.prepare_outtmpl(exec_cmd, {}, _exec=True)
+                    except PostProcessingError as e:
+                        self.report_error(e)
+                        continue
+                    pp_def.setdefault('exec_cmd', []).append(exec_cmd)
+                if not pp_def.get('exec_cmd'):
+                    continue
+
             when = pp_def.pop('when', 'post_process')
             self.add_post_processor(
-                get_postprocessor(pp_def.pop('key'))(self, **pp_def),
+                get_postprocessor(pp_key)(self, **pp_def),
                 when=when)
 
         def preload_download_archive(fn):
@@ -1254,7 +1269,7 @@ class YoutubeDL:
         info_dict.pop('__pending_error', None)
         return info_dict
 
-    def prepare_outtmpl(self, outtmpl, info_dict, sanitize=False):
+    def prepare_outtmpl(self, outtmpl, info_dict, sanitize=False, *, _exec=False):
         """ Make the outtmpl and info_dict suitable for substitution: ydl.escape_outtmpl(outtmpl) % info_dict
         @param sanitize    Whether to sanitize the output as a filename
         """
@@ -1305,6 +1320,8 @@ class YoutubeDL:
                 (?:&(?P<replacement>.*?))?
                 (?:\|(?P<default>.*?))?
             )$''')
+        SAFE_EXEC_CONVERSIONS = {'d', 'q'}
+        UNSAFE_DEFAULT_CHARS = {';', ' ', '\n', '\t', '&', '|', '"', "'", '^', '$', '%', '*'}
 
         def _from_user_input(field):
             if field == ':':
@@ -1428,6 +1445,16 @@ class YoutubeDL:
             fmt = outer_mobj.group('format')
             if fmt == 's' and last_field in field_size_compat_map and isinstance(value, int):
                 fmt = f'0{field_size_compat_map[last_field]:d}d'
+
+            # Validate safety of exec commands
+            if _exec:
+                if fmt[-1] not in SAFE_EXEC_CONVERSIONS:
+                    raise PostProcessingError(f'Unsafe conversion(s) in exec command: {outtmpl!r}')
+                elif any(unsafe_char in default for unsafe_char in UNSAFE_DEFAULT_CHARS):
+                    if default == na:
+                        raise PostProcessingError(f'Unsafe placeholder for exec command: {na!r}')
+                    else:
+                        raise PostProcessingError(f'Unsafe default(s) in exec command: {outtmpl!r}')
 
             flags = outer_mobj.group('conversion') or ''
             str_fmt = f'{fmt[:-1]}s'

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -832,7 +832,7 @@ class YoutubeDL:
             if pp_key == 'Exec':
                 for exec_cmd in pp_def.get('exec_cmd', []):
                     try:
-                        _ = self.prepare_outtmpl(exec_cmd, {}, _exec=True)
+                        self.prepare_outtmpl(exec_cmd, {}, _exec=True)
                     except UnsafeExecExpansionError as e:
                         self.report_error(e)
                         raise
@@ -1317,8 +1317,8 @@ class YoutubeDL:
                 (?:&(?P<replacement>.*?))?
                 (?:\|(?P<default>.*?))?
             )$''')
-        SAFE_EXEC_CONVERSIONS = {'d', 'q'}
-        UNSAFE_DEFAULT_CHARS = {';', ' ', '\n', '\t', '&', '|', '"', "'", '^', '$', '%', '*'}
+        SAFE_EXEC_CONVERSIONS = 'dq'
+        UNSAFE_DEFAULT_CHARS = '"\' \n\t;&|^$%*'
 
         def _from_user_input(field):
             if field == ':':

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1312,7 +1312,7 @@ class YoutubeDL:
                 (?:\|(?P<default>.*?))?
             )$''')
         SAFE_EXEC_CONVERSIONS = 'difq'
-        UNSAFE_DEFAULT_CHARS = '"\' \n\t;&|^$%*'
+        UNSAFE_DEFAULT_CHARS = '"\' \n\t;&|^$%*<>{}()[]`#'
 
         def _from_user_input(field):
             if field == ':':

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -112,6 +112,7 @@ from .utils import (
     RejectedVideoReached,
     SameFileError,
     UnavailableVideoError,
+    UnsafeExecExpansionError,
     UserNotLive,
     YoutubeDLError,
     age_restricted,
@@ -833,9 +834,9 @@ class YoutubeDL:
                 for exec_cmd in exec_cmds:
                     try:
                         _ = self.prepare_outtmpl(exec_cmd, {}, _exec=True)
-                    except PostProcessingError as e:
+                    except UnsafeExecExpansionError as e:
                         self.report_error(e)
-                        continue
+                        raise
                     pp_def.setdefault('exec_cmd', []).append(exec_cmd)
                 if not pp_def.get('exec_cmd'):
                     continue
@@ -1449,12 +1450,12 @@ class YoutubeDL:
             # Validate safety of exec commands
             if _exec:
                 if fmt[-1] not in SAFE_EXEC_CONVERSIONS:
-                    raise PostProcessingError(f'Unsafe conversion(s) in exec command: {outtmpl!r}')
+                    raise UnsafeExecExpansionError(f'Unsafe conversion(s) in exec command: {outtmpl!r}')
                 elif any(unsafe_char in default for unsafe_char in UNSAFE_DEFAULT_CHARS):
                     if default == na:
-                        raise PostProcessingError(f'Unsafe placeholder for exec command: {na!r}')
+                        raise UnsafeExecExpansionError(f'Unsafe placeholder for exec command: {na!r}')
                     else:
-                        raise PostProcessingError(f'Unsafe default(s) in exec command: {outtmpl!r}')
+                        raise UnsafeExecExpansionError(f'Unsafe default(s) in exec command: {outtmpl!r}')
 
             flags = outer_mobj.group('conversion') or ''
             str_fmt = f'{fmt[:-1]}s'

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -829,7 +829,7 @@ class YoutubeDL:
             pp_key = pp_def.pop('key')
 
             # Validate safety of exec commands immediately
-            if pp_key == 'Exec':
+            if pp_key == 'Exec' and 'allow-unsafe-exec-commands' not in self.params['compat_opts']:
                 for exec_cmd in variadic(pp_def.get('exec_cmd', [])):
                     try:
                         self.prepare_outtmpl(exec_cmd, {}, _exec=True)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -829,7 +829,7 @@ class YoutubeDL:
             pp_key = pp_def.pop('key')
 
             # Validate safety of exec commands immediately
-            if pp_key == 'Exec' and 'allow-unsafe-exec-commands' not in self.params['compat_opts']:
+            if pp_key == 'Exec' and 'allow-unsafe-exec-expansion' not in self.params['compat_opts']:
                 for exec_cmd in variadic(pp_def.get('exec_cmd', [])):
                     try:
                         self.prepare_outtmpl(exec_cmd, {}, _exec=True)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -826,21 +826,15 @@ class YoutubeDL:
 
         for pp_def_raw in self.params.get('postprocessors', []):
             pp_def = dict(pp_def_raw)
-            pp_key = pp_def.pop('key')
-
-            # Validate safety of exec commands immediately
-            if pp_key == 'Exec' and 'allow-unsafe-exec-expansion' not in self.params['compat_opts']:
-                for exec_cmd in variadic(pp_def.get('exec_cmd', [])):
-                    try:
-                        self.prepare_outtmpl(exec_cmd, {}, _exec=True)
-                    except UnsafeExecExpansionError as e:
-                        self.report_error(e)
-                        raise
-
             when = pp_def.pop('when', 'post_process')
-            self.add_post_processor(
-                get_postprocessor(pp_key)(self, **pp_def),
-                when=when)
+            # Handle errors for ExecPP command validation
+            try:
+                self.add_post_processor(
+                    get_postprocessor(pp_def.pop('key'))(self, **pp_def),
+                    when=when)
+            except UnsafeExecExpansionError as e:
+                self.report_error(e)
+                raise
 
         def preload_download_archive(fn):
             """Preload the archive, if any is specified"""

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1312,7 +1312,7 @@ class YoutubeDL:
                 (?:\|(?P<default>.*?))?
             )$''')
         SAFE_EXEC_CONVERSIONS = 'difq'
-        UNSAFE_DEFAULT_CHARS = '"\' \n\t;&|^$%*<>{}()[]`#'
+        UNSAFE_DEFAULT_CHARS = '"\' \n\t;&|^$%*<>{}()[]`#\\'
 
         def _from_user_input(field):
             if field == ':':

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1317,7 +1317,7 @@ class YoutubeDL:
                 (?:&(?P<replacement>.*?))?
                 (?:\|(?P<default>.*?))?
             )$''')
-        SAFE_EXEC_CONVERSIONS = 'dq'
+        SAFE_EXEC_CONVERSIONS = 'difq'
         UNSAFE_DEFAULT_CHARS = '"\' \n\t;&|^$%*'
 
         def _from_user_input(field):

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -830,7 +830,7 @@ class YoutubeDL:
 
             # Validate safety of exec commands immediately
             if pp_key == 'Exec':
-                for exec_cmd in pp_def.get('exec_cmd', []):
+                for exec_cmd in variadic(pp_def.get('exec_cmd', [])):
                     try:
                         self.prepare_outtmpl(exec_cmd, {}, _exec=True)
                     except UnsafeExecExpansionError as e:

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -44,6 +44,7 @@ from .utils import (
     GeoUtils,
     PlaylistEntries,
     SameFileError,
+    UnsafeExecExpansionError,
     download_range_func,
     expand_path,
     float_or_none,
@@ -1077,7 +1078,7 @@ def main(argv=None):
     IN_CLI.value = True
     try:
         _exit(*variadic(_real_main(argv)))
-    except (CookieLoadError, DownloadError):
+    except (CookieLoadError, DownloadError, UnsafeExecExpansionError):
         _exit(1)
     except SameFileError as e:
         _exit(f'ERROR: {e}')

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -568,14 +568,15 @@ def create_parser():
                 'embed-metadata', 'seperate-video-versions', 'no-clean-infojson', 'no-keep-subs', 'no-certifi',
                 'no-youtube-channel-redirect', 'no-youtube-unavailable-videos', 'no-youtube-prefer-utc-upload-date',
                 'prefer-legacy-http-handler', 'manifest-filesize-approx', 'allow-unsafe-ext', 'prefer-vp9-sort', 'mtime-by-default',
+                'allow-unsafe-exec-commands',
             }, 'aliases': {
-                'youtube-dl': ['all', '-multistreams', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort'],
-                'youtube-dlc': ['all', '-no-youtube-channel-redirect', '-no-live-chat', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort'],
+                'youtube-dl': ['all', '-multistreams', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort', '-allow-unsafe-exec-commands'],
+                'youtube-dlc': ['all', '-no-youtube-channel-redirect', '-no-live-chat', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort', '-allow-unsafe-exec-commands'],
                 '2021': ['2022', 'no-certifi', 'filename-sanitization'],
                 '2022': ['2023', 'no-external-downloader-progress', 'playlist-match-filter', 'prefer-legacy-http-handler', 'manifest-filesize-approx'],
                 '2023': ['2024', 'prefer-vp9-sort'],
                 '2024': ['2025', 'mtime-by-default'],
-                '2025': [],
+                '2025': ['allow-unsafe-exec-commands'],
             },
         }, help=(
             'Options that can help keep compatibility with youtube-dl or youtube-dlc '

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -568,15 +568,15 @@ def create_parser():
                 'embed-metadata', 'seperate-video-versions', 'no-clean-infojson', 'no-keep-subs', 'no-certifi',
                 'no-youtube-channel-redirect', 'no-youtube-unavailable-videos', 'no-youtube-prefer-utc-upload-date',
                 'prefer-legacy-http-handler', 'manifest-filesize-approx', 'allow-unsafe-ext', 'prefer-vp9-sort', 'mtime-by-default',
-                'allow-unsafe-exec-commands',
+                'allow-unsafe-exec-expansion',
             }, 'aliases': {
-                'youtube-dl': ['all', '-multistreams', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort', '-allow-unsafe-exec-commands'],
-                'youtube-dlc': ['all', '-no-youtube-channel-redirect', '-no-live-chat', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort', '-allow-unsafe-exec-commands'],
+                'youtube-dl': ['all', '-multistreams', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort', '-allow-unsafe-exec-expansion'],
+                'youtube-dlc': ['all', '-no-youtube-channel-redirect', '-no-live-chat', '-playlist-match-filter', '-manifest-filesize-approx', '-allow-unsafe-ext', '-prefer-vp9-sort', '-allow-unsafe-exec-expansion'],
                 '2021': ['2022', 'no-certifi', 'filename-sanitization'],
                 '2022': ['2023', 'no-external-downloader-progress', 'playlist-match-filter', 'prefer-legacy-http-handler', 'manifest-filesize-approx'],
                 '2023': ['2024', 'prefer-vp9-sort'],
                 '2024': ['2025', 'mtime-by-default'],
-                '2025': ['allow-unsafe-exec-commands'],
+                '2025': [],
             },
         }, help=(
             'Options that can help keep compatibility with youtube-dl or youtube-dlc '

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1769,7 +1769,8 @@ def create_parser():
         help=(
             'Execute a command, optionally prefixed with when to execute it, separated by a ":". '
             'Supported values of "WHEN" are the same as that of --use-postprocessor (default: after_move). '
-            'The same syntax as the output template can be used to pass any field as arguments to the command. '
+            'The same syntax as the output template can be used to pass any field as arguments to the command, '
+            'but only "d" and "q" conversions are allowed for security reasons. '
             'If no fields are passed, %(filepath,_filename|)q is appended to the end of the command. '
             'This option can be used multiple times'))
     postproc.add_option(

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1770,8 +1770,9 @@ def create_parser():
         help=(
             'Execute a command, optionally prefixed with when to execute it, separated by a ":". '
             'Supported values of "WHEN" are the same as that of --use-postprocessor (default: after_move). '
-            'The same syntax as the output template can be used to pass any field as arguments to the command, '
-            'but only "d" (digit) and "q" (shell-quote) conversions are allowed for security reasons. '
+            'The same syntax as the output template can be used to pass any field as arguments to the command; '
+            'however, for security reasons the only allowed conversions are: '
+            '"i"/"d" (signed integer decimal), "f" (floating-point decimal) and "q" (shell-quoted). '
             'If no fields are passed, %(filepath,_filename|)q is appended to the end of the command. '
             'This option can be used multiple times'))
     postproc.add_option(

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1770,7 +1770,7 @@ def create_parser():
             'Execute a command, optionally prefixed with when to execute it, separated by a ":". '
             'Supported values of "WHEN" are the same as that of --use-postprocessor (default: after_move). '
             'The same syntax as the output template can be used to pass any field as arguments to the command, '
-            'but only "d" and "q" conversions are allowed for security reasons. '
+            'but only "d" (digit) and "q" (shell-quote) conversions are allowed for security reasons. '
             'If no fields are passed, %(filepath,_filename|)q is appended to the end of the command. '
             'This option can be used multiple times'))
     postproc.add_option(

--- a/yt_dlp/postprocessor/exec.py
+++ b/yt_dlp/postprocessor/exec.py
@@ -8,6 +8,16 @@ class ExecPP(PostProcessor):
         PostProcessor.__init__(self, downloader)
         self.exec_cmd = variadic(exec_cmd)
 
+        if (
+            self._downloader is None
+            or 'allow-unsafe-exec-expansion' in self._downloader.params['compat_opts']
+        ):
+            return
+
+        # Validate safety of exec commands
+        for cmd in self.exec_cmd:
+            _ = self._downloader.prepare_outtmpl(cmd, {}, _exec=True)
+
     def parse_cmd(self, cmd, info):
         tmpl, tmpl_dict = self._downloader.prepare_outtmpl(cmd, info)
         if tmpl_dict:  # if there are no replacements, tmpl_dict = {}

--- a/yt_dlp/postprocessor/exec.py
+++ b/yt_dlp/postprocessor/exec.py
@@ -12,7 +12,8 @@ class ExecPP(PostProcessor):
     def set_downloader(self, downloader):
         super().set_downloader(downloader)
         # Validate safety of exec commands
-        if 'allow-unsafe-exec-expansion' not in self._downloader.params['compat_opts']:
+        params = getattr(self._downloader, 'params', None)
+        if params and 'allow-unsafe-exec-expansion' not in params['compat_opts']:
             for cmd in self.exec_cmd:
                 _ = self._downloader.prepare_outtmpl(cmd, {}, _exec=True)
 

--- a/yt_dlp/postprocessor/exec.py
+++ b/yt_dlp/postprocessor/exec.py
@@ -5,18 +5,16 @@ from ..utils import Popen, PostProcessingError, shell_quote, variadic
 class ExecPP(PostProcessor):
 
     def __init__(self, downloader, exec_cmd):
-        PostProcessor.__init__(self, downloader)
+        # Need to set exec_cmd attribute before set_downloader is called by PostProcessor.__init__
         self.exec_cmd = variadic(exec_cmd)
+        PostProcessor.__init__(self, downloader)
 
-        if (
-            self._downloader is None
-            or 'allow-unsafe-exec-expansion' in self._downloader.params['compat_opts']
-        ):
-            return
-
+    def set_downloader(self, downloader):
+        super().set_downloader(downloader)
         # Validate safety of exec commands
-        for cmd in self.exec_cmd:
-            _ = self._downloader.prepare_outtmpl(cmd, {}, _exec=True)
+        if 'allow-unsafe-exec-expansion' not in self._downloader.params['compat_opts']:
+            for cmd in self.exec_cmd:
+                _ = self._downloader.prepare_outtmpl(cmd, {}, _exec=True)
 
     def parse_cmd(self, cmd, info):
         tmpl, tmpl_dict = self._downloader.prepare_outtmpl(cmd, info)

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -1182,6 +1182,10 @@ class XAttrUnavailableError(YoutubeDLError):
     pass
 
 
+class UnsafeExecExpansionError(YoutubeDLError):
+    pass
+
+
 def is_path_like(f):
     return isinstance(f, (str, bytes, os.PathLike))
 


### PR DESCRIPTION
Remove `--exec` footguns by restricting the conversions and default/placeholder values that are able to be used in the `exec` command template.

Previously, the user was able to pass something like this:
```
--exec 'echo "%(title)s"'
```
This could yield unexpected and possibly damaging results if the `title` value contained a closing quote (`"`) or special character such as `$`.

The only truly safe conversions to use in an exec template are `i`/`d` (signed integer decimal), `f` (floating-point decimal) and `q` (shell-quoted). This patch restricts `--exec` templates to using those conversions.

Furthermore, conversion is not performed on template default values (given after a `|`) or the placeholder value (given with `--output-na-placeholder`).

So a safe conversion could be used with an unsafe default, which would nullify the conversion, e.g.:
```
--exec 'echo %(nonexistent_field|;echo self-pwned)q'
```
...or a safe conversion could be nullified with an unsafe placeholder value, e.g.:
```
--output-na-placeholder ';echo self-pwned' --exec 'echo %(nonexistent_field)q'
```

This patch also restricts the default values and placeholder values that can be used in conjunction with `--exec` such that they cannot contain special shell characters.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
