### PR TITLE
[build] Temporarily pin PyInstaller to v6.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ dev = [
     {include-group = "test"},
 ]
 pyinstaller = [
-    "pyinstaller>=6.17.0",
+    "pyinstaller==6.22.0",
 ]
 delocate = [
     "delocate>=0.13.0 ; sys_platform == 'darwin'",


### PR DESCRIPTION
A patch for a security vulnerability that is irrelevant to yt-dlp has introduced multiple regressions in PyInstaller v6.22.1 and v6.22.2, so pin to v6.22.0 until all regressions are resolved.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Maintenance

</details>
