### PR TITLE
[extractor/murrtube] Fix extraction logic and update tests

### DIFF
--- a/yt_dlp/extractor/murrtube.py
+++ b/yt_dlp/extractor/murrtube.py
@@ -14,6 +14,7 @@ from ..utils import (
     update_url,
     urlencode_postdata,
 )
+from ..utils.traversal import traverse_obj
 
 
 class MurrtubeIE(InfoExtractor):
@@ -28,13 +29,14 @@ class MurrtubeIE(InfoExtractor):
         'url': 'https://murrtube.net/videos/inferno-x-skyler-148b6f2a-fdcc-4902-affe-9c0f41aaaca0',
         'md5': '70380878a77e8565d4aea7f68b8bbb35',
         'info_dict': {
-            'id': 'ca885d8456b95de529b6723b158032e11115d',
+            'id': '148b6f2a-fdcc-4902-affe-9c0f41aaaca0',
             'ext': 'mp4',
             'title': 'Inferno X Skyler',
             'description': 'Humping a very good slutty sheppy (roomate)',
             'uploader': 'Inferno Wolf',
+            'uploader_id': 'inferno-wolf',
             'age_limit': 18,
-            'thumbnail': 'https://storage.murrtube.net/murrtube-production/ekbs3zcfvuynnqfx72nn2tkokvsd',
+            'thumbnail': 'https://storage.murrtube.net/038/ca885d8456b95de529b6723b158032e11115d/thumbnail.jpg',
             'comment_count': int,
             'view_count': int,
             'like_count': int,
@@ -43,13 +45,14 @@ class MurrtubeIE(InfoExtractor):
         'url': 'https://murrtube.net/v/0J2Q',
         'md5': '31262f6ac56f0ca75e5a54a0f3fefcb6',
         'info_dict': {
-            'id': '8442998c52134968d9caa36e473e1a6bac6ca',
+            'id': 'fcfd303b-0002-4da9-9a9f-bef8ce4c0f0d',
             'ext': 'mp4',
             'uploader': 'Hayel',
+            'uploader_id': 'hayel',
             'title': 'Who\'s in charge now?',
-            'description': 'md5:795791e97e5b0f1805ea84573f02a997',
+            'description': str,
             'age_limit': 18,
-            'thumbnail': 'https://storage.murrtube.net/murrtube-production/fb1ojjwiucufp34ya6hxu5vfqi5s',
+            'thumbnail': 'https://storage.murrtube.net/03c/8442998c52134968d9caa36e473e1a6bac6ca/thumbnail.jpg',
             'comment_count': int,
             'view_count': int,
             'like_count': int,
@@ -72,21 +75,34 @@ class MurrtubeIE(InfoExtractor):
         if video_id.startswith('murrtube:'):
             raise ExtractorError('Support for murrtube: prefix URLs is broken')
         video_page = self._download_webpage(url, video_id)
-        video_attrs = extract_attributes(get_element_html_by_id('video', video_page))
-        playlist = update_url(video_attrs['data-url'], query=None)
-        video_id = self._search_regex(r'/([\da-f]+)/index.m3u8', playlist, 'video id')
+
+        props = traverse_obj(
+            get_element_html_by_id('app', video_page),
+            ({extract_attributes}, 'data-page', {json.loads}, 'props')) or {}
+
+        medium = props.get('medium') or {}
+        if not medium:
+            raise ExtractorError('Could not find video metadata in page')
+
+        playlist = medium.get('hls_url')
+        if not playlist:
+            raise ExtractorError('Could not find video stream URL')
+
+        # Extract stable UUID as video ID, or fall back to the one from URL
+        video_id = medium.get('id') or video_id
 
         return {
             'id': video_id,
-            'title': remove_end(self._og_search_title(video_page), ' - Murrtube'),
+            'title': medium.get('title'),
             'age_limit': 18,
             'formats': self._extract_m3u8_formats(playlist, video_id, 'mp4'),
-            'description': self._og_search_description(video_page),
-            'thumbnail': update_url(self._og_search_thumbnail(video_page, default=''), query=None) or None,
-            'uploader': clean_html(get_element_by_class('pl-1 is-size-6 has-text-lighter', video_page)),
-            'view_count': self._extract_count('Views', video_page),
-            'like_count': self._extract_count('Likes', video_page),
-            'comment_count': self._extract_count('Comments', video_page),
+            'description': medium.get('description'),
+            'thumbnail': update_url(medium.get('thumbnail_url') or '', query=None) or None,
+            'uploader': traverse_obj(medium, ('user', 'name')),
+            'uploader_id': traverse_obj(medium, ('user', 'slug')),
+            'view_count': medium.get('views_count'),
+            'like_count': medium.get('likes_count'),
+            'comment_count': medium.get('comments_count'),
         }
 
 


### PR DESCRIPTION
### Description of your *pull request* and other information

Fixes Murrtube video extraction by migrating from legacy HTML tag parsing (`#video` element) to parsing the Inertia.js JSON payload in `<div id="app" data-page="...">`.

**Changes:**
- Extracted video metadata from `props.medium` JSON structure inside the `data-page` attribute.
- Updated video `id` in returned dictionary to use the stable database UUID (`medium.id`) instead of volatile storage path hashes.
- Updated test cases in `MurrtubeIE` to reflect the new UUIDs and updated metadata structure.

<details open><summary>Template</summary>

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>