### PR TITLE
fix: cache netrc credentials to avoid re-reading on every URL (#16897)

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -586,6 +586,7 @@ class InfoExtractor:
     _WORKING = True
     _ENABLED = True
     _NETRC_MACHINE = None
+    _NETRC_CACHE: dict = {}
     IE_DESC = None
     SEARCH_KEY = None
     _VALID_URL = None
@@ -1394,17 +1395,23 @@ class InfoExtractor:
         cmd = self.get_param('netrc_cmd')
         if cmd:
             cmd = cmd.replace('{}', netrc_machine)
-            self.to_screen(f'Executing command: {cmd}')
-            stdout, _, ret = Popen.run(cmd, text=True, shell=True, stdout=subprocess.PIPE)
-            if ret != 0:
-                raise OSError(f'Command returned error code {ret}')
-            info = netrc_from_content(stdout).authenticators(netrc_machine)
+            if cmd in self._NETRC_CACHE:
+                self.write_debug(f'Using cached netrc command: {cmd}')
+            else:
+                self.to_screen(f'Executing command: {cmd}')
+                stdout, _, ret = Popen.run(cmd, text=True, shell=True, stdout=subprocess.PIPE)
+                if ret != 0:
+                    raise OSError(f'Command returned error code {ret}')
+                self._NETRC_CACHE[cmd] = netrc_from_content(stdout)
+            info = self._NETRC_CACHE[cmd].authenticators(netrc_machine)
 
         elif self.get_param('usenetrc', False):
-            netrc_file = compat_expanduser(self.get_param('netrc_location') or '~')
-            if os.path.isdir(netrc_file):
-                netrc_file = os.path.join(netrc_file, '.netrc')
-            info = netrc.netrc(netrc_file).authenticators(netrc_machine)
+            if '' not in self._NETRC_CACHE:
+                netrc_file = compat_expanduser(self.get_param('netrc_location') or '~')
+                if os.path.isdir(netrc_file):
+                    netrc_file = os.path.join(netrc_file, '.netrc')
+                self._NETRC_CACHE[''] = netrc.netrc(netrc_file)
+            info = self._NETRC_CACHE[''].authenticators(netrc_machine)
 
         else:
             return None, None


### PR DESCRIPTION
## Problem

yt-dlp reads netrc credentials multiple times per URL. This causes:
- Interactive credential commands (`--netrc-cmd`) prompting the user multiple times
- File-based netrc (`--netrc`) being re-parsed for every extractor call

## Solution

Cache the netrc object class-wide so each credential source is read exactly once per session. Uses a dictionary keyed on the command string (for `--netrc-cmd`) or an empty string (for `--netrc`/`--netrc-location`).

## Changes

- `yt_dlp/extractor/common.py`: Added `_NETRC_CACHE` class dict, cache netrc objects in `_get_netrc_login_info`

## Testing

- `hatch test` passes
- `--netrc-cmd` now runs once per distinct site
- `--netrc` reads the file once for all URLs

Closes #16897