### PR TITLE
[cleanup] Deprecate `compat_etree_fromstring`

### DIFF
--- a/test/test_InfoExtractor.py
+++ b/test/test_InfoExtractor.py
@@ -10,9 +10,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import http.server
 import threading
+import xml.etree.ElementTree
 
 from test.helper import FakeYDL, expect_dict, expect_value, http_server_port
-from yt_dlp.compat import compat_etree_fromstring
 from yt_dlp.extractor import YoutubeIE, get_info_extractor
 from yt_dlp.extractor.common import InfoExtractor
 from yt_dlp.utils import (
@@ -1466,7 +1466,7 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
         for mpd_file, mpd_url, mpd_base_url, expected_formats, expected_subtitles in _TEST_CASES:
             with open(f'./test/testdata/mpd/{mpd_file}.mpd', encoding='utf-8') as f:
                 formats, subtitles = self.ie._parse_mpd_formats_and_subtitles(
-                    compat_etree_fromstring(f.read().encode()),
+                    xml.etree.ElementTree.fromstring(f.read()),
                     mpd_base_url=mpd_base_url, mpd_url=mpd_url)
                 self.ie._sort_formats(formats)
                 expect_value(self, formats, expected_formats, None)
@@ -1899,7 +1899,7 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
         for ism_file, ism_url, expected_formats, expected_subtitles in _TEST_CASES:
             with open(f'./test/testdata/ism/{ism_file}.Manifest', encoding='utf-8') as f:
                 formats, subtitles = self.ie._parse_ism_formats_and_subtitles(
-                    compat_etree_fromstring(f.read().encode()), ism_url=ism_url)
+                    xml.etree.ElementTree.fromstring(f.read()), ism_url=ism_url)
                 self.ie._sort_formats(formats)
                 expect_value(self, formats, expected_formats, None)
                 expect_value(self, subtitles, expected_subtitles, None)
@@ -1925,7 +1925,7 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
         for f4m_file, f4m_url, expected_formats in _TEST_CASES:
             with open(f'./test/testdata/f4m/{f4m_file}.f4m', encoding='utf-8') as f:
                 formats = self.ie._parse_f4m_formats(
-                    compat_etree_fromstring(f.read().encode()),
+                    xml.etree.ElementTree.fromstring(f.read()),
                     f4m_url, None)
                 self.ie._sort_formats(formats)
                 expect_value(self, formats, expected_formats, None)
@@ -1972,7 +1972,7 @@ jwplayer("mediaplayer").setup({"abouttext":"Visit Indie DB","aboutlink":"http:\/
         for xspf_file, xspf_url, expected_entries in _TEST_CASES:
             with open(f'./test/testdata/xspf/{xspf_file}.xspf', encoding='utf-8') as f:
                 entries = self.ie._parse_xspf(
-                    compat_etree_fromstring(f.read().encode()),
+                    xml.etree.ElementTree.fromstring(f.read()),
                     xspf_file, xspf_url=xspf_url, xspf_base_url=xspf_url)
                 expect_value(self, entries, expected_entries, None)
                 for i in range(len(entries)):

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -13,7 +13,7 @@ import struct
 
 from yt_dlp import compat
 from yt_dlp.compat import urllib  # isort: split
-from yt_dlp.compat import compat_etree_fromstring, compat_expanduser, compat_datetime_from_timestamp
+from yt_dlp.compat import compat_expanduser, compat_datetime_from_timestamp
 from yt_dlp.compat.urllib.request import getproxies
 
 
@@ -35,27 +35,6 @@ class TestCompat(unittest.TestCase):
             self.assertEqual(compat_expanduser('~'), test_str)
         finally:
             os.environ['HOME'] = old_home or ''
-
-    def test_compat_etree_fromstring(self):
-        xml = '''
-            <root foo="bar" spam="中文">
-                <normal>foo</normal>
-                <chinese>中文</chinese>
-                <foo><bar>spam</bar></foo>
-            </root>
-        '''
-        doc = compat_etree_fromstring(xml.encode())
-        self.assertTrue(isinstance(doc.attrib['foo'], str))
-        self.assertTrue(isinstance(doc.attrib['spam'], str))
-        self.assertTrue(isinstance(doc.find('normal').text, str))
-        self.assertTrue(isinstance(doc.find('chinese').text, str))
-        self.assertTrue(isinstance(doc.find('foo/bar').text, str))
-
-    def test_compat_etree_fromstring_doctype(self):
-        xml = '''<?xml version="1.0"?>
-<!DOCTYPE smil PUBLIC "-//W3C//DTD SMIL 2.0//EN" "http://www.w3.org/2001/SMIL20/SMIL20.dtd">
-<smil xmlns="http://www.w3.org/2001/SMIL20/Language"></smil>'''
-        compat_etree_fromstring(xml)
 
     def test_struct_unpack(self):
         self.assertEqual(struct.unpack('!B', b'\x00'), (0,))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,10 +20,7 @@ import unittest.mock
 import warnings
 import xml.etree.ElementTree
 
-from yt_dlp.compat import (
-    compat_etree_fromstring,
-    compat_HTMLParseError,
-)
+from yt_dlp.compat import compat_HTMLParseError
 from yt_dlp.utils import (
     Config,
     DateRange,
@@ -524,7 +521,7 @@ class TestUtil(unittest.TestCase):
             <node x="b" y="d" />
             <node x="" />
         </root>'''
-        doc = compat_etree_fromstring(testxml)
+        doc = xml.etree.ElementTree.fromstring(testxml)
 
         self.assertEqual(find_xpath_attr(doc, './/fourohfour', 'n'), None)
         self.assertEqual(find_xpath_attr(doc, './/fourohfour', 'n', 'v'), None)
@@ -545,7 +542,7 @@ class TestUtil(unittest.TestCase):
                 <url>http://server.com/download.mp3</url>
             </media:song>
         </root>'''
-        doc = compat_etree_fromstring(testxml)
+        doc = xml.etree.ElementTree.fromstring(testxml)
         find = lambda p: doc.find(xpath_with_ns(p, {'media': 'http://example.com/'}))
         self.assertTrue(find('media:song') is not None)
         self.assertEqual(find('media:song/media:author').text, 'The Author')
@@ -574,7 +571,7 @@ class TestUtil(unittest.TestCase):
                 <p>Foo</p>
             </div>
         </root>'''
-        doc = compat_etree_fromstring(testxml)
+        doc = xml.etree.ElementTree.fromstring(testxml)
         self.assertEqual(xpath_text(doc, 'div/p'), 'Foo')
         self.assertEqual(xpath_text(doc, 'div/bar', default='default'), 'default')
         self.assertTrue(xpath_text(doc, 'div/bar') is None)
@@ -586,7 +583,7 @@ class TestUtil(unittest.TestCase):
                 <p x="a">Foo</p>
             </div>
         </root>'''
-        doc = compat_etree_fromstring(testxml)
+        doc = xml.etree.ElementTree.fromstring(testxml)
         self.assertEqual(xpath_attr(doc, 'div/p', 'x'), 'a')
         self.assertEqual(xpath_attr(doc, 'div/bar', 'x'), None)
         self.assertEqual(xpath_attr(doc, 'div/p', 'y'), None)

--- a/yt_dlp/compat/__init__.py
+++ b/yt_dlp/compat/__init__.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import os
-import xml.etree.ElementTree as etree
 
 from .compat_utils import passthrough_module
 
@@ -12,15 +11,6 @@ del passthrough_module
 # Keep a replacement for API compatibility and uniform exception handling.
 class compat_HTMLParseError(ValueError):
     pass
-
-
-class _TreeBuilder(etree.TreeBuilder):
-    def doctype(self, name, pubid, system):
-        pass
-
-
-def compat_etree_fromstring(text):
-    return etree.XML(text, parser=etree.XMLParser(target=_TreeBuilder()))
 
 
 def compat_ord(c):

--- a/yt_dlp/compat/_deprecated.py
+++ b/yt_dlp/compat/_deprecated.py
@@ -10,10 +10,12 @@ del passthrough_module
 
 import functools  # noqa: F401
 import os
+import xml.etree.ElementTree
 
 
 compat_os_name = os.name
 compat_realpath = os.path.realpath
+compat_etree_fromstring = xml.etree.ElementTree.fromstring
 
 
 def compat_shlex_quote(s):

--- a/yt_dlp/downloader/f4m.py
+++ b/yt_dlp/downloader/f4m.py
@@ -4,9 +4,9 @@ import itertools
 import struct
 import time
 import urllib.parse
+import xml.etree.ElementTree
 
 from .fragment import FragmentFD
-from ..compat import compat_etree_fromstring
 from ..networking.exceptions import HTTPError
 from ..utils import fix_xml_ampersands, xpath_text
 
@@ -318,7 +318,7 @@ class F4mFD(FragmentFD):
         # and https://github.com/ytdl-org/youtube-dl/issues/7823)
         manifest = fix_xml_ampersands(urlh.read().decode('utf-8', 'ignore')).strip()
 
-        doc = compat_etree_fromstring(manifest)
+        doc = xml.etree.ElementTree.fromstring(manifest)
         formats = [(int(f.attrib.get('bitrate', -1)), f)
                    for f in self._get_unencrypted_media(doc)]
         if requested_bitrate is None or len(formats) == 1:

--- a/yt_dlp/extractor/brightcove.py
+++ b/yt_dlp/extractor/brightcove.py
@@ -6,7 +6,6 @@ import xml.etree.ElementTree
 
 from .adobepass import AdobePassIE
 from .common import InfoExtractor
-from ..compat import compat_etree_fromstring
 from ..networking.exceptions import HTTPError
 from ..utils import (
     ExtractorError,
@@ -314,7 +313,7 @@ class BrightcoveLegacyIE(InfoExtractor):
         object_str = fix_xml_ampersands(object_str)
 
         try:
-            object_doc = compat_etree_fromstring(object_str.encode())
+            object_doc = xml.etree.ElementTree.fromstring(object_str)
         except xml.etree.ElementTree.ParseError:
             return
 

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -20,11 +20,7 @@ import urllib.parse
 import urllib.request
 import xml.etree.ElementTree
 
-from ..compat import (
-    compat_etree_fromstring,
-    compat_expanduser,
-    urllib_req_to_req,
-)
+from ..compat import compat_expanduser, urllib_req_to_req
 from ..cookies import LenientSimpleCookie
 from ..downloader.f4m import get_base_url, remove_encrypted_media
 from ..downloader.hls import HlsFD
@@ -1075,7 +1071,7 @@ class InfoExtractor:
         if transform_source:
             xml_string = transform_source(xml_string)
         try:
-            return compat_etree_fromstring(xml_string.encode())
+            return xml.etree.ElementTree.fromstring(xml_string)
         except xml.etree.ElementTree.ParseError as ve:
             self.__print_error('Failed to parse XML' if errnote is None else errnote, fatal, video_id, ve)
 

--- a/yt_dlp/extractor/facebook.py
+++ b/yt_dlp/extractor/facebook.py
@@ -1,9 +1,9 @@
 import json
 import re
 import urllib.parse
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
-from ..compat import compat_etree_fromstring
 from ..networking.exceptions import HTTPError
 from ..utils import (
     ExtractorError,
@@ -558,7 +558,7 @@ class FacebookIE(InfoExtractor):
                 vid_data, 'dash_manifest', 'playlist', 'dash_manifest_xml_string', 'manifest_xml', expected_type=str)
             if dash_manifest:
                 formats.extend(self._parse_mpd_formats(
-                    compat_etree_fromstring(urllib.parse.unquote_plus(dash_manifest)),
+                    xml.etree.ElementTree.fromstring(urllib.parse.unquote_plus(dash_manifest)),
                     mpd_url=url_or_none(vid_data.get('dash_manifest_url')) or mpd_url))
 
         def process_formats(info):

--- a/yt_dlp/extractor/faz.py
+++ b/yt_dlp/extractor/faz.py
@@ -1,7 +1,7 @@
 import re
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
-from ..compat import compat_etree_fromstring
 from ..utils import (
     int_or_none,
     xpath_element,
@@ -51,7 +51,7 @@ class FazIE(InfoExtractor):
                 r"<iframe[^>]+?src='((?:http:)?//player\.performgroup\.com/eplayer/eplayer\.html#/?[0-9a-f]{26}\.[0-9a-z]{26})",
                 webpage, 'perform url')
             return self.url_result(perform_url)
-        config = compat_etree_fromstring(media)
+        config = xml.etree.ElementTree.fromstring(media)
 
         encodings = xpath_element(config, 'ENCODINGS', 'encodings', True)
         formats = []

--- a/yt_dlp/extractor/generic.py
+++ b/yt_dlp/extractor/generic.py
@@ -7,7 +7,6 @@ import xml.etree.ElementTree
 from .common import InfoExtractor
 from .commonprotocols import RtmpIE
 from .youtube import YoutubeIE
-from ..compat import compat_etree_fromstring
 from ..cookies import LenientSimpleCookie
 from ..networking.exceptions import HTTPError
 from ..networking.impersonate import ImpersonateTarget
@@ -923,10 +922,7 @@ class GenericIE(InfoExtractor):
 
         # Is it an RSS feed, a SMIL file, an XSPF playlist or a MPD manifest?
         try:
-            try:
-                doc = compat_etree_fromstring(webpage)
-            except xml.etree.ElementTree.ParseError:
-                doc = compat_etree_fromstring(webpage.encode())
+            doc = xml.etree.ElementTree.fromstring(webpage)
             if doc.tag == 'rss':
                 self.report_detected('RSS feed')
                 return self._extract_rss(url, video_id, doc)

--- a/yt_dlp/extractor/odnoklassniki.py
+++ b/yt_dlp/extractor/odnoklassniki.py
@@ -1,7 +1,7 @@
 import urllib.parse
+import xml.etree.ElementTree
 
 from .common import InfoExtractor
-from ..compat import compat_etree_fromstring
 from ..networking import HEADRequest
 from ..utils import (
     ExtractorError,
@@ -386,7 +386,7 @@ class OdnoklassnikiIE(InfoExtractor):
         dash_manifest = metadata.get('metadataEmbedded')
         if dash_manifest:
             formats.extend(self._parse_mpd_formats(
-                compat_etree_fromstring(dash_manifest), 'mpd'))
+                xml.etree.ElementTree.fromstring(dash_manifest), 'mpd'))
 
         for fmt in formats:
             fmt_type = self._search_regex(

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -49,7 +49,6 @@ from . import traversal
 
 from ..compat import (
     compat_datetime_from_timestamp,
-    compat_etree_fromstring,
     compat_expanduser,
     compat_HTMLParseError,
 )
@@ -3529,7 +3528,7 @@ def dfxp2srt(dfxp_data):
         for ns in v:
             dfxp_data = dfxp_data.replace(ns, k)
 
-    dfxp = compat_etree_fromstring(dfxp_data)
+    dfxp = xml.etree.ElementTree.fromstring(dfxp_data)
     out = []
     paras = dfxp.findall(_x('.//ttml:p')) or dfxp.findall('.//p')
 


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

deprecate `compat_etree_fromstring` in favor of `xml.etree.ElementTree.fromstring`
remove obsolete `_TreeBuilder` DOCTYPE handling and Python 2 XML re-encoding workarounds

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Cleanup

</details>
