### PR TITLE
[fd/hls] Fix crash on empty fragment lists in tests

### DIFF
--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -300,7 +300,7 @@ class HlsFD(FragmentFD):
 
         # We only download the first fragment during the test
         if self.params.get('test', False):
-            fragments = [fragments[0] if fragments else None]
+            fragments = fragments[:1]
 
         if real_downloader:
             info_dict['fragments'] = fragments


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

related to https://github.com/yt-dlp/yt-dlp/pull/15932, fix a crash when an extractor test encounters an HLS media playlist with no fragments
`HlsFD` incorrectly converts the empty fragment list to `[None]`, causing a `TypeError` instead of reporting an empty download

<details>
<summary>Traceback</summary>

```
test/test_download.py:169: in test_template
    res_dict = ydl.extract_info(
yt_dlp/YoutubeDL.py:1721: in extract_info
    return self.__extract_info(url, self.get_info_extractor(key), download, extra_info, process)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:1732: in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:1888: in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:1947: in process_ie_result
    ie_result = self.process_video_result(ie_result, download=download)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:3135: in process_video_result
    self.process_info(new_info)
test/test_download.py:54: in process_info
    return super().process_info(info_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:195: in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:3589: in process_info
    success, real_download = self.dl(temp_filename, info_dict)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/YoutubeDL.py:3324: in dl
    return fd.download(name, new_info, subtitle)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/downloader/common.py:480: in download
    ret = self.real_download(filename, info_dict)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/downloader/hls.py:409: in real_download
    return self.download_and_append_fragments(ctx, fragments, info_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
yt_dlp/downloader/fragment.py:513: in download_and_append_fragments
    download_fragment(fragment, ctx)
yt_dlp/downloader/fragment.py:443: in download_fragment
    frag_index = ctx['fragment_index'] = fragment['frag_index']
                                         ^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: 'NoneType' object is not subscriptable
```

</details>

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
