### PR TITLE
[ie/niconicochannelplus] Fix current channel API

### DIFF
--- a/test/test_niconicochannelplus.py
+++ b/test/test_niconicochannelplus.py
@@ -6,7 +6,6 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from test.helper import FakeYDL
 from yt_dlp.extractor.niconicochannelplus import NiconicoChannelPlusBaseIE
 
 
@@ -17,13 +16,8 @@ class NiconicoChannelPlusBaseIETest(NiconicoChannelPlusBaseIE):
 
 
 class TestNiconicoChannelPlusBaseIE(unittest.TestCase):
-    def _make_ie(self, params=None):
-        ie = NiconicoChannelPlusBaseIETest()
-        FakeYDL(params).add_info_extractor(ie)
-        return ie
-
     def test_find_fanclub_site_id_uses_channel_domain_api(self):
-        ie = self._make_ie()
+        ie = NiconicoChannelPlusBaseIETest()
 
         self.assertEqual(ie._find_fanclub_site_id('okazuradio'), 815)
         self.assertEqual(ie.request, {
@@ -38,12 +32,3 @@ class TestNiconicoChannelPlusBaseIE(unittest.TestCase):
             'errnote': 'Unable to fetch channel info',
         })
         self.assertEqual(ie._fanclub_site_id, 815)
-
-    def test_call_api_uses_configured_access_token(self):
-        ie = self._make_ie({
-            'extractor_args': {'niconicochannelplus': {'access_token': ['token']}},
-        })
-
-        ie._call_api('video_pages/sm123', 'sm123')
-
-        self.assertEqual(ie.request['headers']['Authorization'], 'Bearer token')

--- a/test/test_niconicochannelplus.py
+++ b/test/test_niconicochannelplus.py
@@ -6,6 +6,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from test.helper import FakeYDL
 from yt_dlp.extractor.niconicochannelplus import NiconicoChannelPlusBaseIE
 
 
@@ -16,8 +17,13 @@ class NiconicoChannelPlusBaseIETest(NiconicoChannelPlusBaseIE):
 
 
 class TestNiconicoChannelPlusBaseIE(unittest.TestCase):
-    def test_find_fanclub_site_id_uses_channel_domain_api(self):
+    def _make_ie(self, params=None):
         ie = NiconicoChannelPlusBaseIETest()
+        FakeYDL(params).add_info_extractor(ie)
+        return ie
+
+    def test_find_fanclub_site_id_uses_channel_domain_api(self):
+        ie = self._make_ie()
 
         self.assertEqual(ie._find_fanclub_site_id('okazuradio'), 815)
         self.assertEqual(ie.request, {
@@ -32,3 +38,12 @@ class TestNiconicoChannelPlusBaseIE(unittest.TestCase):
             'errnote': 'Unable to fetch channel info',
         })
         self.assertEqual(ie._fanclub_site_id, 815)
+
+    def test_call_api_uses_configured_access_token(self):
+        ie = self._make_ie({
+            'extractor_args': {'niconicochannelplus': {'access_token': ['token']}},
+        })
+
+        ie._call_api('video_pages/sm123', 'sm123')
+
+        self.assertEqual(ie.request['headers']['Authorization'], 'Bearer token')

--- a/test/test_niconicochannelplus.py
+++ b/test/test_niconicochannelplus.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from yt_dlp.extractor.niconicochannelplus import NiconicoChannelPlusBaseIE
+
+
+class NiconicoChannelPlusBaseIETest(NiconicoChannelPlusBaseIE):
+    def _download_json(self, url, video_id, **kwargs):
+        self.request = {'url': url, 'video_id': video_id, **kwargs}
+        return {'data': {'content_providers': {'fanclub_site': {'id': 815}}}}
+
+
+class TestNiconicoChannelPlusBaseIE(unittest.TestCase):
+    def test_find_fanclub_site_id_uses_channel_domain_api(self):
+        ie = NiconicoChannelPlusBaseIETest()
+
+        self.assertEqual(ie._find_fanclub_site_id('okazuradio'), 815)
+        self.assertEqual(ie.request, {
+            'url': 'https://api.nicochannel.jp/fc/content_providers/channel_domain',
+            'video_id': 'channels/okazuradio',
+            'headers': {
+                'fc_site_id': '1',
+                'fc_use_device': 'null',
+            },
+            'query': {'current_site_domain': 'https://nicochannel.jp/okazuradio'},
+            'note': 'Fetching channel info',
+            'errnote': 'Unable to fetch channel info',
+        })
+        self.assertEqual(ie._fanclub_site_id, 815)

--- a/yt_dlp/extractor/niconicochannelplus.py
+++ b/yt_dlp/extractor/niconicochannelplus.py
@@ -109,7 +109,7 @@ class NiconicoChannelPlusIE(NiconicoChannelPlusBaseIE):
         fanclub_site_id = self._find_fanclub_site_id(channel_id)
 
         data_json = self._call_api(
-            f'video_pages/{content_code}', item_id=content_code, headers={'fc_use_device': 'null'},
+            f'video_pages/{content_code}', item_id=content_code,
             note='Fetching video page info', errnote='Unable to fetch video page info',
         )['data']['video_page']
 
@@ -227,7 +227,6 @@ class NiconicoChannelPlusIE(NiconicoChannelPlusBaseIE):
             f'video_pages/{content_code}/session_ids', item_id=f'{content_code}/session',
             data=json.dumps(payload).encode('ascii'), headers={
                 'Content-Type': 'application/json',
-                'fc_use_device': 'null',
                 'origin': 'https://nicochannel.jp',
             },
             note='Getting session id', errnote='Unable to get session id',
@@ -246,7 +245,6 @@ class NiconicoChannelPlusChannelBaseIE(NiconicoChannelPlusBaseIE):
                 'page': (page + 1),
                 'per_page': self._PAGE_SIZE,
             },
-            headers={'fc_use_device': 'null'},
             note=f'Getting channel info (page {page + 1})',
             errnote=f'Unable to get channel info (page {page + 1})')
 

--- a/yt_dlp/extractor/niconicochannelplus.py
+++ b/yt_dlp/extractor/niconicochannelplus.py
@@ -17,21 +17,27 @@ from ..utils import (
 
 class NiconicoChannelPlusBaseIE(InfoExtractor):
     _WEBPAGE_BASE_URL = 'https://nicochannel.jp'
+    _API_BASE_URL = 'https://api.nicochannel.jp/fc'
+    _DEFAULT_FANCLUB_SITE_ID = '1'
 
     def _call_api(self, path, item_id, **kwargs):
+        headers = {
+            'fc_site_id': str(getattr(self, '_fanclub_site_id', self._DEFAULT_FANCLUB_SITE_ID)),
+            'fc_use_device': 'null',
+            **kwargs.pop('headers', {}),
+        }
         return self._download_json(
-            f'https://nfc-api.nicochannel.jp/fc/{path}', video_id=item_id, **kwargs)
+            f'{self._API_BASE_URL}/{path}', video_id=item_id, headers=headers, **kwargs)
 
     def _find_fanclub_site_id(self, channel_name):
-        fanclub_list_json = self._call_api(
-            'content_providers/channels', item_id=f'channels/{channel_name}',
-            note='Fetching channel list', errnote='Unable to fetch channel list',
-        )['data']['content_providers']
-        fanclub_id = traverse_obj(fanclub_list_json, (
-            lambda _, v: v['domain'] == f'{self._WEBPAGE_BASE_URL}/{channel_name}', 'id'),
-            get_all=False)
+        fanclub_id = traverse_obj(self._call_api(
+            'content_providers/channel_domain', item_id=f'channels/{channel_name}',
+            query={'current_site_domain': f'{self._WEBPAGE_BASE_URL}/{channel_name}'},
+            note='Fetching channel info', errnote='Unable to fetch channel info',
+        ), ('data', 'content_providers', 'fanclub_site', 'id', {int_or_none}))
         if not fanclub_id:
             raise ExtractorError(f'Channel {channel_name} does not exist', expected=True)
+        self._fanclub_site_id = fanclub_id
         return fanclub_id
 
     def _get_channel_base_info(self, fanclub_site_id):

--- a/yt_dlp/extractor/niconicochannelplus.py
+++ b/yt_dlp/extractor/niconicochannelplus.py
@@ -21,12 +21,9 @@ class NiconicoChannelPlusBaseIE(InfoExtractor):
     _DEFAULT_FANCLUB_SITE_ID = '1'
 
     def _call_api(self, path, item_id, **kwargs):
-        access_token = self._configuration_arg(
-            'access_token', [None], ie_key='NiconicoChannelPlus', casesense=True)[0]
         headers = {
             'fc_site_id': str(getattr(self, '_fanclub_site_id', self._DEFAULT_FANCLUB_SITE_ID)),
             'fc_use_device': 'null',
-            **({'Authorization': f'Bearer {access_token}'} if access_token else {}),
             **kwargs.pop('headers', {}),
         }
         return self._download_json(

--- a/yt_dlp/extractor/niconicochannelplus.py
+++ b/yt_dlp/extractor/niconicochannelplus.py
@@ -21,9 +21,12 @@ class NiconicoChannelPlusBaseIE(InfoExtractor):
     _DEFAULT_FANCLUB_SITE_ID = '1'
 
     def _call_api(self, path, item_id, **kwargs):
+        access_token = self._configuration_arg(
+            'access_token', [None], ie_key='NiconicoChannelPlus', casesense=True)[0]
         headers = {
             'fc_site_id': str(getattr(self, '_fanclub_site_id', self._DEFAULT_FANCLUB_SITE_ID)),
             'fc_use_device': 'null',
+            **({'Authorization': f'Bearer {access_token}'} if access_token else {}),
             **kwargs.pop('headers', {}),
         }
         return self._download_json(


### PR DESCRIPTION
## Summary

- Replace the retired Niconico Channel Plus channel-list endpoint with the current channel-domain endpoint.
- Use the current API host and send the required fanclub site ID with API requests.
- Remove redundant `fc_use_device` header declarations now that the shared API method adds it once.

## Root cause

The extractor called the retired `nfc-api.nicochannel.jp` channel-list endpoint. The current service resolves a channel through `api.nicochannel.jp/fc/content_providers/channel_domain` and requires `fc_site_id` for subsequent requests, causing extraction to stop with HTTP 400 before video metadata was retrieved.

## Validation

- `python3 test/test_niconicochannelplus.py`
- `python3 -m yt_dlp --flat-playlist --playlist-end 1 --simulate https://nicochannel.jp/okazuradio/videos`
