### PR TITLE
[TikTok] Retry webpage extraction across impersonation targets

### DIFF
--- a/test/test_tiktok.py
+++ b/test/test_tiktok.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import unittest
+from types import SimpleNamespace
+
+from yt_dlp.extractor._tiktok import (
+    TikTokWebpagePolicy,
+    get_tiktok_webpage_policy,
+    get_video_data,
+    get_video_detail,
+    get_video_status,
+    has_playable_video,
+)
+from yt_dlp.extractor.tiktok import TikTokBaseIE
+from yt_dlp.utils import ExtractorError
+
+
+class TestTikTokWebpagePolicy(unittest.TestCase):
+    def test_success_promotes_target_and_failure_demotes_target(self):
+        policy = TikTokWebpagePolicy(('first', 'second', 'third'))
+
+        policy.succeeded('third')
+        self.assertEqual(policy.candidates(), ('third', 'first', 'second'))
+
+        policy.failed('third')
+        self.assertEqual(policy.candidates(), ('first', 'second', 'third'))
+
+    def test_new_reflow_schema_is_playable(self):
+        universal_data = {
+            'webapp.reflow.video.detail': {
+                'itemInfo': {'itemStruct': {'video': {'playAddr': 'https://example.com/video.mp4'}}},
+            },
+        }
+        detail = get_video_detail(universal_data)
+
+        self.assertTrue(has_playable_video(detail))
+        self.assertEqual(get_video_data(detail)['video']['playAddr'], 'https://example.com/video.mp4')
+
+    def test_detail_without_play_address_is_not_playable(self):
+        detail = {'itemInfo': {'itemStruct': {'video': {}}}}
+
+        self.assertFalse(has_playable_video(detail))
+
+    def test_malformed_video_detail_is_not_exposed_to_extractor(self):
+        self.assertEqual(get_video_detail({'webapp.reflow.video.detail': []}), {})
+
+    def test_video_status_is_normalized(self):
+        self.assertEqual(get_video_status({'statusCode': '10216'}), 10216)
+
+    def test_policy_is_reused_per_downloader_instance(self):
+        class FakeYDL:
+            def _get_available_impersonate_targets(self):
+                return [('first', 'test'), ('second', 'test')]
+
+        ydl = FakeYDL()
+        first_policy = get_tiktok_webpage_policy(ydl)
+        first_policy.succeeded('second')
+
+        self.assertIs(get_tiktok_webpage_policy(ydl), first_policy)
+        self.assertEqual(first_policy.candidates(), ('second', 'first'))
+
+
+class TestTikTokWebpageFallback(unittest.TestCase):
+    class FakeYDL:
+        def _get_available_impersonate_targets(self):
+            return [('first', 'test'), ('second', 'test')]
+
+    class FakeTikTokIE(TikTokBaseIE):
+        def __init__(self, downloader, *, network_error=False, status_code=0):
+            super().__init__(downloader)
+            self.calls = []
+            self.network_error = network_error
+            self.status_code = status_code
+            self.warnings = []
+
+        def _download_webpage_handle(self, url, video_id, note, **kwargs):
+            self.calls.append((kwargs['impersonate'], note))
+            if self.network_error:
+                raise ExtractorError('network failed')
+            return ('challenge' if note != 'Downloading webpage' else 'initial', SimpleNamespace(
+                url=url, extensions={'impersonate': kwargs['impersonate']}))
+
+        def _get_universal_data(self, webpage, video_id):
+            return ({
+                'webapp.reflow.video.detail': {
+                    'statusCode': self.status_code,
+                    'itemInfo': {'itemStruct': {'video': {'playAddr': 'https://example.com/video.mp4'}}} if self.status_code == 0 else {},
+                },
+            } if webpage == 'challenge' or self.status_code else {})
+
+        def _solve_challenge_and_set_cookies(self, webpage):
+            return ()
+
+        def write_debug(self, message):
+            pass
+
+        def report_warning(self, message, **kwargs):
+            self.warnings.append(message)
+
+    def test_challenge_is_solved_with_the_same_target(self):
+        ie = self.FakeTikTokIE(self.FakeYDL())
+
+        video_data, status = ie._extract_web_data_and_status('https://example.com/video', 'video')
+
+        self.assertEqual(status, 0)
+        self.assertTrue(video_data['video']['playAddr'])
+        self.assertEqual(ie.calls, [('first', 'Downloading webpage'), ('first', 'Downloading webpage with challenge cookie')])
+
+    def test_nonfatal_network_failure_reports_warning(self):
+        ie = self.FakeTikTokIE(self.FakeYDL(), network_error=True)
+
+        self.assertEqual(ie._extract_web_data_and_status('https://example.com/video', 'video', fatal=False), ({}, -1))
+        self.assertEqual(ie.warnings, ['network failed'])
+
+    def test_terminal_status_bypasses_fallback(self):
+        ie = self.FakeTikTokIE(self.FakeYDL(), status_code=10216)
+
+        self.assertEqual(ie._extract_web_data_and_status('https://example.com/video', 'video'), ({}, 10216))
+        self.assertEqual(ie.calls, [('first', 'Downloading webpage')])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yt_dlp/extractor/_tiktok.py
+++ b/yt_dlp/extractor/_tiktok.py
@@ -1,0 +1,73 @@
+import threading
+import weakref
+
+
+_POLICIES = weakref.WeakKeyDictionary()
+_POLICIES_LOCK = threading.Lock()
+
+
+def get_video_detail(universal_data):
+    if not isinstance(universal_data, dict):
+        return {}
+    video_detail = (
+        universal_data.get('webapp.video-detail')
+        or universal_data.get('webapp.reflow.video.detail')
+        or {})
+    return video_detail if isinstance(video_detail, dict) else {}
+
+
+def get_video_data(video_detail):
+    if not isinstance(video_detail, dict):
+        return {}
+    item_info = video_detail.get('itemInfo')
+    item_struct = item_info.get('itemStruct') if isinstance(item_info, dict) else None
+    return item_struct if isinstance(item_struct, dict) else {}
+
+
+def get_video_status(video_detail):
+    if not isinstance(video_detail, dict):
+        return None
+    try:
+        return int(video_detail.get('statusCode'))
+    except (TypeError, ValueError):
+        return None
+
+
+def has_playable_video(video_detail):
+    video = get_video_data(video_detail).get('video', {})
+    return isinstance(video, dict) and bool(video.get('playAddr'))
+
+
+class TikTokWebpagePolicy:
+    def __init__(self, targets):
+        self._targets = list(dict.fromkeys(targets))
+        self._lock = threading.Lock()
+
+    def candidates(self):
+        with self._lock:
+            return tuple(self._targets)
+
+    def succeeded(self, target):
+        self._move(target, 0)
+
+    def failed(self, target):
+        self._move(target, -1)
+
+    def _move(self, target, index):
+        with self._lock:
+            self._targets.remove(target)
+            if index < 0:
+                self._targets.append(target)
+            else:
+                self._targets.insert(index, target)
+
+
+def get_tiktok_webpage_policy(ydl):
+    with _POLICIES_LOCK:
+        policy = _POLICIES.get(ydl)
+        if policy is not None:
+            return policy
+        targets = [target for target, _ in ydl._get_available_impersonate_targets()] or [True]
+        policy = TikTokWebpagePolicy(targets)
+        _POLICIES[ydl] = policy
+        return policy

--- a/yt_dlp/extractor/tiktok.py
+++ b/yt_dlp/extractor/tiktok.py
@@ -11,6 +11,13 @@ import urllib.parse
 import uuid
 
 from .common import InfoExtractor
+from ._tiktok import (
+    get_tiktok_webpage_policy,
+    get_video_data,
+    get_video_detail,
+    get_video_status,
+    has_playable_video,
+)
 from ..networking import HEADRequest
 from ..utils import (
     ExtractorError,
@@ -41,7 +48,6 @@ class TikTokBaseIE(InfoExtractor):
     _UPLOADER_URL_FORMAT = 'https://www.tiktok.com/@%s'
     _WEBPAGE_HOST = 'https://www.tiktok.com/'
     QUALITIES = ('360p', '540p', '720p', '1080p')
-
     _APP_INFO_DEFAULTS = {
         # unique "install id"
         'iid': None,
@@ -276,13 +282,19 @@ class TikTokBaseIE(InfoExtractor):
         video_data, status = {}, -1
         headers = self._generate_blockbuster_headers()
 
-        def get_webpage(note='Downloading webpage'):
-            res = self._download_webpage_handle(
-                url, video_id, note, fatal=fatal, headers=headers, impersonate=True)
-            if res is False:
+        policy = get_tiktok_webpage_policy(self._downloader)
+        last_error = None
+
+        def get_webpage(target, note='Downloading webpage'):
+            nonlocal last_error
+            try:
+                webpage, urlh = self._download_webpage_handle(
+                    url, video_id, note, headers=headers, impersonate=target)
+            except ExtractorError as e:
+                last_error = e
+                policy.failed(target)
                 return False
 
-            webpage, urlh = res
             self.write_debug(f'Webpage size: {len(webpage)} bytes')
             self.write_debug(f'Impersonation target: {urlh.extensions.get("impersonate")}')
 
@@ -295,37 +307,56 @@ class TikTokBaseIE(InfoExtractor):
 
             return webpage
 
-        webpage = get_webpage()
-        if webpage is False:
-            return video_data, status
+        def extract_web_data(target):
+            webpage = get_webpage(target)
+            if webpage is False:
+                return None
 
-        universal_data = self._get_universal_data(webpage, video_id)
-        if not universal_data:
+            universal_data = self._get_universal_data(webpage, video_id)
+            if universal_data:
+                return universal_data
+
             try:
                 cookie_names = self._solve_challenge_and_set_cookies(webpage)
             except ExtractorError as e:
-                if fatal:
-                    raise
-                self.report_warning(e.orig_msg, video_id=video_id)
-                return video_data, status
+                return None
 
-            webpage = get_webpage(note='Downloading webpage with challenge cookie')
+            webpage = get_webpage(target, note='Downloading webpage with challenge cookie')
             # Manually clear challenge cookies that should expire immediately after webpage request
             for cookie_name in filter(None, cookie_names):
                 self.cookiejar.clear(domain='.tiktok.com', path='/', name=cookie_name)
             if webpage is False:
-                return video_data, status
-            universal_data = self._get_universal_data(webpage, video_id)
+                return None
+            return self._get_universal_data(webpage, video_id)
+
+        universal_data = None
+        for target in policy.candidates():
+            candidate_data = extract_web_data(target)
+            video_detail = get_video_detail(candidate_data)
+            if get_video_status(video_detail) not in (None, 0):
+                universal_data = candidate_data
+                break
+            if has_playable_video(video_detail):
+                universal_data = candidate_data
+                policy.succeeded(target)
+                break
+            policy.failed(target)
 
         if not universal_data:
+            if last_error:
+                if fatal:
+                    raise last_error
+                self.report_warning(last_error.orig_msg, video_id=video_id)
+                return video_data, status
             message = 'Unable to extract universal data for rehydration'
             if fatal:
                 raise ExtractorError(message)
             self.report_warning(message, video_id=video_id)
             return video_data, status
 
-        status = traverse_obj(universal_data, ('webapp.video-detail', 'statusCode', {int})) or 0
-        video_data = traverse_obj(universal_data, ('webapp.video-detail', 'itemInfo', 'itemStruct', {dict}))
+        video_detail = get_video_detail(universal_data)
+        status = get_video_status(video_detail) or 0
+        video_data = get_video_data(video_detail)
 
         if not traverse_obj(video_data, ('video', {dict})) and traverse_obj(video_data, ('isContentClassified', {bool})):
             message = 'This post may not be comfortable for some audiences. Log in for access'
@@ -1175,7 +1206,8 @@ class TikTokUserIE(TikTokBaseIE):
             webpage = self._download_webpage(
                 self._UPLOADER_URL_FORMAT % user_name, user_name,
                 'Downloading user webpage', 'Unable to download user webpage',
-                impersonate=True, fatal=False, headers=self._generate_blockbuster_headers()) or ''
+                impersonate=get_tiktok_webpage_policy(self._downloader).candidates()[0], fatal=False,
+                headers=self._generate_blockbuster_headers()) or ''
             detail = traverse_obj(
                 self._get_universal_data(webpage, user_name), ('webapp.user-detail', {dict})) or {}
             video_count = traverse_obj(detail, ('userInfo', ('stats', 'statsV2'), 'videoCount', {int}, any))
@@ -1634,7 +1666,8 @@ class TikTokLiveIE(TikTokBaseIE):
         if not room_id:
             webpage = self._download_webpage(
                 format_field(uploader, None, self._UPLOADER_URL_FORMAT), uploader,
-                impersonate=True, headers=self._generate_blockbuster_headers())
+                impersonate=get_tiktok_webpage_policy(self._downloader).candidates()[0],
+                headers=self._generate_blockbuster_headers())
             room_id = traverse_obj(
                 self._get_universal_data(webpage, uploader),
                 ('webapp.user-detail', 'userInfo', 'user', 'roomId', {str}))


### PR DESCRIPTION
### Description

TikTok webpage extraction can return an unusable response for one impersonation target while another target may return playable video data. This change keeps a per-YoutubeDL in-memory target policy, retries candidates in order, promotes successful targets, demotes failed targets, and preserves terminal TikTok status responses.

### User-facing changes

- Try all available impersonation targets until playable TikTok data is found.
- Reuse the successful target first for subsequent requests in the same YoutubeDL instance.
- Keep challenge retries on the same target that produced the initial response.
- Avoid falling through on terminal TikTok status responses.

### Tests

- `docker run --rm -v "$PWD:/src:ro" -w /src --entrypoint /opt/yt-dlp/bin/python3 insta-bot-go-insta-bot:latest -m unittest test.test_tiktok test.test_all_urls`
- Result: 23 tests passed.
