### PR TITLE
options: expand escaped braces in aliases

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -182,6 +182,29 @@ class TestConfig(unittest.TestCase):
             opts.outtmpl['default'], 'pass',
             'The earlier group did not override the later ones')
 
+    def test_alias_expands_escaped_braces_without_arguments(self):
+        _, opts, urls = parseOpts([
+            '--alias', 'released-date',
+            '--parse-metadata "description:Released on: (?P<meta_date>\\d{{4}}-\\d\\d-\\d\\d)"',
+            '--released-date',
+            'https://example.com',
+        ], False)
+
+        self.assertEqual(urls, ['https://example.com'])
+        self.assertEqual(
+            opts.parse_metadata['pre_process'],
+            ['description:Released on: (?P<meta_date>\\d{4}-\\d\\d-\\d\\d)'])
+
+    def test_alias_quotes_arguments(self):
+        _, opts, urls = parseOpts([
+            '--alias', 'parse-title', '--parse-metadata "title:{0}"',
+            '--parse-title', 'hello world',
+            'https://example.com',
+        ], False)
+
+        self.assertEqual(urls, ['https://example.com'])
+        self.assertEqual(opts.parse_metadata['pre_process'], ["title:'hello world'"])
+
 
 @contextlib.contextmanager
 def ConfigMock(read_file=None):

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -339,11 +339,9 @@ def create_parser():
         counter[opt_str] += 1
         if counter[opt_str] > parser.ALIAS_TRIGGER_LIMIT:
             raise optparse.OptionValueError(f'Alias {opt_str} exceeded invocation limit')
-        if nargs == 1:
-            value = [value]
-        assert (nargs == 0 and value is None) or len(value) == nargs
-        parser.rargs[:0] = shlex.split(
-            opts if value is None else opts.format(*map(shlex.quote, value)))
+        value = [] if nargs == 0 else [value] if nargs == 1 else value
+        assert len(value) == nargs
+        parser.rargs[:0] = shlex.split(opts.format(*map(shlex.quote, value)))
 
     def _preset_alias_callback(option, opt_str, value, parser):
         if not value:


### PR DESCRIPTION
### What changed
- Always run alias definitions through `str.format`, including aliases without arguments.
- Normalize alias callback argument handling so zero-argument aliases use an empty argument list.
- Add regression coverage for escaped braces in a zero-argument alias and for existing argument quoting behavior.

### Why
Aliases use `{0}`, `{1}`, etc. for positional arguments, so literal braces in an alias definition must be escaped as `{{` and `}}`. Before this change, aliases without arguments skipped `.format()` when triggered, which left escaped braces unexpanded. This broke regex patterns such as `\d{{4}}`, which should expand to `\d{4}` before being passed to options like `--parse-metadata`.

Fixes #9026

### How tested
- RED: `python -m pytest test/test_config.py::TestConfig::test_alias_expands_escaped_braces_without_arguments -q` failed because the parsed metadata regex still contained `\d{{4}}`.
- GREEN: `python -m pytest test/test_config.py -q`
- GREEN: `python -m compileall -q yt_dlp/options.py test/test_config.py`
- GREEN: `git diff --check HEAD~1..HEAD`
