### PR TITLE
fix: correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2479,7 +2479,7 @@ These options may no longer work as intended
     --youtube-print-sig-code         Removed testing functionality
     --dump-user-agent                No longer supported
     --xattr-set-filesize             No longer supported
-    --compat-options seperate-video-versions  No longer needed
+    --compat-options separate-video-versions  No longer needed
     --compat-options no-youtube-prefer-utc-upload-date  No longer supported
 
 #### Removed


### PR DESCRIPTION
## Summary

Corrected the following typos in `README.md`:

- `seperate` → `separate` (line 2482)

---
*Non-functional changes, improves readability.*
