### PR TITLE
[ie/tvp] Fix catastrophic backtracking (ReDoS) in Vue data extraction

### DIFF
--- a/yt_dlp/extractor/tvp.py
+++ b/yt_dlp/extractor/tvp.py
@@ -150,7 +150,7 @@ class TVPIE(InfoExtractor):
         website_data = self._search_regex([
             # website - regiony, tvp.info
             # directory - jp2.tvp.pl
-            r'window\.__(?:website|directory)Data\s*=\s*({(?:.|\s)+?});',
+            r'window\.__(?:website|directory)Data\s*=\s*({[\s\S]+?});',
         ], webpage, 'website data')
         if not website_data:
             return None
@@ -188,7 +188,7 @@ class TVPIE(InfoExtractor):
     def _handle_vuejs_page(self, url, webpage, page_id):
         # vue client-side rendered sites (all regional pages + tvp.info)
         video_data = self._search_regex([
-            r'window\.__(?:news|video)Data\s*=\s*({(?:.|\s)+?})\s*;',
+            r'window\.__(?:news|video)Data\s*=\s*({[\s\S]+?})\s*;',
         ], webpage, 'video data', default=None)
         if video_data:
             return self._extract_vue_video(video_data, page_id=page_id)


### PR DESCRIPTION
### Description of your *pull request* and other information

`_parse_vue_website_data` and `_handle_vuejs_page` each use a `(?:.|\s)+?`
sub-pattern to capture the embedded `window.__…Data = { … }` JSON object from
the page HTML.

`(?:.|\s)` is ambiguous: `.` matches any character except newline while `\s`
matches whitespace *including* newline, so every non-newline whitespace
character (space, tab, `\r`, `\f`, `\v`) is matched by **both** branches. When
the closing `}` is missing or far away, the engine explores an exponential
number of ways to split a whitespace run between the two branches — catastrophic
backtracking that hangs the process. A malformed page is enough to freeze
yt-dlp on a tvp.pl / tvp.info regional page.

PoC (hangs on current master, instant after this change):

    import re
    pat = r'window\.__(?:website|directory)Data\s*=\s*({(?:.|\s)+?});'
    re.search(pat, 'window.__websiteData = {' + '\t' * 40)  # never returns

Fix: replace `(?:.|\s)` with the unambiguous, behaviourally identical `[\s\S]`
(any character, including newlines), which matches the same input in linear
time. Confirmed both patterns produce identical captures on valid single-line
and multi-line inputs, so no test changes are required.

Fixes # (no existing issue)

<details open><summary>Template</summary>

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I have read the [policy against AI/LLM contributions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#automated-contributions-ai--llm-policy) and understand I may be blocked from the repository if it is violated

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>