### PR TITLE
Clarify -x/--extract-audio description (closes #16932)

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,8 +940,11 @@ Tip: Use `CTRL`+`F` (or `Command`+`F`)  to search by keywords
                                     is encrypted, yt-dlp will ask interactively
 
 ## Post-Processing Options:
-    -x, --extract-audio             Convert video files to audio-only files
-                                    (requires ffmpeg and ffprobe)
+    -x, --extract-audio             Download audio-only formats when available, or
+                                    extract audio from video files when no audio-only
+                                    format is available. Changes default format
+                                    selection to -f bestaudio/best if no format is
+                                    specified (requires ffmpeg and ffprobe)
     --audio-format FORMAT           Format to convert the audio to when -x is
                                     used. (currently supported: best (default),
                                     aac, alac, flac, m4a, mp3, opus, vorbis,

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1615,7 +1615,11 @@ def create_parser():
     postproc.add_option(
         '-x', '--extract-audio',
         action='store_true', dest='extractaudio', default=False,
-        help='Convert video files to audio-only files (requires ffmpeg and ffprobe)')
+        help=(
+            'Download audio-only formats when available, or extract audio from video files '
+            'when no audio-only format is available. '
+            'Changes the default format selection to -f bestaudio/best if no format is specified. '
+            '(requires ffmpeg and ffprobe)'))
     postproc.add_option(
         '--audio-format', metavar='FORMAT', dest='audioformat', default='best',
         help=(


### PR DESCRIPTION
## Description

The description of `-x`/`--extract-audio` currently says it "Convert video files to audio-only files", which is misleading. It makes it sound like `-x` always downloads a video and then extracts audio from it.

In reality, `-x` changes the default format selection to `-f bestaudio/best`, so yt-dlp will:

1. **Download an audio-only format directly** when one is available, OR
2. **Extract audio from the best (or user-specified) video format** if no audio-only format exists.

This PR updates the help text in `yt_dlp/options.py` and the corresponding entry in `README.md` to make the behavior explicit.

The wording follows the suggestion from @ruben1PvP in the issue thread, with the addition of explicitly mentioning the `-f bestaudio/best` default change.

## Changes

- `yt_dlp/options.py`: Updated help string for `-x`/`--extract-audio` option
- `README.md`: Updated the corresponding entry in the Post-Processing Options section

## Before

```
-x, --extract-audio             Convert video files to audio-only files
```

```
help='Convert video files to audio-only files (requires ffmpeg and ffprobe)'
```

## After

```
-x, --extract-audio             Download audio-only formats when available, or
                                extract audio from video files when no audio-only
                                format is available. Changes default format
                                selection to -f bestaudio/best if no format is
                                specified (requires ffmpeg and ffprobe)
```

```python
help=(
    'Download audio-only formats when available, or extract audio from video files '
    'when no audio-only format is available. '
    'Changes the default format selection to -f bestaudio/best if no format is specified. '
    '(requires ffmpeg and ffprobe)'))
```

Closes #16932

<details><summary>Template</summary>

### Before submitting a pull request, make sure you have:

- [x] Read the [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#instructions-for-contributing)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/issues?q=is%3Aissue%20-label%3Aspam%20) for similar pull requests
- [x] [Backported](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#backporting) the changes if they are bug fixes (not applicable — docs only)

### In order to be accepted and merged into yt-dlp:

- [x] I understand that this is a documentation-only change and does not require tests
- [x] Each new algorithm is well-documented (not applicable)
- [x] The code has been tested locally and passes all tests (N/A — no code change)

</details>