### PR TITLE
[fd/hls] Add native live HLS streaming support

### DIFF
--- a/test/test_downloader_hls.py
+++ b/test/test_downloader_hls.py
@@ -1,0 +1,823 @@
+#!/usr/bin/env python3
+"""Tests for HLS downloader and HlsManifestParser."""
+import http.server
+import os
+import sys
+import threading
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from test.helper import FakeYDL, http_server_port, try_rm
+
+from yt_dlp.utils import HlsManifestParser
+
+
+class TestHlsManifestParser(unittest.TestCase):
+    """Unit tests for HlsManifestParser class."""
+
+    def test_basic_playlist(self):
+        """Test parsing a simple HLS playlist."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:100
+#EXTINF:5.005,
+segment100.ts
+#EXTINF:6.006,
+segment101.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.target_duration, 6.0)
+        self.assertEqual(parser.media_sequence, 100)
+        self.assertEqual(len(parser.segments), 2)
+        self.assertEqual(parser.segments[0]['media_sequence'], 100)
+        self.assertEqual(parser.segments[0]['duration'], 5.005)
+        self.assertEqual(parser.segments[0]['url'], 'http://example.com/segment100.ts')
+        self.assertEqual(parser.segments[1]['media_sequence'], 101)
+        self.assertEqual(parser.segments[1]['duration'], 6.006)
+        self.assertFalse(parser.is_endlist)
+
+    def test_endlist_detection(self):
+        """Test detection of EXT-X-ENDLIST tag."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:50
+#EXTINF:10.0,
+segment50.ts
+#EXT-X-ENDLIST
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertTrue(parser.is_endlist)
+        self.assertEqual(len(parser.segments), 1)
+
+    def test_no_endlist_for_live(self):
+        """Test that live streams don't have EXT-X-ENDLIST."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:4
+#EXT-X-MEDIA-SEQUENCE:1000
+#EXTINF:4.0,
+segment1000.ts
+#EXTINF:4.0,
+segment1001.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertFalse(parser.is_endlist)
+        self.assertEqual(parser.media_sequence, 1000)
+
+    def test_encrypted_segments_aes128(self):
+        """Test parsing AES-128 encrypted segments."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:50
+#EXT-X-KEY:METHOD=AES-128,URI="https://example.com/key.bin",IV=0x00000000000000000000000000000001
+#EXTINF:5.0,
+segment50.ts
+#EXTINF:5.0,
+segment51.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(len(parser.segments), 2)
+        self.assertEqual(parser.segments[0]['decrypt_info']['METHOD'], 'AES-128')
+        self.assertEqual(parser.segments[0]['decrypt_info']['URI'], 'https://example.com/key.bin')
+        self.assertIsNotNone(parser.segments[0]['decrypt_info']['IV'])
+        # IV should be bytes
+        self.assertIsInstance(parser.segments[0]['decrypt_info']['IV'], bytes)
+
+    def test_key_rotation(self):
+        """Test parsing playlist with key rotation."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:50
+#EXT-X-KEY:METHOD=AES-128,URI="key1.bin"
+#EXTINF:5.0,
+segment50.ts
+#EXT-X-KEY:METHOD=AES-128,URI="key2.bin"
+#EXTINF:5.0,
+segment51.ts
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:5.0,
+segment52.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(len(parser.segments), 3)
+        self.assertEqual(parser.segments[0]['decrypt_info']['URI'], 'http://example.com/key1.bin')
+        self.assertEqual(parser.segments[1]['decrypt_info']['URI'], 'http://example.com/key2.bin')
+        self.assertEqual(parser.segments[2]['decrypt_info']['METHOD'], 'NONE')
+
+    def test_byterange_segments(self):
+        """Test parsing segments with byte ranges."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-BYTERANGE:1000@0
+#EXTINF:5.0,
+media.ts
+#EXT-X-BYTERANGE:1000@1000
+#EXTINF:5.0,
+media.ts
+#EXT-X-BYTERANGE:1000
+#EXTINF:5.0,
+media.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(len(parser.segments), 3)
+        self.assertEqual(parser.segments[0]['byte_range'], {'start': 0, 'end': 1000})
+        self.assertEqual(parser.segments[1]['byte_range'], {'start': 1000, 'end': 2000})
+        # Third segment should continue from previous end
+        self.assertEqual(parser.segments[2]['byte_range'], {'start': 2000, 'end': 3000})
+
+    def test_init_segment_map(self):
+        """Test parsing EXT-X-MAP initialization segment."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:100
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.0,
+segment100.m4s
+#EXTINF:6.0,
+segment101.m4s
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(len(parser.segments), 3)  # init + 2 segments
+        self.assertTrue(parser.segments[0].get('is_init'))
+        self.assertEqual(parser.segments[0]['url'], 'http://example.com/init.mp4')
+        self.assertEqual(parser.segments[0]['media_sequence'], 99)  # Before first segment
+        self.assertFalse(parser.segments[1].get('is_init'))
+        self.assertEqual(parser.segments[1]['media_sequence'], 100)
+
+    def test_init_segment_with_byterange(self):
+        """Test parsing EXT-X-MAP with byte range."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-MAP:URI="media.mp4",BYTERANGE="500@0"
+#EXTINF:6.0,
+segment0.m4s
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(len(parser.segments), 2)
+        self.assertTrue(parser.segments[0].get('is_init'))
+        self.assertEqual(parser.segments[0]['byte_range'], {'start': 0, 'end': 500})
+
+    def test_new_segments_since(self):
+        """Test filtering segments by media sequence."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:100
+#EXTINF:5.0,
+seg100.ts
+#EXTINF:5.0,
+seg101.ts
+#EXTINF:5.0,
+seg102.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        # Get segments after sequence 100
+        new_segments = parser.get_new_segments_since(100)
+        self.assertEqual(len(new_segments), 2)
+        self.assertEqual(new_segments[0]['media_sequence'], 101)
+        self.assertEqual(new_segments[1]['media_sequence'], 102)
+
+        # Get segments after sequence 101
+        new_segments = parser.get_new_segments_since(101)
+        self.assertEqual(len(new_segments), 1)
+        self.assertEqual(new_segments[0]['media_sequence'], 102)
+
+        # Get segments after sequence 102 (none)
+        new_segments = parser.get_new_segments_since(102)
+        self.assertEqual(len(new_segments), 0)
+
+    def test_new_segments_excludes_init(self):
+        """Test that get_new_segments_since excludes init segments."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:100
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.0,
+seg100.m4s
+#EXTINF:6.0,
+seg101.m4s
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        new_segments = parser.get_new_segments_since(99)
+        # Should get both media segments but not the init segment
+        self.assertEqual(len(new_segments), 2)
+        for seg in new_segments:
+            self.assertFalse(seg.get('is_init'))
+
+    def test_last_media_sequence(self):
+        """Test last_media_sequence property."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:500
+#EXTINF:5.0,
+seg500.ts
+#EXTINF:5.0,
+seg501.ts
+#EXTINF:5.0,
+seg502.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.last_media_sequence, 502)
+
+    def test_last_media_sequence_with_init(self):
+        """Test last_media_sequence excludes init segment."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:100
+#EXT-X-MAP:URI="init.mp4"
+#EXTINF:6.0,
+seg100.m4s
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.last_media_sequence, 100)
+
+    def test_extra_segment_query(self):
+        """Test that extra query params are added to segment URLs."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:5.0,
+segment.ts
+'''
+        parser = HlsManifestParser(
+            manifest, 'http://example.com/',
+            extra_segment_query={'token': ['abc123']})
+
+        self.assertIn('token=abc123', parser.segments[0]['url'])
+
+    def test_extra_key_query(self):
+        """Test that extra query params are added to key URLs."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-KEY:METHOD=AES-128,URI="key.bin"
+#EXTINF:5.0,
+segment.ts
+'''
+        parser = HlsManifestParser(
+            manifest, 'http://example.com/',
+            extra_key_query={'auth': ['secret']})
+
+        self.assertIn('auth=secret', parser.segments[0]['decrypt_info']['URI'])
+
+    def test_discontinuity_tracking(self):
+        """Test tracking of discontinuity markers."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:5.0,
+seg0.ts
+#EXT-X-DISCONTINUITY
+#EXTINF:5.0,
+seg1.ts
+#EXT-X-DISCONTINUITY
+#EXTINF:5.0,
+seg2.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.segments[0]['discontinuity_count'], 0)
+        self.assertEqual(parser.segments[1]['discontinuity_count'], 1)
+        self.assertEqual(parser.segments[2]['discontinuity_count'], 2)
+
+    def test_relative_urls(self):
+        """Test that relative URLs are resolved correctly."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:5.0,
+segments/seg0.ts
+#EXTINF:5.0,
+../other/seg1.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/live/playlist.m3u8')
+
+        self.assertEqual(parser.segments[0]['url'], 'http://example.com/live/segments/seg0.ts')
+        self.assertEqual(parser.segments[1]['url'], 'http://example.com/other/seg1.ts')
+
+    def test_absolute_urls(self):
+        """Test that absolute URLs are preserved."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:5
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:5.0,
+https://cdn.example.com/segment.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.segments[0]['url'], 'https://cdn.example.com/segment.ts')
+
+    def test_empty_manifest(self):
+        """Test parsing empty manifest."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:3
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(len(parser.segments), 0)
+        self.assertIsNone(parser.target_duration)
+        self.assertEqual(parser.media_sequence, 0)
+        self.assertFalse(parser.is_endlist)
+
+    def test_extinf_title_ignored(self):
+        """Test that EXTINF title component is ignored."""
+        manifest = '''\
+#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:10.5,Segment Title Here
+segment.ts
+'''
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.segments[0]['duration'], 10.5)
+
+
+class HlsLiveTestHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler that simulates an HLS live stream."""
+
+    # Class-level state for simulating live stream
+    _segment_counter = 100
+    _lock = threading.Lock()
+    _ended = False
+
+    @classmethod
+    def reset(cls, start_sequence=100, ended=False):
+        """Reset the handler state for a new test."""
+        with cls._lock:
+            cls._segment_counter = start_sequence
+            cls._ended = ended
+
+    @classmethod
+    def advance(cls, count=1):
+        """Advance the stream by adding new segments."""
+        with cls._lock:
+            cls._segment_counter += count
+
+    @classmethod
+    def end_stream(cls):
+        """Mark the stream as ended."""
+        with cls._lock:
+            cls._ended = True
+
+    def log_message(self, format, *args):
+        pass  # Suppress logging
+
+    def do_GET(self):
+        if self.path == '/live.m3u8':
+            with self._lock:
+                seq = self._segment_counter
+                ended = self._ended
+
+            manifest = f'''\
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE:{seq}
+#EXTINF:2.0,
+segment{seq}.ts
+#EXTINF:2.0,
+segment{seq + 1}.ts
+'''
+            if ended:
+                manifest += '#EXT-X-ENDLIST\n'
+
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+            self.send_header('Content-Length', str(len(manifest)))
+            self.end_headers()
+            self.wfile.write(manifest.encode())
+
+        elif self.path.startswith('/segment') and self.path.endswith('.ts'):
+            # Serve a small fake segment
+            content = b'\x00' * 1024
+            self.send_response(200)
+            self.send_header('Content-Type', 'video/mp2t')
+            self.send_header('Content-Length', str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+class TestHlsLiveDownloader(unittest.TestCase):
+    """Integration tests for HLS live stream downloading."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.httpd = http.server.HTTPServer(('127.0.0.1', 0), HlsLiveTestHandler)
+        cls.port = http_server_port(cls.httpd)
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+
+    def setUp(self):
+        HlsLiveTestHandler.reset()
+
+    def test_live_generator_protocol_routing(self):
+        """Test that m3u8_native_generator protocol routes to HlsFD."""
+        from yt_dlp.downloader import get_suitable_downloader
+        from yt_dlp.downloader.hls import HlsFD
+
+        info_dict = {
+            'url': f'http://127.0.0.1:{self.port}/live.m3u8',
+            'protocol': 'm3u8_native_generator',
+            'is_live': True,
+        }
+        downloader = get_suitable_downloader(info_dict, {})
+        self.assertEqual(downloader, HlsFD)
+
+    def test_live_manifest_polling_simulation(self):
+        """Test that manifest is polled and new segments are detected."""
+        url = f'http://127.0.0.1:{self.port}/live.m3u8'
+
+        # First poll
+        import urllib.request
+        with urllib.request.urlopen(url) as response:
+            manifest1 = response.read().decode()
+        parser1 = HlsManifestParser(manifest1, url)
+
+        initial_seq = parser1.last_media_sequence
+
+        # Advance the stream
+        HlsLiveTestHandler.advance(2)
+
+        # Second poll
+        with urllib.request.urlopen(url) as response:
+            manifest2 = response.read().decode()
+        parser2 = HlsManifestParser(manifest2, url)
+
+        # Should have new segments
+        new_segments = parser2.get_new_segments_since(initial_seq)
+        self.assertEqual(len(new_segments), 2)
+
+    def test_live_stream_end_detection(self):
+        """Test that stream end is detected via EXT-X-ENDLIST."""
+        url = f'http://127.0.0.1:{self.port}/live.m3u8'
+
+        # First poll - stream not ended
+        import urllib.request
+        with urllib.request.urlopen(url) as response:
+            manifest1 = response.read().decode()
+        parser1 = HlsManifestParser(manifest1, url)
+        self.assertFalse(parser1.is_endlist)
+
+        # End the stream
+        HlsLiveTestHandler.end_stream()
+
+        # Second poll - stream ended
+        with urllib.request.urlopen(url) as response:
+            manifest2 = response.read().decode()
+        parser2 = HlsManifestParser(manifest2, url)
+        self.assertTrue(parser2.is_endlist)
+
+    def test_vod_hls_unchanged(self):
+        """Test that VOD HLS downloads are unaffected by live changes."""
+        from yt_dlp.downloader import get_suitable_downloader
+        from yt_dlp.downloader.hls import HlsFD
+
+        # VOD with m3u8_native should still use HlsFD
+        info_dict = {
+            'url': 'http://example.com/vod.m3u8',
+            'protocol': 'm3u8_native',
+            'is_live': False,
+        }
+        downloader = get_suitable_downloader(info_dict, {})
+        self.assertEqual(downloader, HlsFD)
+
+    def test_live_without_generator_falls_back_to_ffmpeg(self):
+        """Test that live HLS without generator protocol falls back to FFmpeg."""
+        from yt_dlp.downloader import get_suitable_downloader
+        from yt_dlp.downloader.external import FFmpegFD
+
+        info_dict = {
+            'url': 'http://example.com/live.m3u8',
+            'protocol': 'm3u8_native',
+            'is_live': True,
+        }
+        downloader = get_suitable_downloader(info_dict, {})
+        self.assertEqual(downloader, FFmpegFD)
+
+    def test_hls_native_live_option_routes_to_hlsfd(self):
+        """Test that --hls-native-live routes live HLS to HlsFD."""
+        from yt_dlp.downloader import get_suitable_downloader
+        from yt_dlp.downloader.hls import HlsFD
+
+        info_dict = {
+            'url': 'http://example.com/live.m3u8',
+            'protocol': 'm3u8_native',
+            'is_live': True,
+        }
+        # With hls_native_live=True, should use HlsFD
+        downloader = get_suitable_downloader(info_dict, {'hls_native_live': True})
+        self.assertEqual(downloader, HlsFD)
+
+    def test_hls_fd_creates_live_generator(self):
+        """Test that HlsFD creates a fragment generator for live with --hls-native-live."""
+        from yt_dlp.downloader.hls import HlsFD
+
+        ydl = FakeYDL({'hls_native_live': True})
+        fd = HlsFD(ydl, {'hls_native_live': True})
+
+        man_url = f'http://127.0.0.1:{self.port}/live.m3u8'
+        info_dict = {
+            'url': man_url,
+            'is_live': True,
+        }
+
+        # Test that _create_live_fragment_generator returns a callable
+        gen_func = fd._create_live_fragment_generator(man_url, info_dict)
+        self.assertTrue(callable(gen_func))
+
+        # Test that calling it returns a generator that yields fragments
+        ctx = {'start': time.time()}
+        gen = gen_func(ctx)
+
+        # Get just the first fragment to verify it works
+        first_frag = next(gen)
+        self.assertIn('url', first_frag)
+        self.assertIn('frag_index', first_frag)
+        self.assertEqual(first_frag['frag_index'], 1)
+
+    def test_hls_fd_can_download_with_generator_protocol(self):
+        """Test that HlsFD.can_download allows live with generator protocol."""
+        from yt_dlp.downloader.hls import HlsFD
+
+        manifest = '''\
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:100
+#EXTINF:6.0,
+segment100.ts
+'''
+        # Live + generator protocol should be allowed
+        info_dict = {
+            'protocol': 'm3u8_native_generator',
+            'is_live': True,
+        }
+        self.assertTrue(HlsFD.can_download(manifest, info_dict))
+
+        # Live + regular protocol should be rejected
+        info_dict_regular = {
+            'protocol': 'm3u8_native',
+            'is_live': True,
+        }
+        self.assertFalse(HlsFD.can_download(manifest, info_dict_regular))
+
+        # VOD should always be allowed
+        info_dict_vod = {
+            'protocol': 'm3u8_native',
+            'is_live': False,
+        }
+        self.assertTrue(HlsFD.can_download(manifest, info_dict_vod))
+
+    def test_fragment_generator_yields_fragments(self):
+        """Test that the fragment generator correctly yields fragment dicts."""
+        import functools
+
+        url = f'http://127.0.0.1:{self.port}/live.m3u8'
+
+        # Create a simple fragment generator similar to what the extractor does
+        def fragment_generator(ctx):
+            import urllib.request
+            with urllib.request.urlopen(url) as response:
+                manifest = response.read().decode()
+            parser = HlsManifestParser(manifest, url)
+
+            for i, segment in enumerate(parser.segments):
+                yield {
+                    'frag_index': i + 1,
+                    'url': segment['url'],
+                    'decrypt_info': segment['decrypt_info'],
+                    'byte_range': segment['byte_range'],
+                    'media_sequence': segment['media_sequence'],
+                }
+
+        gen_callable = functools.partial(fragment_generator)
+        ctx = {'start': time.time()}
+
+        # Call the generator and collect fragments
+        fragments = list(gen_callable(ctx))
+
+        self.assertEqual(len(fragments), 2)
+        self.assertEqual(fragments[0]['frag_index'], 1)
+        self.assertEqual(fragments[0]['media_sequence'], 100)
+        self.assertIn('segment100.ts', fragments[0]['url'])
+        self.assertEqual(fragments[1]['frag_index'], 2)
+        self.assertEqual(fragments[1]['media_sequence'], 101)
+
+    def test_hls_fd_resolve_fragments_callable(self):
+        """Test that HlsFD._resolve_fragments handles callable correctly."""
+        from yt_dlp.downloader.hls import HlsFD
+
+        ydl = FakeYDL()
+        fd = HlsFD(ydl, {})
+
+        # Test with callable
+        def fragments_gen(ctx):
+            yield {'frag_index': 1, 'url': 'http://example.com/seg1.ts'}
+            yield {'frag_index': 2, 'url': 'http://example.com/seg2.ts'}
+
+        ctx = {}
+        result = fd._resolve_fragments(fragments_gen, ctx)
+        # Should be a generator, collect it
+        fragments = list(result)
+        self.assertEqual(len(fragments), 2)
+
+        # Test with list (non-callable)
+        frag_list = [
+            {'frag_index': 1, 'url': 'http://example.com/seg1.ts'},
+            {'frag_index': 2, 'url': 'http://example.com/seg2.ts'},
+        ]
+        result = fd._resolve_fragments(frag_list, ctx)
+        self.assertEqual(result, frag_list)
+
+    def test_hls_fd_resolve_fragments_test_mode(self):
+        """Test that _resolve_fragments returns only first fragment in test mode."""
+        from yt_dlp.downloader.hls import HlsFD
+
+        ydl = FakeYDL()
+        fd = HlsFD(ydl, {'test': True})
+
+        def fragments_gen(ctx):
+            yield {'frag_index': 1, 'url': 'http://example.com/seg1.ts'}
+            yield {'frag_index': 2, 'url': 'http://example.com/seg2.ts'}
+            yield {'frag_index': 3, 'url': 'http://example.com/seg3.ts'}
+
+        ctx = {}
+        result = fd._resolve_fragments(fragments_gen, ctx)
+        # In test mode, should only return first fragment
+        fragments = list(result) if hasattr(result, '__iter__') else [result]
+        self.assertEqual(len(fragments), 1)
+
+
+class TestHlsManifestParserWithFixtures(unittest.TestCase):
+    """Tests using the M3U8 test fixture files."""
+
+    FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'testdata', 'm3u8')
+
+    def _read_fixture(self, filename):
+        with open(os.path.join(self.FIXTURES_DIR, filename), encoding='utf-8') as f:
+            return f.read()
+
+    def test_livestream_basic_fixture(self):
+        """Test parsing the basic livestream fixture."""
+        manifest = self._read_fixture('livestream_basic.m3u8')
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.target_duration, 6.0)
+        self.assertEqual(parser.media_sequence, 1000)
+        self.assertEqual(len(parser.segments), 3)
+        self.assertFalse(parser.is_endlist)
+        self.assertEqual(parser.last_media_sequence, 1002)
+
+    def test_livestream_encrypted_fixture(self):
+        """Test parsing the encrypted livestream fixture."""
+        manifest = self._read_fixture('livestream_encrypted.m3u8')
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.media_sequence, 500)
+        self.assertEqual(len(parser.segments), 3)
+        # First two segments use key1
+        self.assertEqual(
+            parser.segments[0]['decrypt_info']['URI'],
+            'https://keys.example.com/key1.bin')
+        self.assertIsNotNone(parser.segments[0]['decrypt_info']['IV'])
+        # Third segment uses key2 (no explicit IV)
+        self.assertEqual(
+            parser.segments[2]['decrypt_info']['URI'],
+            'https://keys.example.com/key2.bin')
+
+    def test_livestream_ended_fixture(self):
+        """Test parsing the ended livestream fixture."""
+        manifest = self._read_fixture('livestream_ended.m3u8')
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertTrue(parser.is_endlist)
+        self.assertEqual(parser.media_sequence, 2000)
+        self.assertEqual(len(parser.segments), 3)
+
+    def test_livestream_with_init_fixture(self):
+        """Test parsing the fMP4 livestream with init segment fixture."""
+        manifest = self._read_fixture('livestream_with_init.m3u8')
+        parser = HlsManifestParser(manifest, 'http://example.com/')
+
+        self.assertEqual(parser.media_sequence, 100)
+        # Should have init segment + 3 media segments
+        self.assertEqual(len(parser.segments), 4)
+        self.assertTrue(parser.segments[0].get('is_init'))
+        self.assertEqual(
+            parser.segments[0]['url'],
+            'https://cdn.example.com/live/init.mp4')
+        self.assertFalse(parser.segments[1].get('is_init'))
+
+
+class TestHlsLiveFragmentGenerator(unittest.TestCase):
+    """Tests for the _extract_m3u8_live_fragments helper."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.httpd = http.server.HTTPServer(('127.0.0.1', 0), HlsLiveTestHandler)
+        cls.port = http_server_port(cls.httpd)
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+
+    def setUp(self):
+        HlsLiveTestHandler.reset()
+
+    def test_fragment_generator_from_extractor(self):
+        """Test fragment generator created by extractor helper."""
+        # This test simulates what the extractor helper does
+        # We can't easily test _extract_m3u8_live_fragments directly
+        # without a full extractor, so we test the pattern it uses
+
+        url = f'http://127.0.0.1:{self.port}/live.m3u8'
+
+        # Simulate the generator pattern
+        collected_fragments = []
+        max_fragments = 4
+
+        import urllib.request
+        last_media_sequence = -1
+
+        for _ in range(3):  # Simulate 3 polls
+            with urllib.request.urlopen(url) as response:
+                manifest = response.read().decode()
+            parser = HlsManifestParser(manifest, url)
+
+            new_segments = parser.get_new_segments_since(last_media_sequence)
+            for seg in new_segments:
+                collected_fragments.append({
+                    'url': seg['url'],
+                    'media_sequence': seg['media_sequence'],
+                })
+                if len(collected_fragments) >= max_fragments:
+                    break
+
+            last_media_sequence = parser.last_media_sequence
+
+            if len(collected_fragments) >= max_fragments:
+                break
+
+            # Simulate stream advancing
+            HlsLiveTestHandler.advance(1)
+
+        # Should have collected at least 2 fragments from initial manifest
+        self.assertGreaterEqual(len(collected_fragments), 2)
+        # All fragments should have incrementing media sequences
+        sequences = [f['media_sequence'] for f in collected_fragments]
+        self.assertEqual(sequences, sorted(sequences))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/testdata/m3u8/livestream_basic.m3u8
+++ b/test/testdata/m3u8/livestream_basic.m3u8
@@ -1,0 +1,10 @@
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:1000
+#EXTINF:5.005,
+https://cdn.example.com/live/segment1000.ts
+#EXTINF:6.006,
+https://cdn.example.com/live/segment1001.ts
+#EXTINF:5.505,
+https://cdn.example.com/live/segment1002.ts

--- a/test/testdata/m3u8/livestream_encrypted.m3u8
+++ b/test/testdata/m3u8/livestream_encrypted.m3u8
@@ -1,0 +1,12 @@
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:500
+#EXT-X-KEY:METHOD=AES-128,URI="https://keys.example.com/key1.bin",IV=0x00000000000000000000000000000001
+#EXTINF:10.0,
+https://cdn.example.com/live/encrypted/segment500.ts
+#EXTINF:10.0,
+https://cdn.example.com/live/encrypted/segment501.ts
+#EXT-X-KEY:METHOD=AES-128,URI="https://keys.example.com/key2.bin"
+#EXTINF:10.0,
+https://cdn.example.com/live/encrypted/segment502.ts

--- a/test/testdata/m3u8/livestream_ended.m3u8
+++ b/test/testdata/m3u8/livestream_ended.m3u8
@@ -1,0 +1,11 @@
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:2000
+#EXTINF:6.0,
+https://cdn.example.com/live/segment2000.ts
+#EXTINF:6.0,
+https://cdn.example.com/live/segment2001.ts
+#EXTINF:4.5,
+https://cdn.example.com/live/segment2002.ts
+#EXT-X-ENDLIST

--- a/test/testdata/m3u8/livestream_with_init.m3u8
+++ b/test/testdata/m3u8/livestream_with_init.m3u8
@@ -1,0 +1,11 @@
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:100
+#EXT-X-MAP:URI="https://cdn.example.com/live/init.mp4"
+#EXTINF:6.0,
+https://cdn.example.com/live/fmp4/segment100.m4s
+#EXTINF:6.0,
+https://cdn.example.com/live/fmp4/segment101.m4s
+#EXTINF:6.0,
+https://cdn.example.com/live/fmp4/segment102.m4s

--- a/yt_dlp/downloader/__init__.py
+++ b/yt_dlp/downloader/__init__.py
@@ -15,6 +15,10 @@ def get_suitable_downloader(info_dict, params={}, default=NO_DEFAULT, protocol=N
           and not (to_stdout and len(protocols) > 1)
           and set(protocols) == {'http_dash_segments_generator'}):
         return DashSegmentsFD
+    elif (set(downloaders) == {HlsFD}
+          and not (to_stdout and len(protocols) > 1)
+          and set(protocols) == {'m3u8_native_generator'}):
+        return HlsFD
     elif len(downloaders) == 1:
         return downloaders[0]
     return None
@@ -42,6 +46,7 @@ PROTOCOL_MAP = {
     'rtmpe': RtmpFD,
     'rtmp_ffmpeg': FFmpegFD,
     'm3u8_native': HlsFD,
+    'm3u8_native_generator': HlsFD,
     'm3u8': FFmpegFD,
     'f4m': F4mFD,
     'http_dash_segments': DashSegmentsFD,
@@ -61,6 +66,7 @@ PROTOCOL_MAP = {
 def shorten_protocol_name(proto, simplify=False):
     short_protocol_names = {
         'm3u8_native': 'm3u8',
+        'm3u8_native_generator': 'm3u8G',
         'm3u8': 'm3u8F',
         'rtmp_ffmpeg': 'rtmpF',
         'http_dash_segments': 'dash',
@@ -73,6 +79,7 @@ def shorten_protocol_name(proto, simplify=False):
             'ftps': 'ftp',
             'm3u8': 'm3u8',  # Reverse above m3u8 mapping
             'm3u8_native': 'm3u8',
+            'm3u8_native_generator': 'm3u8',
             'http_dash_segments_generator': 'dash',
             'rtmp_ffmpeg': 'rtmp',
             'm3u8_frag_urls': 'm3u8',
@@ -109,6 +116,9 @@ def _get_suitable_downloader(info_dict, protocol, params, default):
 
     if protocol in ('m3u8', 'm3u8_native'):
         if info_dict.get('is_live'):
+            # Use native HLS for live if --hls-native-live is set
+            if params.get('hls_native_live'):
+                return HlsFD
             return FFmpegFD
         elif (external_downloader or '').lower() == 'native':
             return HlsFD
@@ -119,6 +129,10 @@ def _get_suitable_downloader(info_dict, protocol, params, default):
             return HlsFD
         elif params.get('hls_prefer_native') is False:
             return FFmpegFD
+
+    # m3u8_native_generator is for live HLS with fragment generator pattern
+    if protocol == 'm3u8_native_generator':
+        return HlsFD
 
     return PROTOCOL_MAP.get(protocol, default)
 

--- a/yt_dlp/downloader/hls.py
+++ b/yt_dlp/downloader/hls.py
@@ -64,14 +64,148 @@ class HlsFD(FragmentFD):
             ]
 
         def check_results():
-            yield not info_dict.get('is_live')
+            # Allow live streams if using the generator protocol or hls_native_live option
+            # Note: hls_native_live is checked at routing time, not here
+            if info_dict.get('is_live') and info_dict.get('protocol') != 'm3u8_native_generator':
+                # Will be handled by real_download if hls_native_live is set
+                yield not info_dict.get('is_live')
             for feature in UNSUPPORTED_FEATURES:
                 yield not re.search(feature, manifest)
             if not allow_unplayable_formats:
                 yield not cls._has_drm(manifest)
         return all(check_results())
 
+    def _resolve_fragments(self, fragments, ctx):
+        """Resolve fragment source - handles both callables and iterables.
+
+        Following the DASH pattern from dash.py for generator-based live streams.
+        """
+        fragments = fragments(ctx) if callable(fragments) else fragments
+        return [next(iter(fragments))] if self.params.get('test') else fragments
+
+    def _create_live_fragment_generator(self, man_url, info_dict):
+        """Create a fragment generator for live HLS streams.
+
+        This is used when --hls-native-live is set and the extractor didn't
+        provide a fragment generator.
+        """
+        import time
+        from ..utils import HlsManifestParser
+
+        extra_segment_query = None
+        if extra_param := info_dict.get('extra_param_to_segment_url'):
+            extra_segment_query = urllib.parse.parse_qs(extra_param)
+        extra_key_query = None
+        if extra_param := info_dict.get('extra_param_to_key_url'):
+            extra_key_query = urllib.parse.parse_qs(extra_param)
+
+        def fragment_generator(ctx):
+            NO_NEW_SEGMENTS_THRESHOLD = 30
+            last_media_sequence = -1
+            init_segment_yielded = False
+            no_new_segments_count = 0
+            frag_index = 0
+            manifest_base_url = man_url
+
+            self.to_screen(f'[{self.FD_NAME}] Starting live HLS download with manifest polling')
+
+            while True:
+                fetch_time = time.time()
+
+                if no_new_segments_count > NO_NEW_SEGMENTS_THRESHOLD:
+                    self.to_screen(f'[{self.FD_NAME}] No new segments for too long, assuming stream ended')
+                    return
+
+                try:
+                    urlh = self.ydl.urlopen(self._prepare_url(info_dict, manifest_base_url))
+                    manifest_base_url = urlh.url
+                    manifest_content = urlh.read().decode('utf-8', 'ignore')
+                except Exception as e:
+                    self.report_warning(f'Failed to download manifest: {e}')
+                    no_new_segments_count += 2
+                    time.sleep(2)
+                    continue
+
+                parser = HlsManifestParser(
+                    manifest_content,
+                    manifest_base_url,
+                    extra_segment_query,
+                    extra_key_query,
+                )
+
+                poll_interval = parser.target_duration or 2
+
+                # Yield init segment once
+                for segment in parser.segments:
+                    if segment.get('is_init') and not init_segment_yielded:
+                        frag_index += 1
+                        yield {
+                            'frag_index': frag_index,
+                            'url': segment['url'],
+                            'decrypt_info': segment['decrypt_info'],
+                            'byte_range': segment['byte_range'],
+                            'media_sequence': segment['media_sequence'],
+                        }
+                        init_segment_yielded = True
+
+                new_segments = parser.get_new_segments_since(last_media_sequence)
+
+                if new_segments:
+                    no_new_segments_count = 0
+                    for segment in new_segments:
+                        frag_index += 1
+                        yield {
+                            'frag_index': frag_index,
+                            'url': segment['url'],
+                            'decrypt_info': segment['decrypt_info'],
+                            'byte_range': segment['byte_range'],
+                            'media_sequence': segment['media_sequence'],
+                        }
+                    last_media_sequence = parser.last_media_sequence
+                else:
+                    no_new_segments_count += 1
+
+                if parser.is_endlist:
+                    self.to_screen(f'[{self.FD_NAME}] Stream ended (EXT-X-ENDLIST found)')
+                    return
+
+                elapsed = time.time() - fetch_time
+                sleep_time = max(0, poll_interval - elapsed)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+
+        return fragment_generator
+
+    def _real_download_live(self, filename, info_dict, fragments_callable):
+        """Handle live HLS streams using the fragment generator pattern."""
+        self.to_screen(f'[{self.FD_NAME}] Downloading live HLS stream')
+
+        ctx = {
+            'filename': filename,
+            'total_frags': None,
+            'live': True,
+        }
+
+        self._prepare_and_start_frag_download(ctx, info_dict)
+        fragments = self._resolve_fragments(fragments_callable, ctx)
+
+        return self.download_and_append_fragments(ctx, fragments, info_dict)
+
     def real_download(self, filename, info_dict):
+        # Handle live HLS with generator protocol (extractor provided generator)
+        if info_dict.get('protocol') == 'm3u8_native_generator':
+            fragments_callable = info_dict.get('fragments')
+            if not callable(fragments_callable):
+                self.report_error('Live HLS with m3u8_native_generator protocol requires callable fragments')
+                return False
+            return self._real_download_live(filename, info_dict, fragments_callable)
+
+        # Handle live HLS with --hls-native-live option (create generator ourselves)
+        if info_dict.get('is_live') and self.params.get('hls_native_live'):
+            man_url = info_dict['url']
+            fragments_callable = self._create_live_fragment_generator(man_url, info_dict)
+            return self._real_download_live(filename, info_dict, fragments_callable)
+
         man_url = info_dict['url']
 
         s = info_dict.get('hls_media_playlist_data')

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -2491,6 +2491,140 @@ class InfoExtractor:
             float(line[len('#EXTINF:'):].split(',')[0])
             for line in m3u8_vod.splitlines() if line.startswith('#EXTINF:'))) or None
 
+    def _extract_m3u8_live_fragments(
+            self, m3u8_url, video_id, *,
+            poll_interval=None,
+            max_duration=None,
+            headers=None,
+            extra_param_to_segment_url=None,
+            extra_param_to_key_url=None):
+        """
+        Create a fragment generator for live HLS streams.
+
+        This method returns a callable that, when invoked with a context dict,
+        yields fragments by polling the HLS manifest for new segments.
+
+        Args:
+            m3u8_url: URL of the HLS media playlist
+            video_id: Video ID for logging
+            poll_interval: Seconds between manifest polls (default: auto from target duration)
+            max_duration: Maximum download duration in seconds (default: unlimited)
+            headers: HTTP headers for requests
+            extra_param_to_segment_url: Additional query params for segment URLs
+            extra_param_to_key_url: Additional query params for key URLs
+
+        Returns:
+            A callable(ctx) -> generator that yields fragment dicts
+        """
+        import functools
+        import urllib.parse
+
+        extra_segment_query = None
+        if extra_param_to_segment_url:
+            extra_segment_query = urllib.parse.parse_qs(extra_param_to_segment_url)
+
+        extra_key_query = None
+        if extra_param_to_key_url:
+            extra_key_query = urllib.parse.parse_qs(extra_param_to_key_url)
+
+        def fragment_generator(ctx):
+            from ..utils import HlsManifestParser
+
+            current_poll_interval = poll_interval
+            NO_NEW_SEGMENTS_THRESHOLD = 30  # Give up after 30 consecutive polls with no new segments
+
+            download_start_time = ctx.get('start') or time.time()
+            last_media_sequence = -1
+            init_segment_yielded = False
+            no_new_segments_count = 0
+            frag_index = 0
+            manifest_base_url = m3u8_url
+
+            self.write_debug(f'[{video_id}] Starting live HLS fragment generator')
+
+            while True:
+                fetch_time = time.time()
+
+                # Check max duration
+                if max_duration and (fetch_time - download_start_time) > max_duration:
+                    self.to_screen(f'[{video_id}] Maximum duration reached, stopping')
+                    return
+
+                # Check for too many failures
+                if no_new_segments_count > NO_NEW_SEGMENTS_THRESHOLD:
+                    self.to_screen(f'[{video_id}] No new segments for too long, assuming stream ended')
+                    return
+
+                # Fetch and parse manifest
+                try:
+                    urlh = self._request_webpage(
+                        manifest_base_url, video_id,
+                        note=False, errnote='Failed to download HLS manifest',
+                        headers=headers)
+                    manifest_base_url = urlh.url  # Handle redirects
+                    manifest_content = urlh.read().decode('utf-8', 'ignore')
+                except ExtractorError as e:
+                    self.write_debug(f'[{video_id}] Manifest fetch error: {e}')
+                    no_new_segments_count += 2
+                    time.sleep(current_poll_interval or 2)
+                    continue
+
+                parser = HlsManifestParser(
+                    manifest_content,
+                    manifest_base_url,
+                    extra_segment_query,
+                    extra_key_query,
+                )
+
+                # Auto-determine poll interval from target duration
+                if current_poll_interval is None:
+                    current_poll_interval = parser.target_duration or 2
+
+                # Yield init segment once
+                for segment in parser.segments:
+                    if segment.get('is_init') and not init_segment_yielded:
+                        frag_index += 1
+                        yield {
+                            'frag_index': frag_index,
+                            'url': segment['url'],
+                            'decrypt_info': segment['decrypt_info'],
+                            'byte_range': segment['byte_range'],
+                            'media_sequence': segment['media_sequence'],
+                        }
+                        init_segment_yielded = True
+
+                # Get new segments
+                new_segments = parser.get_new_segments_since(last_media_sequence)
+
+                if new_segments:
+                    no_new_segments_count = 0
+                    for segment in new_segments:
+                        frag_index += 1
+                        yield {
+                            'frag_index': frag_index,
+                            'url': segment['url'],
+                            'decrypt_info': segment['decrypt_info'],
+                            'byte_range': segment['byte_range'],
+                            'media_sequence': segment['media_sequence'],
+                            'fragment_count': None,  # Unknown for live
+                        }
+                    last_media_sequence = parser.last_media_sequence
+                else:
+                    no_new_segments_count += 1
+
+                # Check for end of stream
+                if parser.is_endlist:
+                    self.to_screen(f'[{video_id}] Stream ended (EXT-X-ENDLIST found)')
+                    return
+
+                # Wait before next poll
+                elapsed = time.time() - fetch_time
+                sleep_time = max(0, current_poll_interval - elapsed)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+
+        return functools.partial(fragment_generator)
+
     def _extract_mpd_vod_duration(
             self, mpd_url, video_id, note=None, errnote=None, data=None, headers={}, query={}):
 

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1112,6 +1112,16 @@ def create_parser():
         dest='hls_prefer_native', action='store_false', default=None,
         help=optparse.SUPPRESS_HELP)
     downloader.add_option(
+        '--hls-native-live',
+        dest='hls_native_live', action='store_true', default=False,
+        help=(
+            'Use the native HLS downloader for live streams instead of ffmpeg. '
+            'This enables fragment retry and better error handling. (Experimental)'))
+    downloader.add_option(
+        '--no-hls-native-live',
+        dest='hls_native_live', action='store_false',
+        help='Use ffmpeg for live HLS streams (default)')
+    downloader.add_option(
         '--hls-use-mpegts',
         dest='hls_use_mpegts', action='store_true', default=None,
         help=(

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -4521,6 +4521,146 @@ def parse_m3u8_attributes(attrib):
     return info
 
 
+class HlsManifestParser:
+    """
+    Parser for HLS media playlists with live stream support.
+
+    Tracks media sequence numbers, detects stream end, and handles
+    the sliding window of segments in live playlists.
+    """
+
+    def __init__(self, manifest_content, base_url, extra_segment_query=None, extra_key_query=None):
+        self.base_url = base_url
+        self.extra_segment_query = extra_segment_query
+        self.extra_key_query = extra_key_query
+        self.is_endlist = '#EXT-X-ENDLIST' in manifest_content
+        self.target_duration = None
+        self.media_sequence = 0
+        self.segments = []
+        self._current_decrypt_info = {'METHOD': 'NONE'}
+        self._parse(manifest_content)
+
+    def _parse(self, content):
+        """Parse HLS manifest and extract segment information."""
+        import binascii
+
+        byte_range_offset = 0
+        current_byte_range = {}
+        current_duration = None
+        discontinuity_count = 0
+
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if line.startswith('#EXT-X-TARGETDURATION:'):
+                self.target_duration = float(line.split(':', 1)[1])
+            elif line.startswith('#EXT-X-MEDIA-SEQUENCE:'):
+                self.media_sequence = int(line.split(':', 1)[1])
+            elif line.startswith('#EXTINF:'):
+                # Handle both "duration," and "duration,title" formats
+                duration_str = line.split(':', 1)[1].split(',')[0]
+                current_duration = float(duration_str)
+            elif line.startswith('#EXT-X-BYTERANGE:'):
+                parts = line[17:].split('@')
+                length = int(parts[0])
+                start = int(parts[1]) if len(parts) > 1 else byte_range_offset
+                current_byte_range = {'start': start, 'end': start + length}
+            elif line.startswith('#EXT-X-KEY:'):
+                self._parse_key(line[11:], binascii)
+            elif line.startswith('#EXT-X-MAP:'):
+                self._parse_map(line[11:])
+            elif line.startswith('#EXT-X-DISCONTINUITY'):
+                discontinuity_count += 1
+            elif not line.startswith('#'):
+                # Segment URL
+                segment_url = urljoin(self.base_url, line)
+                if self.extra_segment_query:
+                    segment_url = update_url_query(segment_url, self.extra_segment_query)
+
+                self.segments.append({
+                    'url': segment_url,
+                    'media_sequence': self.media_sequence + len([
+                        s for s in self.segments if not s.get('is_init')
+                    ]),
+                    'duration': current_duration,
+                    'decrypt_info': self._current_decrypt_info.copy(),
+                    'byte_range': current_byte_range.copy() if current_byte_range else {},
+                    'discontinuity_count': discontinuity_count,
+                })
+                current_duration = None
+                if current_byte_range:
+                    byte_range_offset = current_byte_range['end']
+                    current_byte_range = {}
+
+    def _parse_key(self, attrib, binascii):
+        """Parse #EXT-X-KEY directive."""
+        key_info = parse_m3u8_attributes(attrib)
+        method = key_info.get('METHOD', 'NONE')
+
+        if method == 'NONE':
+            self._current_decrypt_info = {'METHOD': 'NONE'}
+        elif method == 'AES-128':
+            uri = key_info.get('URI')
+            if uri:
+                uri = urljoin(self.base_url, uri)
+                if self.extra_key_query:
+                    uri = update_url_query(uri, self.extra_key_query)
+
+            iv = key_info.get('IV')
+            if iv:
+                iv = binascii.unhexlify(iv[2:].zfill(32))
+
+            self._current_decrypt_info = {
+                'METHOD': 'AES-128',
+                'URI': uri,
+                'IV': iv,
+                'KEY': None,  # Fetched on demand by downloader
+            }
+
+    def _parse_map(self, attrib):
+        """Parse #EXT-X-MAP directive for initialization segment."""
+        map_info = parse_m3u8_attributes(attrib)
+        uri = map_info.get('URI')
+        if not uri:
+            return
+
+        uri = urljoin(self.base_url, uri)
+        if self.extra_segment_query:
+            uri = update_url_query(uri, self.extra_segment_query)
+
+        byte_range = {}
+        if map_info.get('BYTERANGE'):
+            parts = map_info['BYTERANGE'].split('@')
+            length = int(parts[0])
+            start = int(parts[1]) if len(parts) > 1 else 0
+            byte_range = {'start': start, 'end': start + length}
+
+        # Insert init segment at beginning of segments list
+        self.segments.insert(0, {
+            'url': uri,
+            'media_sequence': self.media_sequence - 1,  # Before first segment
+            'duration': 0,
+            'decrypt_info': self._current_decrypt_info.copy(),
+            'byte_range': byte_range,
+            'is_init': True,
+        })
+
+    def get_new_segments_since(self, last_media_sequence):
+        """Return segments newer than the given media sequence number."""
+        return [s for s in self.segments
+                if s['media_sequence'] > last_media_sequence and not s.get('is_init')]
+
+    @property
+    def last_media_sequence(self):
+        """Return the media sequence of the last non-init segment."""
+        non_init_segments = [s for s in self.segments if not s.get('is_init')]
+        if not non_init_segments:
+            return self.media_sequence - 1
+        return max(s['media_sequence'] for s in non_init_segments)
+
+
 def urshift(val, n):
     return val >> n if val >= 0 else (val + 0x100000000) >> n
 


### PR DESCRIPTION
## Summary

Implements native HLS livestream downloading using the fragment generator pattern, following DASH's proven `http_dash_segments_generator` approach. This provides retry/resume capabilities that ffmpeg lacks.

### Features
- Add `HlsManifestParser` utility class for parsing HLS media playlists
- Add `_extract_m3u8_live_fragments()` extractor helper method  
- Add `m3u8_native_generator` protocol for extractor opt-in
- Add `--hls-native-live` CLI option for immediate usability
- Manifest polling with automatic interval detection from `EXT-X-TARGETDURATION`
- `EXT-X-ENDLIST` detection for stream end
- AES-128 encryption support
- Comprehensive test suite (35 tests)

### Usage

```bash
# Use the new --hls-native-live option
yt-dlp --hls-native-live "https://example.com/live.m3u8"
```

Extractors can also opt-in by using the new protocol:
```python
fragments_gen = self._extract_m3u8_live_fragments(m3u8_url, video_id)
format_info = {
    'url': m3u8_url,
    'protocol': 'm3u8_native_generator',
    'fragments': fragments_gen,
    'is_live': True,
}
```

## Test plan

- [x] All 35 new tests pass (`python -m unittest test.test_downloader_hls`)
- [x] Existing tests unaffected (`python -m unittest test.test_utils`)
- [ ] Manual testing with real livestream

Closes #262  
Related to #5039