### PR TITLE
Extract subtitle language name and sort by it

### DIFF
--- a/test/test_InfoExtractor.py
+++ b/test/test_InfoExtractor.py
@@ -1412,6 +1412,7 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
                             'url': 'https://sdn-global-streaming-cache-3qsdn.akamaized.net/stream/3144/files/17/07/672975/3144-kZT4LWMQw6Rh7Kpd.ism/manifest.mpd',
                             'fragment_base_url': 'https://sdn-global-streaming-cache-3qsdn.akamaized.net/stream/3144/files/17/07/672975/3144-kZT4LWMQw6Rh7Kpd.ism/dash/',
                             'protocol': 'http_dash_segments',
+                            'name': 'English (US)',
                         },
                     ],
                 },

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -529,10 +529,18 @@ class TestFormatSelection(unittest.TestCase):
 class TestYoutubeDL(unittest.TestCase):
     def test_subtitles(self):
         def s_formats(lang, autocaption=False):
+            names = {
+                'en': 'English',
+                'fr': 'Français',
+                'es': 'Español',
+                'it': 'Italiano',
+                'pt': 'Português',
+            }
             return [{
                 'ext': ext,
                 'url': f'http://localhost/video.{lang}.{ext}',
                 '_auto': autocaption,
+                'name': names[lang],
             } for ext in ['vtt', 'srt', 'ass']]
         subtitles = {l: s_formats(l) for l in ['en', 'fr', 'es']}
         auto_captions = {l: s_formats(l, True) for l in ['it', 'pt', 'es']}
@@ -591,21 +599,25 @@ class TestYoutubeDL(unittest.TestCase):
         result = get_info({'writesubtitles': True, 'subtitleslangs': ['e.+']})
         subs = result['requested_subtitles']
         self.assertTrue(subs)
-        self.assertEqual(set(subs.keys()), {'es', 'en'})
+        self.assertEqual(list(subs.keys()), ['en', 'es'])
 
         result = get_info({'writesubtitles': True, 'writeautomaticsub': True, 'subtitleslangs': ['es', 'pt']})
         subs = result['requested_subtitles']
         self.assertTrue(subs)
-        self.assertEqual(set(subs.keys()), {'es', 'pt'})
+        self.assertEqual(list(subs.keys()), ['es', 'pt'])
         self.assertFalse(subs['es']['_auto'])
         self.assertTrue(subs['pt']['_auto'])
 
         result = get_info({'writeautomaticsub': True, 'subtitleslangs': ['es', 'pt']})
         subs = result['requested_subtitles']
         self.assertTrue(subs)
-        self.assertEqual(set(subs.keys()), {'es', 'pt'})
+        self.assertEqual(list(subs.keys()), ['es', 'pt'])
         self.assertTrue(subs['es']['_auto'])
         self.assertTrue(subs['pt']['_auto'])
+
+        result = get_info({'writesubtitles': True, 'writeautomaticsub': True, 'subtitleslangs': ['pt', 'all', 'e.*']})
+        subs = result['requested_subtitles']
+        self.assertEqual(list(subs.keys()), ['pt', 'fr', 'it', 'en', 'es'])
 
     def test_add_extra_info(self):
         test_dict = {

--- a/test/testdata/mpd/subtitles.mpd
+++ b/test/testdata/mpd/subtitles.mpd
@@ -266,6 +266,7 @@
       group="3"
       contentType="text"
       lang="en"
+      label="English (US)"
       mimeType="application/mp4"
       codecs="stpp"
       startWithSAP="1">

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -3173,7 +3173,7 @@ class YoutubeDL:
                 and not self.params.get('writeautomaticsub')):
             return None
 
-        all_sub_langs = tuple(available_subs.keys())
+        all_sub_langs = tuple(sorted(available_subs.keys()))
         if self.params.get('allsubtitles', False):
             requested_langs = all_sub_langs
         elif self.params.get('subtitleslangs', False):
@@ -3215,7 +3215,27 @@ class YoutubeDL:
                     'No subtitle format found matching "{}" for language {}, '
                     'using {}. Use --list-subs for a list of available subtitles'.format(formats_query, lang, f['ext']))
             subs[lang] = f
-        return subs
+        return self._sort_subtitles(subs, all_sub_langs)
+
+    def _sort_subtitles(self, subs, all_sub_langs):
+        subtitleslangs = self.params.get('subtitleslangs', [])
+        if self.params.get('allsubtitles', False):
+            subtitleslangs = ['all']
+
+        all_pos = subtitleslangs.index('all') if 'all' in subtitleslangs else -1
+        sort_group = {}
+        for i, lang_opt in enumerate(subtitleslangs):
+            if lang_opt == 'all' or lang_opt.startswith('-'):
+                continue
+
+            for lang in orderedSet_from_options([lang_opt], {'all': all_sub_langs}, use_regex=True):
+                sort_group[lang] = i
+
+        def sort_fn(item):
+            lang, subtitle_format = item
+            return (sort_group.get(lang, all_pos), subtitle_format.get('name') or lang, lang)
+
+        return dict(sorted(subs.items(), key=sort_fn))
 
     def _forceprint(self, key, info_dict):
         if info_dict is None:

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -3035,6 +3035,9 @@ class InfoExtractor:
                             'manifest_url': mpd_url,
                             'filesize': filesize,
                         }
+                        # Not in spec, but seen in wild, containing subtitle natural language
+                        if representation_attrib.get('label'):
+                            f['name'] = representation_attrib.get('label')
                     elif content_type in ('image/avif', 'image/jpeg'):
                         # See test case in VikiIE
                         # https://www.viki.com/videos/1175236v-choosing-spouse-by-lottery-episode-1


### PR DESCRIPTION
### Description of your *pull request* and other information

Currently when all subtitles are asked to be embedded into video file then they are in unspecified order which depends on extractor/server response (can be random every time).
This PR implements subtitle sorting based on language name.
When subtitles are manually specified with `--sub-langs 'ko,ja,en'` then specified order is preserved.

Also some .MPD files contain subtitle natural language in `label=` attribute so that is implemented as well.
```xml
<AdaptationSet contentType="text" lang="ro" label="Română" mimeType="text/vtt">
```
Note that I didn't actually see such attribute mentioned in DASH-MPD schema so I'm guessing it's non-standard/custom but doesn't seem rare as can find such examples.

With this PR:

<img width="624" height="588" alt="attels" src="https://github.com/user-attachments/assets/7f7c4821-93df-4d78-b27c-6665448e29a5" />


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [x] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
