### PR TITLE
[utils] Fix 12-hour (AM/PM) conversion in `unified_timestamp`

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -495,7 +495,11 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(unified_timestamp('December 15, 2017 at 7:49 am'), 1513324140)
         self.assertEqual(unified_timestamp('2018-03-14T08:32:43.1493874+00:00'), 1521016363)
         self.assertEqual(unified_timestamp('Sunday, 26 Nov 2006, 19:00'), 1164567600)
-        self.assertEqual(unified_timestamp('wed, aug 16, 2008, 12:00pm'), 1218931200)
+        self.assertEqual(unified_timestamp('wed, aug 16, 2008, 12:00pm'), 1218888000)  # noon, not next-day midnight
+        self.assertEqual(unified_timestamp('Dec 15, 2017 at 12:00 pm'), 1513339200)
+        self.assertEqual(unified_timestamp('Dec 15, 2017 at 12:00 am'), 1513296000)
+        self.assertEqual(unified_timestamp('Dec 15, 2017 at 12:30 am'), 1513297800)
+        self.assertEqual(unified_timestamp('May 16, 2016 12:15 PM'), 1463400900)
 
         self.assertEqual(unified_timestamp('December 31 1969 20:00:01 EDT'), 1)
         self.assertEqual(unified_timestamp('Wednesday 31 December 1969 18:01:26 MDT'), 86)

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -1280,7 +1280,19 @@ def unified_timestamp(date_str, day_first=True, tz_offset=0):
     date_str = re.sub(r'\s+', ' ', re.sub(
         r'(?i)[,|]|(mon|tues?|wed(nes)?|thu(rs)?|fri|sat(ur)?|sun)(day)?', '', date_str))
 
-    pm_delta = 12 if re.search(r'(?i)PM', date_str) else 0
+    meridiem = re.search(r'(?i)(AM|PM)', date_str)
+    meridiem = meridiem.group(1).lower() if meridiem else None
+
+    def _meridiem_hours(hour):
+        # 12-hour clock correction: 12 PM is noon and 12 AM is midnight, while
+        # every other PM hour is +12. Keying on the parsed hour (rather than just
+        # the presence of "PM") is what fixes the 12 o'clock cases, which were
+        # previously off by 12 hours (12 PM -> next-day midnight, 12 AM -> noon).
+        if meridiem == 'pm' and hour != 12:
+            return 12
+        if meridiem == 'am' and hour == 12:
+            return -12
+        return 0
     timezone, date_str = extract_timezone(
         date_str, default=dt.timedelta(hours=tz_offset) if tz_offset else None)
 
@@ -1299,12 +1311,13 @@ def unified_timestamp(date_str, day_first=True, tz_offset=0):
 
     for expression in date_formats(day_first):
         with contextlib.suppress(ValueError):
-            dt_ = dt.datetime.strptime(date_str, expression) - timezone + dt.timedelta(hours=pm_delta)
-            return calendar.timegm(dt_.timetuple())
+            upload_datetime = dt.datetime.strptime(date_str, expression)
+            upload_datetime += dt.timedelta(hours=_meridiem_hours(upload_datetime.hour))
+            return calendar.timegm((upload_datetime - timezone).timetuple())
 
     timetuple = email.utils.parsedate_tz(date_str)
     if timetuple:
-        return calendar.timegm(timetuple) + pm_delta * 3600 - int(timezone.total_seconds())
+        return calendar.timegm(timetuple) + _meridiem_hours(timetuple[3]) * 3600 - int(timezone.total_seconds())
 
 
 @partial_application


### PR DESCRIPTION
## Summary

`unified_timestamp` mishandles 12 o'clock times: **`12:00 PM` → the next day's `00:00`** and **`12:00 AM` → noon**, both off by 12 hours. Hours 1–11 are correct.

## Root cause

`yt_dlp/utils/_utils.py` computed the correction as `pm_delta = 12 if re.search(r'(?i)PM', date_str) else 0` — decoupled from the parsed hour. The format strings parse the hour with `%H`, so `12:00` parses to hour 12; blindly adding 12 for any PM gives 24:00 → next-day midnight, and for AM the missing `12 → 0` rule leaves midnight at noon. The two 12-o'clock rules (12 PM → +0, 12 AM → −12) were never implemented.

```pycon
>>> from yt_dlp.utils import unified_timestamp
>>> unified_timestamp('Dec 15, 2017 at 12:00 pm')  # want 2017-12-15 12:00 = 1513339200
1513382400   # got 2017-12-16 00:00
>>> unified_timestamp('Dec 15, 2017 at 12:00 am')  # want 2017-12-15 00:00 = 1513296000
1513339200   # got 2017-12-15 12:00
```

## Fix

Apply the correction based on the parsed hour: 12 PM is noon, 12 AM is midnight, every other PM hour is +12. Fixes both the `strptime` and the `parsedate_tz` fallback paths.

The existing `test_unified_timestamps` asserted the buggy value for `'wed, aug 16, 2008, 12:00pm'` (`1218931200` = next-day midnight); corrected to noon (`1218888000`), and added 12 AM/PM regression cases covering both parse paths. Full `test/test_utils.py`: 115 passed / 1 skipped. `ruff` clean.
