### PR TITLE
[ie/CrazyGames] Add extractor

### DIFF
--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -106,6 +106,7 @@ from .archiveorg import (
 )
 from .arcpublishing import ArcPublishingIE
 from .ard import (
+    ARDIE,
     ARDAudiothekIE,
     ARDAudiothekPlaylistIE,
     ARDBetaMediathekIE,
@@ -371,6 +372,7 @@ from .cpac import (
 )
 from .cracked import CrackedIE
 from .craftsy import CraftsyIE
+from .crazygames import CrazyGamesIE
 from .croatianfilm import CroatianFilmIE
 from .crooksandliars import CrooksAndLiarsIE
 from .crowdbunker import (
@@ -1718,10 +1720,7 @@ from .shahid import (
 from .sharepoint import SharePointIE
 from .shemaroome import ShemarooMeIE
 from .shiey import ShieyIE
-from .showroomlive import (
-    ShowRoomLiveIE,
-    ShowRoomVodIE,
-)
+from .showroomlive import ShowRoomLiveIE
 from .sibnet import SibnetEmbedIE
 from .simplecast import (
     SimplecastEpisodeIE,

--- a/yt_dlp/extractor/_extractors.py
+++ b/yt_dlp/extractor/_extractors.py
@@ -106,7 +106,6 @@ from .archiveorg import (
 )
 from .arcpublishing import ArcPublishingIE
 from .ard import (
-    ARDIE,
     ARDAudiothekIE,
     ARDAudiothekPlaylistIE,
     ARDBetaMediathekIE,
@@ -1720,7 +1719,10 @@ from .shahid import (
 from .sharepoint import SharePointIE
 from .shemaroome import ShemarooMeIE
 from .shiey import ShieyIE
-from .showroomlive import ShowRoomLiveIE
+from .showroomlive import (
+    ShowRoomLiveIE,
+    ShowRoomVodIE,
+)
 from .sibnet import SibnetEmbedIE
 from .simplecast import (
     SimplecastEpisodeIE,

--- a/yt_dlp/extractor/crazygames.py
+++ b/yt_dlp/extractor/crazygames.py
@@ -1,0 +1,81 @@
+from .common import InfoExtractor
+from ..utils import (
+    traverse_obj,
+    unified_strdate,
+)
+
+
+class CrazyGamesIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)crazygames\.com/game/(?P<id>[^/?#]+)'
+    _TESTS = [{
+        'url': 'https://www.crazygames.com/game/cut-the-rope-ebx',
+        'info_dict': {
+            'id': 'cut-the-rope-ebx',
+            'ext': 'mp4',
+            'title': 'Cut the Rope',
+            'description': 'Cut the Rope to feed large pieces of candy to a hungry creature called Om Nom. Collect all the stars for the highest rating and progress to more challenging levels with new puzzles.',
+            'uploader': 'Famobi',
+            'upload_date': '20240530',
+            'like_count': int,
+            'dislike_count': int,
+            'average_rating': float,
+            'categories': ['Puzzle'],
+            'tags': ['Mobile', 'Physics', '2D', 'Logic', 'Mouse', 'Collect', 'Brain'],
+        },
+    }]
+
+    def _real_extract(self, url):
+        game_id = self._match_id(url)
+        url_prefix = 'https://videos.crazygames.com/'
+
+        metadata = self._download_json(
+            f'https://api.crazygames.com/v4/en_US/page/game/{game_id}',
+            game_id,
+        )
+
+        category = traverse_obj(metadata, ('game', 'category', 'name'))
+        categories = [category] if category else None
+
+        sizes = traverse_obj(metadata, ('game', 'videos', 'sizes', ...), default=[])
+        blurred = traverse_obj(metadata, ('game', 'videos', 'blurredVideo'))
+        original = traverse_obj(metadata, ('game', 'videos', 'original'))
+
+        formats = []
+        if original:
+            formats.append({
+                'url': f'{url_prefix}{original}',
+                'format_note': 'Original',
+            })
+
+        for video in sizes:
+            if not video.get('location'):
+                continue
+            formats.append({
+                'url': f'{url_prefix}{video["location"]}',
+                'width': video.get('width'),
+                'height': video.get('height'),
+                'preference': -2,
+            })
+
+        if blurred and blurred.get('location'):
+            formats.append({
+                'url': f'{url_prefix}{blurred["location"]}',
+                'width': blurred.get('width'),
+                'height': blurred.get('height'),
+                'format_note': 'Blurred',
+                'preference': -3,
+            })
+
+        return {
+            'id': game_id,
+            'title': traverse_obj(metadata, ('game', 'name')),
+            'formats': formats,
+            'description': traverse_obj(metadata, ('game', 'metaDescription')),
+            'uploader': traverse_obj(metadata, ('game', 'developer')),
+            'upload_date': unified_strdate(traverse_obj(metadata, ('game', 'addedOn'))),
+            'like_count': traverse_obj(metadata, ('game', 'upvotes')),
+            'dislike_count': traverse_obj(metadata, ('game', 'downvotes')),
+            'average_rating': traverse_obj(metadata, ('game', 'rating')),
+            'categories': categories,
+            'tags': traverse_obj(metadata, ('game', 'tags', ..., 'name'), default=[]),
+        }


### PR DESCRIPTION
Add support for downloading the game preview video from CrazyGames.
Original quality video is the highest priority, downscaled videos are medium priority, and the blurred video is the lowest priority.
<details open><summary>Template</summary>

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's **NO AI / NO LLM POLICY**
- [x] I have skimmed through contributing guidelines including yt-dlp coding conventions
- [x] I have searched the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under Unlicense. Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under Unlicense
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under Unlicense (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [x] New extractor (Piracy websites will not be accepted)
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly recommended to open an issue first)
</details>