### PR TITLE
fix(extractor/nexx): Fix mutable default argument in _call_api

### DIFF
--- a/yt_dlp/extractor/nexx.py
+++ b/yt_dlp/extractor/nexx.py
@@ -144,7 +144,8 @@ class NexxIE(InfoExtractor):
             '{} said: {}'.format(self.IE_NAME, response['metadata']['errorhint']),
             expected=True)
 
-    def _call_api(self, domain_id, path, video_id, data=None, headers={}):
+    def _call_api(self, domain_id, path, video_id, data=None, headers=None):
+        headers = headers or {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
         result = self._download_json(
             f'https://api.nexx.cloud/v3/{domain_id}/{path}', video_id,


### PR DESCRIPTION
## Description
Fixes a mutable default argument bug in `NexxBaseIE._call_api`.

## Bug
The method signature was:
```python
def _call_api(self, domain_id, path, video_id, data=None, headers={}):
```

Using a mutable object (`{}`) as a default argument is a well-known Python pitfall. Since the method mutates `headers` by adding `Content-Type`, the same dict object would be reused across calls, potentially causing unexpected behavior.

## Fix
Changed to:
```python
def _call_api(self, domain_id, path, video_id, data=None, headers=None):
    headers = headers or {}
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have tested my changes