### PR TITLE
[ie/yandexdisk] Fix KeyError on password-protected files

### DIFF
--- a/yt_dlp/extractor/yandexdisk.py
+++ b/yt_dlp/extractor/yandexdisk.py
@@ -3,6 +3,7 @@ import json
 from .common import InfoExtractor
 from ..utils import (
     determine_ext,
+    ExtractorError,
     float_or_none,
     int_or_none,
     join_nonempty,
@@ -54,6 +55,9 @@ class YandexDiskIE(InfoExtractor):
     }, {
         'url': 'https://disk.360.yandex.ru/i/TM2xsIVsgjY4uw',
         'only_matching': True,
+    }, {
+        'url': 'https://disk.yandex.ru/i/Nawj6uOS9oUVaQ',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
@@ -64,6 +68,44 @@ class YandexDiskIE(InfoExtractor):
             r'<script[^>]+id="store-prefetch"[^>]*>\s*({.+?})\s*</script>',
             webpage, 'store'), video_id)
         resource = store['resources'][store['rootResourceId']]
+
+        if 'name' not in resource:
+            password = self.get_param('videopassword')
+            if not password:
+                raise ExtractorError(
+                    'This file is protected by a password, use the --video-password option',
+                    expected=True)
+            environment = store.get('environment') or {}
+            sk = environment.get('sk')
+            video_hash = resource.get('hash')
+            env_url = store.get('url') or {}
+            short_url = env_url.get('pathname')
+            if not sk or not video_hash:
+                raise ExtractorError('Unable to obtain password challenge data', expected=True)
+
+            data = self._download_json(
+                urljoin(url, '/public/api/check-password'), video_id,
+                'Submitting video password',
+                data=json.dumps({
+                    'hash': video_hash,
+                    'sk': sk,
+                    'password': password,
+                    'short_url': short_url,
+                }).encode(), headers={
+                    'Content-Type': 'text/plain',
+                }) or {}
+            token = data.get('token')
+            if not token:
+                raise ExtractorError('Invalid password', expected=True)
+
+            cookie_domain = env_url.get('host') or domain
+            self._set_cookie(cookie_domain, 'passToken', token)
+
+            webpage = self._download_webpage(url, video_id)
+            store = self._parse_json(self._search_regex(
+                r'<script[^>]+id="store-prefetch"[^>]*>\s*({.+?})\s*</script>',
+                webpage, 'store'), video_id)
+            resource = store['resources'][store['rootResourceId']]
 
         title = resource['name']
         meta = resource.get('meta') or {}


### PR DESCRIPTION
When a Yandex Disk file is password-protected, the store-prefetch serves a placeholder resource with rootResourceId='password-protected' and no 'name' key, causing a KeyError.

Detect this by checking 'name' in resource, then:
- Require --video-password via get_param('videopassword')
- POST to /public/api/check-password with {hash, sk, password, short_url}
- Set passToken cookie on the serving domain
- Re-fetch the page to obtain the unlocked resource data

<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

ADD DETAILED DESCRIPTION HERE

Fixes #


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [ ] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [ ] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [ ] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [ ] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
