### PR TITLE
[ie/Telewebion] Fix extractor

### DIFF
--- a/supportedsites.md
+++ b/supportedsites.md
@@ -1369,7 +1369,7 @@ The only reliable way to check if a site is supported is to try it.
  - **TeleQuebecSquat**
  - **TeleQuebecVideo**
  - **TeleTask**: (**Currently broken**)
- - **Telewebion**
+**Telewebion**: (**Currently broken**)
  - **TennisTV**: [*tennistv*](## "netrc machine")
  - **TF1**
  - **TFO**: (**Currently broken**)

--- a/supportedsites.md
+++ b/supportedsites.md
@@ -1369,7 +1369,7 @@ The only reliable way to check if a site is supported is to try it.
  - **TeleQuebecSquat**
  - **TeleQuebecVideo**
  - **TeleTask**: (**Currently broken**)
- - **Telewebion**: (**Currently broken**)
+ - **Telewebion**
  - **TennisTV**: [*tennistv*](## "netrc machine")
  - **TF1**
  - **TFO**: (**Currently broken**)

--- a/supportedsites.md
+++ b/supportedsites.md
@@ -1369,7 +1369,7 @@ The only reliable way to check if a site is supported is to try it.
  - **TeleQuebecSquat**
  - **TeleQuebecVideo**
  - **TeleTask**: (**Currently broken**)
-**Telewebion**: (**Currently broken**)
+ - **Telewebion**: (**Currently broken**)
  - **TennisTV**: [*tennistv*](## "netrc machine")
  - **TF1**
  - **TFO**: (**Currently broken**)

--- a/yt_dlp/extractor/telewebion.py
+++ b/yt_dlp/extractor/telewebion.py
@@ -56,7 +56,7 @@ class TelewebionIE(InfoExtractor):
             'tags': ['کلیپ های منتخب', ' کلیپ طنز ', ' کلیپ سیاست ', 'پاورقی', 'ویژه فلسطین'],
             'thumbnail': 'https://static.telewebion.ir/episodeImages/871e9455-7567-49a5-9648-34c22c197f5f/default',
         },
-        'skip_download': 'm3u8',
+        'skip': 'Dead link',
     }]
 
     def _call_graphql_api(

--- a/yt_dlp/extractor/telewebion.py
+++ b/yt_dlp/extractor/telewebion.py
@@ -14,7 +14,7 @@ def _fmt_url(url):
 
 
 class TelewebionIE(InfoExtractor):
-    _WORKING = False
+    _WORKING = True
     _VALID_URL = r'https?://(?:www\.)?telewebion\.ir/episode/(?P<id>(?:0x[a-fA-F\d]+|\d+))'
     _TESTS = [{
         'url': 'http://www.telewebion.ir/episode/0x1b3139c/',

--- a/yt_dlp/extractor/telewebion.py
+++ b/yt_dlp/extractor/telewebion.py
@@ -35,7 +35,7 @@ class TelewebionIE(InfoExtractor):
             'tags': ['ورزشی', 'لیگ اروپا', 'اروپا'],
             'thumbnail': 'https://static.telewebion.ir/episodeImages/YjFhM2MxMDBkMDNiZTU0MjE5YjQ3ZDY0Mjk1ZDE0ZmUwZWU3OTE3OWRmMDAyODNhNzNkNjdmMWMzMWIyM2NmMA/default',
         },
-        'skip_download': 'm3u8',
+        'params': {'skip_download': 'm3u8'},
     }, {
         'url': 'https://telewebion.ir/episode/162175536',
         'info_dict': {

--- a/yt_dlp/extractor/telewebion.py
+++ b/yt_dlp/extractor/telewebion.py
@@ -15,9 +15,9 @@ def _fmt_url(url):
 
 class TelewebionIE(InfoExtractor):
     _WORKING = False
-    _VALID_URL = r'https?://(?:www\.)?telewebion\.com/episode/(?P<id>(?:0x[a-fA-F\d]+|\d+))'
+    _VALID_URL = r'https?://(?:www\.)?telewebion\.ir/episode/(?P<id>(?:0x[a-fA-F\d]+|\d+))'
     _TESTS = [{
-        'url': 'http://www.telewebion.com/episode/0x1b3139c/',
+        'url': 'http://www.telewebion.ir/episode/0x1b3139c/',
         'info_dict': {
             'id': '0x1b3139c',
             'ext': 'mp4',
@@ -26,7 +26,7 @@ class TelewebionIE(InfoExtractor):
             'series_id': '0x1b2505c',
             'channel': 'شبکه 3',
             'channel_id': '0x1b1a761',
-            'channel_url': 'https://telewebion.com/live/tv3',
+            'channel_url': 'https://telewebion.ir/live/tv3',
             'timestamp': 1425522414,
             'upload_date': '20150305',
             'release_timestamp': 1425517020,
@@ -34,11 +34,11 @@ class TelewebionIE(InfoExtractor):
             'duration': 420,
             'view_count': int,
             'tags': ['ورزشی', 'لیگ اروپا', 'اروپا'],
-            'thumbnail': 'https://static.telewebion.com/episodeImages/YjFhM2MxMDBkMDNiZTU0MjE5YjQ3ZDY0Mjk1ZDE0ZmUwZWU3OTE3OWRmMDAyODNhNzNkNjdmMWMzMWIyM2NmMA/default',
+            'thumbnail': 'https://static.telewebion.ir/episodeImages/YjFhM2MxMDBkMDNiZTU0MjE5YjQ3ZDY0Mjk1ZDE0ZmUwZWU3OTE3OWRmMDAyODNhNzNkNjdmMWMzMWIyM2NmMA/default',
         },
         'skip_download': 'm3u8',
     }, {
-        'url': 'https://telewebion.com/episode/162175536',
+        'url': 'https://telewebion.ir/episode/162175536',
         'info_dict': {
             'id': '0x9aa9a30',
             'ext': 'mp4',
@@ -47,7 +47,7 @@ class TelewebionIE(InfoExtractor):
             'series_id': '0x29a7426',
             'channel': 'شبکه 2',
             'channel_id': '0x1b1a719',
-            'channel_url': 'https://telewebion.com/live/tv2',
+            'channel_url': 'https://telewebion.ir/live/tv2',
             'timestamp': 1699979968,
             'upload_date': '20231114',
             'release_timestamp': 1699991638,
@@ -55,7 +55,7 @@ class TelewebionIE(InfoExtractor):
             'duration': 78,
             'view_count': int,
             'tags': ['کلیپ های منتخب', ' کلیپ طنز ', ' کلیپ سیاست ', 'پاورقی', 'ویژه فلسطین'],
-            'thumbnail': 'https://static.telewebion.com/episodeImages/871e9455-7567-49a5-9648-34c22c197f5f/default',
+            'thumbnail': 'https://static.telewebion.ir/episodeImages/871e9455-7567-49a5-9648-34c22c197f5f/default',
         },
         'skip_download': 'm3u8',
     }]
@@ -70,7 +70,7 @@ class TelewebionIE(InfoExtractor):
             parameters = ', '.join(f'${name}: {type_}' for name, (type_, _) in variables.items())
             parameters = f'({parameters})'
 
-        result = self._download_json('https://graph.telewebion.com/graphql', video_id, note, data=json.dumps({
+        result = self._download_json('https://graph.telewebion.ir/graphql', video_id, note, data=json.dumps({
             'operationName': operation,
             'query': f'query {operation}{parameters} @cacheControl(maxAge: 60) {{{query}\n}}\n',
             'variables': {name: value for name, (_, value) in (variables or {}).items()},
@@ -123,11 +123,11 @@ class TelewebionIE(InfoExtractor):
             'series_id': ('program', 'ProgramID', {str}),
             'channel': ('channel', 'name', {str}),
             'channel_id': ('channel', 'ChannelID', {str}),
-            'channel_url': ('channel', 'descriptor', {_fmt_url('https://telewebion.com/live/%s')}),
-            'thumbnail': ('image', {_fmt_url('https://static.telewebion.com/episodeImages/%s/default')}),
+            'channel_url': ('channel', 'descriptor', {_fmt_url('https://telewebion.ir/live/%s')}),
+            'thumbnail': ('image', {_fmt_url('https://static.telewebion.ir/episodeImages/%s/default')}),
             'formats': (
                 'channel', 'descriptor', {str},
-                {_fmt_url(f'https://cdna.telewebion.com/%s/episode/{video_id}/playlist.m3u8')},
+                {_fmt_url(f'https://cdna.telewebion.ir/%s/episode/{video_id}/playlist.m3u8')},
                 {functools.partial(self._extract_m3u8_formats, video_id=video_id, ext='mp4', m3u8_id='hls')}),
         }))
         info_dict['id'] = video_id

--- a/yt_dlp/extractor/telewebion.py
+++ b/yt_dlp/extractor/telewebion.py
@@ -14,7 +14,6 @@ def _fmt_url(url):
 
 
 class TelewebionIE(InfoExtractor):
-    _WORKING = True
     _VALID_URL = r'https?://(?:www\.)?telewebion\.ir/episode/(?P<id>(?:0x[a-fA-F\d]+|\d+))'
     _TESTS = [{
         'url': 'http://www.telewebion.ir/episode/0x1b3139c/',


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fixes Telewebion extractor by replacing every .com with .ir . Credit to @dirkf for [coming up with this solution](https://github.com/yt-dlp/yt-dlp/issues/16826#issuecomment-4576183215).
Also I don't really know what "add/update tests" means, please forgive me for not doing so. Though there is this `_TESTS` thing which had some URLs; I updated the TLDs in them too. Maybe those are what "tests" means?

Fixes #16826 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
