### PR TITLE
[utils] Deprecate `encode_compat_str`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,6 +391,7 @@ banned-from = [
 "yt_dlp.compat.compat_urllib_parse_urlencode".msg = "Use `urllib.parse.urlencode` instead."
 "yt_dlp.compat.compat_urllib_parse_urlparse".msg = "Use `urllib.parse.urlparse` instead."
 "yt_dlp.compat.compat_shlex_quote".msg = "Use `yt_dlp.utils.shell_quote` instead."
+"yt_dlp.utils.encode_compat_str".msg = "Do not use"
 "yt_dlp.utils.error_to_compat_str".msg = "Use `str` instead."
 "yt_dlp.utils.bytes_to_intlist".msg = "Use `list` instead."
 "yt_dlp.utils.intlist_to_bytes".msg = "Use `bytes` instead."

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -49,7 +49,6 @@ from yt_dlp.utils import (
     determine_file_encoding,
     dfxp2srt,
     encode_base_n,
-    encode_compat_str,
     expand_path,
     extract_attributes,
     extract_basic_auth,
@@ -854,10 +853,6 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(merge_dicts({'a': ''}, {'a': 1}), {'a': ''})
         self.assertEqual(merge_dicts({'a': ''}, {'a': 'abc'}), {'a': 'abc'})
         self.assertEqual(merge_dicts({'a': None}, {'a': ''}, {'a': 'abc'}), {'a': 'abc'})
-
-    def test_encode_compat_str(self):
-        self.assertEqual(encode_compat_str(b'\xd1\x82\xd0\xb5\xd1\x81\xd1\x82', 'utf-8'), 'тест')
-        self.assertEqual(encode_compat_str('тест', 'utf-8'), 'тест')
 
     def test_parse_iso8601(self):
         self.assertEqual(parse_iso8601('2014-03-23T23:04:26+0100'), 1395612266)

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -121,7 +121,6 @@ from .utils import (
     deprecation_warning,
     determine_ext,
     determine_protocol,
-    encode_compat_str,
     escapeHTML,
     expand_path,
     extract_basic_auth,
@@ -1086,7 +1085,7 @@ class YoutubeDL:
                     tb = ''
                     if hasattr(sys.exc_info()[1], 'exc_info') and sys.exc_info()[1].exc_info[0]:
                         tb += ''.join(traceback.format_exception(*sys.exc_info()[1].exc_info))
-                    tb += encode_compat_str(traceback.format_exc())
+                    tb += traceback.format_exc()
                 else:
                     tb_data = traceback.format_list(traceback.extract_stack())
                     tb = ''.join(tb_data)
@@ -1748,7 +1747,7 @@ class YoutubeDL:
                     self.report_error(str(e), e.format_traceback())
                 except Exception as e:
                     if self.params.get('ignoreerrors'):
-                        self.report_error(str(e), tb=encode_compat_str(traceback.format_exc()))
+                        self.report_error(str(e), tb=traceback.format_exc())
                     else:
                         raise
                 break

--- a/yt_dlp/utils/_deprecated.py
+++ b/yt_dlp/utils/_deprecated.py
@@ -6,6 +6,7 @@ import json
 import uuid
 import warnings
 
+from ._utils import preferredencoding
 from ..compat.compat_utils import passthrough_module
 
 # XXX: Implement this the same way as other DeprecationWarnings without circular import
@@ -65,6 +66,10 @@ def number_of_digits(number):
 
 def random_uuidv4():
     return str(uuid.uuid4())
+
+
+def encode_compat_str(string, encoding=preferredencoding(), errors='strict'):
+    return string if isinstance(string, str) else str(string, encoding, errors)
 
 
 compiled_regex_type = type(re.compile(''))

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -2715,10 +2715,6 @@ def merge_dicts(*dicts):
     return merged
 
 
-def encode_compat_str(string, encoding=preferredencoding(), errors='strict'):
-    return string if isinstance(string, str) else str(string, encoding, errors)
-
-
 US_RATINGS = {
     'G': 0,
     'PG': 10,


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED

    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.

    PLEASE MAKE SURE TO ENABLE EDITS BY MAINTAINERS!
-->

### Description of your *pull request* and other information

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
    - If any of the questions are left unanswered, your pull request will be closed
    - If any of your answers are dishonest, you will be permanently blocked from this repository
-->

### Before submitting a *pull request* you must attest to the following:
- [x] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [x] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [x] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [x] Cleanup

</details>
