### PR TITLE
networking: strip auth on cross-origin redirects

### DIFF
--- a/yt_dlp/networking/_urllib.py
+++ b/yt_dlp/networking/_urllib.py
@@ -226,6 +226,15 @@ class RedirectHandler(urllib.request.HTTPRedirectHandler):
         # We will remove it here to prevent any leaks.
         remove_headers = ['Cookie']
 
+        def origin(url):
+            parsed = urllib.parse.urlsplit(url)
+            scheme = parsed.scheme.lower()
+            return scheme, parsed.hostname, parsed.port or {'http': 80, 'https': 443}.get(scheme)
+
+        # Credentials must not be sent to a different origin after a redirect.
+        if origin(req.full_url) != origin(newurl):
+            remove_headers.extend(['Authorization', 'Proxy-Authorization'])
+
         new_method = get_redirect_method(req.get_method(), code)
         # only remove payload if method changed (e.g. POST to GET)
         if new_method != req.get_method():


### PR DESCRIPTION
The urllib request handler retained Authorization headers when following a cross-origin redirect. This could disclose credentials from URL userinfo to a redirect target.

Strip Authorization and Proxy-Authorization when the redirect origin differs, while preserving them for same-origin redirects.

Verified with a local two-server dependency-free urllib reproduction.