### PR TITLE
Fix uppercase thumbnail extensions in EmbedThumbnailPP

### DIFF
--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -79,7 +79,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         # Convert unsupported thumbnail formats (see #25687, #25717)
         # PNG is preferred since JPEG is lossy
-        thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:]
+        thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:].lower()
         if info['ext'] not in ('mkv', 'mka') and thumbnail_ext not in ('jpg', 'jpeg', 'png'):
             thumbnail_filename = convertor.convert_thumbnail(thumbnail_filename, 'png')
             thumbnail_ext = 'png'


### PR DESCRIPTION

This PR fixes thumbnail extension handling in "EmbedThumbnailPP".

Previously, the thumbnail extension was extracted without normalizing its case:

thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:]

As a result, thumbnails with uppercase extensions such as ".JPG", ".JPEG", or ".PNG" could be incorrectly treated as unsupported when compared against lowercase extension lists.

This change normalizes the extracted extension to lowercase before performing format checks:

thumbnail_ext = os.path.splitext(thumbnail_filename)[1][1:].lower()

This ensures that thumbnail processing behaves consistently regardless of the capitalization of the file extension.

Fixes #16993

Before submitting a pull request make sure you have:

- [x] At least skimmed through contributing guidelines including yt-dlp coding conventions
- [x] Searched the bugtracker for similar pull requests

In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under Unlicense:

- [x] I am the original author of the code in this PR, and I am willing to release it under Unlicense
- [x] I have read the policy against AI/LLM contributions and understand I may be blocked from the repository if it is violated

What is the purpose of your pull request?

- [x] Core bug fix/improvement
