### PR TITLE
Fix `allow-unsafe-ext` compat option

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -327,6 +327,12 @@ class TestUtil(unittest.TestCase):
             with self.assertRaises(_UnsafeExtensionError):
                 prepend_extension('abc.unexpected_ext', ext, 'ext')
 
+        # Test allow-unsafe-ext compat option
+        _UnsafeExtensionError._enabled = False
+        self.assertEqual(prepend_extension('abc.ext', 'un/safe'), 'abc.un/safe.ext')
+        # Re-enable sanitization for other tests
+        _UnsafeExtensionError._enabled = True
+
     def test_replace_extension(self):
         self.assertEqual(replace_extension('abc.ext', 'temp'), 'abc.temp')
         self.assertEqual(replace_extension('abc.ext', 'temp', 'ext'), 'abc.temp')
@@ -344,6 +350,12 @@ class TestUtil(unittest.TestCase):
                 replace_extension('abc.ext', ext, 'ext')
             with self.assertRaises(_UnsafeExtensionError):
                 replace_extension('abc.unexpected_ext', ext, 'ext')
+
+        # Test allow-unsafe-ext compat option
+        _UnsafeExtensionError._enabled = False
+        self.assertEqual(replace_extension('abc.ext', 'bin'), 'abc.bin')
+        # Re-enable sanitization for other tests
+        _UnsafeExtensionError._enabled = True
 
     def test_subtitles_filename(self):
         self.assertEqual(subtitles_filename('abc.ext', 'en', 'vtt'), 'abc.en.vtt')

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -619,7 +619,7 @@ def validate_options(opts):
         warnings.append(
             'Using allow-unsafe-ext opens you up to potential attacks. '
             'Use with great care!')
-        _UnsafeExtensionError.sanitize_extension = lambda x, prepend=False: x
+        _UnsafeExtensionError.sanitize_extension = lambda x, prepend=False, _allowed_exts=(): x
 
     return warnings, deprecation_warnings
 

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -619,7 +619,7 @@ def validate_options(opts):
         warnings.append(
             'Using allow-unsafe-ext opens you up to potential attacks. '
             'Use with great care!')
-        _UnsafeExtensionError.sanitize_extension = lambda x, prepend=False, _allowed_exts=(): x
+        _UnsafeExtensionError._enabled = False
 
     return warnings, deprecation_warnings
 

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -5218,12 +5218,17 @@ class _UnsafeExtensionError(Exception):
         'sbv',
     ])
 
+    _enabled = True
+
     def __init__(self, extension, /):
         super().__init__(f'unsafe file extension: {extension!r}')
         self.extension = extension
 
     @classmethod
     def sanitize_extension(cls, extension, /, *, prepend=False, _allowed_exts=()):
+        if not cls._enabled:
+            return extension
+
         if extension is None:
             return None
 


### PR DESCRIPTION
Fix regression introduced in e578e265f7c6ca94a74b30e0d8d6196a4d19fb6a

Closes #16919

<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
