### PR TITLE
[ie/tiktok] Add referer to webpage requests

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -274,9 +274,14 @@ class TikTokBaseIE(InfoExtractor):
 
     def _extract_web_data_and_status(self, url, video_id, fatal=True):
         video_data, status = {}, -1
+        # Akamai may block Chromium 140-149 UAs when no Referer is provided
+        webpage_headers = {
+            'Referer': self.get_param('http_headers', {}).get('Referer') or self._WEBPAGE_HOST,
+        }
 
         def get_webpage(note='Downloading webpage'):
-            res = self._download_webpage_handle(url, video_id, note, fatal=fatal, impersonate=True)
+            res = self._download_webpage_handle(
+                url, video_id, note, fatal=fatal, headers=webpage_headers, impersonate=True)
             if res is False:
                 return False
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

The issue #17403 describes a problem with downloading the TikTok webpage, which consequently prevented videos from being downloaded. The workaround described was to use a user agent that does not match Chromium versions 140–149. After running several tests, I determined that the problem was the absence of the `Referer` header. Simply specifying it (even with an empty value or a random link) is enough for the webpage to download on all Chromium versions. To make things less suspicious for Akamai, I decided to use the URL https://www.tiktok.com/ in header.

Also you can test this fix by likely command:
```bash
yt_dlp --referer "https://example.com" "https://vt.tiktok.com/video"
```  

Fixes #17403


<details open><summary>Template</summary> <!-- OPEN is intentional -->


### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
</details>
