### PR TITLE
Closes #17006 by fixing the sportdeutschland extractor

### DIFF
--- a/yt_dlp/extractor/sportdeutschland.py
+++ b/yt_dlp/extractor/sportdeutschland.py
@@ -128,13 +128,15 @@ class SportDeutschlandIE(InfoExtractor):
     def _real_extract(self, url):
         display_id = self._match_id(url)
         meta = self._download_json(
-            f'https://api.sporteurope.tv/api/stateless/frontend/assets/{display_id}',
-            display_id, query={'access_token': 'true'})
+            f'https://api.sporteurope.tv/api/web/public/assets/{display_id}',
+            display_id, note='Downloading asset metadata')
+
+        asset_id = traverse_obj(meta, (('id', 'uuid'), ), get_all=False)
 
         info = {
+            'id': asset_id,
             'display_id': display_id,
             **traverse_obj(meta, {
-                'id': (('id', 'uuid'), ),
                 'title': (('title', 'name'), {strip_or_none}),
                 'description': 'description',
                 'channel': ('profile', 'name'),
@@ -142,23 +144,34 @@ class SportDeutschlandIE(InfoExtractor):
                 'is_live': 'currently_live',
                 'was_live': 'was_live',
                 'channel_url': ('profile', 'slug', {lambda x: f'https://sporteurope.tv/{x}'}),
+                'duration': ('duration_in_seconds', {lambda x: float(x) > 0 and float(x)}),
             }, get_all=False),
         }
+        player_meta = self._download_json(
+            f'https://api.sporteurope.tv/api/web-player/personal/assets/{asset_id}',
+            display_id, note='Downloading player metadata',
+            headers={
+                'Origin': 'https://sporteurope.tv',
+                'Referer': 'https://sporteurope.tv/',
+                'x-version': '2',
+                },)
 
-        parts = traverse_obj(meta, (('livestream', ('videos', ...)), ))
-        entries = [{
-            'title': join_nonempty(info.get('title'), f'Part {i}', delim=' '),
-            **traverse_obj(info, {'channel': 'channel', 'channel_id': 'channel_id',
-                                  'channel_url': 'channel_url', 'was_live': 'was_live'}),
-            **self._process_video(info['id'], video),
-        } for i, video in enumerate(parts, 1)]
+        formats, subtitles = [], {}
+        for track in traverse_obj(player_meta, ('tracks', ...)):
+            language = traverse_obj(track, 'audio_language')
+            for source in traverse_obj(track, ('sources', ...)):
+                hls_url = traverse_obj(source, 'hls')
+                if not hls_url:
+                    continue
+                fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                    hls_url, display_id, 'mp4',
+                    live=info.get('is_live'), fatal=False)
+                for f in fmts:
+                    if language:
+                        f['language'] = language
+                formats.extend(fmts)
+                self._merge_subtitles(subs, target=subtitles)
 
-        return {
-            '_type': 'multi_video',
-            **info,
-            'entries': entries,
-        } if len(entries) > 1 else {
-            **info,
-            **entries[0],
-            'title': info.get('title'),
-        }
+        info['formats'] = formats
+        info['subtitles'] = subtitles
+        return info


### PR DESCRIPTION
### Description of your *pull request* and other information

Fix `sporteurope.tv` extraction by resolving the asset UUID from the initial public metadata request, then using that UUID with the updated player API endpoint to fetch playback info.

The site API changed, and the old frontend asset endpoint now returns 404. This restores extraction for affected videos and livestreams.

Fixes #17006


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>