### PR TITLE
[ie/youtube] Remove `android_vr` from default clients

### DIFF
--- a/yt_dlp/extractor/youtube/_base.py
+++ b/yt_dlp/extractor/youtube/_base.py
@@ -225,6 +225,7 @@ INNERTUBE_CLIENTS = {
     # "Made for kids" videos aren't available with this client
     # Using a clientVersion>1.65 may return SABR streams only
     # Since 2026.07, intermittent/selective POT enforcement has been observed for non-HLS formats
+    # Since 2026.08.17, ALL formats (including live HLS and itag 18) are 403'd with version 1.65.10
     'android_vr': {
         'INNERTUBE_CONTEXT': {
             'client': {

--- a/yt_dlp/extractor/youtube/_video.py
+++ b/yt_dlp/extractor/youtube/_video.py
@@ -140,8 +140,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     _RETURN_TYPE = 'video'  # XXX: How to handle multifeed?
 
     _SUBTITLE_FORMATS = ('json3', 'srv1', 'srv2', 'srv3', 'ttml', 'srt', 'vtt')
-    _DEFAULT_CLIENTS = ('visionos', 'android_vr', 'web')
-    _DEFAULT_JSLESS_CLIENTS = ('visionos', 'android_vr')
+    _DEFAULT_CLIENTS = ('visionos', 'web')
+    _DEFAULT_JSLESS_CLIENTS = ('visionos',)
     _DEFAULT_AUTHED_CLIENTS = ('tv_downgraded', 'web')
     # Premium does not require POT (except for subtitles)
     _DEFAULT_PREMIUM_CLIENTS = ('tv_downgraded', 'web_creator', 'web')


### PR DESCRIPTION
Since 2026.08.17, ALL formats (including live HLS and itag 18) are 403'd with `android_vr` client version 1.65.10

Closes #17456


<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
