### PR TITLE
[ie/tubitv:series] Fix extractor

### DIFF
--- a/yt_dlp/extractor/tubitv.py
+++ b/yt_dlp/extractor/tubitv.py
@@ -3,11 +3,10 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     js_to_json,
-    require,
     strip_or_none,
-    traverse_obj,
     url_or_none,
 )
+from ..utils.traversal import require, traverse_obj
 
 
 class TubiTvIE(InfoExtractor):

--- a/yt_dlp/extractor/tubitv.py
+++ b/yt_dlp/extractor/tubitv.py
@@ -6,6 +6,7 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     js_to_json,
+    require,
     strip_or_none,
     traverse_obj,
     url_or_none,
@@ -162,20 +163,20 @@ class TubiTvShowIE(InfoExtractor):
             'id': 'the-joy-of-painting-with-bob-ross',
         },
     }, {
-        'url': 'https://tubitv.com/series/2311/the-saddle-club/season-1',
+        'url': 'https://tubitv.com/series/300000435/the-saddle-club/season-1',
         'playlist_count': 26,
         'info_dict': {
             'id': 'the-saddle-club-season-1',
         },
     }, {
-        'url': 'https://tubitv.com/series/2311/the-saddle-club/season-3',
-        'playlist_count': 19,
+        'url': 'https://tubitv.com/series/300000435/the-saddle-club/season-2',
+        'playlist_count': 26,
         'info_dict': {
-            'id': 'the-saddle-club-season-3',
+            'id': 'the-saddle-club-season-2',
         },
     }, {
-        'url': 'https://tubitv.com/series/2311/the-saddle-club/',
-        'playlist_mincount': 71,
+        'url': 'https://tubitv.com/series/300000435/the-saddle-club/',
+        'playlist_mincount': 52,
         'info_dict': {
             'id': 'the-saddle-club',
         },
@@ -184,14 +185,15 @@ class TubiTvShowIE(InfoExtractor):
     def _entries(self, show_url, playlist_id, selected_season):
         webpage = self._download_webpage(show_url, playlist_id)
 
-        data = self._search_json(
+        season_data = traverse_obj(self._search_json(
             r'window\.__REACT_QUERY_STATE__\s*=', webpage, 'data', playlist_id,
-            transform_source=js_to_json)['queries'][0]['state']['data']
+            transform_source=js_to_json), (
+                'queries', ..., 'state', 'data', 'seasons', {list}, any, {require('season data')}))
 
         # v['number'] is already a decimal string, but stringify to protect against API changes
         path = [lambda _, v: str(v['number']) == selected_season] if selected_season else [..., {dict}]
 
-        for season in traverse_obj(data, ('seasons', *path)):
+        for season in traverse_obj(season_data, path):
             season_number = int_or_none(season.get('number'))
             for episode in traverse_obj(season, ('episodes', lambda _, v: v['id'])):
                 episode_id = episode['id']

--- a/yt_dlp/extractor/tubitv.py
+++ b/yt_dlp/extractor/tubitv.py
@@ -170,15 +170,17 @@ class TubiTvShowIE(InfoExtractor):
     def _entries(self, show_url, playlist_id, selected_season):
         webpage = self._download_webpage(show_url, playlist_id, headers=self.geo_verification_headers())
 
-        season_data = traverse_obj(self._search_json(
-            r'window\.__REACT_QUERY_STATE__\s*=', webpage, 'data', playlist_id,
-            transform_source=js_to_json), (
-                'queries', ..., 'state', 'data', 'seasons', {list}, any, {require('season data')}))
+        react_query_state = self._search_json(
+            r'window\.__REACT_QUERY_STATE__\s*=', webpage,
+            'react query state', playlist_id, transform_source=js_to_json)
+        data = traverse_obj(react_query_state, (
+            'queries', lambda _, v: v['state']['data']['seasons'][0],
+            'state', 'data', any, {require('season data')}))
 
         # v['number'] is already a decimal string, but stringify to protect against API changes
         path = [lambda _, v: str(v['number']) == selected_season] if selected_season else [..., {dict}]
 
-        for season in traverse_obj(season_data, path):
+        for season in traverse_obj(data, ('seasons', *path)):
             season_number = int_or_none(season.get('number'))
             for episode in traverse_obj(season, ('episodes', lambda _, v: v['id'])):
                 episode_id = episode['id']


### PR DESCRIPTION
### Description of your *pull request* and other information

Season data can now be in the second query object as well.

Test changes were copied from #16428.

Fixes #17543


<details open><summary>Template</summary> 

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/).
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
