### PR TITLE
[downloader/fragment] Fix --max-filesize check for fragmented downloads

### DIFF
--- a/yt_dlp/downloader/fragment.py
+++ b/yt_dlp/downloader/fragment.py
@@ -171,7 +171,9 @@ class FragmentFD(FileDownloader):
             'sleep_interval': 0,
             'max_sleep_interval': 0,
             'sleep_interval_subtitles': 0,
-        })
+             # Bypass filesize limits for individual fragments
+            'max_filesize': None,  
+            'min_filesize': None,  
         tmpfilename = self.temp_name(ctx['filename'])
         open_mode = 'wb'
 
@@ -478,6 +480,13 @@ class FragmentFD(FileDownloader):
                 ctx['dest_stream'].close()
                 self.report_error(f'fragment {frag_index} not found, unable to continue')
                 return False
+            
+             # Enforce max-filesize limit on the cumulative downloaded size
+            max_filesize = self.params.get('max_filesize')
+            if max_filesize is not None and ctx.get('complete_frags_downloaded_bytes', 0) > max_filesize:
+                self.to_screen(f'\r[download] File is larger than max-filesize ({ctx.get("complete_frags_downloaded_bytes", 0)} bytes > {max_filesize} bytes). Aborting.')
+                return False
+
             return True
 
         decrypt_fragment = self.decrypter(info_dict)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This PR fixes an issue where the `--max-filesize` limit was being evaluated against individual fragment sizes instead of the cumulative downloaded bytes in fragmented downloads (like HLS/DASH). 

I have updated `FragmentFD` to bypass the max/min filesize constraints on individual `HttpQuietDownloader` fragment requests, and explicitly added a cumulative downloaded size check when appending the fragments to the destination stream.

Fixes #14628

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>