### PR TITLE
Cache netrc credentials to avoid re-reading on every URL

### DIFF
--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -588,6 +588,7 @@ class InfoExtractor:
     _WORKING = True
     _ENABLED = True
     _NETRC_MACHINE = None
+    _NETRC_CACHE = {}
     IE_DESC = None
     SEARCH_KEY = None
     _VALID_URL = None
@@ -1391,17 +1392,23 @@ class InfoExtractor:
         cmd = self.get_param('netrc_cmd')
         if cmd:
             cmd = cmd.replace('{}', netrc_machine)
-            self.to_screen(f'Executing command: {cmd}')
-            stdout, _, ret = Popen.run(cmd, text=True, shell=True, stdout=subprocess.PIPE)
-            if ret != 0:
-                raise OSError(f'Command returned error code {ret}')
-            info = netrc_from_content(stdout).authenticators(netrc_machine)
+            if cmd in self._NETRC_CACHE:
+                self.write_debug(f'Using cached command: {cmd}')
+            else:
+                self.to_screen(f'Executing command: {cmd}')
+                stdout, _, ret = Popen.run(cmd, text=True, shell=True, stdout=subprocess.PIPE)
+                if ret != 0:
+                    raise OSError(f'Command returned error code {ret}')
+                self._NETRC_CACHE[cmd] = netrc_from_content(stdout)
+            info = self._NETRC_CACHE[cmd].authenticators(netrc_machine)
 
         elif self.get_param('usenetrc', False):
-            netrc_file = compat_expanduser(self.get_param('netrc_location') or '~')
-            if os.path.isdir(netrc_file):
-                netrc_file = os.path.join(netrc_file, '.netrc')
-            info = netrc.netrc(netrc_file).authenticators(netrc_machine)
+            if '' not in self._NETRC_CACHE:
+                netrc_file = compat_expanduser(self.get_param('netrc_location') or '~')
+                if os.path.isdir(netrc_file):
+                    netrc_file = os.path.join(netrc_file, '.netrc')
+                self._NETRC_CACHE[''] = netrc.netrc(netrc_file)
+            info = self._NETRC_CACHE[''].authenticators(netrc_machine)
 
         else:
             return None, None


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

I did a full deep dive in https://github.com/yt-dlp/yt-dlp/issues/16897#issuecomment-4862191684

This PR fixes redundant netrc credential fetching in `_get_netrc_login_info()`. Credentials are currently re-fetched from scratch on every call, even when the same extractor instance needs them multiple times within a single run.

Fix I propose:

Add a class-level `_NETRC_CACHE` dict, shared across all `InfoExtractor` instances, keyed appropriately:

- For `--netrc-cmd`: keyed by the fully-substituted command string, so different sites/machines get separate cache entries but repeated calls for the same command hit the cache.
- For `--netrc`: keyed by an empty string, since the whole file is parsed once and `.authenticators()` is just a dict lookup afterward - safe to reuse across machines.

Cache hits log via `write_debug` instead of `to_screen`, so there's no repeated "Executing command" noise once a value is cached and it reuses it.

The result:

- `--netrc-cmd` runs the credential command once per unique command, not 2-4× per URL.
- `--netrc` reads and parses the file once per run instead of on every call.
- `--netrc-location=<(command)` now works correctly for batches, since the FIFO is only consumed once.'

I ran the netrc tests and it is correctly using the cached command for subsequent reads

---

Fixes #16897 


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
