### PR TITLE
Fix metadata parsing for string type

### DIFF
--- a/yt_dlp/extractor/odnoklassniki.py
+++ b/yt_dlp/extractor/odnoklassniki.py
@@ -288,7 +288,8 @@ class OdnoklassnikiIE(InfoExtractor):
 
         metadata = flashvars.get('metadata')
         if metadata:
-            metadata = self._parse_json(metadata, video_id)
+            if isinstance(metadata, str):
+                metadata = self._parse_json(metadata, video_id)
         else:
             data = {}
             st_location = flashvars.get('location')


### PR DESCRIPTION
This is failing the downloader.

ERROR: the JSON object must be str, bytes or bytearray, not dict
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/dist-packages/yt_dlp/YoutubeDL.py", line 1731, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.14/dist-packages/yt_dlp/YoutubeDL.py", line 1866, in __extract_info
    ie_result = ie.extract(url)
  File "/usr/local/lib/python3.14/dist-packages/yt_dlp/extractor/common.py", line 765, in extract
    ie_result = self._real_extract(url)
  File "/usr/local/lib/python3.14/dist-packages/yt_dlp/extractor/odnoklassniki.py", line 246, in _real_extract
    return self._extract_desktop(url)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/usr/local/lib/python3.14/dist-packages/yt_dlp/extractor/odnoklassniki.py", line 291, in _extract_desktop
    metadata = self._parse_json(metadata, video_id)
  File "/usr/local/lib/python3.14/dist-packages/yt_dlp/extractor/common.py", line 1085, in _parse_json
    return json.loads(
           ~~~~~~~~~~^
        json_string, cls=LenientJSONDecoder, strict=False, transform_source=transform_source, **parser_kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/json/__init__.py", line 345, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
                    f'not {s.__class__.__name__}')
TypeError: the JSON object must be str, bytes or bytearray, not dict