### PR TITLE
Fix issues with uppercase file extensions during post-processing

### DIFF
--- a/test/test_postprocessors.py
+++ b/test/test_postprocessors.py
@@ -16,6 +16,7 @@ from yt_dlp.utils import (
     shell_quote,
 )
 from yt_dlp.postprocessor import (
+    EmbedThumbnailPP,
     ExecPP,
     FFmpegThumbnailsConvertorPP,
     MetadataFromFieldPP,
@@ -678,6 +679,18 @@ outpoint 10.000000
         self.assertEqual(
             r"'special '\'' characters '\'' galore'\'\'\'",
             self._pp._quote_for_ffmpeg("special ' characters ' galore'''"))
+
+
+class TestEmbedThumbnail(unittest.TestCase):
+    def test_uppercase_ext(self):
+        pp = EmbedThumbnailPP(YoutubeDL())
+        info = {
+            'filepath': 'test.MP3',
+            'ext': 'MP3',
+            'thumbnails': [{'filepath': 'nonexistent_thumb.jpg'}],
+        }
+        _, returned_info = pp.run(info)
+        self.assertEqual(returned_info['ext'], 'mp3')
 
 
 if __name__ == '__main__':

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3467,7 +3467,7 @@ class YoutubeDL:
                     file = self.existing_file(itertools.chain(*zip(map(converted, filepaths), filepaths, strict=True)),
                                               default_overwrite=False)
                     if file:
-                        info_dict['ext'] = os.path.splitext(file)[1][1:]
+                        info_dict['ext'] = os.path.splitext(file)[1][1:].lower()
                     return file
 
                 fd, success = None, True
@@ -3496,7 +3496,7 @@ class YoutubeDL:
                     def correct_ext(filename, ext=new_ext):
                         if filename == '-':
                             return filename
-                        filename_real_ext = os.path.splitext(filename)[1][1:]
+                        filename_real_ext = os.path.splitext(filename)[1][1:].lower()
                         filename_wo_ext = (
                             os.path.splitext(filename)[0]
                             if filename_real_ext in (old_ext, new_ext)

--- a/yt_dlp/postprocessor/embedthumbnail.py
+++ b/yt_dlp/postprocessor/embedthumbnail.py
@@ -56,6 +56,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
     @PostProcessor._restrict_to(images=False)
     def run(self, info):
         filename = info['filepath']
+        info['ext'] = info.get('ext', '').lower()
         temp_filename = prepend_extension(filename, 'temp')
 
         if not info.get('thumbnails'):


### PR DESCRIPTION
When a downloaded file has an uppercase extension (such as `.MP3`), postprocessors like `EmbedThumbnailPP` that check for file formats (e.g. `info['ext']`) fail because the extension check is case-sensitive, raising a `Supported filetypes for thumbnail embedding are...` exception. Additionally, `correct_ext` in `YoutubeDL.py` does not correctly match the uppercase extension, resulting in names like `filename.MP3.mp3`. This PR normalizes all extracted file extensions to lowercase to fix these issues.