### PR TITLE
[core] Normalize `impersonate` parameter to `ImpersonateTarget` early

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -766,6 +766,11 @@ class YoutubeDL:
             self.deprecated_feature(msg)
 
         if impersonate_target := self.params.get('impersonate'):
+            if not isinstance(impersonate_target, ImpersonateTarget):
+                impersonate_target = (
+                    ImpersonateTarget() if impersonate_target is True
+                    else ImpersonateTarget.from_str(impersonate_target))
+                self.params['impersonate'] = impersonate_target
             if not self._impersonate_target_available(impersonate_target):
                 raise YoutubeDLError(
                     f'Impersonate target "{impersonate_target}" is not available. '


### PR DESCRIPTION
## Description

Fixes an `AssertionError` raised when `curl_cffi` is installed and an `impersonate` target is supplied (e.g. `--impersonate chrome`).

The `impersonate` option was forwarded to request handlers and the availability check as a raw string, but `ImpersonateRequestHandler` expects an `ImpersonateTarget` instance. `YoutubeDL.__init__` now normalizes `params['impersonate']` to an `ImpersonateTarget` once, so the early availability check and the handler defaults both receive the correct type.

## Related

Helps impersonation-based extraction (e.g. TikTok), which is required by #17207.