### PR TITLE
fix(downloader/niconico): Fix typo 'occured' -> 'occurred'

### DIFF
--- a/yt_dlp/downloader/niconico.py
+++ b/yt_dlp/downloader/niconico.py
@@ -78,7 +78,7 @@ class NiconicoLiveFD(FileDownloader):
                         return
                 except BaseException as e:
                     self.to_screen(
-                        f'[niconico:live] {video_id}: Connection error occured, reconnecting after 10 seconds: {e}')
+                        f'[niconico:live] {video_id}: Connection error occurred, reconnecting after 10 seconds: {e}')
                     time.sleep(10)
                     continue
                 finally:


### PR DESCRIPTION
## Description
Fixes a typo in the error message in `yt_dlp/downloader/niconico.py` where "occured" should be "occurred".

## Motivation
While the typo is in a user-facing log message, it should be corrected for proper spelling.

## Changes
- `yt_dlp/downloader/niconico.py`: Fixed typo "occured" → "occurred" in the connection error message at line 81.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have tested my changes