### PR TITLE
[core] Truncate filename to prevent ENAMETOOLONG errors

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -1549,6 +1549,16 @@ class YoutubeDL:
                 no_ext, *ext = filename.rsplit('.', 2)
                 filename = join_nonempty(no_ext[:trim_file_name], *ext, delim='.')
 
+            # Prevent ENAMETOOLONG (errno 63) errors on Unix/macOS
+            # NAME_MAX is 255 bytes; leave room for extension + '.part' suffix
+            if filename and filename != '-':
+                no_ext, *ext = filename.rsplit('.', 2)
+                MAX_FILENAME_BYTES = 200
+                no_ext_bytes = no_ext.encode('utf-8')
+                if len(no_ext_bytes) > MAX_FILENAME_BYTES:
+                    no_ext = no_ext_bytes[:MAX_FILENAME_BYTES].decode('utf-8', errors='ignore')
+                    filename = join_nonempty(no_ext, *ext, delim='.')
+
             return filename
         except ValueError as err:
             self.report_error('Error in output template: ' + str(err) + ' (encoding: ' + repr(preferredencoding()) + ')')


### PR DESCRIPTION
## Description

When a video title is very long (e.g., Thai text with emoji and hashtags, as seen on Facebook reels), the generated filename can exceed the filesystem's `NAME_MAX` limit (255 bytes on Unix/macOS), causing an `ENAMETOOLONG (errno 63)` error when trying to open the file for writing.

## Fix

Added automatic byte-length-aware truncation in `_prepare_filename()`. After all other filename processing:
- The base filename (without extension) is truncated to 200 bytes
- Uses `decode('utf-8', errors='ignore')` to safely handle multi-byte character boundaries
- Leaves ~55 bytes of headroom for the extension (e.g., `.mp4`) and the temporary `.part` suffix within the 255-byte `NAME_MAX`
- Only affects filenames that exceed the limit; short filenames pass through unchanged

## Related

Fixes https://github.com/yt-dlp/yt-dlp/issues/8908