### PR TITLE
WAL-aware cookie db copy

### DIFF
--- a/yt_dlp/cookies.py
+++ b/yt_dlp/cookies.py
@@ -10,6 +10,7 @@ import http.cookies
 import io
 import json
 import os
+import pathlib
 import re
 import shutil
 import struct
@@ -1112,9 +1113,37 @@ def _config_home():
 def _open_database_copy(database_path, tmpdir):
     # cannot open sqlite databases if they are already in use (e.g. by the browser)
     database_copy_path = os.path.join(tmpdir, 'temporary.sqlite')
-    shutil.copy(database_path, database_copy_path)
-    conn = sqlite3.connect(database_copy_path)
-    return conn.cursor()
+
+    # The database may be in WAL mode, in which case recently committed data lives in
+    # the -wal file and is missing from the main database until the next checkpoint.
+    # sqlite3's backup API is WAL-aware, so prefer it over copying the file directly.
+    destination = None
+    try:
+        source_uri = pathlib.Path(os.path.abspath(database_path)).as_uri()
+        source = sqlite3.connect(f'{source_uri}?mode=ro', uri=True, timeout=1)
+        try:
+            destination = sqlite3.connect(database_copy_path)
+            with destination:
+                source.backup(destination)
+        finally:
+            source.close()
+    except (sqlite3.Error, OSError, ValueError):
+        # Discard whatever the failed attempt left behind
+        if destination is not None:
+            destination.close()
+        with contextlib.suppress(OSError):
+            os.remove(database_copy_path)
+
+        # Fall back to copying the files. The main database must be copied before the
+        # -wal file: if a checkpoint happens in between, the stale -wal is rejected by
+        # its salt and simply ignored, whereas the reverse order can apply outdated
+        # frames over newer pages. The -shm file is rebuilt during recovery.
+        shutil.copy(database_path, database_copy_path)
+        with contextlib.suppress(FileNotFoundError):
+            shutil.copy(f'{database_path}-wal', f'{database_copy_path}-wal')
+        destination = sqlite3.connect(database_copy_path)
+
+    return destination.cursor()
 
 
 def _get_column_names(cursor, table_name):


### PR DESCRIPTION
### Description of your *pull request* and other information

Firefox (and other Firefox-based browsers) can keep committed cookie data in a `-wal` (write-ahead log) file rather than the main `cookies.sqlite` file until the next checkpoint. Since `_open_database_copy` only copied the main database file, `--cookies-from-browser firefox` could extract stale/missing cookies whenever a checkpoint hadn't happened recently.

This uses sqlite3's WAL-aware `backup()` API to copy the live database (opened read-only via a `file:` URI) into the temporary copy, so recently committed data in the `-wal` file is included. If that fails for any reason, it falls back to the previous behavior of copying the file directly, and additionally copies the `-wal` file alongside it (copying the main db first, then the `-wal`, so a concurrent checkpoint can't leave the copies inconsistent) so the fallback path also benefits when possible.

Fixes #17601

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* you must attest to the following:
- [X] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [x] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
