### PR TITLE
Fix test_remove_logging_handler for Python 3.14.7

### DIFF
--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -862,12 +862,12 @@ class TestRequestHandlerMisc:
         # Ensure any logging handlers, which may contain a YoutubeDL instance,
         # are removed when we close the request handler
         # See: https://github.com/yt-dlp/yt-dlp/issues/8922
-        logging_handlers = logging.getLogger(logger_name).handlers
-        before_count = len(logging_handlers)
+        logger = logging.getLogger(logger_name)
+        before_count = len(logger.handlers)
         rh = handler()
-        assert len(logging_handlers) == before_count + 1
+        assert len(logger.handlers) == before_count + 1
         rh.close()
-        assert len(logging_handlers) == before_count
+        assert len(logger.handlers) == before_count
 
     def test_wrap_request_errors(self):
         class TestRequestHandler(RequestHandler):


### PR DESCRIPTION


<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

The test_remove_logging_handler test is broken because python 3.14.7 changed how removeHandler works.

The `yt-dlp` test was relying on the implementation detail that `handlers` was a mutable list that stayed the same object for the lifetime of the logger. Python 3.14.7 has moved to an immutable-style update pattern for thread safety, breaking any code that holds a direct reference to the `handlers` list expecting it to be updated in-place.

See python 3.14.7 commit: eae50e7a04f3a0cf219adc97c625f17b6e2e0d56


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [ x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x ] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
