### PR TITLE
webvtt: accept negative MPEGTS timestamp maps

### DIFF
--- a/test/test_webvtt.py
+++ b/test/test_webvtt.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# Allow direct execution
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+import unittest
+
+from yt_dlp import webvtt
+
+
+class TestWebVTT(unittest.TestCase):
+    def test_parse_negative_mpegts_timestamp_map(self):
+        blocks = list(webvtt.parse_fragment(b'''WEBVTT
+X-TIMESTAMP-MAP=MPEGTS:-6000,LOCAL:00:00:00.000
+
+00:00:03.770 --> 00:00:05.000
+Text
+'''))
+
+        self.assertIsInstance(blocks[0], webvtt.Magic)
+        self.assertEqual(blocks[0].mpegts, -6000)
+        self.assertEqual(blocks[0].local, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yt_dlp/webvtt.py
+++ b/yt_dlp/webvtt.py
@@ -157,7 +157,7 @@ class Magic(HeaderBlock):
 
     _REGEX_TSMAP = re.compile(r'X-TIMESTAMP-MAP=')
     _REGEX_TSMAP_LOCAL = re.compile(r'LOCAL:')
-    _REGEX_TSMAP_MPEGTS = re.compile(r'MPEGTS:([0-9]+)')
+    _REGEX_TSMAP_MPEGTS = re.compile(r'MPEGTS:(-?[0-9]+)')
     _REGEX_TSMAP_SEP = re.compile(r'[ \t]*,[ \t]*')
 
     # This was removed from the spec in the 2017 revision;


### PR DESCRIPTION
### What changed
- Allow WebVTT `X-TIMESTAMP-MAP` headers to parse signed `MPEGTS` values, e.g. `MPEGTS:-6000`.
- Add a regression test for a WebVTT fragment with a negative MPEGTS timestamp map.

### Why
Some HLS WebVTT subtitle fragments in the wild include negative MPEGTS values. Before this change, yt-dlp raised a `ParseError` before the HLS subtitle assembly code could handle the timestamp map.

Related: #4413

### How tested
- `python -m pytest test/test_webvtt.py -q`
- `python -m compileall -q yt_dlp/webvtt.py test/test_webvtt.py`
- `git diff --check HEAD~1..HEAD`

I also tried `python -m pytest test/test_downloader_http.py test/test_subtitles.py -q`; the WebVTT-adjacent HTTP tests passed, but several external subtitle extractor tests failed due to live-site/environment issues unrelated to this parser change, including YouTube HTTP 429, missing Dailymotion impersonation dependencies, ThePlatform HTTP 502, NRK extractor routing, and changed Vimeo/PBS subtitle hashes.
