### PR TITLE
fix(extractor/radiko): Fix misleading assert statement

### DIFF
--- a/yt_dlp/extractor/radiko.py
+++ b/yt_dlp/extractor/radiko.py
@@ -114,7 +114,7 @@ class RadikoBaseIE(InfoExtractor):
                 break
         if not prog:
             raise ExtractorError('Cannot identify radio program to download!')
-        assert ft, to
+        assert ft and to
         return prog, station_program, ft, ft_str, to_str
 
     def _extract_formats(self, video_id, station, is_onair, ft, cursor, auth_token, area_id, query):


### PR DESCRIPTION
## Description
Fixes a misleading `assert` statement in `RadikoBaseIE._find_program`.

## Bug
On line 117, the code reads:
```python
assert ft, to
```

In Python, `assert ft, to` does **not** assert both `ft` and `to`. Instead, it asserts that `ft` is truthy, and uses `to` as the error message if the assertion fails. This is a common Python pitfall.

The intent was clearly to assert that both `ft` and `to` are truthy (i.e., both timestamps were successfully parsed).

## Fix
Changed to:
```python
assert ft and to
```

This correctly asserts both values are truthy.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have tested my changes