### PR TITLE
[ie/BBC] Fix BBC extractor failing to extract BBC Sounds playlist data

### DIFF
--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -1166,6 +1166,16 @@ class BBCIE(BBCCoUkIE):  # XXX: Do not subclass from concrete IE
         # PRELOADED_STATE with current programmme
         current_programme = traverse_obj(preload_state, ('programmes', 'current', {dict}))
         programme_id = traverse_obj(current_programme, ('id', {str}))
+        if not (programme_id and current_programme.get('type') == 'playable_item'):
+            # BBC Sounds migrated to Next.js __NEXT_DATA__ with dehydrated React Query state at some point
+            # so cover that edge case off
+            current_programme = traverse_obj(
+                self._search_nextjs_data(webpage, playlist_id, default={}), (
+                    'props', 'pageProps', 'dehydratedState', 'queries', ...,
+                    'state', 'data', 'data', ..., 'data',
+                    lambda _, v: v.get('type') == 'playable_item' and v.get('urn', '').endswith(playlist_id),
+                    any))
+            programme_id = traverse_obj(current_programme, ('id', {str}))
         if programme_id and current_programme.get('type') == 'playable_item':
             title = traverse_obj(current_programme, ('titles', ('tertiary', 'secondary'), {str}, any)) or playlist_title
             formats, subtitles = self._download_media_selector(programme_id)

--- a/yt_dlp/extractor/bbc.py
+++ b/yt_dlp/extractor/bbc.py
@@ -1164,16 +1164,15 @@ class BBCIE(BBCCoUkIE):  # XXX: Do not subclass from concrete IE
             r'window\.__(?:PWA_)?PRELOADED_STATE__\s*=', webpage,
             'preload state', playlist_id, transform_source=js_to_json, default={})
         # PRELOADED_STATE with current programmme
-        current_programme = traverse_obj(preload_state, ('programmes', 'current', {dict}))
+        current_programme = traverse_obj(preload_state, ('programmes', 'current', {dict})) or {}
         programme_id = traverse_obj(current_programme, ('id', {str}))
         if not (programme_id and current_programme.get('type') == 'playable_item'):
-            # BBC Sounds migrated to Next.js __NEXT_DATA__ with dehydrated React Query state at some point
-            # so cover that edge case off
+            # BBC Sounds migrated to Next.js __NEXT_DATA__
             current_programme = traverse_obj(
                 self._search_nextjs_data(webpage, playlist_id, default={}), (
                     'props', 'pageProps', 'dehydratedState', 'queries', ...,
                     'state', 'data', 'data', ..., 'data',
-                    lambda _, v: v.get('type') == 'playable_item' and v.get('urn', '').endswith(playlist_id),
+                    lambda _, v: v['type'] == 'playable_item' and v['urn'].endswith(playlist_id),
                     any))
             programme_id = traverse_obj(current_programme, ('id', {str}))
         if programme_id and current_programme.get('type') == 'playable_item':


### PR DESCRIPTION
### Description of your *pull request* and other information

At some point, BBC sounds pages switched from `window.__PRELOADED_STATE__` to Next.js's `__NEXT_DATA__` page with a dehydrated React Query state. The BBC extractor ended up exhausting all extraction paths, and then fell through to running a regex search for `vxp-playlist-data`, which seemingly isn't present on Sounds pages.

This fix adds a fallback in the `PRELOADED_STATE` block. If the `programmes.current` is not found (or isn't a `playable_item`), then traverse `__NEXT_DATA__`'s `dehydratedState.queries[*].state.data.data[*].data[*]` to find the `playable_item` whose URN ends with the URL PID. The resulting matched item has an identical field shape to the existing `PRELOADED_STATE` extraction, so I didn't have to create a separate metadata mapping.

Existing tests cover this edge, so I elected not to expand the existing tests. If you'd like me to look at expanding coverage, let me know and I'll be happy to :) 

Fixes #14569

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>