### PR TITLE
[ie/youtube] Support new web client versions

### DIFF
--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime as dt
 import enum
 import functools
+import gzip
 import hashlib
 import json
 import re
@@ -99,11 +100,12 @@ INNERTUBE_CLIENTS = {
         'INNERTUBE_CONTEXT': {
             'client': {
                 'clientName': 'WEB',
-                'clientVersion': '2.20260114.08.00',
+                'clientVersion': '2.20260618.05.00',
             },
         },
         'INNERTUBE_CONTEXT_CLIENT_NAME': 1,
         'SUPPORTS_COOKIES': True,
+        'REQUIRE_GZIP': True,
         **WEB_PO_TOKEN_POLICIES,
     },
     # Safari UA returns pre-merged video+audio 144p/240p/360p/720p/1080p HLS formats
@@ -111,12 +113,13 @@ INNERTUBE_CLIENTS = {
         'INNERTUBE_CONTEXT': {
             'client': {
                 'clientName': 'WEB',
-                'clientVersion': '2.20260114.08.00',
+                'clientVersion': '2.20260618.05.00',
                 'userAgent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)',
             },
         },
         'INNERTUBE_CONTEXT_CLIENT_NAME': 1,
         'SUPPORTS_COOKIES': True,
+        'REQUIRE_GZIP': True,
         **WEB_PO_TOKEN_POLICIES,
     },
     'web_embedded': {
@@ -389,6 +392,7 @@ def build_innertube_clients():
         ytcfg.setdefault('SUPPORTS_COOKIES', False)
         ytcfg.setdefault('SUPPORTS_AD_PLAYBACK_CONTEXT', False)
         ytcfg.setdefault('PLAYER_PARAMS', None)
+        ytcfg.setdefault('REQUIRE_GZIP', False)
         ytcfg['INNERTUBE_CONTEXT']['client'].setdefault('hl', 'en')
 
         _, base_client, variant = _split_innertube_client(client)
@@ -802,10 +806,19 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         real_headers.update({'content-type': 'application/json'})
         if headers:
             real_headers.update(headers)
+
+        json_bytes = json.dumps(data).encode('utf8')
+
+        if INNERTUBE_CLIENTS[default_client].get('REQUIRE_GZIP'):
+            body = gzip.compress(json_bytes)
+            real_headers['Content-Encoding'] = 'gzip'
+        else:
+            body = json_bytes
+
         return self._download_json(
             f'https://{self._select_api_hostname(api_hostname, default_client)}/youtubei/v1/{ep}',
             video_id=video_id, fatal=fatal, note=note, errnote=errnote,
-            data=json.dumps(data).encode('utf8'), headers=real_headers,
+            data=body, headers=real_headers,
             query=filter_dict({
                 'key': self._configuration_arg(
                     'innertube_key', [api_key], ie_key=CONFIGURATION_ARG_KEY, casesense=True)[0],


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

#### ⚠️ pls note that this issue couldn't be reproduced on yt-dlp, this pr is more of a proof of concept or preparation for future

for the past 1-2 weeks, youtube no longer returns continuation token in the continuation response for old clients (eg: `WEB 2.20260114.08.00`), so a playlist could only load up to 200 videos only. **the issue doesn't seem to happen with ytdlp** so it might not be needed but it's worth noticing since ytdlp uses older clients versions. it could also be an internal youtube bug but it's worth be ready for such changes.

by using the newest client version (currently `2.20260618.05.00`) and gzip encoding the body, the issue was fixed immediately

example for old responses attached below (not from ytdlp)
(playlist: https://www.youtube.com/playlist?list=PLQOaTSbfxUtCrKs0nicOg2npJQYSPGO9r - 204 videos):

[playlist_0+ (has continuation).json](https://github.com/user-attachments/files/29254793/playlist_0%2B.has.continuation.json)
[playlist_100+ (no continuation).json](https://github.com/user-attachments/files/29254795/playlist_100%2B.no.continuation.json)
[playlist_200+ (continuation not for videos).json](https://github.com/user-attachments/files/29254799/playlist_200%2B.continuation.not.for.videos.json)

Fixes #
can't tell for sure but i believe it could fix any info extraction and continuation issues, if not now then in future
this can also open the door for new endpoints like `get_watch`, which returns both page info and video streams in 1 response

im sorry for not providing test results properly as i didn't find/know how to run info tests for `YoutubeBaseInfoExtractor`, so only tested locally for simple playlist T.T
u can treat this pr as a proof of concept more than an actual pr, i just wanted to provide any help for this awesome tool, tysm ❤️

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
