### PR TITLE
[twitcasting] imporved error message for the restricted archive access

### DIFF
--- a/yt_dlp/extractor/twitcasting.py
+++ b/yt_dlp/extractor/twitcasting.py
@@ -215,6 +215,11 @@ class TwitCastingIE(InfoExtractor):
                 '_format_sort_fields': ('source', ),
             }
         elif not m3u8_urls:
+            msg = self._html_search_regex(
+                r'(?i)\b(members only|login required)\b', webpage, 'access check', fatal=False,
+            )
+            if msg:
+                self.raise_login_required(msg=msg)
             raise ExtractorError('Failed to get m3u8 playlist')
         elif len(m3u8_urls) == 1:
             formats = self._extract_m3u8_formats(


### PR DESCRIPTION

### Description of your *pull request* and other information

It adds a check for login required content on Twitcasting page. Previously, restricted archives would fail with
'Failed to get m3u8 playlist', now the extractor calls "raise_login_required", making it more meaning full for user and giving suggestions like "Use --cookies-from-browser or --cookies for the authentication".

Fixes [#17089](https://github.com/yt-dlp/yt-dlp/issues/17089)

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] Core bug fix/improvement

</details>
