### PR TITLE
[ie/tiktok] Retry item_list on empty API response

### DIFF
--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -1098,9 +1098,15 @@ class TikTokUserIE(TikTokBaseIE):
         cursor = int(time.time() * 1E3)
         for page in itertools.count(1):
             for retry in self.RetryManager():
-                response = self._download_json(
-                    self._API_BASE_URL, display_id, f'Downloading page {page}',
-                    query=self._build_web_query(sec_uid, cursor))
+                try:
+                    response = self._download_json(
+                        self._API_BASE_URL, display_id, f'Downloading page {page}',
+                        query=self._build_web_query(sec_uid, cursor))
+                except ExtractorError as e:
+                    if isinstance(e.cause, json.JSONDecodeError) and e.cause.pos == 0:
+                        retry.error = e
+                        continue
+                    raise
 
                 # Avoid infinite loop caused by bad device_id
                 # See: https://github.com/yt-dlp/yt-dlp/issues/14031


### PR DESCRIPTION
### Description of your *pull request* and other information

Tiktok fetch profile videos is broken because sometimes there is an empty response. it is hard to replicate this empty response so the try...catch I added provides a guard for when it happens. Specific part of code I identified to cause trigger the error is: `TikTokUserIE._entries()'s` call to the /api/creator/item_list/ endpoint.

A deterministic regression test isn't feasible here in my opinion but I am happy to hear an alternative opinion.

How I tested:

I ran the exact command mentioned in the issue #17500 : `yt-dlp -vU --simulate --flat-playlist --playlist-end 5 "https://www.tiktok.com/@lelepons"` four times and it worked okay no more error:

Before fix:
```
➜  .yt-dlp-fix git:(master) yt-dlp -vU --simulate --flat-playlist --playlist-end 5 "https://www.tiktok.com/@lelepons"
[debug] Command-line config: ['-vU', '--simulate', '--flat-playlist', '--playlist-end', '5', 'https://www.tiktok.com/@lelepons']

...truncated 

WARNING: [tiktok:user] This user's account is either private or has embedding disabled
ERROR: [tiktok:user] lelepons: Unable to extract secondary user ID. If you are able to get the channel_id from a video posted by this user, try using "tiktokuser:channel_id" as the input URL (replacing `channel_id` with its actual value)
  File "/Users/main/.yt-dlp-fix/yt_dlp/extractor/common.py", line 764, in extract
    ie_result = self._real_extract(url)
  File "/Users/main/.yt-dlp-fix/yt_dlp/extractor/tiktok.py", line 1195, in _real_extract
    raise ExtractorError(
    ...<2 lines>...
        'input URL (replacing `channel_id` with its actual value)', expected=True)
```

After fix

```
➜  .yt-dlp-fix git:(fix-tiktok-user-empty-response) yt-dlp -vU --simulate --flat-playlist --playlist-end 5 "https://www.tiktok.com/@lelepons"
[debug] Command-line config: ['-vU', '--simulate', '--flat-playlist', '--playlist-end', '5', 'https://www.tiktok.com/@lelepons']
[debug] Encodings: locale UTF-8, fs utf-8, pref UTF-8, out utf-8, error utf-8, screen utf-8
[debug] yt-dlp version stable@2026.08.19 from yt-dlp/yt-dlp [594bd50c2]
[debug] Lazy loading extractors is disabled
[debug] Python 3.14.2 (CPython arm64 64bit) - macOS-26.5.1-arm64-arm-64bit-Mach-O (OpenSSL 3.6.2 7 Apr 2026)
[debug] exe versions: ffmpeg 7.1.1 (setts), ffprobe 7.1.1
[debug] Optional libraries: Cryptodome-3.23.0, brotli-1.2.0, certifi-2026.07.22, curl_cffi-0.13.0, mutagen-1.48.1, requests-2.34.2, sqlite3-3.51.1, urllib3-2.7.0, websockets-17.1, yt_dlp_ejs-0.8.0
[debug] JS runtimes: none
[debug] Proxy map: {}
[debug] Request Handlers: urllib, requests, websockets, curl_cffi
[debug] Plugin directories: none
[debug] Loaded 1745 extractors
[debug] Fetching release info: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest

... truncated

[debug] The information of all playlist entries will be held in memory
[download] Downloading item 1 of 5
[download] Downloading item 2 of 5
[download] Downloading item 3 of 5
[download] Downloading item 4 of 5
[download] Downloading item 5 of 5
[download] Finished downloading playlist: lelepons
```

Fixes #17500


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
