### PR TITLE
[build] Support release tags that shadow branch names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,7 @@ jobs:
         if: env.TARGET_REPO == github.repository
         run: |
           git tag "${TARGET_TAG}" "${HEAD_SHA}"
-          git push origin "${TARGET_TAG}"
+          git push origin "refs/tags/${TARGET_TAG}"
           sleep 5  # Enough time to cover git-push vs gh-release-create race condition
 
       - name: Publish release


### PR DESCRIPTION
### Description of your *pull request* and other information

Prior to this change, trying to create binaries for a branch from an open PR would fail if the name of the branch matched the name of the tag which the release was pushed for. The reason is an ambiguous reference name when trying to push the new tag:
```
Run git tag "${TARGET_TAG}" "${HEAD_SHA}"
error: src refspec fix-release-tag-push matches more than one
error: failed to push some refs to 'https://github.com/InvalidUsernameException/yt-dlp'
Error: Process completed with exit code 1.
```
* [Failed run before this change](https://github.com/InvalidUsernameException/yt-dlp/actions/runs/31538175312)
* [Successful run after](https://github.com/InvalidUsernameException/yt-dlp/actions/runs/31538552440)

This used to work in the past and presumably broke in #16444.

<details open><summary>Template</summary> 

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/).
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Build bugfix

</details>
