### PR TITLE
[ie/mgtv] Support /s/ share URLs

### DIFF
--- a/yt_dlp/extractor/mgtv.py
+++ b/yt_dlp/extractor/mgtv.py
@@ -17,7 +17,7 @@ from ..utils import (
 
 
 class MGTVIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:w(?:ww)?\.)?mgtv\.com/[bv]/(?:[^/]+/)*(?P<id>\d+)\.html'
+    _VALID_URL = r'https?://(?:w(?:ww)?\.)?mgtv\.com/[bvs]/(?:[^/]+/)*(?P<id>\d+)\.html'
     IE_DESC = '芒果TV'
     IE_NAME = 'MangoTV'
 
@@ -65,6 +65,12 @@ class MGTVIE(InfoExtractor):
         'only_matching': True,
     }, {
         'url': 'https://w.mgtv.com/b/301817/3826653.html',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.mgtv.com/s/3186853.html',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.mgtv.com/s/3186780.html',
         'only_matching': True,
     }]
 


### PR DESCRIPTION
## Summary
Fixes #17205

## Fix

Extend `_VALID_URL` to accept `/s/` paths: `[bv]` → `[bvs]`.

The numeric id in `/s/<id>.html` is the same `video_id` used by the existing API (confirmed via page HTML: canonical `/b/100994/<id>.html`).

## Validation

```bash
python3 -m yt_dlp --ignore-config --simulate --print id "https://www.mgtv.com/s/3186780.html"
# 3186780
```

## Test plan
- [x] Local tests pass (see README in staging folder)
