### PR TITLE
[update] Delete old Windows executable with -LiteralPath (fixes paths containing %)

### DIFF
--- a/yt_dlp/update.py
+++ b/yt_dlp/update.py
@@ -557,8 +557,16 @@ class Updater:
 
         variant = detect_variant()
         if variant.startswith('win'):
-            atexit.register(Popen, f'ping 127.0.0.1 -n 5 -w 1000 & del /F "{old_filename}"',
-                            shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            # Delete the old executable after this process exits. A plain 'del'
+            # via cmd.exe would parse the filename: '%' would be expanded as an
+            # environment variable (e.g. a path like "C:\100% stuff") and the
+            # file would never be removed. PowerShell's -LiteralPath avoids any
+            # parsing; a single quote in the path is escaped by doubling it.
+            ps_command = (
+                'Start-Sleep -Seconds 5; '
+                f'Remove-Item -LiteralPath \'{old_filename.replace("\'", "\'\'")}\' -Force')
+            atexit.register(Popen, ['powershell', '-NoProfile', '-Command', ps_command],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         elif old_filename:
             try:
                 os.remove(old_filename)


### PR DESCRIPTION
## Problem

On Windows, after a self-update, the old executable is scheduled for deletion with:

```python
atexit.register(Popen, f'ping 127.0.0.1 -n 5 -w 1000 & del /F "{old_filename}"', shell=True, ...)
```

`shell=True` runs the string through `cmd.exe`, which **parses the filename**: any `%` in the path is expanded as an environment variable (e.g. yt-dlp installed under a folder named `100% up` or similar). The `del` command then targets the wrong path and **the old executable is never removed**, leaving `yt-dlp.exe.old` behind on every update.

Reproduced on Windows with Python 3.14:
- Path `...\del %USERPROFILE%.txt` with the old code: file **not** deleted (cmd expands `%USERPROFILE%`).
- Path with spaces, `&`, `%` and `'` with the new code: file **deleted**.

## Fix

Replace the `cmd.exe` compound command with PowerShell, using `Remove-Item -LiteralPath` so the filename is never parsed as a shell token:

```python
ps_command = (
    'Start-Sleep -Seconds 5; '
    f'Remove-Item -LiteralPath \'{old_filename.replace("\'", "\'\'")}\' -Force')
atexit.register(Popen, ['powershell', '-NoProfile', '-Command', ps_command], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
```

- `-LiteralPath` takes the path verbatim; no `%`/`&`/space parsing.
- Single quotes in the path are escaped by doubling (`''`), PowerShell's standard escaping.
- `Popen` (yt-dlp's wrapper) still hides the console window on Windows.
- Delay preserved: the old file is deleted ~5 s after the updater exits.

## Tests

- `python -m pytest test/test_update.py -q` → `3 passed`
- Functional test on Windows: file with `100% & o'brien` in the name removed after exit.
