### PR TITLE
Load all sound profiles for CBC Gem

### DIFF
--- a/yt_dlp/extractor/cbc.py
+++ b/yt_dlp/extractor/cbc.py
@@ -553,7 +553,7 @@ class CBCGemBaseIE(InfoExtractor):
                 'output': 'json',
                 'tech': 'hls',
                 'manifestVersion': '2',
-                'manifestType': 'desktop',
+                'manifestType': 'smart-tv',
                 'idMedia': media_id,
             })
 
@@ -740,7 +740,7 @@ class CBCGemIE(CBCGemBaseIE):
         m3u8_url = self._call_media_api(
             item_info['idMedia'], display_id=video_id, headers=headers)['url']
         formats = self._extract_m3u8_formats(
-            m3u8_url, video_id, 'mp4', m3u8_id='hls', query={'manifestType': ''})
+            m3u8_url, video_id, 'mp4', m3u8_id='hls', query={'manifestType': 'smart-tv'})
         self._remove_duplicate_formats(formats)
 
         for fmt in formats:


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

ADD DETAILED DESCRIPTION HERE
CBC Gen hides some sound profiles (N=namely surround sound) from the web based player, but makes them available for smart tv's. Updated the manifest type to return the missing sound profile

Fixes #17544


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
