### PR TITLE
[ie/bilibili] Fix HTTP 412 Precondition Failed when downloading webpage

### DIFF
--- a/yt_dlp/extractor/openload.py
+++ b/yt_dlp/extractor/openload.py
@@ -110,7 +110,7 @@ class PhantomJSwrapper:
     def __init__(self, extractor, required_version=None, timeout=10000):
         self._TMP_FILES = {}
 
-        self.exe = check_executable('phantomjs', ['-v'])
+        self.exe = check_executable(extractor.get_param('phantomjs'), ['-v'])
         if not self.exe:
             raise ExtractorError(f'PhantomJS not found, {self.INSTALL_HINT}', expected=True)
 


### PR DESCRIPTION
Bilibili returns HTTP 412 when `buvid3`/`buvid4` fingerprint cookies are absent, even without login. This happens when no browser cookies are passed or when existing cookies are stale/invalid.

Fix adds `_get_buvid()` to `BilibiliBaseIE` which fetches fresh fingerprint cookies from Bilibili's finger API (`/x/frontend/finger/spi`). In `BiliBiliIE._real_extract`, the webpage download is wrapped in a try/except — if a 412 is encountered, it calls `_get_buvid()` to inject the cookies and retries.

Fixes #14830

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
