### PR TITLE
[ie] Always include `id` in request error output

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -920,9 +920,9 @@ class InfoExtractor:
 
             errmsg = f'{errnote}: {err}'
             if fatal:
-                raise ExtractorError(errmsg, cause=err)
+                raise ExtractorError(errmsg, cause=err, video_id=video_id)
             else:
-                self.report_warning(errmsg)
+                self.report_warning(errmsg, video_id=video_id)
                 return False
 
     def _download_webpage_handle(self, url_or_request, video_id, note=None, errnote=None, fatal=True,

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -732,9 +732,7 @@ class SoundcloudIE(SoundcloudBaseIE):
             info_json_url = self._resolv_url(self._BASE_URL + resolve_title)
 
         info = self._call_api(
-            info_json_url, full_title, 'Downloading info JSON', query=query,
-            headers=self._HEADERS,
-            errnote=f'{full_title}: Could not download info JSON')
+            info_json_url, full_title, 'Downloading info JSON', query=query, headers=self._HEADERS)
 
         for retry in self.RetryManager():
             try:

--- a/yt_dlp/extractor/soundcloud.py
+++ b/yt_dlp/extractor/soundcloud.py
@@ -732,7 +732,9 @@ class SoundcloudIE(SoundcloudBaseIE):
             info_json_url = self._resolv_url(self._BASE_URL + resolve_title)
 
         info = self._call_api(
-            info_json_url, full_title, 'Downloading info JSON', query=query, headers=self._HEADERS)
+            info_json_url, full_title, 'Downloading info JSON', query=query,
+            headers=self._HEADERS,
+            errnote=f'{full_title}: Could not download info JSON')
 
         for retry in self.RetryManager():
             try:


### PR DESCRIPTION
### Description of your *pull request* and other information

If I pass a list of soundcloud URLs to `yt-dlp --no-playlist --get-title` and some of them no longer work, the error messages hide which of the URLs did not work. With this change, it shows the track_id or uploader and title in the error message.

#### Some context

Soundcloud URLs are non-permanent and break very often, e.g. when the author changes its username.
I use yt-dlp to check for a list of soundcloud URLs which of them are broken using `yt-dlp --no-playlist --get-title`.
Since the error messages hide which of the URLs is broken, I currently start one yt-dlp process for each URL even though yt-dlp supports passing multiple URLs at once.

#### Example

Command:
```
./yt-dlp.sh --no-playlist --get-title https://astrophysicsbrazil.bandcamp.com/track/take-on-meku https://www.youtube.com/watch?v=orHDCWUo-Ym https://soundcloud.com/kimchi-tan/ppap-king-harkinian-utau-cover https://soundcloud.com/kimchi-tan/ppap https://soundcloud.com/bla/0
```

Output before:
For YouTube and Bandcamp it shows info from the URL but for Soundcloud it does not.
```
ERROR: [Bandcamp] take-on-meku: Unable to download webpage: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
ERROR: [youtube] orHDCWUo-Ym: Video unavailable
PPAP - King Harkinian (UTAU cover)
ERROR: [soundcloud] Unable to download JSON metadata: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
ERROR: [soundcloud] Unable to download JSON metadata: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
```

Output after:
```
ERROR: [Bandcamp] take-on-meku: Unable to download webpage: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
ERROR: [youtube] orHDCWUo-Ym: Video unavailable
PPAP - King Harkinian (UTAU cover)
ERROR: [soundcloud] kimchi-tan/ppap: Could not download info JSON: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
ERROR: [soundcloud] bla/0: Could not download info JSON: HTTP Error 404: Not Found (caused by <HTTPError 404: Not Found>)
```



<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
