### PR TITLE
[sporteurope] fixed 404 error after the API changes

### DIFF
--- a/yt_dlp/extractor/sportdeutschland.py
+++ b/yt_dlp/extractor/sportdeutschland.py
@@ -14,7 +14,7 @@ class SportDeutschlandIE(InfoExtractor):
         'url': 'https://sporteurope.tv/rostock-griffins/gfl2-rostock-griffins-vs-elmshorn-fighting-pirates',
         'md5': '35c11a19395c938cdd076b93bda54cde',
         'info_dict': {
-            'id': '9f27a97d-1544-4d0b-aa03-48d92d17a03a',
+            'id': '9e9619c4-7d77-43c4-926d-49fb57dc06dc',
             'ext': 'mp4',
             'title': 'GFL2: Rostock Griffins vs. Elmshorn Fighting Pirates',
             'display_id': 'rostock-griffins/gfl2-rostock-griffins-vs-elmshorn-fighting-pirates',
@@ -23,15 +23,13 @@ class SportDeutschlandIE(InfoExtractor):
             'live_status': 'was_live',
             'description': r're:Video-Livestream des Spiels Rostock Griffins vs\. Elmshorn Fighting Pirates.+',
             'channel_id': '9635f21c-3f67-4584-9ce4-796e9a47276b',
-            'timestamp': 1749913117,
-            'upload_date': '20250614',
             'duration': 12287.0,
         },
     }, {
         # Single-part video, embedded player link
         'url': 'https://player.sporteurope.tv/9e9619c4-7d77-43c4-926d-49fb57dc06dc',
         'info_dict': {
-            'id': '9f27a97d-1544-4d0b-aa03-48d92d17a03a',
+            'id': '9e9619c4-7d77-43c4-926d-49fb57dc06dc',
             'ext': 'mp4',
             'title': 'GFL2: Rostock Griffins vs. Elmshorn Fighting Pirates',
             'display_id': '9e9619c4-7d77-43c4-926d-49fb57dc06dc',
@@ -40,8 +38,6 @@ class SportDeutschlandIE(InfoExtractor):
             'live_status': 'was_live',
             'description': r're:Video-Livestream des Spiels Rostock Griffins vs\. Elmshorn Fighting Pirates.+',
             'channel_id': '9635f21c-3f67-4584-9ce4-796e9a47276b',
-            'timestamp': 1749913117,
-            'upload_date': '20250614',
             'duration': 12287.0,
         },
         'params': {'skip_download': True},
@@ -50,6 +46,8 @@ class SportDeutschlandIE(InfoExtractor):
         'url': 'https://sporteurope.tv/en/deutsche-turnliga/2025-iwa-nachwuchsbundesliga-dtl-finale-turnen-heidelberg',
         'info_dict': {
             'id': 'a0731851-5ac2-4024-a20f-20c5fc1655de',
+            'title': '2025 | IWA-Nachwuchsbundesliga | DTL-Finale Turnen | Heidelberg',
+            'ext': 'mp4',
             'display_id': 'deutsche-turnliga/2025-iwa-nachwuchsbundesliga-dtl-finale-turnen-heidelberg',
             'channel': 'Deutsche Turnligaaaa',
             'channel_id': '936ed054-572c-48a6-8132-4a20ea81bbca',

--- a/yt_dlp/extractor/sportdeutschland.py
+++ b/yt_dlp/extractor/sportdeutschland.py
@@ -1,6 +1,5 @@
 from .common import InfoExtractor
 from ..utils import (
-    join_nonempty,
     strip_or_none,
     traverse_obj,
     unified_timestamp,
@@ -9,7 +8,7 @@ from ..utils import (
 
 class SportDeutschlandIE(InfoExtractor):
     IE_NAME = 'sporteurope'
-    _VALID_URL = r'https?://(?:player\.)?sporteurope\.tv/(?P<id>(?:[^/?#]+/)?[^?#/&]+)'
+    _VALID_URL = r'https?://(?:player\.)?sporteurope\.tv/(?:[a-z]{2}(?:-[a-z]{2})?/)?(?P<id>[^?#]+)'
     _TESTS = [{
         # Single-part video, direct link
         'url': 'https://sporteurope.tv/rostock-griffins/gfl2-rostock-griffins-vs-elmshorn-fighting-pirates',
@@ -44,6 +43,18 @@ class SportDeutschlandIE(InfoExtractor):
             'timestamp': 1749913117,
             'upload_date': '20250614',
             'duration': 12287.0,
+        },
+        'params': {'skip_download': True},
+    }, {
+        # Single-part video, match locale prefixed URL
+        'url': 'https://sporteurope.tv/en/deutsche-turnliga/2025-iwa-nachwuchsbundesliga-dtl-finale-turnen-heidelberg',
+        'info_dict': {
+            'id': 'a0731851-5ac2-4024-a20f-20c5fc1655de',
+            'display_id': 'deutsche-turnliga/2025-iwa-nachwuchsbundesliga-dtl-finale-turnen-heidelberg',
+            'channel': 'Deutsche Turnligaaaa',
+            'channel_id': '936ed054-572c-48a6-8132-4a20ea81bbca',
+            'channel_url': 'https://sporteurope.tv/deutsche-turnliga',
+            'live_status': 'was_live',
         },
         'params': {'skip_download': True},
     }, {
@@ -126,15 +137,17 @@ class SportDeutschlandIE(InfoExtractor):
         }
 
     def _real_extract(self, url):
-        display_id = self._match_id(url)
+        display_id = self._match_id(url).rstrip('/')
         meta = self._download_json(
-            f'https://api.sporteurope.tv/api/stateless/frontend/assets/{display_id}',
-            display_id, query={'access_token': 'true'})
+            f'https://api.sporteurope.tv/api/web/public/assets/{display_id}',
+            display_id, note='Downloading asset metadata')
+
+        asset_id = traverse_obj(meta, (('id', 'uuid'), ), get_all=False)
 
         info = {
+            'id': asset_id,
             'display_id': display_id,
             **traverse_obj(meta, {
-                'id': (('id', 'uuid'), ),
                 'title': (('title', 'name'), {strip_or_none}),
                 'description': 'description',
                 'channel': ('profile', 'name'),
@@ -142,23 +155,35 @@ class SportDeutschlandIE(InfoExtractor):
                 'is_live': 'currently_live',
                 'was_live': 'was_live',
                 'channel_url': ('profile', 'slug', {lambda x: f'https://sporteurope.tv/{x}'}),
+                'duration': ('duration_in_seconds', {lambda x: float(x) > 0 and float(x)}),
             }, get_all=False),
         }
 
-        parts = traverse_obj(meta, (('livestream', ('videos', ...)), ))
-        entries = [{
-            'title': join_nonempty(info.get('title'), f'Part {i}', delim=' '),
-            **traverse_obj(info, {'channel': 'channel', 'channel_id': 'channel_id',
-                                  'channel_url': 'channel_url', 'was_live': 'was_live'}),
-            **self._process_video(info['id'], video),
-        } for i, video in enumerate(parts, 1)]
+        player_meta = self._download_json(
+            f'https://api.sporteurope.tv/api/web-player/personal/assets/{asset_id}',
+            display_id, note='Downloading player metadata',
+            headers={
+                'Origin': 'https://sporteurope.tv',
+                'Referer': 'https://sporteurope.tv/',
+                'x-version': '2',
+            })
 
-        return {
-            '_type': 'multi_video',
-            **info,
-            'entries': entries,
-        } if len(entries) > 1 else {
-            **info,
-            **entries[0],
-            'title': info.get('title'),
-        }
+        formats, subtitles = [], {}
+        for track in traverse_obj(player_meta, ('tracks', ...)):
+            language = traverse_obj(track, 'audio_language')
+            for source in traverse_obj(track, ('sources', ...)):
+                hls_url = traverse_obj(source, 'hls')
+                if not hls_url:
+                    continue
+                fmts, subs = self._extract_m3u8_formats_and_subtitles(
+                    hls_url, display_id, 'mp4',
+                    live=info.get('is_live'), fatal=False)
+                for f in fmts:
+                    if language:
+                        f['language'] = language
+                formats.extend(fmts)
+                self._merge_subtitles(subs, target=subtitles)
+
+        info['formats'] = formats
+        info['subtitles'] = subtitles
+        return info


### PR DESCRIPTION
### Description of your *pull request* and other information

Fix sporteurope.tv extraction giving 404 after the API changes, also added the support for locale-prefixed URLs that returned 404 previously

Inspiration taken from this [pull request](https://github.com/yt-dlp/yt-dlp/pull/17057)

Fixes [#17006](https://github.com/yt-dlp/yt-dlp/issues/17006)


### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
