### PR TITLE
[ie/adn] Add `profile_id` extractor-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1981,6 +1981,7 @@ The following extractors use this feature:
 #### adn
 
 - `profile_id`: The numeric ID of the premium account profile that will be used to download videos (default: `1`)
+
 #### zan
 * `split_angles`: Split multi-angle streams into separate angle formats. Forces re-encoding of the video stream during download, and requires ffmpeg. Either `true` or `false` (default)
 

--- a/README.md
+++ b/README.md
@@ -1981,7 +1981,6 @@ The following extractors use this feature:
 #### adn
 
 - `profile_id`: The numeric ID of the premium account profile that will be used to download videos (default: `1`)
-
 #### zan
 * `split_angles`: Split multi-angle streams into separate angle formats. Forces re-encoding of the video stream during download, and requires ffmpeg. Either `true` or `false` (default)
 

--- a/README.md
+++ b/README.md
@@ -1979,8 +1979,8 @@ The following extractors use this feature:
 * `original_format_policy`: Policy for when to try extracting original formats. One of `always`, `never`, or `auto`. The default `auto` policy tries to avoid exceeding the web client's API rate-limit by only making an extra request when Vimeo publicizes the video's downloadability
 
 #### adn
+* `profile_id`: The numeric ID of the premium account profile that will be used to download videos (default: `1`)
 
-- `profile_id`: The numeric ID of the premium account profile that will be used to download videos (default: `1`)
 #### zan
 * `split_angles`: Split multi-angle streams into separate angle formats. Forces re-encoding of the video stream during download, and requires ffmpeg. Either `true` or `false` (default)
 

--- a/README.md
+++ b/README.md
@@ -1978,6 +1978,12 @@ The following extractors use this feature:
 * `client`: Client to extract video data from. The currently available clients are `android` and `web`. Only one client can be used. The `web` client is used by default, and it only works with account cookies or login credentials. The `android` client only works with previously cached OAuth tokens
 * `original_format_policy`: Policy for when to try extracting original formats. One of `always`, `never`, or `auto`. The default `auto` policy tries to avoid exceeding the web client's API rate-limit by only making an extra request when Vimeo publicizes the video's downloadability
 
+#### adn
+
+- `profile_id`: The ID of the profile that will be used to download videos, default is to use the profile `1`. Profile is a feature of premium subscriber. Has no effect for not logged-in people and free or started subscribers.
+
+#
+
 #### zan
 * `split_angles`: Split multi-angle streams into separate angle formats. Forces re-encoding of the video stream during download, and requires ffmpeg. Either `true` or `false` (default)
 

--- a/README.md
+++ b/README.md
@@ -1980,10 +1980,7 @@ The following extractors use this feature:
 
 #### adn
 
-- `profile_id`: The ID of the profile that will be used to download videos, default is to use the profile `1`. Profile is a feature of premium subscriber. Has no effect for not logged-in people and free or started subscribers.
-
-#
-
+- `profile_id`: The numeric ID of the premium account profile that will be used to download videos (default: `1`)
 #### zan
 * `split_angles`: Split multi-angle streams into separate angle formats. Forces re-encoding of the video stream during download, and requires ffmpeg. Either `true` or `false` (default)
 

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -50,14 +50,13 @@ class ADNIE(ADNBaseIE):
     _VALID_URL = r'https?://(?:www\.)?animationdigitalnetwork\.com/(?:(?P<lang>de)/)?video/[^/?#]+/(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://animationdigitalnetwork.com/video/558-fruits-basket/9841-episode-1-a-ce-soir',
-        'md5': '1c9ef066ceb302c86f80c2b371615261',
+        'md5': '3999b7b235ffb3591a385d1913cd3cd1',
         'info_dict': {
             'id': '9841',
             'ext': 'mp4',
             'title': 'Fruits Basket - Episode 1',
-            'description': 'md5:14be2f72c3c96809b0ca424b0097d336',
             'series': 'Fruits Basket',
-            'duration': 1437,
+            'duration': 1436,
             'release_date': '20190405',
             'comment_count': int,
             'average_rating': float,

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -174,6 +174,7 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
         self._HEADERS['X-Target-Distribution'] = lang or 'fr'
+        self._HEADERS['X-Profile-ID'] = 1
         video_base_url = self._PLAYER_BASE_URL + f'video/{video_id}/'
         player = self._download_json(
             video_base_url + 'configuration', video_id,
@@ -309,6 +310,7 @@ class ADNSeasonIE(ADNBaseIE):
     def _real_extract(self, url):
         lang, video_show_slug = self._match_valid_url(url).group('lang', 'id')
         self._HEADERS['X-Target-Distribution'] = lang or 'fr'
+        self._HEADERS['X-Profile-ID'] = 1
         show = self._download_json(
             f'{self._API_BASE_URL}show/{video_show_slug}/', video_show_slug,
             'Downloading show JSON metadata', headers=self._HEADERS)['show']

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -309,7 +309,6 @@ class ADNSeasonIE(ADNBaseIE):
     def _real_extract(self, url):
         lang, video_show_slug = self._match_valid_url(url).group('lang', 'id')
         self._HEADERS['X-Target-Distribution'] = lang or 'fr'
-        self._HEADERS['X-Profile-ID'] = 1
         show = self._download_json(
             f'{self._API_BASE_URL}show/{video_show_slug}/', video_show_slug,
             'Downloading show JSON metadata', headers=self._HEADERS)['show']

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -173,7 +173,7 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
         self._HEADERS['X-Target-Distribution'] = lang or 'fr'
-        self._HEADERS['X-Profile-ID'] = 1
+        self._HEADERS['X-Profile-ID'] = int_or_none(self._configuration_arg('profile', ['1'])[0], default=1)
         video_base_url = self._PLAYER_BASE_URL + f'video/{video_id}/'
         player = self._download_json(
             video_base_url + 'configuration', video_id,

--- a/yt_dlp/extractor/adn.py
+++ b/yt_dlp/extractor/adn.py
@@ -173,7 +173,8 @@ Format: Marked,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text'''
     def _real_extract(self, url):
         lang, video_id = self._match_valid_url(url).group('lang', 'id')
         self._HEADERS['X-Target-Distribution'] = lang or 'fr'
-        self._HEADERS['X-Profile-ID'] = int_or_none(self._configuration_arg('profile', ['1'])[0], default=1)
+        if 'Authorization' in self._HEADERS:
+            self._HEADERS['X-Profile-ID'] = self._configuration_arg('profile_id', ['1'])[0]
         video_base_url = self._PLAYER_BASE_URL + f'video/{video_id}/'
         player = self._download_json(
             video_base_url + 'configuration', video_id,


### PR DESCRIPTION
ADN now requieres that you select which "profile" is actually downloading the video.

Used with premium account that "can" be shared with up to 4 profiles. But there is still no option to add another profile to an account.

And the first profile should always be defined (I suppose).

So ... This should fix the issue for now.
But when they will implement account sharing, it will download the video to the wrong profile.

### Description of your *pull request* and other information

added 'X-Profile-ID': 1  to HTTP params.
There is no github issue YET about it.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

But to be honest, it's a one line fix... Can I claim "original author" about a so short edit?
But yes, sure, I write it myself. Thanks to "curl" and print debuging, I checked the diffs and here we are...

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>

I did check tests.

`hatch test ADN` => test skipped, I don't know why it was skipped
I unskip it manually and fixed the test. Test break isn't about what I did.

```shell
$ hatch test ADN
Running ['pytest', '-Werror', '--tb=short', '-p', 'no:randomly', 'test/test_download.py::TestDownload::test_ADN']
======================================================== test session starts =========================================================
platform linux -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/ache/git/yt-dlp
configfile: pyproject.toml
plugins: xdist-3.8.0, rerunfailures-16.5
collected 1 item                                                                                                                     

test/test_download.py::TestDownload::test_ADN PASSED                                                                           [100%]

========================================================= 1 passed in 9.19s ==========================================================
```