### PR TITLE
Fix spelling in networking docs and niconico message

### DIFF
--- a/yt_dlp/downloader/niconico.py
+++ b/yt_dlp/downloader/niconico.py
@@ -78,7 +78,7 @@ class NiconicoLiveFD(FileDownloader):
                         return
                 except BaseException as e:
                     self.to_screen(
-                        f'[niconico:live] {video_id}: Connection error occured, reconnecting after 10 seconds: {e}')
+                        f'[niconico:live] {video_id}: Connection error occurred, reconnecting after 10 seconds: {e}')
                     time.sleep(10)
                     continue
                 finally:

--- a/yt_dlp/networking/common.py
+++ b/yt_dlp/networking/common.py
@@ -211,7 +211,7 @@ class RequestHandler(abc.ABC):
 
     Apart from the url protocol, proxies dict may contain the following keys:
     - `all`: proxy to use for all protocols. Used as a fallback if no proxy is set for a specific protocol.
-    - `no`: comma seperated list of hostnames (optionally with port) to not use a proxy for.
+    - `no`: comma-separated list of hostnames (optionally with port) to not use a proxy for.
     Note: a RequestHandler may not support these, as defined in `_SUPPORTED_FEATURES`.
 
     """
@@ -568,7 +568,7 @@ class Response(io.IOBase):
 
     def get_header(self, name, default=None):
         """Get header for name.
-        If there are multiple matching headers, return all seperated by comma."""
+        If there are multiple matching headers, return all separated by commas."""
         headers = self.headers.get_all(name)
         if not headers:
             return default


### PR DESCRIPTION
## Summary

- fix a spelling typo in the niconico live reconnect message
- fix spelling in networking proxy and header documentation

## Validation

- `git diff --check`
