### PR TITLE
[core] Add `--no-download-manifests`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,13 @@ Make chapter entries for, or remove various segments (sponsor,
     --no-hls-split-discontinuity    Do not split HLS playlists into different
                                     formats at discontinuities such as ad breaks
                                     (default)
+    --download-manifests            Download HLS/DASH manifests to extract the
+                                    formats they contain (default)
+    --no-download-manifests         Do not download HLS/DASH manifests. Each
+                                    manifest is reported as a single format with
+                                    "manifest_url" set, so that an external
+                                    player can open the manifest itself. Meant
+                                    for use with --dump-json
     --extractor-args IE_KEY:ARGS    Pass ARGS arguments to the IE_KEY extractor.
                                     See "EXTRACTOR ARGUMENTS" for details. You
                                     can use this option multiple times to give

--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -536,6 +536,9 @@ class YoutubeDL:
     dynamic_mpd:       Whether to process dynamic DASH manifests (default: True)
     hls_split_discontinuity: Split HLS playlists into different formats at
                        discontinuities such as ad breaks (default: False)
+    download_manifests: Whether to download HLS/DASH manifests to extract the
+                       formats they contain. If False, each manifest is reported
+                       as a single format with manifest_url set (default: True)
     extractor_args:    A dictionary of arguments to be passed to the extractors.
                        See "EXTRACTOR ARGUMENTS" for details.
                        Argument values must always be a list of string(s).

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -945,6 +945,7 @@ def parse_options(argv=None):
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
         'hls_split_discontinuity': opts.hls_split_discontinuity,
+        'download_manifests': opts.download_manifests,
         'external_downloader_args': opts.external_downloader_args,
         'postprocessor_args': opts.postprocessor_args,
         'geo_verification_proxy': opts.geo_verification_proxy,

--- a/yt_dlp/extractor/common.py
+++ b/yt_dlp/extractor/common.py
@@ -89,6 +89,7 @@ from ..utils import (
     unescapeHTML,
     unified_strdate,
     unified_timestamp,
+    update_url_query,
     url_basename,
     url_or_none,
     urlhandle_detect_ext,
@@ -2167,6 +2168,19 @@ class InfoExtractor:
             'if any subtitle tracks are missing,',
         ), only_once=True)
 
+    def _manifest_only_format(self, manifest_url, manifest_id, protocol, data, query, **format_fields):
+        if data or self.get_param('download_manifests', True):
+            return None
+        if query:
+            manifest_url = update_url_query(manifest_url, query)
+        return {
+            'format_id': manifest_id,
+            'url': manifest_url,
+            'manifest_url': manifest_url,
+            'protocol': protocol,
+            **format_fields,
+        }
+
     def _extract_m3u8_formats(self, *args, **kwargs):
         fmts, subs = self._extract_m3u8_formats_and_subtitles(*args, **kwargs)
         if subs:
@@ -2189,6 +2203,11 @@ class InfoExtractor:
                     raise ExtractorError(errnote, video_id=video_id)
                 self.report_warning(f'{errnote}{bug_reports_message()}')
             return [], {}
+        manifest_only = self._manifest_only_format(
+            m3u8_url, m3u8_id, entry_protocol, data, query,
+            ext=ext, preference=preference, quality=quality)
+        if manifest_only:
+            return [manifest_only], {}
         if note is None:
             note = 'Downloading m3u8 information'
         if errnote is None:
@@ -2802,8 +2821,16 @@ class InfoExtractor:
             self._report_ignoring_subs('DASH')
         return fmts
 
-    def _extract_mpd_formats_and_subtitles(self, *args, **kwargs):
-        periods = self._extract_mpd_periods(*args, **kwargs)
+    def _extract_mpd_formats_and_subtitles(
+            self, mpd_url, video_id, mpd_id=None, note=None, errnote=None,
+            fatal=True, data=None, headers={}, query={}):
+        manifest_only = self._manifest_only_format(
+            mpd_url, mpd_id, 'http_dash_segments', data, query)
+        if manifest_only:
+            return [manifest_only], {}
+        periods = self._extract_mpd_periods(
+            mpd_url, video_id, mpd_id, note=note, errnote=errnote,
+            fatal=fatal, data=data, headers=headers, query=query)
         return self._merge_mpd_periods(periods)
 
     def _extract_mpd_periods(

--- a/yt_dlp/options.py
+++ b/yt_dlp/options.py
@@ -1922,6 +1922,17 @@ def create_parser():
         '--no-hls-split-discontinuity',
         dest='hls_split_discontinuity', action='store_false',
         help='Do not split HLS playlists into different formats at discontinuities such as ad breaks (default)')
+    extractor.add_option(
+        '--download-manifests',
+        dest='download_manifests', action='store_true', default=True,
+        help='Download HLS/DASH manifests to extract the formats they contain (default)')
+    extractor.add_option(
+        '--no-download-manifests',
+        dest='download_manifests', action='store_false',
+        help=(
+            'Do not download HLS/DASH manifests. Each manifest is reported as a single format '
+            'with "manifest_url" set, so that an external player can open the manifest itself. '
+            'Meant for use with --dump-json'))
     _extractor_arg_parser = lambda key, vals='': (key.strip().lower().replace('-', '_'), [
         val.replace(r'\,', ',').strip() for val in re.split(r'(?<!\\),', vals)])
     extractor.add_option(


### PR DESCRIPTION
External players such as mpv can play HLS and DASH manifests themselves and use `manifest_url` from the JSON output for that, but by then the manifest has already been downloaded to extract the formats. It's duplicated work to fetch all formats again. Also we got reports that some servers allow only single fetch of master playlist.

With the option, `_extract_m3u8_formats` and `_extract_mpd_formats` do not download the manifest and return a single format pointing at it instead, with `manifest_url` set. Manifests requested with POST data are still downloaded, since they cannot be represented by a URL.

<details open><summary>Template</summary> <!-- OPEN is intentional -->

### Before submitting a *pull request* you must attest to the following:
- [X] This pull request complies with yt-dlp's [**NO AI / NO LLM POLICY**](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#no-ai--no-llm-policy)
- [X] I have skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] I have [searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the tracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [X] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
