### PR TITLE
fix: clarify description of -x/--extract-audio option

### DIFF
--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1615,7 +1615,7 @@ def create_parser():
     postproc.add_option(
         '-x', '--extract-audio',
         action='store_true', dest='extractaudio', default=False,
-        help='Convert video files to audio-only files (requires ffmpeg and ffprobe)')
+        help='Download audio-only files or convert video files to audio-only files (requires ffmpeg and ffprobe)')
     postproc.add_option(
         '--audio-format', metavar='FORMAT', dest='audioformat', default='best',
         help=(


### PR DESCRIPTION
Refs #16932

Clarify that -x/--extract-audio defaults to downloading the best audio format instead of converting video to audio.