### PR TITLE
[ie/rutube] Surface error messages provided by the site

### DIFF
--- a/yt_dlp/extractor/rutube.py
+++ b/yt_dlp/extractor/rutube.py
@@ -1,6 +1,9 @@
 import itertools
 
-from .common import InfoExtractor
+from .common import (
+    ExtractorError,
+    InfoExtractor,
+)
 from ..utils import (
     UnsupportedError,
     bool_or_none,
@@ -66,11 +69,17 @@ class RutubeBaseIE(InfoExtractor):
         if not query:
             query = {}
         query['format'] = 'json'
-        return self._download_json(
+        query['no_404'] = 'true'
+        resp = self._download_json(
             f'https://rutube.ru/api/play/options/{video_id}/',
             video_id, 'Downloading options JSON',
             'Unable to download options JSON',
             headers=self.geo_verification_headers(), query=query)
+        if traverse_obj(resp, ('detail', 'type')) == 'blocking_rule':
+            raise ExtractorError(traverse_obj(
+                resp, ('detail', 'languages', ..., 'title', {str}, any),
+                default='Request is blocked for unknown reasons'), expected=True)
+        return resp
 
     def _extract_formats_and_subtitles(self, options, video_id):
         formats = []


### PR DESCRIPTION
### Description of your *pull request* and other information

Show the error messages that the site displays in place of the video player if the video cannot be played. For example for geo-blocked content the extractor now errors with:

> ERROR: [rutube] c5f07ec0d81df507f3f70ec0c09a38e5: Видео недоступно из-за ограничений в вашей стране, VPN или окончания прав на его показ

<img width="1371" height="855" alt="image" src="https://github.com/user-attachments/assets/dfbf07b2-f9bc-4605-9e71-33856d4a37e7" />

Relates to #17387


<details open><summary>Template</summary> 

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/).
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)

</details>
