### PR TITLE
[ie/niconico] Fix watch history extraction

### DIFF
--- a/yt_dlp/extractor/niconico.py
+++ b/yt_dlp/extractor/niconico.py
@@ -580,6 +580,9 @@ class NiconicoPlaylistBaseIE(InfoExtractor):
             'page': page,
             'pageSize': self._PAGE_SIZE,
         })
+        yield from self._parse_videos(resp)
+
+    def _parse_videos(self, resp):
         # this is needed to support both mylist and user
         for video in traverse_obj(resp, ('items', ..., ('video', None))) or []:
             video_id = video.get('id')
@@ -693,11 +696,19 @@ class NiconicoSeriesIE(NiconicoPlaylistBaseIE):
 class NiconicoHistoryIE(NiconicoPlaylistBaseIE):
     IE_NAME = 'niconico:history'
     IE_DESC = 'NicoNico user history or likes. Requires cookies.'
-    _VALID_URL = r'https?://(?:www\.|sp\.)?nicovideo\.jp/my/(?P<id>history(?:/like)?)'
+    _VALID_URL = r'https?://(?:www\.|sp\.)?nicovideo\.jp/my/(?P<id>history(?:/(?:video(?:/(?:long|short))?|like))?)/?(?=$|[?#])'
 
     _TESTS = [{
         'note': 'PC page, with /video',
         'url': 'https://www.nicovideo.jp/my/history/video',
+        'only_matching': True,
+    }, {
+        'note': 'PC page, with /video/long',
+        'url': 'https://www.nicovideo.jp/my/history/video/long',
+        'only_matching': True,
+    }, {
+        'note': 'PC page, with /video/short',
+        'url': 'https://www.nicovideo.jp/my/history/video/short',
         'only_matching': True,
     }, {
         'note': 'PC page, without /video',
@@ -722,15 +733,39 @@ class NiconicoHistoryIE(NiconicoPlaylistBaseIE):
     }]
 
     def _call_api(self, list_id, resource, query):
-        path = 'likes' if list_id == 'history/like' else 'watch/history'
+        if list_id == 'history/like':
+            path = 'v1/users/me/likes'
+        else:
+            path = 'v2/users/me/watch/history'
+            query = {'selectContentType': 'short' if list_id.endswith('short') else 'long', **query}
         return self._download_json(
-            f'https://nvapi.nicovideo.jp/v1/users/me/{path}', list_id,
+            f'https://nvapi.nicovideo.jp/{path}', list_id,
             f'Downloading {resource}', query=query, headers=self._API_HEADERS)['data']
+
+    def _watch_history_entries(self, list_id):
+        cursor = None
+        for page in itertools.count(1):
+            query = {'limit': self._PAGE_SIZE}
+            if cursor:
+                query['cursor'] = cursor
+            resp = self._call_api(list_id, f'page {page}', query)
+            if not resp.get('items'):
+                break
+            yield from self._parse_videos(resp)
+            cursor = traverse_obj(resp, ('nextCursor', {str}))
+            if not cursor:
+                break
+
+    def _entries(self, list_id):
+        if list_id == 'history/like':
+            return super()._entries(list_id)
+        return self._watch_history_entries(list_id)
 
     def _real_extract(self, url):
         list_id = self._match_id(url)
         try:
-            mylist = self._call_api(list_id, 'list', {'pageSize': 1})
+            query = {'pageSize': 1} if list_id == 'history/like' else {'limit': 1}
+            mylist = self._call_api(list_id, 'list', query)
         except ExtractorError as e:
             if isinstance(e.cause, HTTPError) and e.cause.status == 401:
                 self.raise_login_required('You have to be logged in to get your history')


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

Fix NicoNico watch history extraction.

The old `v1/users/me/watch/history` endpoint now returns HTTP 404, causing extraction from `https://www.nicovideo.jp/my/history/video` to fail.

The current NicoNico website uses the `v2/users/me/watch/history` endpoint for watch history. This PR updates the extractor to use the `v2/users/me/watch/history` endpoint to match the current website behavior.

API-related changes:

- Since regular videos and short videos are now distinguished in the watch history API, use the `selectContentType` query parameter with `long` for regular videos and `short` for short videos.
- Add URL matching for:
  - `https://www.nicovideo.jp/my/history/video/long`
  - `https://www.nicovideo.jp/my/history/video/short`
- Update watch history pagination to use cursor-based pagination.

The likes history page still uses the existing `v1/users/me/likes` endpoint on the current website, so the likes history endpoint is kept unchanged.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
