### PR TITLE
[test:socks] Fix compatibility with `websockets>=17`

### DIFF
--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -213,8 +213,13 @@ class SocksHTTPTestRequestHandler(http.server.BaseHTTPRequestHandler, SocksTestR
 class SocksWebSocketTestRequestHandler(SocksTestRequestHandler):
     def handle(self):
         import websockets.sync.server
+        import websockets.version
+
         protocol = websockets.ServerProtocol()
-        connection = websockets.sync.server.ServerConnection(socket=self.request, protocol=protocol, close_timeout=0)
+        connection_args = [self.request, protocol]
+        if int(websockets.version.version.partition('.')[0]) >= 17:
+            connection_args.append(self.server)
+        connection = websockets.sync.server.ServerConnection(*connection_args, close_timeout=0)
         connection.handshake()
         for message in connection:
             if message == 'socks_info':
@@ -230,6 +235,7 @@ def socks_server(socks_server_class, request_handler, bind_ip=None, **socks_serv
         server_type = ThreadingTCPServer if '.' in bind_address else IPv6ThreadingTCPServer
         server = server_type(
             (bind_address, 0), functools.partial(socks_server_class, request_handler, socks_server_kwargs))
+        server.socket_closed = threading.Event()
         server_port = http_server_port(server)
         server_thread = threading.Thread(target=server.serve_forever)
         server_thread.daemon = True
@@ -240,6 +246,7 @@ def socks_server(socks_server_class, request_handler, bind_ip=None, **socks_serv
             yield f'{bind_address}:{server_port}'
     finally:
         server.shutdown()
+        server.socket_closed.set()
         server.server_close()
         server_thread.join(2.0)
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

Closes https://github.com/yt-dlp/yt-dlp/issues/17383

`websockets` 17 renamed the `ServerConnection` `socket` argument to `sock` and added a required `server` argument for server shutdown handling

https://websockets.readthedocs.io/en/17.0.1/project/changelog.html#backwards-incompatible-changes
https://websockets.readthedocs.io/en/17.0.1/reference/sync/server.html#using-a-connection
https://github.com/python-websockets/websockets/commit/afb97a37519706c722f2a88b21a10aa0e1f2efcd
https://github.com/python-websockets/websockets/commit/3df83f32a02f0e8b7d181e41e7c8fb7ba485be59

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
