### PR TITLE
narrow exception types to OSError and TypeError in cache store

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </div>
 <!-- MANPAGE: END EXCLUDED SECTION -->
 
-yt-dlp is a feature-rich command-line audio/video downloader with support for [thousands of sites](supportedsites.md). The project is a fork of [youtube-dl](https://github.com/ytdl-org/youtube-dl) based on the now inactive [youtube-dlc](https://github.com/blackjack4494/yt-dlc).
+yt-dlp is a feature-rich command-line audio/video downloader with support for [thousands of sites (see Supported Sites)](supportedsites.md). The project is a fork of [youtube-dl](https://github.com/ytdl-org/youtube-dl) based on the now inactive [youtube-dlc](https://github.com/blackjack4494/yt-dlc).
 
 <!-- MANPAGE: MOVE "USAGE AND OPTIONS" SECTION HERE -->
 

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -422,7 +422,7 @@ def validate_options(opts):
             cmd = f'--parse-metadata {shell_quote(f)}'
             try:
                 actions = [MetadataFromFieldPP.to_action(f)]
-            except Exception as err:
+            except (ValueError, TypeError) as err:
                 raise ValueError(f'{cmd} is invalid; {err}')
         else:
             cmd = f'--replace-in-metadata {shell_quote(f)}'
@@ -431,7 +431,7 @@ def validate_options(opts):
         for action in actions:
             try:
                 MetadataParserPP.validate_action(*action)
-            except Exception as err:
+            except (ValueError, TypeError) as err:
                 raise ValueError(f'{cmd} is invalid; {err}')
             yield action
 
@@ -450,14 +450,14 @@ def validate_options(opts):
     if opts.playlist_items is not None:
         try:
             tuple(PlaylistEntries.parse_playlist_items(opts.playlist_items))
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             raise ValueError(f'Invalid playlist-items {opts.playlist_items!r}: {err}')
 
     opts.geo_bypass_country, opts.geo_bypass_ip_block = None, None
     if opts.geo_bypass.lower() not in ('default', 'never'):
         try:
             GeoUtils.random_ipv4(opts.geo_bypass)
-        except Exception:
+        except ValueError:
             raise ValueError(f'Unsupported --xff "{opts.geo_bypass}"')
         if len(opts.geo_bypass) == 2:
             opts.geo_bypass_country = opts.geo_bypass
@@ -989,7 +989,7 @@ def _real_main(argv=None):
             updater = Updater(ydl, opts.update_self)
             if opts.update_self and updater.update() and actual_use and updater.cmd:
                 return updater.restart()
-        except Exception:
+        except ValueError:
             traceback.print_exc()
             ydl._download_retcode = 100
 

--- a/yt_dlp/cache.py
+++ b/yt_dlp/cache.py
@@ -41,7 +41,7 @@ class Cache:
             os.makedirs(os.path.dirname(fn), exist_ok=True)
             self._ydl.write_debug(f'Saving {section}.{key} to cache')
             write_json_file({'yt-dlp_version': __version__, 'data': data}, fn)
-        except Exception:
+        except (OSError, TypeError):
             tb = traceback.format_exc()
             self._ydl.report_warning(f'Writing cache to {fn!r} failed: {tb}')
 

--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -109,7 +109,7 @@ def load_cookies(cookie_file, browser_specification, ydl):
             cookie_jars.append(jar)
 
         return _merge_cookie_jars(cookie_jars)
-    except Exception:
+    except (OSError, ValueError, KeyError):
         raise CookieLoadError('failed to load cookies')
 
 

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -390,7 +390,7 @@ class JSInterpreter:
             return len(obj)
         try:
             return obj[int(idx)] if isinstance(obj, list) else obj[str(idx)]
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, IndexError) as e:
             if allow_undefined:
                 return JS_Undefined
             raise self.Exception(f'Cannot get index {idx}', repr(obj), cause=e)

--- a/yt_dlp/jsinterp.py
+++ b/yt_dlp/jsinterp.py
@@ -382,7 +382,7 @@ class JSInterpreter:
 
         try:
             return _OPERATORS[op](left_val, right_val)
-        except Exception as e:
+        except (TypeError, KeyError, ZeroDivisionError) as e:
             raise self.Exception(f'Failed to evaluate {left_val!r} {op} {right_val!r}', expr, cause=e)
 
     def _index(self, obj, idx, allow_undefined=False):

--- a/yt_dlp/networking/__init__.py
+++ b/yt_dlp/networking/__init__.py
@@ -21,18 +21,18 @@ try:
 except ImportError:
     pass
 except Exception as e:
-    warnings.warn(f'Failed to import "requests" request handler: {e}' + bug_reports_message())
+    warnings.warn(f'Failed to import "_requests" request handler: {e}' + bug_reports_message())
 
 try:
     from . import _websockets
 except ImportError:
     pass
 except Exception as e:
-    warnings.warn(f'Failed to import "websockets" request handler: {e}' + bug_reports_message())
+    warnings.warn(f'Failed to import "_websockets" request handler: {e}' + bug_reports_message())
 
 try:
     from . import _curlcffi
 except ImportError:
     pass
 except Exception as e:
-    warnings.warn(f'Failed to import "curl_cffi" request handler: {e}' + bug_reports_message())
+    warnings.warn(f'Failed to import "_curlcffi" request handler: {e}' + bug_reports_message())

--- a/yt_dlp/networking/_requests.py
+++ b/yt_dlp/networking/_requests.py
@@ -241,7 +241,7 @@ class Urllib3LoggingHandler(logging.Handler):
             else:
                 self._logger.stdout(msg)
 
-        except Exception:
+        except (ValueError, TypeError, AttributeError):
             self.handleError(record)
 
 

--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -327,7 +327,7 @@ class UrllibResponseAdapter(Response):
                 # Catch-all for any cases where underlying file is closed
                 self.close()
             return data
-        except Exception as e:
+        except OSError as e:
             handle_response_read_exceptions(e)
             raise e
 

--- a/yt_dlp/plugins.py
+++ b/yt_dlp/plugins.py
@@ -12,7 +12,7 @@ import pkgutil
 import sys
 import traceback
 from pathlib import Path
-from zipfile import ZipFile
+from zipfile import ZipFile, BadZipFile
 
 from .globals import (
     Indirect,
@@ -73,7 +73,7 @@ def dirs_in_zip(archive):
                 Path(file).parents for file in zip_.namelist()))
     except FileNotFoundError:
         pass
-    except Exception as e:
+    except (OSError, BadZipFile) as e:
         write_string(f'WARNING: Could not read zip file {archive}: {e}\n')
     return ()
 
@@ -204,6 +204,9 @@ def load_plugins(plugin_spec: PluginSpec):
             spec = finder.find_spec(module_name)
             module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = module
+        except (ModuleNotFoundError, ValueError):
+            continue
+        try:
             spec.loader.exec_module(module)
         except Exception:
             write_string(

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4974,7 +4974,7 @@ class Config:
             # FIXME: https://github.com/ytdl-org/youtube-dl/commit/dfe5fa49aed02cf36ba9f743b11b0903554b5e56
             contents = optionf.read().decode(enc or preferredencoding())
             res = shlex.split(contents, comments=True)
-        except Exception as err:
+        except (ValueError, OSError) as err:
             raise ValueError(f'Unable to parse "{filename}": {err}')
         finally:
             optionf.close()

--- a/yt_dlp/utils/jslib/devalue.py
+++ b/yt_dlp/utils/jslib/devalue.py
@@ -99,7 +99,7 @@ def parse_iter(parsed: typing.Any, /, *, revivers: dict[str, collections.abc.Cal
                 elif value[0] == 'Date':
                     try:
                         result = dt.datetime.fromtimestamp(parse_iso8601(value[1]), tz=dt.timezone.utc)
-                    except Exception:
+                    except ValueError:
                         yield ValueError(f'invalid date: {value[1]!r}')
                         result = None
 


### PR DESCRIPTION
Cache.store() catches all Exception, but the only code paths in the try block that can raise are os.makedirs (OSError), write_json_file's json.dump path (TypeError for non-serializable data, OSError for I/O), and write_json_file's own file write (OSError).