### PR TITLE
fix(networking): handle multi-value headers in websockets response adapter

### DIFF
--- a/yt_dlp/networking/_websockets.py
+++ b/yt_dlp/networking/_websockets.py
@@ -54,10 +54,14 @@ with contextlib.suppress(Exception):
 class WebsocketsResponseAdapter(WebSocketResponse):
 
     def __init__(self, ws: websockets.sync.client.ClientConnection, url):
+        from email.message import Message
+        headers = Message()
+        for name, value in getattr(ws.response.headers, "raw_items", ws.response.headers.items)():
+            headers.add_header(name, value)
         super().__init__(
             fp=io.BytesIO(ws.response.body or b''),
             url=url,
-            headers=ws.response.headers,
+            headers=headers,
             status=ws.response.status_code,
             reason=ws.response.reason_phrase,
         )


### PR DESCRIPTION
## Description
This PR resolves issue #17303 by using `raw_items()` on `ws.response.headers` when constructing `WebsocketsResponseAdapter` in `yt_dlp/networking/_websockets.py`.

## Details
- Prevents `websockets.datastructures.MultipleValuesError` when response headers contain multi-value headers such as multiple `Set-Cookie` headers.