### PR TITLE
fix: Correct typo 'preferedformat' -> 'preferredformat'

### DIFF
--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -662,12 +662,12 @@ def get_postprocessors(opts):
     if opts.remuxvideo:
         yield {
             'key': 'FFmpegVideoRemuxer',
-            'preferedformat': opts.remuxvideo,
+            'preferredformat': opts.remuxvideo,
         }
     if opts.recodevideo:
         yield {
             'key': 'FFmpegVideoConvertor',
-            'preferedformat': opts.recodevideo,
+            'preferredformat': opts.recodevideo,
         }
     # If ModifyChapters is going to remove chapters, subtitles must already be in the container.
     if opts.embedsubtitles:

--- a/yt_dlp/postprocessor/ffmpeg.py
+++ b/yt_dlp/postprocessor/ffmpeg.py
@@ -543,9 +543,9 @@ class FFmpegVideoConvertorPP(FFmpegPostProcessor):
     FORMAT_RE = create_mapping_re(SUPPORTED_EXTS)
     _ACTION = 'converting'
 
-    def __init__(self, downloader=None, preferedformat=None):
+    def __init__(self, downloader=None, preferredformat=None):
         super().__init__(downloader)
-        self.mapping = preferedformat
+        self.mapping = preferredformat
 
     @staticmethod
     def _options(target_ext):


### PR DESCRIPTION
## Description
Fixes a long-standing typo in the parameter name `preferedformat` which should be `preferredformat` (double 'r').

## Changes
- `yt_dlp/postprocessor/ffmpeg.py`: Renamed `preferedformat` parameter to `preferredformat` in `FFmpegVideoConvertorPP.__init__`
- `yt_dlp/__init__.py`: Updated the dict keys from `preferedformat` to `preferredformat` for both `FFmpegVideoRemuxer` and `FFmpegVideoConvertor` post-processors

## Motivation
The parameter name `preferedformat` is a misspelling of "preferred". This is an internal API so the rename is safe.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have tested my changes