### PR TITLE
[test] Fix handshake error matching for OpenSSL 4.x

### DIFF
--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -338,7 +338,7 @@ class TestHTTPRequestHandler(TestRequestHandlerBase):
         https_server_thread.start()
 
         with handler(verify=False) as rh:
-            with pytest.raises(SSLError, match=r'(?i)ssl(?:v3|/tls).alert.handshake.failure') as exc_info:
+            with pytest.raises(SSLError, match=r'(?i)(?:sslv3|ssl/tls|tls).alert.handshake.failure') as exc_info:
                 validate_and_send(rh, Request(f'https://127.0.0.1:{https_port}/headers'))
             assert not issubclass(exc_info.type, CertificateVerifyError)
 

--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -338,7 +338,7 @@ class TestHTTPRequestHandler(TestRequestHandlerBase):
         https_server_thread.start()
 
         with handler(verify=False) as rh:
-            with pytest.raises(SSLError, match=r'(?i)(?:sslv3|ssl/tls|tls).alert.handshake.failure') as exc_info:
+            with pytest.raises(SSLError, match=r'(?i)(?:sslv3|tls).alert.handshake.failure') as exc_info:
                 validate_and_send(rh, Request(f'https://127.0.0.1:{https_port}/headers'))
             assert not issubclass(exc_info.type, CertificateVerifyError)
 

--- a/test/test_websockets.py
+++ b/test/test_websockets.py
@@ -186,7 +186,7 @@ class TestWebsSocketRequestHandlerConformance:
 
     def test_ssl_error(self, handler):
         with handler(verify=False) as rh:
-            with pytest.raises(SSLError, match=r'(?:sslv3|ssl/tls|tls) alert handshake failure') as exc_info:
+            with pytest.raises(SSLError, match=r'(?:sslv3|tls) alert handshake failure') as exc_info:
                 ws_validate_and_send(rh, Request(self.bad_wss_host))
             assert not issubclass(exc_info.type, CertificateVerifyError)
 

--- a/test/test_websockets.py
+++ b/test/test_websockets.py
@@ -186,7 +186,7 @@ class TestWebsSocketRequestHandlerConformance:
 
     def test_ssl_error(self, handler):
         with handler(verify=False) as rh:
-            with pytest.raises(SSLError, match=r'ssl(?:v3|/tls) alert handshake failure') as exc_info:
+            with pytest.raises(SSLError, match=r'(?:sslv3|ssl/tls|tls) alert handshake failure') as exc_info:
                 ws_validate_and_send(rh, Request(self.bad_wss_host))
             assert not issubclass(exc_info.type, CertificateVerifyError)
 


### PR DESCRIPTION
### Description of your *pull request* and other information

Newer Python/OpenSSL combinations may report TLS handshake failures as "TLS_ALERT_HANDSHAKE_FAILURE" / "tls alert handshake failure" instead of the older "sslv3 alert handshake failure" wording expected by the test suite.

Relax the test regexes to accept both forms without changing the behavior being tested.

Fixes #17490

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Core bug fix/improvement

</details>
