### PR TITLE
Adding XVideos channel extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -2326,6 +2326,7 @@ from .xminus import XMinusIE
 from .xnxx import XNXXIE
 from .xvideos import (
     XVideosIE,
+    XVideosChannelIE,
     XVideosQuickiesIE,
 )
 from .xxxymovies import XXXYMoviesIE

--- a/yt_dlp/extractor/xvideos.py
+++ b/yt_dlp/extractor/xvideos.py
@@ -8,6 +8,7 @@ from ..utils import (
     determine_ext,
     int_or_none,
     parse_duration,
+    urlencode_postdata,
 )
 
 
@@ -223,3 +224,88 @@ class XVideosQuickiesIE(InfoExtractor):
     def _real_extract(self, url):
         domain, id_ = self._match_valid_url(url).group('domain', 'id')
         return self.url_result(f'https://{domain}/video{"" if id_.isdecimal() else "."}{id_}/_', XVideosIE, id_)
+
+
+class XVideosChannelIE(InfoExtractor):
+    IE_NAME = 'xvideos:channel'
+    _VALID_URL = r'https?://(?P<domain>(?:[^/?#]+\.)?xvideos2?\.com)/(?:(?:profiles|amateur-channels)/)?(?P<id>[^/?#]+)(?:#.*)?$'
+
+    _TESTS = [{
+        'url': 'https://www.xvideos.com/profiles/lili_love',
+        'info_dict': {
+            'id': 'lili_love',
+            'title': 'Lili Love',
+        },
+        'playlist_mincount': 10,
+    }, {
+        'url': 'https://www.xvideos.com/glanceweb#_tabVideos',
+        'info_dict': {
+            'id': 'glanceweb',
+            'title': 'Hidden Zone',
+        },
+        'playlist_mincount': 10,
+    }, {
+        'url': 'https://www.xvideos.com/amateur-channels/wifeluna',
+        'info_dict': {
+            'id': 'wifeluna',
+            'title': 'My Wife Luna',
+        },
+        'playlist_mincount': 1,
+    }]
+
+    def _real_extract(self, url):
+        mobj = self._match_valid_url(url)
+        domain = mobj.group('domain')
+        channel_id = mobj.group('id')
+        base_url = f'https://{domain}'
+
+        webpage = self._download_webpage(url, channel_id)
+
+        title = self._html_extract_title(webpage)
+        if title:
+            title = re.sub(r'\s+-\s+(?:Channel page\s*-\s+)?XVIDEOS\.COM\s*$', '', title) or None
+
+        def _entries():
+            page_url = f'{base_url}/profiles/{channel_id}/feed'
+            prev_timestamp = None
+
+            for page in range(1, 10000):
+                if prev_timestamp:
+                    feed_url = f'{page_url}/{prev_timestamp}'
+                else:
+                    feed_url = page_url
+
+                data = self._download_json(
+                    feed_url, channel_id,
+                    data=urlencode_postdata({
+                        'feedSettings[contentType]': 0,
+                        'feedSettings[showFreePremium]': 0,
+                    }),
+                    headers={
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    note=f'Downloading page {page}')
+
+                if not data.get('result'):
+                    break
+
+                content = data.get('data', {}).get('content', [])
+                if not content:
+                    break
+
+                timestamp = content[-1].get('t')
+                if timestamp == prev_timestamp:
+                    break
+                prev_timestamp = timestamp
+
+                for item in content:
+                    for video in item.get('v', []):
+                        video_id = video.get('id')
+                        if not video_id:
+                            continue
+                        video_title = video.get('t')
+                        video_url = f'{base_url}/video{"" if str(video_id).isdigit() else "."}{video_id}/_'
+                        yield self.url_result(video_url, XVideosIE, video_id, video_title)
+
+        entries = _entries()
+        return self.playlist_result(entries, channel_id, title)


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

Adds support for downloading channels from xvideos with a new simple channel extractor.

Supports `/username`, `/profiles/username`, and `/amateur-channels/username/` channel URLs. Actual video handling is unchanged, this just makes it easier to download whole channels. It's a bit complicated as the xvideos site uses AJAX requests from a variety of channel page types, with their own janky pagination, but it works as long as we keep the duplicate timestamp checks (otherwise some channel pages are hard to disambiguate after the end of the video lists).

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))

</details>
